### PR TITLE
bug: fixes always failing tests for *TREXC which was erroneous tests

### DIFF
--- a/SRC/ctrexc.f
+++ b/SRC/ctrexc.f
@@ -182,7 +182,7 @@
 *
 *     Quick return if possible
 *
-      IF( N.EQ.1 .OR. IFST.EQ.ILST )
+      IF( N.LE.1 .OR. IFST.EQ.ILST )
      $   RETURN
 *
       IF( IFST.LT.ILST ) THEN

--- a/SRC/ctrexc.f
+++ b/SRC/ctrexc.f
@@ -57,6 +57,7 @@
 *> \verbatim
 *>          N is INTEGER
 *>          The order of the matrix T. N >= 0.
+*>          If N == 0 arguments ILST and IFST may be any value.
 *> \endverbatim
 *>
 *> \param[in,out] T

--- a/SRC/dtrexc.f
+++ b/SRC/dtrexc.f
@@ -63,6 +63,7 @@
 *> \verbatim
 *>          N is INTEGER
 *>          The order of the matrix T. N >= 0.
+*>          If N == 0 arguments ILST and IFST may be any value.
 *> \endverbatim
 *>
 *> \param[in,out] T

--- a/SRC/strexc.f
+++ b/SRC/strexc.f
@@ -63,6 +63,7 @@
 *> \verbatim
 *>          N is INTEGER
 *>          The order of the matrix T. N >= 0.
+*>          If N == 0 arguments ILST and IFST may be any value.
 *> \endverbatim
 *>
 *> \param[in,out] T

--- a/SRC/ztrexc.f
+++ b/SRC/ztrexc.f
@@ -182,7 +182,7 @@
 *
 *     Quick return if possible
 *
-      IF( N.EQ.1 .OR. IFST.EQ.ILST )
+      IF( N.LE.1 .OR. IFST.EQ.ILST )
      $   RETURN
 *
       IF( IFST.LT.ILST ) THEN

--- a/SRC/ztrexc.f
+++ b/SRC/ztrexc.f
@@ -57,6 +57,7 @@
 *> \verbatim
 *>          N is INTEGER
 *>          The order of the matrix T. N >= 0.
+*>          If N == 0 arguments ILST and IFST may be any value.
 *> \endverbatim
 *>
 *> \param[in,out] T

--- a/TESTING/EIG/cerrec.f
+++ b/TESTING/EIG/cerrec.f
@@ -152,6 +152,9 @@
       INFOT = 1
       CALL CTREXC( 'X', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'CTREXC', INFOT, NOUT, LERR, OK )
