### PR TITLE
Split SRC_OBJ list to avoid build problem with mingw/msys 

### DIFF
--- a/LAPACKE/src/Makefile
+++ b/LAPACKE/src/Makefile
@@ -32,9 +32,12 @@
 ##############################################################################
 # makefile for LAPACKE, used to build lapacke binary.
 #
+# Note: we use multiple SRC_OBJA, SRC_OBJB, etc, instead of a single SRC_OBJ 
+# to allow build with mingw (argument list too long for the msys ar)
+#
 include ../../make.inc
 
-SRC_OBJ = \
+SRC_OBJA = \
 lapacke_cbbcsd.o \
 lapacke_cbbcsd_work.o \
 lapacke_cbdsqr.o \
@@ -1080,7 +1083,9 @@ lapacke_dsytri_3.o \
 lapacke_dsytri_3_work.o \
 lapacke_dsytri2x.o \
 lapacke_dsytri2x_work.o \
-lapacke_dsytri_work.o \
+lapacke_dsytri_work.o 
+
+SRC_OBJB = \
 lapacke_dsytrs.o \
 lapacke_dsytrs_rook.o \
 lapacke_dsytrs2.o \
@@ -2365,7 +2370,8 @@ lapacke_slagsy_work.o \
 lapacke_zlagsy.o \
 lapacke_zlagsy_work.o
 
-ALLOBJ = $(SRC_OBJ) $(MATGEN_OBJ)
+ALLOBJA = $(SRC_OBJA)
+ALLOBJB = $(SRC_OBJB) $(MATGEN_OBJ)
 
 ifdef USEXBLAS
 ALLXOBJ = $(SXLASRC) $(DXLASRC) $(CXLASRC) $(ZXLASRC)
@@ -2377,8 +2383,9 @@ endif
 
 all: ../../$(LAPACKELIB)
 
-../../$(LAPACKELIB): $(ALLOBJ) $(ALLXOBJ) $(DEPRECATED)
-	$(ARCH) $(ARCHFLAGS) $@ $(ALLOBJ) $(ALLXOBJ) $(DEPRECATED)
+../../$(LAPACKELIB): $(ALLOBJA) $(ALLOBJB) $(ALLXOBJ) $(DEPRECATED)
+	$(ARCH) $(ARCHFLAGS) $@ $(ALLOBJA) 
+	$(ARCH) $(ARCHFLAGS) $@ $(ALLOBJB) $(ALLXOBJ) $(DEPRECATED)
 	$(RANLIB) $@
 
 .c.o:


### PR DESCRIPTION
Fixes #111, "argument list too long" error from msys ar