### PR TITLE
Doc fixes for xGEEQUB, xGBEQUB, and xPOEQUB

### DIFF
--- a/SRC/cgbequb.f
+++ b/SRC/cgbequb.f
@@ -49,7 +49,7 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from CGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
 *> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).

--- a/SRC/cgbequb.f
+++ b/SRC/cgbequb.f
@@ -51,7 +51,7 @@
 *> This routine differs from CGEEQU by restricting the scaling factors
 *> to a power of the radix.  Baring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/cgeequb.f
+++ b/SRC/cgeequb.f
@@ -49,9 +49,9 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from CGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/cpoequb.f
+++ b/SRC/cpoequb.f
@@ -37,12 +37,12 @@
 *>
 *> CPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the spectral norm). S contains the scale factors,
-*> chosen so that the scaled matrix B with elements
-*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
-*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
-*> the basis use for floating point numbers on this machine. This choice
-*> of S avoids round-off errors when computing B.
+*> (with respect to the two-norm).  S contains the scale factors,
+*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
+*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
+*> choice of S puts the condition number of B within a factor N of the
+*> smallest possible condition number over all possible diagonal
+*> scalings.
 *> \endverbatim
 *
 *  Arguments:
@@ -150,6 +150,8 @@
 *     .. Executable Statements ..
 *
 *     Test the input parameters.
+*
+*     Positive definite only performs 1 pass of equilibration.
 *
       INFO = 0
       IF( N.LT.0 ) THEN

--- a/SRC/cpoequb.f
+++ b/SRC/cpoequb.f
@@ -36,13 +36,19 @@
 *> \verbatim
 *>
 *> CPOEQUB computes row and column scalings intended to equilibrate a
-*> symmetric positive definite matrix A and reduce its condition number
+*> Hermitian positive definite matrix A and reduce its condition number
 *> (with respect to the two-norm).  S contains the scale factors,
 *> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
 *> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
 *> choice of S puts the condition number of B within a factor N of the
 *> smallest possible condition number over all possible diagonal
 *> scalings.
+*>
+*> This routine differs from CPOEQU by restricting the scaling factors
+*> to a power of the radix.  Barring over- and underflow, scaling by
+*> these factors introduces no additional rounding errors.  However, the
+*> scaled diagonal entries are no longer approximately 1 but lie
+*> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *
 *  Arguments:
@@ -57,7 +63,7 @@
 *> \param[in] A
 *> \verbatim
 *>          A is COMPLEX array, dimension (LDA,N)
-*>          The N-by-N symmetric positive definite matrix whose scaling
+*>          The N-by-N Hermitian positive definite matrix whose scaling
 *>          factors are to be computed.  Only the diagonal elements of A
 *>          are referenced.
 *> \endverbatim

--- a/SRC/cpoequb.f
+++ b/SRC/cpoequb.f
@@ -37,12 +37,12 @@
 *>
 *> CPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the two-norm).  S contains the scale factors,
-*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
-*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
-*> choice of S puts the condition number of B within a factor N of the
-*> smallest possible condition number over all possible diagonal
-*> scalings.
+*> (with respect to the spectral norm). S contains the scale factors,
+*> chosen so that the scaled matrix B with elements
+*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
+*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
+*> the basis use for floating point numbers on this machine. This choice
+*> of S avoids round-off errors when computing B.
 *> \endverbatim
 *
 *  Arguments:
@@ -150,8 +150,6 @@
 *     .. Executable Statements ..
 *
 *     Test the input parameters.
-*
-*     Positive definite only performs 1 pass of equilibration.
 *
       INFO = 0
       IF( N.LT.0 ) THEN

--- a/SRC/dgbequb.f
+++ b/SRC/dgbequb.f
@@ -48,7 +48,7 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from DGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
 *> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).

--- a/SRC/dgbequb.f
+++ b/SRC/dgbequb.f
@@ -50,7 +50,7 @@
 *> This routine differs from DGEEQU by restricting the scaling factors
 *> to a power of the radix.  Baring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/dgeequb.f
+++ b/SRC/dgeequb.f
@@ -48,9 +48,9 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from DGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/dpoequb.f
+++ b/SRC/dpoequb.f
@@ -34,14 +34,14 @@
 *>
 *> \verbatim
 *>
