### PR TITLE
make SY/HE imat match LAWN 41 (different than PO)

### DIFF
--- a/TESTING/LIN/clatb4.f
+++ b/TESTING/LIN/clatb4.f
@@ -340,12 +340,10 @@
             ANORM = ONE
          END IF
 *
-      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) .OR.
-     $         LSAMEN( 2, C2, 'HE' ) .OR. LSAMEN( 2, C2, 'HP' ) .OR.
-     $         LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) ) THEN
 *
-*        xPO, xPP, xHE, xHP, xSY, xSP: Set parameters to generate a
-*        symmetric or Hermitian matrix.
+*        xPO, xPP: Set parameters to generate a
+*        symmetric or Hermitian positive definite matrix.
 *
 *        Set TYPE, the type of matrix to be generated.
 *
@@ -373,6 +371,43 @@
          IF( IMAT.EQ.8 ) THEN
             ANORM = SMALL
          ELSE IF( IMAT.EQ.9 ) THEN
+            ANORM = LARGE
+         ELSE
+            ANORM = ONE
+         END IF
+*
+      ELSE IF( LSAMEN( 2, C2, 'HE' ) .OR. LSAMEN( 2, C2, 'HP' ) .OR.
+     $         LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+*
+*        xHE, xHP, xSY, xSP: Set parameters to generate a
+*        symmetric or Hermitian matrix.
+*
+*        Set TYPE, the type of matrix to be generated.
+*
+         TYPE = C2( 1: 1 )
+*
+*        Set the lower and upper bandwidths.
+*
+         IF( IMAT.EQ.1 ) THEN
+            KL = 0
+         ELSE
+            KL = MAX( N-1, 0 )
+         END IF
+         KU = KL
+*
+*        Set the condition number and norm.
+*
+         IF( IMAT.EQ.7 ) THEN
+            CNDNUM = BADC1
+         ELSE IF( IMAT.EQ.8 ) THEN
+            CNDNUM = BADC2
+         ELSE
+            CNDNUM = TWO
+         END IF
+*
+         IF( IMAT.EQ.9 ) THEN
+            ANORM = SMALL
+         ELSE IF( IMAT.EQ.10 ) THEN
             ANORM = LARGE
          ELSE
             ANORM = ONE

--- a/TESTING/LIN/dlatb4.f
+++ b/TESTING/LIN/dlatb4.f
@@ -339,11 +339,10 @@
             ANORM = ONE
          END IF
 *
-      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) .OR.
-     $         LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) ) THEN
 *
-*        xPO, xPP, xSY, xSP: Set parameters to generate a
-*        symmetric matrix.
+*        xPO, xPP: Set parameters to generate a
+*        symmetric positive definite matrix.
 *
 *        Set TYPE, the type of matrix to be generated.
 *
@@ -371,6 +370,43 @@
          IF( IMAT.EQ.8 ) THEN
             ANORM = SMALL
          ELSE IF( IMAT.EQ.9 ) THEN
+            ANORM = LARGE
+         ELSE
+            ANORM = ONE
+         END IF
+*
+*
+      ELSE IF( LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+*
+*        xSY, xSP: Set parameters to generate a
+*        symmetric matrix.
+*
+*        Set TYPE, the type of matrix to be generated.
+*
+         TYPE = C2( 1: 1 )
+*
+*        Set the lower and upper bandwidths.
+*
+         IF( IMAT.EQ.1 ) THEN
+            KL = 0
+         ELSE
+            KL = MAX( N-1, 0 )
+         END IF
+         KU = KL
+*
+*        Set the condition number and norm.
+*
+         IF( IMAT.EQ.7 ) THEN
+            CNDNUM = BADC1
+         ELSE IF( IMAT.EQ.8 ) THEN
+            CNDNUM = BADC2
+         ELSE
+            CNDNUM = TWO
+         END IF
+*
+         IF( IMAT.EQ.9 ) THEN
+            ANORM = SMALL
+         ELSE IF( IMAT.EQ.10 ) THEN
             ANORM = LARGE
          ELSE
             ANORM = ONE

--- a/TESTING/LIN/slatb4.f
+++ b/TESTING/LIN/slatb4.f
@@ -339,11 +339,10 @@
             ANORM = ONE
          END IF
 *
-      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) .OR.
-     $         LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) ) THEN
 *
 *        xPO, xPP, xSY, xSP: Set parameters to generate a
-*        symmetric matrix.
+*        symmetric positive definite matrix.
 *
 *        Set TYPE, the type of matrix to be generated.
 *
@@ -371,6 +370,43 @@
          IF( IMAT.EQ.8 ) THEN
             ANORM = SMALL
          ELSE IF( IMAT.EQ.9 ) THEN
