### PR TITLE
Improve pkgconfig file generation

### DIFF
--- a/BLAS/CMakeLists.txt
+++ b/BLAS/CMakeLists.txt
@@ -2,7 +2,7 @@ add_subdirectory(SRC)
 if(BUILD_TESTING)
 add_subdirectory(TESTING)
 endif()
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/blas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/blas.pc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/blas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/blas.pc @ONLY)
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/blas.pc
   DESTINATION ${PKG_CONFIG_DIR}

--- a/BLAS/blas.pc.in
+++ b/BLAS/blas.pc.in
@@ -1,9 +1,9 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+prefix=@prefix@
+libdir=@libdir@
 
-Name: blas
-Description: Basic Linear Algebra Subprograms F77 reference implementations
+Name: BLAS
+Description: FORTRAN reference implementation of BLAS Basic Linear Algebra Subprograms
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/blas/
-Libs: -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lblas
+Libs: -L${libdir} -lblas
 Libs.private: -lm

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -67,7 +67,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-build.cmake.in
   ${LAPACK_BINARY_DIR}/cblas-config.cmake @ONLY)
 
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/cblas.pc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/cblas.pc @ONLY)
   install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/cblas.pc
   DESTINATION ${PKG_CONFIG_DIR}

--- a/CBLAS/cblas.pc.in
+++ b/CBLAS/cblas.pc.in
@@ -1,9 +1,9 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+prefix=@prefix@
+libdir=@libdir@
 
-Name: lapacke
-Description: C Standard Interface to BLAS Linear Algebra PACKage
+Name: CBLAS
+Description: C Standard Interface to BLAS Basic Linear Algebra Subprograms
 Version: @LAPACK_VERSION@
-URL: http://www.netlib.org/lapack/
-Libs: -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lcblas
+URL: http://www.netlib.org/blas/#_cblas
+Libs: -L${libdir} -lcblas
 Requires: blas

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,14 @@ macro(lapack_install_library lib)
   )
 endmacro()
 
+set(PKG_CONFIG_DIR ${LIBRARY_DIR}/pkgconfig)
+set(prefix ${CMAKE_INSTALL_PREFIX})
+if(NOT IS_ABSOLUTE ${LIBRARY_DIR})
+  set(libdir "\${prefix}/${LIBRARY_DIR}")
+else()
+  set(libdir "${LIBRARY_DIR}")
+endif()
+
 # --------------------------------------------------
 # Testing
 
@@ -149,8 +157,6 @@ message(STATUS "--> Will use second_${TIME_FUNC}.f and dsecnd_${TIME_FUNC}.f as 
 
 set(SECOND_SRC  ${LAPACK_SOURCE_DIR}/INSTALL/second_${TIME_FUNC}.f)
 set(DSECOND_SRC  ${LAPACK_SOURCE_DIR}/INSTALL/dsecnd_${TIME_FUNC}.f)
-set(PKG_CONFIG_DIR ${LIBRARY_DIR}/pkgconfig)
-
 
 # By default static library
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF )
@@ -371,7 +377,7 @@ configure_file(${LAPACK_SOURCE_DIR}/CMAKE/lapack-config-build.cmake.in
   ${LAPACK_BINARY_DIR}/lapack-config.cmake @ONLY)
 
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapack.pc.in ${CMAKE_CURRENT_BINARY_DIR}/lapack.pc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapack.pc.in ${CMAKE_CURRENT_BINARY_DIR}/lapack.pc @ONLY)
   install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/lapack.pc
   DESTINATION ${PKG_CONFIG_DIR}

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -62,7 +62,7 @@ if(BUILD_TESTING)
 endif()
 
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapacke.pc.in ${CMAKE_CURRENT_BINARY_DIR}/lapacke.pc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lapacke.pc.in ${CMAKE_CURRENT_BINARY_DIR}/lapacke.pc @ONLY)
  install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/lapacke.pc
   DESTINATION ${PKG_CONFIG_DIR}

--- a/LAPACKE/lapacke.pc.in
+++ b/LAPACKE/lapacke.pc.in
@@ -1,9 +1,9 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+prefix=@prefix@
+libdir=@libdir@
 
-Name: lapacke
+Name: LAPACKE
 Description: C Standard Interface to LAPACK Linear Algebra PACKage
 Version: @LAPACK_VERSION@
-URL: http://www.netlib.org/lapack/
-Libs: -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -llapacke
+URL: http://www.netlib.org/lapack/#_standard_c_language_apis_for_lapack
+Libs: -L${libdir} -llapacke
 Requires: lapack blas

--- a/lapack.pc.in
+++ b/lapack.pc.in
@@ -1,9 +1,9 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+prefix=@prefix@
+libdir=@libdir@
 
-Name: lapack
+Name: LAPACK
 Description: FORTRAN reference implementation of LAPACK Linear Algebra PACKage
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/lapack/
-Libs: -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -llapack
+Libs: -L${libdir} -llapack
 Requires: blas


### PR DESCRIPTION
The prefix and libdir lines at the top of the .pc files are variable
declarations.  Set these variables appropriately, reference them in the
rest of the file, and prevent cmake from expanding ${}-style references.
Switch back to @prefix@ and @libdir@ for compatibility with autoconf.

Make the descriptions consistent and update the URLs.