-*> DPOEQUB computes row and column scalings intended to equilibrate a
+*> DPOEQU computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the spectral norm). S contains the scale factors,
-*> chosen so that the scaled matrix B with elements
-*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
-*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
-*> the basis use for floating point numbers on this machine. This choice
-*> of S avoids round-off errors when computing B.
+*> (with respect to the two-norm).  S contains the scale factors,
+*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
+*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
+*> choice of S puts the condition number of B within a factor N of the
+*> smallest possible condition number over all possible diagonal
+*> scalings.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/dpoequb.f
+++ b/SRC/dpoequb.f
@@ -34,7 +34,7 @@
 *>
 *> \verbatim
 *>
-*> DPOEQU computes row and column scalings intended to equilibrate a
+*> DPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
 *> (with respect to the two-norm).  S contains the scale factors,
 *> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
@@ -42,6 +42,12 @@
 *> choice of S puts the condition number of B within a factor N of the
 *> smallest possible condition number over all possible diagonal
 *> scalings.
+*>
+*> This routine differs from DPOEQU by restricting the scaling factors
+*> to a power of the radix.  Barring over- and underflow, scaling by
+*> these factors introduces no additional rounding errors.  However, the
+*> scaled diagonal entries are no longer approximately 1 but lie
+*> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/dpoequb.f
+++ b/SRC/dpoequb.f
@@ -34,14 +34,14 @@
 *>
 *> \verbatim
 *>
-*> DPOEQU computes row and column scalings intended to equilibrate a
+*> DPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the two-norm).  S contains the scale factors,
-*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
-*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
-*> choice of S puts the condition number of B within a factor N of the
-*> smallest possible condition number over all possible diagonal
-*> scalings.
+*> (with respect to the spectral norm). S contains the scale factors,
+*> chosen so that the scaled matrix B with elements
+*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
+*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
+*> the basis use for floating point numbers on this machine. This choice
+*> of S avoids round-off errors when computing B.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/sgbequb.f
+++ b/SRC/sgbequb.f
@@ -50,7 +50,7 @@
 *> This routine differs from SGEEQU by restricting the scaling factors
 *> to a power of the radix.  Baring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/sgbequb.f
+++ b/SRC/sgbequb.f
@@ -48,7 +48,7 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from SGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
 *> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).

--- a/SRC/sgeequb.f
+++ b/SRC/sgeequb.f
@@ -48,9 +48,9 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from SGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/spoequb.f
+++ b/SRC/spoequb.f
@@ -34,7 +34,7 @@
 *>
 *> \verbatim
 *>
-*> SPOEQU computes row and column scalings intended to equilibrate a
+*> SPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
 *> (with respect to the two-norm).  S contains the scale factors,
 *> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
@@ -42,6 +42,12 @@
 *> choice of S puts the condition number of B within a factor N of the
 *> smallest possible condition number over all possible diagonal
 *> scalings.
+*>
+*> This routine differs from SPOEQU by restricting the scaling factors
+*> to a power of the radix.  Barring over- and underflow, scaling by
+*> these factors introduces no additional rounding errors.  However, the
+*> scaled diagonal entries are no longer approximately 1 but lie
+*> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/spoequb.f
+++ b/SRC/spoequb.f
@@ -34,14 +34,14 @@
 *>
 *> \verbatim
 *>
-*> SPOEQUB computes row and column scalings intended to equilibrate a
+*> SPOEQU computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the spectral norm). S contains the scale factors,
-*> chosen so that the scaled matrix B with elements
-*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
-*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
-*> the basis use for floating point numbers on this machine. This choice
-*> of S avoids round-off errors when computing B.
+*> (with respect to the two-norm).  S contains the scale factors,
+*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
+*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
+*> choice of S puts the condition number of B within a factor N of the
+*> smallest possible condition number over all possible diagonal
+*> scalings.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/spoequb.f
+++ b/SRC/spoequb.f
@@ -34,14 +34,14 @@
 *>
 *> \verbatim
 *>
-*> SPOEQU computes row and column scalings intended to equilibrate a
+*> SPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the two-norm).  S contains the scale factors,
-*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
-*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
-*> choice of S puts the condition number of B within a factor N of the
-*> smallest possible condition number over all possible diagonal
-*> scalings.
+*> (with respect to the spectral norm). S contains the scale factors,
+*> chosen so that the scaled matrix B with elements
+*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
+*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
+*> the basis use for floating point numbers on this machine. This choice
+*> of S avoids round-off errors when computing B.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/zgbequb.f
+++ b/SRC/zgbequb.f
@@ -49,7 +49,7 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from ZGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
 *> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).

