### PR TITLE
ENH: Set default build type to "Release"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,13 @@
 cmake_minimum_required(VERSION 2.8.10)
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 project(LAPACK Fortran)
 
 set(LAPACK_MAJOR_VERSION 3)


### PR DESCRIPTION
One of the most common reasons for using lapack & blas is to
provide efficient computations.

In my experience of working with newcomers to software bulding, I
find that their first experience (and often their first year of
experience) is with the most default build possible.  It is
very common that the first impressions of the software are based on whatever is
produced by "mkdir –p PKG-build; cmake ../PKG; make".

This proposal aims to improve initial impressions of the package by making the
defaults such that the "mkdir –p PKG-build; cmake ../PKG; make" builds
PKG in "Release" mode.

Rational for Release:  It has more support in differnt IDE's by default.
As a default it should be the supportive of those with little or no
software development experience.  Those developers who need debugging
information will likely have the experience needed to know how to change
from the default.  Developers should be smart enough to build
with Debug, but the typical new user is often not educated enough to
change to Release.