### PR TITLE
BUG: path failure for find_package config files

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -45,7 +45,7 @@ endif(NOT BLAS_FOUND)
 set(_cblas_config_install_guard_target "")
 if(ALL_TARGETS)
   install(EXPORT cblas-targets
-    DESTINATION lib/cmake/cblas-${LAPACK_VERSION})
+    DESTINATION ${LIBRARY_DIR}/cmake/cblas-${LAPACK_VERSION})
   # Choose one of the cblas targets to use as a guard for
   # cblas-config.cmake to load targets from the install tree.
   list(GET ALL_TARGETS 0 _cblas_config_install_guard_target)
@@ -78,9 +78,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-install.cmake.in
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cblas-config.cmake
   ${LAPACK_BINARY_DIR}/cblas-config-version.cmake
-  DESTINATION lib/cmake/cblas-${LAPACK_VERSION}
+  DESTINATION ${LIBRARY_DIR}/cmake/cblas-${LAPACK_VERSION}
   )
 
 #install(EXPORT cblas-targets
-#  DESTINATION lib/cmake/cblas-${LAPACK_VERSION})
+#  DESTINATION ${LIBRARY_DIR}/cmake/cblas-${LAPACK_VERSION})
 

--- a/CBLAS/cmake/cblas-config-install.cmake.in
+++ b/CBLAS/cmake/cblas-config-install.cmake.in
@@ -1,11 +1,11 @@
-# Compute locations from <prefix>/lib/cmake/lapacke-<v>/<self>.cmake
+# Compute locations from <prefix>/@{LIBRARY_DIR@/cmake/lapacke-<v>/<self>.cmake
 get_filename_component(_CBLAS_SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(_CBLAS_PREFIX "${_CBLAS_SELF_DIR}" PATH)
 get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
 get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
 
 # Load the LAPACK package with which we were built.
-set(LAPACK_DIR "${_CBLAS_PREFIX}/lib/cmake/lapack-@LAPACK_VERSION@")
+set(LAPACK_DIR "${_CBLAS_PREFIX}/@{LIBRARY_DIR@/cmake/lapack-@LAPACK_VERSION@")
 find_package(LAPACK NO_MODULE)
 
 # Load lapacke targets from the install tree.

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -82,4 +82,4 @@ install(FILES
   )
 
 install(EXPORT lapacke-targets
-  DESTINATION lib/cmake/lapacke-${LAPACK_VERSION})
+  DESTINATION ${LIBRARY_DIR}/cmake/lapacke-${LAPACK_VERSION})

--- a/LAPACKE/cmake/lapacke-config-install.cmake.in
+++ b/LAPACKE/cmake/lapacke-config-install.cmake.in
@@ -1,11 +1,11 @@
-# Compute locations from <prefix>/lib/cmake/lapacke-<v>/<self>.cmake
+# Compute locations from <prefix>/@{LIBRARY_DIR@/cmake/lapacke-<v>/<self>.cmake
 get_filename_component(_LAPACKE_SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_SELF_DIR}" PATH)
 get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
 get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
 
 # Load the LAPACK package with which we were built.
-set(LAPACK_DIR "${_LAPACKE_PREFIX}/lib/cmake/lapack-@LAPACK_VERSION@")
+set(LAPACK_DIR "${_LAPACKE_PREFIX}/@{LIBRARY_DIR@/cmake/lapack-@LAPACK_VERSION@")
 find_package(LAPACK NO_MODULE)
 
 # Load lapacke targets from the install tree.


### PR DESCRIPTION
CMake Error at src/lapack-install/lib64/cmake/lapacke-3.6.1/lapacke-config.cmake:13 (include):
  include could not find load file:

    src/lapack-install/lib64/cmake/lapacke-3.6.1/lapacke-targets.cmake
Call Stack (most recent call first):
  CMakeLists.txt:26 (find_package)

-- src/lapack-install/lib64/cmake/lapacke-3.6.1
-- Configuring incomplete, errors occurred!
See also "src/lapackTest-bld/CMakeFiles/CMakeOutput.log".

The file was installed in:
    src/lapack-install/lib/cmake/lapacke-3.6.1/lapacke-targets.cmake
                          ^^ - Missing lib suffix of 64