--- a/SRC/zgbequb.f
+++ b/SRC/zgbequb.f
@@ -51,7 +51,7 @@
 *> This routine differs from ZGEEQU by restricting the scaling factors
 *> to a power of the radix.  Baring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/zgeequb.f
+++ b/SRC/zgeequb.f
@@ -49,9 +49,9 @@
 *> number of A but works well in practice.
 *>
 *> This routine differs from ZGEEQU by restricting the scaling factors
-*> to a power of the radix.  Baring over- and underflow, scaling by
+*> to a power of the radix.  Barring over- and underflow, scaling by
 *> these factors introduces no additional rounding errors.  However, the
-*> scaled entries' magnitured are no longer approximately 1 but lie
+*> scaled entries' magnitudes are no longer approximately 1 but lie
 *> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *

--- a/SRC/zpoequb.f
+++ b/SRC/zpoequb.f
@@ -37,12 +37,12 @@
 *>
 *> ZPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the spectral norm). S contains the scale factors,
-*> chosen so that the scaled matrix B with elements
-*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
-*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
-*> the basis use for floating point numbers on this machine. This choice
-*> of S avoids round-off errors when computing B.
+*> (with respect to the two-norm).  S contains the scale factors,
+*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
+*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
+*> choice of S puts the condition number of B within a factor N of the
+*> smallest possible condition number over all possible diagonal
+*> scalings.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/zpoequb.f
+++ b/SRC/zpoequb.f
@@ -36,13 +36,19 @@
 *> \verbatim
 *>
 *> ZPOEQUB computes row and column scalings intended to equilibrate a
-*> symmetric positive definite matrix A and reduce its condition number
+*> Hermitian positive definite matrix A and reduce its condition number
 *> (with respect to the two-norm).  S contains the scale factors,
 *> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
 *> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
 *> choice of S puts the condition number of B within a factor N of the
 *> smallest possible condition number over all possible diagonal
 *> scalings.
+*>
+*> This routine differs from ZPOEQU by restricting the scaling factors
+*> to a power of the radix.  Barring over- and underflow, scaling by
+*> these factors introduces no additional rounding errors.  However, the
+*> scaled diagonal entries are no longer approximately 1 but lie
+*> between sqrt(radix) and 1/sqrt(radix).
 *> \endverbatim
 *
 *  Arguments:
@@ -57,7 +63,7 @@
 *> \param[in] A
 *> \verbatim
 *>          A is COMPLEX*16 array, dimension (LDA,N)
-*>          The N-by-N symmetric positive definite matrix whose scaling
+*>          The N-by-N Hermitian positive definite matrix whose scaling
 *>          factors are to be computed.  Only the diagonal elements of A
 *>          are referenced.
 *> \endverbatim

--- a/SRC/zpoequb.f
+++ b/SRC/zpoequb.f
@@ -37,12 +37,12 @@
 *>
 *> ZPOEQUB computes row and column scalings intended to equilibrate a
 *> symmetric positive definite matrix A and reduce its condition number
-*> (with respect to the two-norm).  S contains the scale factors,
-*> S(i) = 1/sqrt(A(i,i)), chosen so that the scaled matrix B with
-*> elements B(i,j) = S(i)*A(i,j)*S(j) has ones on the diagonal.  This
-*> choice of S puts the condition number of B within a factor N of the
-*> smallest possible condition number over all possible diagonal
-*> scalings.
+*> (with respect to the spectral norm). S contains the scale factors,
+*> chosen so that the scaled matrix B with elements
+*> B(i,j) = S(i)*A(i,j)*S(j) has diagonal entries close to one. S(i) is
+*> a power of b nearest to but not exceeding 1/sqrt(A(i,i)), where b is
+*> the basis use for floating point numbers on this machine. This choice
+*> of S avoids round-off errors when computing B.
 *> \endverbatim
 *
 *  Arguments:


### PR DESCRIPTION
These patches fix typos in xGEEQUB, xGBEQUB and highlight the difference between xPOEQU as well as xPOEQUB.