### PR TITLE
ENH: Add LAPACKE_WITH_TMG to default testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - cd ${BLD_DIR}
 # See issue #17 on github dashboard.  Once resolved, use -DCBLAS=ON
 #  - cmake -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DLAPACKE=ON ${SRC_DIR}
-  - cmake -DBUILDNAME:STRING="travis-${TRAVIS_OS_NAME}-${BRANCH}" -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DLAPACKE=ON ${SRC_DIR}
+  - cmake -DBUILDNAME:STRING="travis-${TRAVIS_OS_NAME}-${BRANCH}" -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DLAPACKE:BOOL=ON -DLAPACKE_WITH_TMG:BOOL=ON ${SRC_DIR}
   - ctest -D ExperimentalStart
   - ctest -D ExperimentalConfigure
   - ctest -D ExperimentalBuild -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,9 +278,9 @@ option(LAPACKE "Build LAPACKE" OFF)
 option(LAPACKE_WITH_TMG "Build LAPACKE with tmglib routines" OFF)
 if (LAPACKE_WITH_TMG)
   set(LAPACKE ON)
-  if(NOT BUILD_TESTING)
+endif()
+if(BUILD_TESTING OR LAPACKE_WITH_TMG) #already included, avoid double inclusion
      add_subdirectory(TESTING/MATGEN)
-   endif()
 endif()
 
 if(LAPACKE)

--- a/TESTING/CMakeLists.txt
+++ b/TESTING/CMakeLists.txt
@@ -4,7 +4,6 @@ if(MSVC_VERSION)
   string(REGEX REPLACE "(.*)/STACK:(.*) (.*)" "\\1/STACK:900000000000000000 \\3"
     CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
 endif()
-add_subdirectory(MATGEN)
 add_subdirectory(LIN)
 add_subdirectory(EIG)
 macro(add_lapack_test output input target)


### PR DESCRIPTION
In order to maximize code testing options, turn
LAPACKE_WITH_TMG=ON for travis builds.