### PR TITLE
BUG: Fix pathing to include files

### DIFF
--- a/CBLAS/cmake/cblas-config-build.cmake.in
+++ b/CBLAS/cmake/cblas-config-build.cmake.in
@@ -7,8 +7,8 @@ if(NOT TARGET lapacke)
   include("@LAPACK_BINARY_DIR@/lapack-targets.cmake")
 endif()
 
-# Report lapacke header search locations.
-set(CBLAS_INCLUDE_DIRS "@LAPACK_SOURCE_DIR@/cblas/include")
+# Report cblas header search locations from build tree.
+set(CBLAS_INCLUDE_DIRS "@LAPACK_BINARY_DIR@/include")
 
-# Report lapacke libraries.
+# Report cblas libraries.
 set(CBLAS_LIBRARIES cblas)

--- a/LAPACKE/cmake/lapacke-config-build.cmake.in
+++ b/LAPACKE/cmake/lapacke-config-build.cmake.in
@@ -7,8 +7,8 @@ if(NOT TARGET lapacke)
   include("@LAPACK_BINARY_DIR@/lapack-targets.cmake")
 endif()
 
-# Report lapacke header search locations.
-set(LAPACKE_INCLUDE_DIRS "@LAPACK_SOURCE_DIR@/lapacke/include")
+# Report lapacke header search locations from build tree.
+set(LAPACKE_INCLUDE_DIRS "@LAPACK_BINARY_DIR@/include")
 
 # Report lapacke libraries.
 set(LAPACKE_LIBRARIES lapacke)


### PR DESCRIPTION
During building of external packages, only the build tree or install
tree files should be used (the source tree may not be available from
the binary package).  Set to use the build tree locations for the
configuration files.