### PR TITLE
Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports # cmake
+    packages:
+      - cmake
+      - cmake-data
+      - gfortran
+
+os:
+  - linux
+  - osx
+
+script:
+  - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DLAPACKE=ON -DCBLAS=ON .
+  - make install -j2 && ctest -j2 --output-on-failure --timeout 100

--- a/CBLAS/testing/CMakeLists.txt
+++ b/CBLAS/testing/CMakeLists.txt
@@ -16,7 +16,6 @@ macro(add_cblas_test output input target)
       -DINTDIR=${CMAKE_CFG_INTDIR}
       -P "${LAPACK_SOURCE_DIR}/TESTING/runtest.cmake")
     else()
-      string(REPLACE "." "_" input_name ${input})
       add_test(NAME CBLAS-${testName} COMMAND "${CMAKE_COMMAND}" 
         -DTEST=$<TARGET_FILE:${target}>
         -DOUTPUT=${TEST_OUTPUT} 


### PR DESCRIPTION
This fixes a bug with CBLAS enabled where an unused string replace cmake command is given an empty argument:
 ```
-- CBLAS enable
CMake Error at CBLAS/testing/CMakeLists.txt:19 (string):
  string sub-command REPLACE requires at least four arguments.
Call Stack (most recent call first):
  CBLAS/testing/CMakeLists.txt:62 (add_cblas_test)
```

I added a travis config file in case you want to use continuous integration.