### PR TITLE
Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - cd ${BLD_DIR}
 # See issue #17 on github dashboard.  Once resolved, use -DCBLAS=ON
 #  - cmake -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DLAPACKE=ON ${SRC_DIR}
-  - cmake -DBUILDNAME:STRING="travis-${TRAVIS_OS_NAME}-${BRANCH}" -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DCBLAS:BOOL=ON -DLAPACKE:BOOL=ON -DLAPACKE_WITH_TMG:BOOL=ON ${SRC_DIR}
+  - cmake -DBUILDNAME:STRING="travis-${TRAVIS_OS_NAME}-${BRANCH}" -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DCBLAS:BOOL=ON -DLAPACKE:BOOL=ON -DBUILD_TESTING=ON -DLAPACKE_WITH_TMG:BOOL=ON ${SRC_DIR}
   - ctest -D ExperimentalStart
   - ctest -D ExperimentalConfigure
   - ctest -D ExperimentalBuild -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - cd ${BLD_DIR}
 # See issue #17 on github dashboard.  Once resolved, use -DCBLAS=ON
 #  - cmake -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DLAPACKE=ON ${SRC_DIR}
-  - cmake -DBUILDNAME:STRING="travis-${TRAVIS_OS_NAME}-${BRANCH}" -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DLAPACKE:BOOL=ON -DLAPACKE_WITH_TMG:BOOL=ON ${SRC_DIR}
+  - cmake -DBUILDNAME:STRING="travis-${TRAVIS_OS_NAME}-${BRANCH}" -DCMAKE_INSTALL_PREFIX=${INST_DIR} -DCBLAS:BOOL=ON -DLAPACKE:BOOL=ON -DLAPACKE_WITH_TMG:BOOL=ON ${SRC_DIR}
   - ctest -D ExperimentalStart
   - ctest -D ExperimentalConfigure
   - ctest -D ExperimentalBuild -j2

--- a/CBLAS/testing/CMakeLists.txt
+++ b/CBLAS/testing/CMakeLists.txt
@@ -4,8 +4,8 @@
 #######################################################################
 
 macro(add_cblas_test output input target)
-  set(TEST_INPUT "${LAPACK_SOURCE_DIR}/cblas/testing/${input}")
-  set(TEST_OUTPUT "${LAPACK_BINARY_DIR}/cblas/testing/${output}")
+  set(TEST_INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
+  set(TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${output}")
   set(testName "${target}")
 
   if(EXISTS "${TEST_INPUT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,16 +151,26 @@ set(SECOND_SRC  ${LAPACK_SOURCE_DIR}/INSTALL/second_${TIME_FUNC}.f)
 set(DSECOND_SRC  ${LAPACK_SOURCE_DIR}/INSTALL/dsecnd_${TIME_FUNC}.f)
 set(PKG_CONFIG_DIR ${LIBRARY_DIR}/pkgconfig)
 
+
+# By default static library
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF )
+
+option(BUILD_TESTING "Build tests" OFF)
+
+# deprecated LAPACK routines
+option(BUILD_DEPRECATED "Build deprecated routines" OFF)
+
 # --------------------------------------------------
 # Precision to build
 # By default all precisions are generated
-
+option(BUILD_SINGLE "Build LAPACK Single Precision" ON)
+option(BUILD_DOUBLE "Build LAPACK Double Precision" ON)
+option(BUILD_COMPLEX "Build LAPACK Complex Precision" ON)
+option(BUILD_COMPLEX16 "Build LAPACK Double Complex Precision" ON)
 
 # --------------------------------------------------
 # Subdirectories that need to be processed
-
 option(USE_OPTIMIZED_BLAS "Whether or not to use an optimized BLAS library instead of included netlib BLAS" OFF)
-
 
 # Check the usage of the user provided BLAS libraries
 if(BLAS_LIBRARIES)
@@ -246,10 +256,6 @@ endif ()
 if(NOT LATESTLAPACK_FOUND)
   message(STATUS "Using supplied NETLIB LAPACK implementation")
   set( LAPACK_LIBRARIES lapack )
-  option(BUILD_SINGLE "Build LAPACK Single Precision" ON)
-  option(BUILD_DOUBLE "Build LAPACK Double Precision" ON)
-  option(BUILD_COMPLEX "Build LAPACK Complex Precision" ON)
-  option(BUILD_COMPLEX16 "Build LAPACK Double Complex Precision" ON)
   add_subdirectory(SRC)
 else()
   set( CMAKE_EXE_LINKER_FLAGS
@@ -267,9 +273,6 @@ message(STATUS "BUILD TESTING : ${BUILD_TESTING}" )
 if(BUILD_TESTING)
   add_subdirectory(TESTING)
 endif()
-
-# deprecated LAPACK routines
-option(BUILD_DEPRECATED "Build deprecated routines" OFF)
 
 # --------------------------------------------------
 # LAPACKE
@@ -319,10 +322,6 @@ include(CPack)
 
 
 # --------------------------------------------------
-# By default static library
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF )
-option(BUILD_STATIC_LIBS "Build static libraries" ON )
-#option(BUILD_SHARED_LIBS "Build shared libraries" ON )
 
 if(NOT BLAS_FOUND)
   set(ALL_TARGETS ${ALL_TARGETS} blas)


### PR DESCRIPTION
Fixes #17 and supercedes #22

Also 48a4a89 fixes the options values definition in the cache because they were not defined when first used.