+      INFOT = 2
+      CALL CTREXC( 'N', -1, A, 1, B, 1, IFST, ILST, INFO )
+      CALL CHKXER( 'CTREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL CTREXC( 'N', 2, A, 1, B, 1, IFST, ILST, INFO )
@@ -177,7 +180,7 @@
       ILST = 2
       CALL CTREXC( 'V', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'CTREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 7
+      NT = NT + 8
 *
 *     Test CTRSNA
 *

--- a/TESTING/EIG/cerrec.f
+++ b/TESTING/EIG/cerrec.f
@@ -152,9 +152,6 @@
       INFOT = 1
       CALL CTREXC( 'X', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'CTREXC', INFOT, NOUT, LERR, OK )
-      INFOT = 7
-      CALL CTREXC( 'N', 0, A, 1, B, 1, IFST, ILST, INFO )
-      CALL CHKXER( 'CTREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL CTREXC( 'N', 2, A, 1, B, 1, IFST, ILST, INFO )
@@ -180,7 +177,7 @@
       ILST = 2
       CALL CTREXC( 'V', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'CTREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 8
+      NT = NT + 7
 *
 *     Test CTRSNA
 *

--- a/TESTING/EIG/derrec.f
+++ b/TESTING/EIG/derrec.f
@@ -23,7 +23,7 @@
 *>
 *> DERREC tests the error exits for the routines for eigen- condition
 *> estimation for DOUBLE PRECISION matrices:
-*>    DTRSYL, STREXC, STRSNA and STRSEN.
+*>    DTRSYL, DTREXC, DTRSNA and DTRSEN.
 *> \endverbatim
 *
 *  Arguments:
@@ -152,9 +152,6 @@
       INFOT = 1
       CALL DTREXC( 'X', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'DTREXC', INFOT, NOUT, LERR, OK )
-      INFOT = 7
-      CALL DTREXC( 'N', 0, A, 1, B, 1, IFST, ILST, WORK, INFO )
-      CALL CHKXER( 'DTREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL DTREXC( 'N', 2, A, 1, B, 1, IFST, ILST, WORK, INFO )
@@ -180,7 +177,7 @@
       ILST = 2
       CALL DTREXC( 'V', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'DTREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 8
+      NT = NT + 7
 *
 *     Test DTRSNA
 *

--- a/TESTING/EIG/derrec.f
+++ b/TESTING/EIG/derrec.f
@@ -152,6 +152,9 @@
       INFOT = 1
       CALL DTREXC( 'X', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'DTREXC', INFOT, NOUT, LERR, OK )
+      INFOT = 2
+      CALL DTREXC( 'N', -1, A, 1, B, 1, IFST, ILST, WORK, INFO )
+      CALL CHKXER( 'DTREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL DTREXC( 'N', 2, A, 1, B, 1, IFST, ILST, WORK, INFO )
@@ -177,7 +180,7 @@
       ILST = 2
       CALL DTREXC( 'V', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'DTREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 7
+      NT = NT + 8
 *
 *     Test DTRSNA
 *

--- a/TESTING/EIG/serrec.f
+++ b/TESTING/EIG/serrec.f
@@ -152,6 +152,9 @@
       INFOT = 1
       CALL STREXC( 'X', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'STREXC', INFOT, NOUT, LERR, OK )
+      INFOT = 2
+      CALL STREXC( 'N', -1, A, 1, B, 1, IFST, ILST, WORK, INFO )
+      CALL CHKXER( 'STREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL STREXC( 'N', 2, A, 1, B, 1, IFST, ILST, WORK, INFO )
@@ -177,7 +180,7 @@
       ILST = 2
       CALL STREXC( 'V', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'STREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 7
+      NT = NT + 8
 *
 *     Test STRSNA
 *

--- a/TESTING/EIG/serrec.f
+++ b/TESTING/EIG/serrec.f
@@ -152,9 +152,6 @@
       INFOT = 1
       CALL STREXC( 'X', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'STREXC', INFOT, NOUT, LERR, OK )
-      INFOT = 7
-      CALL STREXC( 'N', 0, A, 1, B, 1, IFST, ILST, WORK, INFO )
-      CALL CHKXER( 'STREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL STREXC( 'N', 2, A, 1, B, 1, IFST, ILST, WORK, INFO )
@@ -180,7 +177,7 @@
       ILST = 2
       CALL STREXC( 'V', 1, A, 1, B, 1, IFST, ILST, WORK, INFO )
       CALL CHKXER( 'STREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 8
+      NT = NT + 7
 *
 *     Test STRSNA
 *

--- a/TESTING/EIG/zerrec.f
+++ b/TESTING/EIG/zerrec.f
@@ -23,7 +23,7 @@
 *>
 *> ZERREC tests the error exits for the routines for eigen- condition
 *> estimation for DOUBLE PRECISION matrices:
-*>    ZTRSYL, CTREXC, CTRSNA and CTRSEN.
+*>    ZTRSYL, ZTREXC, ZTRSNA and ZTRSEN.
 *> \endverbatim
 *
 *  Arguments:
@@ -152,9 +152,6 @@
       INFOT = 1
       CALL ZTREXC( 'X', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'ZTREXC', INFOT, NOUT, LERR, OK )
-      INFOT = 7
-      CALL ZTREXC( 'N', 0, A, 1, B, 1, IFST, ILST, INFO )
-      CALL CHKXER( 'ZTREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL ZTREXC( 'N', 2, A, 1, B, 1, IFST, ILST, INFO )
@@ -180,7 +177,7 @@
       ILST = 2
       CALL ZTREXC( 'V', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'ZTREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 8
+      NT = NT + 7
 *
 *     Test ZTRSNA
 *

--- a/TESTING/EIG/zerrec.f
+++ b/TESTING/EIG/zerrec.f
@@ -152,6 +152,9 @@
       INFOT = 1
       CALL ZTREXC( 'X', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'ZTREXC', INFOT, NOUT, LERR, OK )
+      INFOT = 2
+      CALL ZTREXC( 'N', -1, A, 1, B, 1, IFST, ILST, INFO )
+      CALL CHKXER( 'ZTREXC', INFOT, NOUT, LERR, OK )
       INFOT = 4
       ILST = 2
       CALL ZTREXC( 'N', 2, A, 1, B, 1, IFST, ILST, INFO )
@@ -177,7 +180,7 @@
       ILST = 2
       CALL ZTREXC( 'V', 1, A, 1, B, 1, IFST, ILST, INFO )
       CALL CHKXER( 'ZTREXC', INFOT, NOUT, LERR, OK )
-      NT = NT + 7
+      NT = NT + 8
 *
 *     Test ZTRSNA
 *


### PR DESCRIPTION
There where checks for *TREXC for the argument of N = 0 with a return value
of -7. However, the documentation of the *TREXC routines specify that
N = 0 is a valid argument with instant return.

Hence the checks have been removed and the quick returns established in the
affected routines.

Also comments for [dz]errec.f files are fixed.

**NOTE**: I have instantiated quick returns as `N.LE.1` which is equivalent to the [SD]TREXC checks. Please remark that these codes does not check for `N<0` and return an error code accordingly. This check is beyond what I am comfortable inserting as it may not be desired.