+            ANORM = LARGE
+         ELSE
+            ANORM = ONE
+         END IF
+*
+*
+      ELSE IF( LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+*
+*        xSY, xSP: Set parameters to generate a
+*        symmetric matrix.
+*
+*        Set TYPE, the type of matrix to be generated.
+*
+         TYPE = C2( 1: 1 )
+*
+*        Set the lower and upper bandwidths.
+*
+         IF( IMAT.EQ.1 ) THEN
+            KL = 0
+         ELSE
+            KL = MAX( N-1, 0 )
+         END IF
+         KU = KL
+*
+*        Set the condition number and norm.
+*
+         IF( IMAT.EQ.7 ) THEN
+            CNDNUM = BADC1
+         ELSE IF( IMAT.EQ.8 ) THEN
+            CNDNUM = BADC2
+         ELSE
+            CNDNUM = TWO
+         END IF
+*
+         IF( IMAT.EQ.9 ) THEN
+            ANORM = SMALL
+         ELSE IF( IMAT.EQ.10 ) THEN
             ANORM = LARGE
          ELSE
             ANORM = ONE

--- a/TESTING/LIN/zlatb4.f
+++ b/TESTING/LIN/zlatb4.f
@@ -340,12 +340,10 @@
             ANORM = ONE
          END IF
 *
-      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) .OR.
-     $         LSAMEN( 2, C2, 'HE' ) .OR. LSAMEN( 2, C2, 'HP' ) .OR.
-     $         LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+      ELSE IF( LSAMEN( 2, C2, 'PO' ) .OR. LSAMEN( 2, C2, 'PP' ) ) THEN
 *
-*        xPO, xPP, xHE, xHP, xSY, xSP: Set parameters to generate a
-*        symmetric or Hermitian matrix.
+*        xPO, xPP: Set parameters to generate a
+*        symmetric or Hermitian positive definite matrix.
 *
 *        Set TYPE, the type of matrix to be generated.
 *
@@ -373,6 +371,43 @@
          IF( IMAT.EQ.8 ) THEN
             ANORM = SMALL
          ELSE IF( IMAT.EQ.9 ) THEN
+            ANORM = LARGE
+         ELSE
+            ANORM = ONE
+         END IF
+*
+      ELSE IF( LSAMEN( 2, C2, 'HE' ) .OR. LSAMEN( 2, C2, 'HP' ) .OR.
+     $         LSAMEN( 2, C2, 'SY' ) .OR. LSAMEN( 2, C2, 'SP' ) ) THEN
+*
+*        xHE, xHP, xSY, xSP: Set parameters to generate a
+*        symmetric or Hermitian matrix.
+*
+*        Set TYPE, the type of matrix to be generated.
+*
+         TYPE = C2( 1: 1 )
+*
+*        Set the lower and upper bandwidths.
+*
+         IF( IMAT.EQ.1 ) THEN
+            KL = 0
+         ELSE
+            KL = MAX( N-1, 0 )
+         END IF
+         KU = KL
+*
+*        Set the condition number and norm.
+*
+         IF( IMAT.EQ.7 ) THEN
+            CNDNUM = BADC1
+         ELSE IF( IMAT.EQ.8 ) THEN
+            CNDNUM = BADC2
+         ELSE
+            CNDNUM = TWO
+         END IF
+*
+         IF( IMAT.EQ.9 ) THEN
+            ANORM = SMALL
+         ELSE IF( IMAT.EQ.10 ) THEN
             ANORM = LARGE
          ELSE
             ANORM = ONE


### PR DESCRIPTION
LAWN 41 (Table 1) lists these matrix types for PO, PP and SY, SP, HE, HP:

```
                            PO, PP      SY, SP, HE, HP
Diagonal                    1           1
Upper triangular            
Lower triangular            
Random, k = 2               2           2
Random, k = sqrt(0.1/eps)   6           7
Random, k = 0.1/eps         7           8
First column zero           3           3
Last column zero            4           4
Middle column zero          5           5
Last n/2 columns zero                   6
Scaled near underflow       8           9
Scaled near overflow        9           10
Random, unspecified k               
Block diagonal                          11
```

Note that, going from PO => SY, matrix 6 => 7, ..., 9 => 10.

zchksy.f seems to follow this numbering for SY, zeroing entries for matrices 3-6. However, zlatb4.f, which zchksy.f uses, had the exact same code for both PO and SY. Thus for SY, matrix 6 ended up both with cond = sqrt(0.1/eps) _and_ zeroing Last n/2 columns.

This fixes that, making latb4 have a separate condition for SY, SP, HE, HP type, with imat cases changed from 6, 7, 8, 9 to 7, 8, 9, 10.