### PR TITLE
maint: removed unused variables

### DIFF
--- a/SRC/cgebal.f
+++ b/SRC/cgebal.f
@@ -190,7 +190,6 @@
       INTEGER            I, ICA, IEXC, IRA, J, K, L, M
       REAL               C, CA, F, G, R, RA, S, SFMAX1, SFMAX2, SFMIN1,
      $                   SFMIN2
-      COMPLEX            CDUM
 *     ..
 *     .. External Functions ..
       LOGICAL            SISNAN, LSAME

--- a/SRC/zgebal.f
+++ b/SRC/zgebal.f
@@ -189,7 +189,6 @@
       INTEGER            I, ICA, IEXC, IRA, J, K, L, M
       DOUBLE PRECISION   C, CA, F, G, R, RA, S, SFMAX1, SFMAX2, SFMIN1,
      $                   SFMIN2
-      COMPLEX*16         CDUM
 *     ..
 *     .. External Functions ..
       LOGICAL            DISNAN, LSAME

--- a/SRC/zunbdb.f
+++ b/SRC/zunbdb.f
@@ -314,7 +314,7 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            COLMAJOR, LQUERY
-      INTEGER            I, LWORKMIN, LWORKOPT, PI1, QI1
+      INTEGER            I, LWORKMIN, LWORKOPT
       DOUBLE PRECISION   Z1, Z2, Z3, Z4
 *     ..
 *     .. External Subroutines ..


### PR DESCRIPTION
Removed 3 unused variables from 2 different routines. 

I have compiled with `-Wunused` and these where the only ones which popped up.