### PR TITLE
?LALN2: fix doc for the D2 parameter

### DIFF
--- a/SRC/dlaln2.f
+++ b/SRC/dlaln2.f
@@ -127,7 +127,7 @@
 *> \param[in] D2
 *> \verbatim
 *>          D2 is DOUBLE PRECISION
-*>          The 2,2 element in the diagonal matrix D.  Not used if NW=1.
+*>          The 2,2 element in the diagonal matrix D.  Not used if NA=1.
 *> \endverbatim
 *>
 *> \param[in] B

--- a/SRC/slaln2.f
+++ b/SRC/slaln2.f
@@ -127,7 +127,7 @@
 *> \param[in] D2
 *> \verbatim
 *>          D2 is REAL
-*>          The 2,2 element in the diagonal matrix D.  Not used if NW=1.
+*>          The 2,2 element in the diagonal matrix D.  Not used if NA=1.
 *> \endverbatim
 *>
 *> \param[in] B


### PR DESCRIPTION
D is a NA×NA diagonal real matrix. Therefore, its (2,2) element D2 is not used if NA=1. There is no relation to NW.

Also reported at http://icl.cs.utk.edu/lapack-forum/viewtopic.php?f=13&t=4997