### PR TITLE
Fix complex to int conversion

### DIFF
--- a/LAPACKE/src/lapacke_chetri_3.c
+++ b/LAPACKE/src/lapacke_chetri_3.c
@@ -60,7 +60,7 @@ lapack_int LAPACKE_chetri_3( int matrix_layout, char uplo, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    lwork = (lapack_int)work_query;
+    lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for working array(s) */
     work = (lapack_complex_float*)
         LAPACKE_malloc( sizeof(lapack_complex_float) * lwork );

--- a/LAPACKE/src/lapacke_csytri_3.c
+++ b/LAPACKE/src/lapacke_csytri_3.c
@@ -60,7 +60,7 @@ lapack_int LAPACKE_csytri_3( int matrix_layout, char uplo, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    lwork = (lapack_int)work_query;
+    lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for working array(s) */
     work = (lapack_complex_float*)
         LAPACKE_malloc( sizeof(lapack_complex_float) * lwork );

--- a/LAPACKE/src/lapacke_zhetri_3.c
+++ b/LAPACKE/src/lapacke_zhetri_3.c
@@ -60,7 +60,7 @@ lapack_int LAPACKE_zhetri_3( int matrix_layout, char uplo, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    lwork = (lapack_int)work_query;
+    lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for working array(s) */
     work = (lapack_complex_double*)
         LAPACKE_malloc( sizeof(lapack_complex_double) * lwork );

--- a/LAPACKE/src/lapacke_zsytri_3.c
+++ b/LAPACKE/src/lapacke_zsytri_3.c
@@ -60,7 +60,7 @@ lapack_int LAPACKE_zsytri_3( int matrix_layout, char uplo, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    lwork = (lapack_int)work_query;
+    lwork = LAPACK_Z2INT( work_query );
    /* Allocate memory for working array(s) */
     work = (lapack_complex_double*)
         LAPACKE_malloc( sizeof(lapack_complex_double) * lwork );


### PR DESCRIPTION
This PR fixes these:
```
lapack/LAPACKE/src/lapacke_zsytri_3.c: In function ‘LAPACKE_zsytri_3’:
lapack/LAPACKE/src/lapacke_zsytri_3.c:63:5: error: aggregate value used where an integer was expected
     lwork = (lapack_int)work_query;
```