### PR TITLE
Fixes for LAPACKE

### DIFF
--- a/LAPACKE/include/lapacke.h
+++ b/LAPACKE/include/lapacke.h
@@ -5759,35 +5759,35 @@ lapack_int LAPACKE_zgesvd_work( int matrix_layout, char jobu, char jobvt,
                                 lapack_int lwork, double* rwork );
 
 lapack_int LAPACKE_sgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, float* a,
-                          		lapack_int lda, float vl, float vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		float* s, float* u, lapack_int ldu,
-                           		float* vt, lapack_int ldvt,
-                                float* work, lapack_int lwork, lapack_int* iwork );
+                                 lapack_int m, lapack_int n, float* a,
+                                 lapack_int lda, float vl, float vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 float* s, float* u, lapack_int ldu,
+                                 float* vt, lapack_int ldvt,
+                                 float* work, lapack_int lwork, lapack_int* iwork );
 lapack_int LAPACKE_dgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, double* a,
-                          		lapack_int lda, double vl, double vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		double* s, double* u, lapack_int ldu,
-                           		double* vt, lapack_int ldvt,
-                                double* work, lapack_int lwork, lapack_int* iwork );
+                                 lapack_int m, lapack_int n, double* a,
+                                 lapack_int lda, double vl, double vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 double* s, double* u, lapack_int ldu,
+                                 double* vt, lapack_int ldvt,
+                                 double* work, lapack_int lwork, lapack_int* iwork );
 lapack_int LAPACKE_cgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, lapack_complex_float* a,
-                          		lapack_int lda, float vl, float vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		float* s, lapack_complex_float* u, lapack_int ldu,
-                           		lapack_complex_float* vt, lapack_int ldvt,
-                                lapack_complex_float* work, lapack_int lwork,
-                                float* rwork, lapack_int* iwork );
+                                 lapack_int m, lapack_int n, lapack_complex_float* a,
+                                 lapack_int lda, float vl, float vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 float* s, lapack_complex_float* u, lapack_int ldu,
+                                 lapack_complex_float* vt, lapack_int ldvt,
+                                 lapack_complex_float* work, lapack_int lwork,
+                                 float* rwork, lapack_int* iwork );
 lapack_int LAPACKE_zgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, lapack_complex_double* a,
-                          		lapack_int lda, double vl, double vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		double* s, lapack_complex_double* u, lapack_int ldu,
-                           		lapack_complex_double* vt, lapack_int ldvt,
-                                lapack_complex_double* work, lapack_int lwork,
-                                double* rwork, lapack_int* iwork );
+                                 lapack_int m, lapack_int n, lapack_complex_double* a,
+                                 lapack_int lda, double vl, double vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 double* s, lapack_complex_double* u, lapack_int ldu,
+                                 lapack_complex_double* vt, lapack_int ldvt,
+                                 lapack_complex_double* work, lapack_int lwork,
+                                 double* rwork, lapack_int* iwork );
 
 lapack_int LAPACKE_sgesvj_work( int matrix_layout, char joba, char jobu,
                                 char jobv, lapack_int m, lapack_int n, float* a,
@@ -5804,7 +5804,7 @@ lapack_int LAPACKE_cgesvj_work( int matrix_layout, char joba, char jobu,
                                 lapack_int lda, float* sva, lapack_int mv,
                                 lapack_complex_float* v, lapack_int ldv,
                                 lapack_complex_float* cwork, lapack_int lwork,
- 								float* rwork,lapack_int lrwork );
+                                float* rwork,lapack_int lrwork );
 lapack_int LAPACKE_zgesvj_work( int matrix_layout, char joba, char jobu,
                                 char jobv, lapack_int m, lapack_int n,
                                 lapack_complex_double* a, lapack_int lda, double* sva,
@@ -11619,7 +11619,7 @@ lapack_int LAPACKE_zhesv_rk_work( int matrix_layout, char uplo, lapack_int n,
                                lapack_int lda, lapack_complex_double* e, lapack_int* ipiv,
                                lapack_complex_double* b, lapack_int ldb,
                                lapack_complex_double* work, lapack_int lwork );
-                               
+
 lapack_int LAPACKE_ssytrf_rk( int matrix_layout, char uplo, lapack_int n, float* a,
                            lapack_int lda, float* e, lapack_int* ipiv );
 lapack_int LAPACKE_dsytrf_rk( int matrix_layout, char uplo, lapack_int n, double* a,
@@ -11773,12 +11773,12 @@ lapack_int LAPACKE_csycon_3( int matrix_layout, char uplo, lapack_int n,
                            const lapack_int* ipiv, float anorm, float* rcond );
 lapack_int LAPACKE_zsycon_3( int matrix_layout, char uplo, lapack_int n,
                            const lapack_complex_double* a, lapack_int lda,
-                           const lapack_complex_double* e, 
+                           const lapack_complex_double* e,
                            const lapack_int* ipiv, double anorm,
                            double* rcond );
 lapack_int LAPACKE_checon_3( int matrix_layout, char uplo, lapack_int n,
                            const lapack_complex_float* a, lapack_int lda,
-                           const lapack_complex_float* e, 
+                           const lapack_complex_float* e,
                            const lapack_int* ipiv, float anorm, float* rcond );
 lapack_int LAPACKE_zhecon_3( int matrix_layout, char uplo, lapack_int n,
                            const lapack_complex_double* a, lapack_int lda,
@@ -11803,7 +11803,7 @@ lapack_int LAPACKE_zsycon_3_work( int matrix_layout, char uplo, lapack_int n,
                                 const lapack_complex_double* a, lapack_int lda,
                                 const lapack_complex_double* e,
                                 const lapack_int* ipiv, double anorm,
-                                double* rcond, lapack_complex_double* work );                                               
+                                double* rcond, lapack_complex_double* work );
 lapack_int LAPACKE_checon_3_work( int matrix_layout, char uplo, lapack_int n,
                                 const lapack_complex_float* a, lapack_int lda,
                                 const lapack_complex_float* e,
@@ -18758,7 +18758,7 @@ void LAPACK_zhetrs_3( char* uplo, lapack_int* n,
                      const lapack_int* ipiv,
                      lapack_complex_double* b, lapack_int* ldb,  lapack_int *info );
 
-void LAPACK_ssytri_3( char* uplo, lapack_int* n, float* a, lapack_int* lda, const float* e, 
+void LAPACK_ssytri_3( char* uplo, lapack_int* n, float* a, lapack_int* lda, const float* e,
                     const lapack_int* ipiv, float* work, lapack_int* lwork, lapack_int *info );
 void LAPACK_dsytri_3( char* uplo, lapack_int* n, double* a, lapack_int* lda, const double* e,
                     const lapack_int* ipiv, double* work, lapack_int* lwork, lapack_int *info );
@@ -18775,7 +18775,7 @@ void LAPACK_zhetri_3( char* uplo, lapack_int* n, lapack_complex_double* a,
                     lapack_int* lda, const lapack_complex_double* e, const lapack_int* ipiv,
                     lapack_complex_double* work, lapack_int* lwork, lapack_int *info );
 
-void LAPACK_ssycon_3( char* uplo, lapack_int* n, const float* a, lapack_int* lda, const float* e, 
+void LAPACK_ssycon_3( char* uplo, lapack_int* n, const float* a, lapack_int* lda, const float* e,
                     const lapack_int* ipiv, float* anorm, float* rcond,
                     float* work, lapack_int* iwork, lapack_int *info );
 void LAPACK_dsycon_3( char* uplo, lapack_int* n, const double* a, lapack_int* lda, const double* e,

--- a/LAPACKE/src/CMakeLists.txt
+++ b/LAPACKE/src/CMakeLists.txt
@@ -47,6 +47,8 @@ lapacke_cgehrd.c
 lapacke_cgehrd_work.c
 lapacke_cgejsv.c
 lapacke_cgejsv_work.c
+lapacke_cgelq.c
+lapacke_cgelq_work.c
 lapacke_cgelq2.c
 lapacke_cgelq2_work.c
 lapacke_cgelqf.c
@@ -59,6 +61,8 @@ lapacke_cgelss.c
 lapacke_cgelss_work.c
 lapacke_cgelsy.c
 lapacke_cgelsy_work.c
+lapacke_cgemlq.c
+lapacke_cgemlq_work.c
 lapacke_cgemqr.c
 lapacke_cgemqr_work.c
 lapacke_cgemqrt.c
@@ -67,6 +71,8 @@ lapacke_cgeqlf.c
 lapacke_cgeqlf_work.c
 lapacke_cgeqp3.c
 lapacke_cgeqp3_work.c
+lapacke_cgeqr.c
+lapacke_cgeqr_work.c
 lapacke_cgeqr2.c
 lapacke_cgeqr2_work.c
 lapacke_cgeqrf.c
@@ -631,6 +637,8 @@ lapacke_dgehrd.c
 lapacke_dgehrd_work.c
 lapacke_dgejsv.c
 lapacke_dgejsv_work.c
+lapacke_dgelq.c
+lapacke_dgelq_work.c
 lapacke_dgelq2.c
 lapacke_dgelq2_work.c
 lapacke_dgelqf.c
@@ -643,6 +651,8 @@ lapacke_dgelss.c
 lapacke_dgelss_work.c
 lapacke_dgelsy.c
 lapacke_dgelsy_work.c
+lapacke_dgemlq.c
+lapacke_dgemlq_work.c
 lapacke_dgemqr.c
 lapacke_dgemqr_work.c
 lapacke_dgemqrt.c
@@ -651,6 +661,8 @@ lapacke_dgeqlf.c
 lapacke_dgeqlf_work.c
 lapacke_dgeqp3.c
 lapacke_dgeqp3_work.c
+lapacke_dgeqr.c
+lapacke_dgeqr_work.c
 lapacke_dgeqr2.c
 lapacke_dgeqr2_work.c
 lapacke_dgeqrf.c
@@ -1179,6 +1191,8 @@ lapacke_sgehrd.c
 lapacke_sgehrd_work.c
 lapacke_sgejsv.c
 lapacke_sgejsv_work.c
+lapacke_sgelq.c
+lapacke_sgelq_work.c
 lapacke_sgelq2.c
 lapacke_sgelq2_work.c
 lapacke_sgelqf.c
@@ -1191,6 +1205,8 @@ lapacke_sgelss.c
 lapacke_sgelss_work.c
 lapacke_sgelsy.c
 lapacke_sgelsy_work.c
+lapacke_sgemlq.c
+lapacke_sgemlq_work.c
 lapacke_sgemqr.c
 lapacke_sgemqr_work.c
 lapacke_sgemqrt.c
@@ -1199,6 +1215,8 @@ lapacke_sgeqlf.c
 lapacke_sgeqlf_work.c
 lapacke_sgeqp3.c
 lapacke_sgeqp3_work.c
+lapacke_sgeqr.c
+lapacke_sgeqr_work.c
 lapacke_sgeqr2.c
 lapacke_sgeqr2_work.c
 lapacke_sgeqrf.c
@@ -1721,6 +1739,8 @@ lapacke_zgehrd.c
 lapacke_zgehrd_work.c
 lapacke_zgejsv.c
 lapacke_zgejsv_work.c
+lapacke_zgelq.c
+lapacke_zgelq_work.c
 lapacke_zgelq2.c
 lapacke_zgelq2_work.c
 lapacke_zgelqf.c
@@ -1733,6 +1753,8 @@ lapacke_zgelss.c
 lapacke_zgelss_work.c
 lapacke_zgelsy.c
 lapacke_zgelsy_work.c
+lapacke_zgemlq.c
+lapacke_zgemlq_work.c
 lapacke_zgemqr.c
 lapacke_zgemqr_work.c
 lapacke_zgemqrt.c
@@ -1741,6 +1763,8 @@ lapacke_zgeqlf.c
 lapacke_zgeqlf_work.c
 lapacke_zgeqp3.c
 lapacke_zgeqp3_work.c
+lapacke_zgeqr.c
+lapacke_zgeqr_work.c
 lapacke_zgeqr2.c
 lapacke_zgeqr2_work.c
 lapacke_zgeqrf.c

--- a/LAPACKE/src/Makefile
+++ b/LAPACKE/src/Makefile
@@ -82,6 +82,8 @@ lapacke_cgeevx.o \
 lapacke_cgeevx_work.o \
 lapacke_cgehrd.o \
 lapacke_cgehrd_work.o \
+lapacke_cgelq.o \
+lapacke_cgelq_work.o \
 lapacke_cgelq2.o \
 lapacke_cgelq2_work.o \
 lapacke_cgejsv.o \
@@ -96,6 +98,8 @@ lapacke_cgelss.o \
 lapacke_cgelss_work.o \
 lapacke_cgelsy.o \
 lapacke_cgelsy_work.o \
+lapacke_cgemlq.o \
+lapacke_cgemlq_work.o \
 lapacke_cgemqr.o \
 lapacke_cgemqr_work.o \
 lapacke_cgemqrt.o \
@@ -104,6 +108,8 @@ lapacke_cgeqlf.o \
 lapacke_cgeqlf_work.o \
 lapacke_cgeqp3.o \
 lapacke_cgeqp3_work.o \
+lapacke_cgeqr.o \
+lapacke_cgeqr_work.o \
 lapacke_cgeqr2.o \
 lapacke_cgeqr2_work.o \
 lapacke_cgeqrf.o \
@@ -668,6 +674,8 @@ lapacke_dgehrd.o \
 lapacke_dgehrd_work.o \
 lapacke_dgejsv.o \
 lapacke_dgejsv_work.o \
+lapacke_dgelq.o \
+lapacke_dgelq_work.o \
 lapacke_dgelq2.o \
 lapacke_dgelq2_work.o \
 lapacke_dgelqf.o \
@@ -680,6 +688,8 @@ lapacke_dgelss.o \
 lapacke_dgelss_work.o \
 lapacke_dgelsy.o \
 lapacke_dgelsy_work.o \
+lapacke_dgemlq.o \
+lapacke_dgemlq_work.o \
 lapacke_dgemqr.o \
 lapacke_dgemqr_work.o \
 lapacke_dgemqrt.o \
@@ -688,6 +698,8 @@ lapacke_dgeqlf.o \
 lapacke_dgeqlf_work.o \
 lapacke_dgeqp3.o \
 lapacke_dgeqp3_work.o \
+lapacke_dgeqr.o \
+lapacke_dgeqr_work.o \
 lapacke_dgeqr2.o \
 lapacke_dgeqr2_work.o \
 lapacke_dgeqrf.o \
@@ -1218,6 +1230,8 @@ lapacke_sgehrd.o \
 lapacke_sgehrd_work.o \
 lapacke_sgejsv.o \
 lapacke_sgejsv_work.o \
+lapacke_sgelq.o \
+lapacke_sgelq_work.o \
 lapacke_sgelq2.o \
 lapacke_sgelq2_work.o \
 lapacke_sgelqf.o \
@@ -1230,6 +1244,8 @@ lapacke_sgelss.o \
 lapacke_sgelss_work.o \
 lapacke_sgelsy.o \
 lapacke_sgelsy_work.o \
+lapacke_sgemlq.o \
+lapacke_sgemlq_work.o \
 lapacke_sgemqr.o \
 lapacke_sgemqr_work.o \
 lapacke_sgemqrt.o \
@@ -1238,6 +1254,8 @@ lapacke_sgeqlf.o \
 lapacke_sgeqlf_work.o \
 lapacke_sgeqp3.o \
 lapacke_sgeqp3_work.o \
+lapacke_sgeqr.o \
+lapacke_sgeqr_work.o \
 lapacke_sgeqr2.o \
 lapacke_sgeqr2_work.o \
 lapacke_sgeqrf.o \
@@ -1760,6 +1778,8 @@ lapacke_zgehrd.o \
 lapacke_zgehrd_work.o \
 lapacke_zgejsv.o \
 lapacke_zgejsv_work.o \
+lapacke_zgelq.o \
+lapacke_zgelq_work.o \
 lapacke_zgelq2.o \
 lapacke_zgelq2_work.o \
 lapacke_zgelqf.o \
@@ -1772,6 +1792,8 @@ lapacke_zgelss.o \
 lapacke_zgelss_work.o \
 lapacke_zgelsy.o \
 lapacke_zgelsy_work.o \
+lapacke_zgemlq.o \
+lapacke_zgemlq_work.o \
 lapacke_zgemqr.o \
 lapacke_zgemqr_work.o \
 lapacke_zgemqrt.o \
@@ -1780,6 +1802,8 @@ lapacke_zgeqlf.o \
 lapacke_zgeqlf_work.o \
 lapacke_zgeqp3.o \
 lapacke_zgeqp3_work.o \
+lapacke_zgeqr.o \
+lapacke_zgeqr_work.o \
 lapacke_zgeqr2.o \
 lapacke_zgeqr2_work.o \
 lapacke_zgeqrf.o \

--- a/LAPACKE/src/lapacke_cgejsv.c
+++ b/LAPACKE/src/lapacke_cgejsv.c
@@ -41,22 +41,22 @@ lapack_int LAPACKE_cgejsv( int matrix_layout, char joba, char jobu, char jobv,
 {
     lapack_int info = 0;
     lapack_int lwork = (
-    			// 1.1
-    	(	     LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
+                // 1.1
+        (        LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? 2*n+1 :
 
                 //1.2
-     (   (        LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
+     (   (       LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? n*n+3*n :
 
                 //2.1
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
-              !( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+              !( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) )&&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 3*n :
 
 
                 //2.2
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
               !( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 3*n :
 
@@ -81,8 +81,8 @@ lapack_int LAPACKE_cgejsv( int matrix_layout, char joba, char jobu, char jobv,
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 4*n*n:
                        1) ) ) ) ) ) ) );
     lapack_int lrwork = (
-    			// 1.1
-    	(	     LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
+                // 1.1
+        (        LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? MAX(7,n+2*m) :
 
                 //1.2
@@ -90,13 +90,13 @@ lapack_int LAPACKE_cgejsv( int matrix_layout, char joba, char jobu, char jobv,
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? MAX(7,2*n) :
 
                 //2.1
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
-              !( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+              !( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? MAX( 7, n+ 2*m ) :
 
 
                 //2.2
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
               !( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? MAX(7,2*n) :
 
@@ -119,7 +119,7 @@ lapack_int LAPACKE_cgejsv( int matrix_layout, char joba, char jobu, char jobv,
      (  (       ( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
                ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? MAX(7,2*n) :
-                       7 ))))))));
+                       7) ) ) ) ) ) ) );
     lapack_int* iwork = NULL;
     float* rwork = NULL;
     lapack_complex_float* cwork = NULL;

--- a/LAPACKE/src/lapacke_cgelq.c
+++ b/LAPACKE/src/lapacke_cgelq.c
@@ -33,9 +33,9 @@
 
 #include "lapacke_utils.h"
 
-lapack_int LAPACKE_cgelq_work( int matrix_layout, lapack_int m, lapack_int n,
-                               lapack_complex_float* a, lapack_int lda,
-                               lapack_complex_float* t, lapack_int tsize )
+lapack_int LAPACKE_cgelq( int matrix_layout, lapack_int m, lapack_int n,
+                          lapack_complex_float* a, lapack_int lda,
+                          lapack_complex_float* t, lapack_int tsize )
 {
     lapack_int info = 0;
     lapack_int lwork = -1;

--- a/LAPACKE/src/lapacke_cgemlq.c
+++ b/LAPACKE/src/lapacke_cgemlq.c
@@ -55,7 +55,7 @@ lapack_int LAPACKE_cgemlq( int matrix_layout, char side, char trans,
     if( LAPACKE_cge_nancheck( matrix_layout, m, n, c, ldc ) ) {
         return -10;
     }
-    if( LAPACKE_d_nancheck( tsize, t, 1 ) ) {
+    if( LAPACKE_c_nancheck( tsize, t, 1 ) ) {
         return -9;
     }
 #endif

--- a/LAPACKE/src/lapacke_cgesdd.c
+++ b/LAPACKE/src/lapacke_cgesdd.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_cgesdd( int matrix_layout, char jobz, lapack_int m,
     if( LAPACKE_lsame( jobz, 'n' ) ) {
         lrwork = MAX(1,7*MIN(m,n));
     } else {
-        lrwork = (size_t)MIN(m,n)*MAX(5*MIN(m,n)+7,2*MAX(m,n)+2*MIN(m,n)+1);
+        lrwork = (size_t)MAX(1,MIN(m,n)*MAX(5*MIN(m,n)+7,2*MAX(m,n)+2*MIN(m,n)+1));
     }
     /* Allocate memory for working array(s) */
     iwork = (lapack_int*)

--- a/LAPACKE/src/lapacke_cgesvdx.c
+++ b/LAPACKE/src/lapacke_cgesvdx.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_cgesvdx( int matrix_layout, char jobu, char jobvt, char range
 #endif
     /* Query optimal working array(s) size */
     info = LAPACKE_cgesvdx_work( matrix_layout, jobu, jobvt, range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
                                  ldu, vt, ldvt, &work_query, lwork, rwork, iwork );
     if( info != 0 ) {
         goto exit_level_0;
@@ -69,7 +69,7 @@ lapack_int LAPACKE_cgesvdx( int matrix_layout, char jobu, char jobvt, char range
     lwork = LAPACK_C2INT (work_query);
     /* Allocate memory for work arrays */
     work = (lapack_complex_float*)
-    	LAPACKE_malloc( sizeof(lapack_complex_float) * lwork );
+        LAPACKE_malloc( sizeof(lapack_complex_float) * lwork );
     if( work == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
         goto exit_level_1;
@@ -86,8 +86,8 @@ lapack_int LAPACKE_cgesvdx( int matrix_layout, char jobu, char jobvt, char range
     }
     /* Call middle-level interface */
     info = LAPACKE_cgesvdx_work( matrix_layout, jobu, jobvt,  range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
-                                ldu, vt, ldvt, work, lwork, rwork, iwork );
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 ldu, vt, ldvt, work, lwork, rwork, iwork );
     /* Backup significant data from working array(s) */
     for( i=0; i<12*MIN(m,n)-1; i++ ) {
         superb[i] = iwork[i+1];

--- a/LAPACKE/src/lapacke_cgesvdx_work.c
+++ b/LAPACKE/src/lapacke_cgesvdx_work.c
@@ -34,19 +34,19 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_cgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, lapack_complex_float* a,
-                          		lapack_int lda, float vl, float vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		float* s, lapack_complex_float* u, lapack_int ldu,
-                           		lapack_complex_float* vt, lapack_int ldvt,
-                                lapack_complex_float* work, lapack_int lwork,
-                                float* rwork, lapack_int* iwork )
+                                 lapack_int m, lapack_int n, lapack_complex_float* a,
+                                 lapack_int lda, float vl, float vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 float* s, lapack_complex_float* u, lapack_int ldu,
+                                 lapack_complex_float* vt, lapack_int ldvt,
+                                 lapack_complex_float* work, lapack_int lwork,
+                                 float* rwork, lapack_int* iwork )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_cgesvdx( &jobu, &jobvt, &range, &m, &n, a, &lda, &vl, &vu,
-            			&il, &iu, ns, s, u, &ldu, vt, &ldvt,
+                        &il, &iu, ns, s, u, &ldu, vt, &ldvt,
                         work, &lwork, rwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
@@ -85,7 +85,7 @@ lapack_int LAPACKE_cgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {
             LAPACK_cgesvdx( &jobu, &jobvt, &range, &m, &n, a, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u, &ldu_t, vt,
+                            &il, &iu, ns, s, u, &ldu_t, vt,
                             &ldvt_t, work, &lwork, rwork, iwork, &info );
             return (info < 0) ? (info - 1) : info;
         }
@@ -116,8 +116,8 @@ lapack_int LAPACKE_cgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         LAPACKE_cge_trans( matrix_layout, m, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_cgesvdx( &jobu, &jobvt, &range, &m, &n, a_t, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u_t, &ldu_t, vt_t,
-                            &ldvt_t, work, &lwork, rwork, iwork, &info );
+                        &il, &iu, ns, s, u_t, &ldu_t, vt_t,
+                        &ldvt_t, work, &lwork, rwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
         }

--- a/LAPACKE/src/lapacke_cgesvj_work.c
+++ b/LAPACKE/src/lapacke_cgesvj_work.c
@@ -76,7 +76,7 @@ lapack_int LAPACKE_cgesvj_work( int matrix_layout, char joba, char jobu,
         }
         if( LAPACKE_lsame( jobv, 'a' ) || LAPACKE_lsame( jobv, 'v' ) ) {
             v_t = (lapack_complex_float*)
-            	LAPACKE_malloc( sizeof(lapack_complex_float) * ldv_t * MAX(1,n) );
+                LAPACKE_malloc( sizeof(lapack_complex_float) * ldv_t * MAX(1,n) );
             if( v_t == NULL ) {
                 info = LAPACK_TRANSPOSE_MEMORY_ERROR;
                 goto exit_level_1;

--- a/LAPACKE/src/lapacke_cggsvd3.c
+++ b/LAPACKE/src/lapacke_cggsvd3.c
@@ -45,7 +45,7 @@ lapack_int LAPACKE_cggsvd3( int matrix_layout, char jobu, char jobv, char jobq,
 {
     lapack_int info = 0;
     float* rwork = NULL;
-		lapack_int lwork = -1;
+    lapack_int lwork = -1;
     lapack_complex_float* work = NULL;
     lapack_complex_float work_query;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
@@ -65,9 +65,9 @@ lapack_int LAPACKE_cggsvd3( int matrix_layout, char jobu, char jobv, char jobq,
     info = LAPACKE_cggsvd3_work( matrix_layout, jobu, jobv, jobq, m, n, p, k, l,
                                  a, lda, b, ldb, alpha, beta, u, ldu, v, ldv, q,
                                  ldq, &work_query, lwork, rwork, iwork );
-		if( info != 0 )
-			goto exit_level_0;
-		lwork = LAPACK_C2INT( work_query );
+    if( info != 0 )
+        goto exit_level_0;
+    lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for working array(s) */
     rwork = (float*)LAPACKE_malloc( sizeof(float) * MAX(1,2*n) );
     if( rwork == NULL ) {

--- a/LAPACKE/src/lapacke_chbev_2stage_work.c
+++ b/LAPACKE/src/lapacke_chbev_2stage_work.c
@@ -44,7 +44,7 @@ lapack_int LAPACKE_chbev_2stage_work( int matrix_layout, char jobz, char uplo,
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_chbev_2stage( &jobz, &uplo, &n, &kd, ab, &ldab, w, z, &ldz, work, &lwork,
-         			  rwork, &info );
+                             rwork, &info );
         if( info < 0 ) {
             info = info - 1;
         }

--- a/LAPACKE/src/lapacke_cheevr_work.c
+++ b/LAPACKE/src/lapacke_cheevr_work.c
@@ -54,8 +54,9 @@ lapack_int LAPACKE_cheevr_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_cheevx_work.c
+++ b/LAPACKE/src/lapacke_cheevx_work.c
@@ -53,8 +53,9 @@ lapack_int LAPACKE_cheevx_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_chetrf_rk_work.c
+++ b/LAPACKE/src/lapacke_chetrf_rk_work.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_chetrf_rk_work( int matrix_layout, char uplo, lapack_int n,
                                 lapack_complex_float* a, lapack_int lda,
-                                lapack_complex_float* e, 
+                                lapack_complex_float* e,
                                 lapack_int* ipiv, lapack_complex_float* work,
                                 lapack_int lwork )
 {

--- a/LAPACKE/src/lapacke_chetrs_3.c
+++ b/LAPACKE/src/lapacke_chetrs_3.c
@@ -56,5 +56,5 @@ lapack_int LAPACKE_chetrs_3( int matrix_layout, char uplo, lapack_int n,
     }
 #endif
     return LAPACKE_chetrs_3_work( matrix_layout, uplo, n, nrhs, a, lda,
-    							  e, ipiv, b, ldb );
+                                  e, ipiv, b, ldb );
 }

--- a/LAPACKE/src/lapacke_clacp2_work.c
+++ b/LAPACKE/src/lapacke_clacp2_work.c
@@ -31,7 +31,6 @@
 * Generated January, 2013
 *****************************************************************************/
 
-#include "lapacke.h"
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_clacp2_work( int matrix_layout, char uplo, lapack_int m,

--- a/LAPACKE/src/lapacke_clarfb.c
+++ b/LAPACKE/src/lapacke_clarfb.c
@@ -41,7 +41,7 @@ lapack_int LAPACKE_clarfb( int matrix_layout, char side, char trans, char direct
                            lapack_int ldc )
 {
     lapack_int info = 0;
-    lapack_int ldwork = ( side=='l')?n:(( side=='r')?m:1);
+    lapack_int ldwork;
     lapack_complex_float* work = NULL;
     lapack_int ncols_v, nrows_v;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
@@ -100,6 +100,13 @@ lapack_int LAPACKE_clarfb( int matrix_layout, char side, char trans, char direct
             return -9;
     }
 #endif
+    if( LAPACKE_lsame( side, 'l' ) ) {
+        ldwork = n;
+    } else if( LAPACKE_lsame( side, 'r' ) ) {
+        ldwork = m;
+    } else {
+        ldwork = 1;
+    }
     /* Allocate memory for working array(s) */
     work = (lapack_complex_float*)
         LAPACKE_malloc( sizeof(lapack_complex_float) * ldwork * MAX(1,k) );

--- a/LAPACKE/src/lapacke_claswp_work.c
+++ b/LAPACKE/src/lapacke_claswp_work.c
@@ -46,7 +46,11 @@ lapack_int LAPACKE_claswp_work( int matrix_layout, lapack_int n,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int lda_t = MAX(1,lda);
+        lapack_int lda_t = MAX(1,k2);
+        lapack_int i;
+        for( i = k1; i <= k2; i++ ) {
+            lda_t = MAX( lda_t, ipiv[k1 + ( i - k1 ) * ABS( incx ) - 1] );
+        }
         lapack_complex_float* a_t = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
@@ -62,12 +66,12 @@ lapack_int LAPACKE_claswp_work( int matrix_layout, lapack_int n,
             goto exit_level_0;
         }
         /* Transpose input matrices */
-        LAPACKE_cge_trans( matrix_layout, lda, n, a, lda, a_t, lda_t );
+        LAPACKE_cge_trans( matrix_layout, lda_t, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_claswp( &n, a_t, &lda_t, &k1, &k2, ipiv, &incx );
         info = 0;  /* LAPACK call is ok! */
         /* Transpose output matrices */
-        LAPACKE_cge_trans( LAPACK_COL_MAJOR, lda, n, a_t, lda_t, a, lda );
+        LAPACKE_cge_trans( LAPACK_COL_MAJOR, lda_t, n, a_t, lda_t, a, lda );
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_cstemr_work.c
+++ b/LAPACKE/src/lapacke_cstemr_work.c
@@ -56,7 +56,7 @@ lapack_int LAPACKE_cstemr_work( int matrix_layout, char jobz, char range,
         lapack_int ldz_t = MAX(1,n);
         lapack_complex_float* z_t = NULL;
         /* Check leading dimension(s) */
-        if( ldz < n ) {
+        if( ldz < 1 || ( LAPACKE_lsame( jobz, 'v' ) && ldz < n ) ) {
             info = -14;
             LAPACKE_xerbla( "LAPACKE_cstemr_work", info );
             return info;

--- a/LAPACKE/src/lapacke_csycon_3_work.c
+++ b/LAPACKE/src/lapacke_csycon_3_work.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_csycon_3_work( int matrix_layout, char uplo, lapack_int n,
                                 const lapack_complex_float* a, lapack_int lda,
-                                const lapack_complex_float* e, 
+                                const lapack_complex_float* e,
                                 const lapack_int* ipiv, float anorm,
                                 float* rcond, lapack_complex_float* work )
 {

--- a/LAPACKE/src/lapacke_cunmlq_work.c
+++ b/LAPACKE/src/lapacke_cunmlq_work.c
@@ -42,9 +42,6 @@ lapack_int LAPACKE_cunmlq_work( int matrix_layout, char side, char trans,
 {
     lapack_int info = 0;
     lapack_int r;
-    lapack_int lda_t, ldc_t;
-	lapack_complex_float* a_t = NULL;
-    lapack_complex_float* c_t = NULL;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_cunmlq( &side, &trans, &m, &n, &k, a, &lda, tau, c, &ldc, work,
@@ -54,8 +51,10 @@ lapack_int LAPACKE_cunmlq_work( int matrix_layout, char side, char trans,
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         r = LAPACKE_lsame( side, 'l' ) ? m : n;
-        lda_t = MAX(1,k);
-        ldc_t = MAX(1,m);
+        lapack_int lda_t = MAX(1,k);
+        lapack_int ldc_t = MAX(1,m);
+        lapack_complex_float* a_t = NULL;
+        lapack_complex_float* c_t = NULL;
         /* Check leading dimension(s) */
         if( lda < r ) {
             info = -8;

--- a/LAPACKE/src/lapacke_dbdsvdx.c
+++ b/LAPACKE/src/lapacke_dbdsvdx.c
@@ -71,8 +71,8 @@ lapack_int LAPACKE_dbdsvdx( int matrix_layout, char uplo, char jobz, char range,
     }
     /* Call middle-level interface */
     info = LAPACKE_dbdsvdx_work( matrix_layout, uplo, jobz,  range,
-    				n, d, e, vl, vu, il, iu, ns, s, z,
-                                ldz, work, iwork);
+                                 n, d, e, vl, vu, il, iu, ns, s, z,
+                                 ldz, work, iwork);
     /* Backup significant data from working array(s) */
     for( i=0; i<12*n-1; i++ ) {
         superb[i] = iwork[i+1];

--- a/LAPACKE/src/lapacke_dbdsvdx_work.c
+++ b/LAPACKE/src/lapacke_dbdsvdx_work.c
@@ -64,7 +64,7 @@ lapack_int LAPACKE_dbdsvdx_work( int matrix_layout, char uplo, char jobz, char r
         /* Allocate memory for temporary array(s) */
         if( LAPACKE_lsame( jobz, 'v' ) ) {
            z_t = (double*)
-              LAPACKE_malloc( sizeof(double) * ldz_t * MAX(2*n,1) );
+              LAPACKE_malloc( sizeof(double) * ldz_t * MAX(ncols_z,1) );
            if( z_t == NULL ) {
               info = LAPACK_TRANSPOSE_MEMORY_ERROR;
               goto exit_level_0;

--- a/LAPACKE/src/lapacke_dbdsvdx_work.c
+++ b/LAPACKE/src/lapacke_dbdsvdx_work.c
@@ -34,17 +34,17 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_dbdsvdx_work( int matrix_layout, char uplo, char jobz, char range,
-                           		lapack_int n, double* d, double* e,
-                           		double vl, double vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		double* s, double* z, lapack_int ldz,
-                                double* work, lapack_int* iwork )
+                                 lapack_int n, double* d, double* e,
+                                 double vl, double vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 double* s, double* z, lapack_int ldz,
+                                 double* work, lapack_int* iwork )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_dbdsvdx( &uplo, &jobz,  &range, &n, d, e, &vl, &vu,
-            			&il, &iu, ns, s, z, &ldz,
+                        &il, &iu, ns, s, z, &ldz,
                         work, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
@@ -72,8 +72,8 @@ lapack_int LAPACKE_dbdsvdx_work( int matrix_layout, char uplo, char jobz, char r
         }
         /* Call LAPACK function and adjust info */
         LAPACK_dbdsvdx( &uplo, &jobz, &range, &n, d, e, &vl, &vu,
-            			&il, &iu, ns, s, z_t, &ldz_t, work,
-            			iwork, &info );
+                        &il, &iu, ns, s, z_t, &ldz_t, work,
+                        iwork, &info );
         if( info < 0 ) {
             info = info - 1;
         }

--- a/LAPACKE/src/lapacke_dgelq.c
+++ b/LAPACKE/src/lapacke_dgelq.c
@@ -33,9 +33,9 @@
 
 #include "lapacke_utils.h"
 
-lapack_int LAPACKE_dgelq_work( int matrix_layout, lapack_int m, lapack_int n,
-                               double* a, lapack_int lda,
-                               double* t, lapack_int tsize )
+lapack_int LAPACKE_dgelq( int matrix_layout, lapack_int m, lapack_int n,
+                          double* a, lapack_int lda,
+                          double* t, lapack_int tsize )
 {
     lapack_int info = 0;
     lapack_int lwork = -1;

--- a/LAPACKE/src/lapacke_dgesvdx.c
+++ b/LAPACKE/src/lapacke_dgesvdx.c
@@ -59,7 +59,7 @@ lapack_int LAPACKE_dgesvdx( int matrix_layout, char jobu, char jobvt, char range
 #endif
     /* Query optimal working array(s) size */
     info = LAPACKE_dgesvdx_work( matrix_layout, jobu, jobvt, range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
                                  ldu, vt, ldvt, &work_query, lwork, iwork );
     if( info != 0 ) {
         goto exit_level_0;
@@ -78,8 +78,8 @@ lapack_int LAPACKE_dgesvdx( int matrix_layout, char jobu, char jobvt, char range
     }
     /* Call middle-level interface */
     info = LAPACKE_dgesvdx_work( matrix_layout, jobu, jobvt,  range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
-                                ldu, vt, ldvt, work, lwork, iwork );
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 ldu, vt, ldvt, work, lwork, iwork );
     /* Backup significant data from working array(s) */
     for( i=0; i<12*MIN(m,n)-1; i++ ) {
         superb[i] = iwork[i+1];

--- a/LAPACKE/src/lapacke_dgesvdx_work.c
+++ b/LAPACKE/src/lapacke_dgesvdx_work.c
@@ -34,18 +34,18 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_dgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, double* a,
-                          		lapack_int lda, double vl, double vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		double* s, double* u, lapack_int ldu,
-                           		double* vt, lapack_int ldvt,
-                                double* work, lapack_int lwork, lapack_int* iwork )
+                                 lapack_int m, lapack_int n, double* a,
+                                 lapack_int lda, double vl, double vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 double* s, double* u, lapack_int ldu,
+                                 double* vt, lapack_int ldvt,
+                                 double* work, lapack_int lwork, lapack_int* iwork )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_dgesvdx( &jobu, &jobvt,  &range, &m, &n, a, &lda, &vl, &vu,
-            			&il, &iu, ns, s, u, &ldu, vt, &ldvt,
+                        &il, &iu, ns, s, u, &ldu, vt, &ldvt,
                         work, &lwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
@@ -84,7 +84,7 @@ lapack_int LAPACKE_dgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {
             LAPACK_dgesvdx( &jobu, &jobvt, &range, &m, &n, a, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u, &ldu_t, vt,
+                            &il, &iu, ns, s, u, &ldu_t, vt,
                             &ldvt_t, work, &lwork, iwork, &info );
             return (info < 0) ? (info - 1) : info;
         }
@@ -114,8 +114,8 @@ lapack_int LAPACKE_dgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         LAPACKE_dge_trans( matrix_layout, m, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_dgesvdx( &jobu, &jobvt, &range, &m, &n, a_t, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u_t, &ldu_t, vt_t,
-                            &ldvt_t, work, &lwork, iwork, &info );
+                        &il, &iu, ns, s, u_t, &ldu_t, vt_t,
+                        &ldvt_t, work, &lwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
         }

--- a/LAPACKE/src/lapacke_dlange.c
+++ b/LAPACKE/src/lapacke_dlange.c
@@ -37,7 +37,7 @@ double LAPACKE_dlange( int matrix_layout, char norm, lapack_int m,
                            lapack_int n, const double* a, lapack_int lda )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     double* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_dlange", -1 );

--- a/LAPACKE/src/lapacke_dlange_work.c
+++ b/LAPACKE/src/lapacke_dlange_work.c
@@ -38,7 +38,7 @@ double LAPACKE_dlange_work( int matrix_layout, char norm, lapack_int m,
                                 double* work )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_dlange( &norm, &m, &n, a, &lda, work );

--- a/LAPACKE/src/lapacke_dlansy.c
+++ b/LAPACKE/src/lapacke_dlansy.c
@@ -37,7 +37,7 @@ double LAPACKE_dlansy( int matrix_layout, char norm, char uplo, lapack_int n,
                            const double* a, lapack_int lda )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     double* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_dlansy", -1 );

--- a/LAPACKE/src/lapacke_dlansy_work.c
+++ b/LAPACKE/src/lapacke_dlansy_work.c
@@ -38,7 +38,7 @@ double LAPACKE_dlansy_work( int matrix_layout, char norm, char uplo,
                                 double* work )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_dlansy( &norm, &uplo, &n, a, &lda, work );

--- a/LAPACKE/src/lapacke_dlantr.c
+++ b/LAPACKE/src/lapacke_dlantr.c
@@ -38,7 +38,7 @@ double LAPACKE_dlantr( int matrix_layout, char norm, char uplo, char diag,
                            lapack_int lda )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     double* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_dlantr", -1 );

--- a/LAPACKE/src/lapacke_dlarfb.c
+++ b/LAPACKE/src/lapacke_dlarfb.c
@@ -40,7 +40,7 @@ lapack_int LAPACKE_dlarfb( int matrix_layout, char side, char trans, char direct
                            lapack_int ldc )
 {
     lapack_int info = 0;
-    lapack_int ldwork = ( side=='l')?n:(( side=='r')?m:1);
+    lapack_int ldwork;
     double* work = NULL;
     lapack_int ncols_v, nrows_v;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
@@ -99,6 +99,13 @@ lapack_int LAPACKE_dlarfb( int matrix_layout, char side, char trans, char direct
             return -9;
     }
 #endif
+    if( LAPACKE_lsame( side, 'l' ) ) {
+        ldwork = n;
+    } else if( LAPACKE_lsame( side, 'r' ) ) {
+        ldwork = m;
+    } else {
+        ldwork = 1;
+    }
     /* Allocate memory for working array(s) */
     work = (double*)LAPACKE_malloc( sizeof(double) * ldwork * MAX(1,k) );
     if( work == NULL ) {

--- a/LAPACKE/src/lapacke_dlaswp_work.c
+++ b/LAPACKE/src/lapacke_dlaswp_work.c
@@ -45,7 +45,11 @@ lapack_int LAPACKE_dlaswp_work( int matrix_layout, lapack_int n, double* a,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int lda_t = MAX(1,lda);
+        lapack_int lda_t = MAX(1,k2);
+        lapack_int i;
+        for( i = k1; i <= k2; i++ ) {
+            lda_t = MAX( lda_t, ipiv[k1 + ( i - k1 ) * ABS( incx ) - 1] );
+        }
         double* a_t = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
@@ -60,12 +64,12 @@ lapack_int LAPACKE_dlaswp_work( int matrix_layout, lapack_int n, double* a,
             goto exit_level_0;
         }
         /* Transpose input matrices */
-        LAPACKE_dge_trans( matrix_layout, lda, n, a, lda, a_t, lda_t );
+        LAPACKE_dge_trans( matrix_layout, lda_t, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_dlaswp( &n, a_t, &lda_t, &k1, &k2, ipiv, &incx );
         info = 0;  /* LAPACK call is ok! */
         /* Transpose output matrices */
-        LAPACKE_dge_trans( LAPACK_COL_MAJOR, lda, n, a_t, lda_t, a, lda );
+        LAPACKE_dge_trans( LAPACK_COL_MAJOR, lda_t, n, a_t, lda_t, a, lda );
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dormlq_work.c
+++ b/LAPACKE/src/lapacke_dormlq_work.c
@@ -41,8 +41,6 @@ lapack_int LAPACKE_dormlq_work( int matrix_layout, char side, char trans,
 {
     lapack_int info = 0;
     lapack_int r;
-    lapack_int lda_t, ldc_t;
-    double *a_t = NULL, *c_t = NULL;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_dormlq( &side, &trans, &m, &n, &k, a, &lda, tau, c, &ldc, work,
@@ -52,8 +50,10 @@ lapack_int LAPACKE_dormlq_work( int matrix_layout, char side, char trans,
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         r = LAPACKE_lsame( side, 'l' ) ? m : n;
-        lda_t = MAX(1,k);
-        ldc_t = MAX(1,m);
+        lapack_int lda_t = MAX(1,k);
+        lapack_int ldc_t = MAX(1,m);
+        double *a_t = NULL;
+        double *c_t = NULL;
         /* Check leading dimension(s) */
         if( lda < r ) {
             info = -8;

--- a/LAPACKE/src/lapacke_dstemr_work.c
+++ b/LAPACKE/src/lapacke_dstemr_work.c
@@ -55,7 +55,7 @@ lapack_int LAPACKE_dstemr_work( int matrix_layout, char jobz, char range,
         lapack_int ldz_t = MAX(1,n);
         double* z_t = NULL;
         /* Check leading dimension(s) */
-        if( ldz < n ) {
+        if( ldz < 1 || ( LAPACKE_lsame( jobz, 'v' ) && ldz < n ) ) {
             info = -14;
             LAPACKE_xerbla( "LAPACKE_dstemr_work", info );
             return info;

--- a/LAPACKE/src/lapacke_dsyevr_work.c
+++ b/LAPACKE/src/lapacke_dsyevr_work.c
@@ -52,8 +52,9 @@ lapack_int LAPACKE_dsyevr_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_dsyevx_work.c
+++ b/LAPACKE/src/lapacke_dsyevx_work.c
@@ -51,8 +51,9 @@ lapack_int LAPACKE_dsyevx_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_dsytrs_3.c
+++ b/LAPACKE/src/lapacke_dsytrs_3.c
@@ -55,5 +55,5 @@ lapack_int LAPACKE_dsytrs_3( int matrix_layout, char uplo, lapack_int n,
     }
 #endif
     return LAPACKE_dsytrs_3_work( matrix_layout, uplo, n, nrhs, a, lda,
-    							  e, ipiv, b, ldb );
+                                  e, ipiv, b, ldb );
 }

--- a/LAPACKE/src/lapacke_dsytrs_aa.c
+++ b/LAPACKE/src/lapacke_dsytrs_aa.c
@@ -60,7 +60,7 @@ lapack_int LAPACKE_dsytrs_aa( int matrix_layout, char uplo, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-	lwork = (lapack_int)work_query;
+    lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     work = (double*)
         LAPACKE_malloc( sizeof(double) * lwork );

--- a/LAPACKE/src/lapacke_sbdsvdx.c
+++ b/LAPACKE/src/lapacke_sbdsvdx.c
@@ -71,8 +71,8 @@ lapack_int LAPACKE_sbdsvdx( int matrix_layout, char uplo, char jobz, char range,
     }
     /* Call middle-level interface */
     info = LAPACKE_sbdsvdx_work( matrix_layout, uplo, jobz,  range,
-    				n, d, e, vl, vu, il, iu, ns, s, z,
-                                ldz, work, iwork);
+                                 n, d, e, vl, vu, il, iu, ns, s, z,
+                                 ldz, work, iwork);
     /* Backup significant data from working array(s) */
     for( i=0; i<12*n-1; i++ ) {
         superb[i] = iwork[i+1];

--- a/LAPACKE/src/lapacke_sbdsvdx_work.c
+++ b/LAPACKE/src/lapacke_sbdsvdx_work.c
@@ -34,17 +34,17 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_sbdsvdx_work( int matrix_layout, char uplo, char jobz, char range,
-                           		lapack_int n, float* d, float* e,
-                           		float vl, float vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		float* s, float* z, lapack_int ldz,
-                                float* work, lapack_int* iwork )
+                                 lapack_int n, float* d, float* e,
+                                 float vl, float vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 float* s, float* z, lapack_int ldz,
+                                 float* work, lapack_int* iwork )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_sbdsvdx( &uplo, &jobz,  &range, &n, d, e, &vl, &vu,
-            			&il, &iu, ns, s, z, &ldz,
+                        &il, &iu, ns, s, z, &ldz,
                         work, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
@@ -64,7 +64,7 @@ lapack_int LAPACKE_sbdsvdx_work( int matrix_layout, char uplo, char jobz, char r
         /* Allocate memory for temporary array(s) */
         if( LAPACKE_lsame( jobz, 'v' ) ) {
            z_t = (float*)
-               LAPACKE_malloc( sizeof(float) * ldz_t * MAX(2*n,1) );
+               LAPACKE_malloc( sizeof(float) * ldz_t * MAX(ncols_z,1) );
            if( z_t == NULL ) {
               info = LAPACK_TRANSPOSE_MEMORY_ERROR;
               goto exit_level_0;
@@ -72,8 +72,8 @@ lapack_int LAPACKE_sbdsvdx_work( int matrix_layout, char uplo, char jobz, char r
         }
         /* Call LAPACK function and adjust info */
         LAPACK_sbdsvdx( &uplo, &jobz, &range, &n, d, e, &vl, &vu,
-            			&il, &iu, ns, s, z_t, &ldz_t, work,
-            			iwork, &info );
+                        &il, &iu, ns, s, z_t, &ldz_t, work,
+                        iwork, &info );
         if( info < 0 ) {
             info = info - 1;
         }

--- a/LAPACKE/src/lapacke_sgelq.c
+++ b/LAPACKE/src/lapacke_sgelq.c
@@ -33,9 +33,9 @@
 
 #include "lapacke_utils.h"
 
-lapack_int LAPACKE_sgelq_work( int matrix_layout, lapack_int m, lapack_int n,
-                               float* a, lapack_int lda,
-                               float* t, lapack_int tsize )
+lapack_int LAPACKE_sgelq( int matrix_layout, lapack_int m, lapack_int n,
+                          float* a, lapack_int lda,
+                          float* t, lapack_int tsize )
 {
     lapack_int info = 0;
     lapack_int lwork = -1;

--- a/LAPACKE/src/lapacke_sgemlq.c
+++ b/LAPACKE/src/lapacke_sgemlq.c
@@ -55,7 +55,7 @@ lapack_int LAPACKE_sgemlq( int matrix_layout, char side, char trans,
     if( LAPACKE_sge_nancheck( matrix_layout, m, n, c, ldc ) ) {
         return -10;
     }
-    if( LAPACKE_d_nancheck( tsize, t, 1 ) ) {
+    if( LAPACKE_s_nancheck( tsize, t, 1 ) ) {
         return -9;
     }
 #endif

--- a/LAPACKE/src/lapacke_sgesvdx.c
+++ b/LAPACKE/src/lapacke_sgesvdx.c
@@ -59,7 +59,7 @@ lapack_int LAPACKE_sgesvdx( int matrix_layout, char jobu, char jobvt, char range
 #endif
     /* Query optimal working array(s) size */
     info = LAPACKE_sgesvdx_work( matrix_layout, jobu, jobvt, range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
                                  ldu, vt, ldvt, &work_query, lwork, iwork );
     if( info != 0 ) {
         goto exit_level_0;
@@ -78,8 +78,8 @@ lapack_int LAPACKE_sgesvdx( int matrix_layout, char jobu, char jobvt, char range
     }
     /* Call middle-level interface */
     info = LAPACKE_sgesvdx_work( matrix_layout, jobu, jobvt,  range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
-                                ldu, vt, ldvt, work, lwork, iwork );
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 ldu, vt, ldvt, work, lwork, iwork );
     /* Backup significant data from working array(s) */
     for( i=0; i<12*MIN(m,n)-1; i++ ) {
         superb[i] = iwork[i+1];

--- a/LAPACKE/src/lapacke_sgesvdx_work.c
+++ b/LAPACKE/src/lapacke_sgesvdx_work.c
@@ -34,18 +34,18 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_sgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, float* a,
-                          		lapack_int lda, float vl, float vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		float* s, float* u, lapack_int ldu,
-                           		float* vt, lapack_int ldvt,
-                                float* work, lapack_int lwork, lapack_int* iwork )
+                                 lapack_int m, lapack_int n, float* a,
+                                 lapack_int lda, float vl, float vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 float* s, float* u, lapack_int ldu,
+                                 float* vt, lapack_int ldvt,
+                                 float* work, lapack_int lwork, lapack_int* iwork )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_sgesvdx( &jobu, &jobvt,  &range, &m, &n, a, &lda, &vl, &vu,
-            			&il, &iu, ns, s, u, &ldu, vt, &ldvt,
+                        &il, &iu, ns, s, u, &ldu, vt, &ldvt,
                         work, &lwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
@@ -84,7 +84,7 @@ lapack_int LAPACKE_sgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {
             LAPACK_sgesvdx( &jobu, &jobvt, &range, &m, &n, a, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u, &ldu_t, vt,
+                            &il, &iu, ns, s, u, &ldu_t, vt,
                             &ldvt_t, work, &lwork, iwork, &info );
             return (info < 0) ? (info - 1) : info;
         }
@@ -114,8 +114,8 @@ lapack_int LAPACKE_sgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         LAPACKE_sge_trans( matrix_layout, m, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_sgesvdx( &jobu, &jobvt, &range, &m, &n, a_t, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u_t, &ldu_t, vt_t,
-                            &ldvt_t, work, &lwork, iwork, &info );
+                        &il, &iu, ns, s, u_t, &ldu_t, vt_t,
+                        &ldvt_t, work, &lwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
         }

--- a/LAPACKE/src/lapacke_slange.c
+++ b/LAPACKE/src/lapacke_slange.c
@@ -37,7 +37,7 @@ float LAPACKE_slange( int matrix_layout, char norm, lapack_int m,
                            lapack_int n, const float* a, lapack_int lda )
 {
     lapack_int info = 0;
-	float res = 0.;
+    float res = 0.;
     float* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_slange", -1 );

--- a/LAPACKE/src/lapacke_slange_work.c
+++ b/LAPACKE/src/lapacke_slange_work.c
@@ -38,7 +38,7 @@ float LAPACKE_slange_work( int matrix_layout, char norm, lapack_int m,
                                 float* work )
 {
     lapack_int info = 0;
-	float res = 0.;
+    float res = 0.;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_slange( &norm, &m, &n, a, &lda, work );

--- a/LAPACKE/src/lapacke_slansy.c
+++ b/LAPACKE/src/lapacke_slansy.c
@@ -37,7 +37,7 @@ float LAPACKE_slansy( int matrix_layout, char norm, char uplo, lapack_int n,
                            const float* a, lapack_int lda )
 {
     lapack_int info = 0;
-	float res = 0.;
+    float res = 0.;
     float* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_slansy", -1 );

--- a/LAPACKE/src/lapacke_slansy_work.c
+++ b/LAPACKE/src/lapacke_slansy_work.c
@@ -38,7 +38,7 @@ float LAPACKE_slansy_work( int matrix_layout, char norm, char uplo,
                                 float* work )
 {
     lapack_int info = 0;
-	float res = 0.;
+    float res = 0.;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_slansy( &norm, &uplo, &n, a, &lda, work );

--- a/LAPACKE/src/lapacke_slarfb.c
+++ b/LAPACKE/src/lapacke_slarfb.c
@@ -40,7 +40,7 @@ lapack_int LAPACKE_slarfb( int matrix_layout, char side, char trans, char direct
                            lapack_int ldc )
 {
     lapack_int info = 0;
-    lapack_int ldwork = ( side=='l')?n:(( side=='r')?m:1);
+    lapack_int ldwork;
     float* work = NULL;
     lapack_int ncols_v, nrows_v;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
@@ -99,6 +99,13 @@ lapack_int LAPACKE_slarfb( int matrix_layout, char side, char trans, char direct
             return -9;
     }
 #endif
+    if( LAPACKE_lsame( side, 'l' ) ) {
+        ldwork = n;
+    } else if( LAPACKE_lsame( side, 'r' ) ) {
+        ldwork = m;
+    } else {
+        ldwork = 1;
+    }
     /* Allocate memory for working array(s) */
     work = (float*)LAPACKE_malloc( sizeof(float) * ldwork * MAX(1,k) );
     if( work == NULL ) {

--- a/LAPACKE/src/lapacke_slaswp_work.c
+++ b/LAPACKE/src/lapacke_slaswp_work.c
@@ -45,7 +45,11 @@ lapack_int LAPACKE_slaswp_work( int matrix_layout, lapack_int n, float* a,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int lda_t = MAX(1,lda);
+        lapack_int lda_t = MAX(1,k2);
+        lapack_int i;
+        for( i = k1; i <= k2; i++ ) {
+            lda_t = MAX( lda_t, ipiv[k1 + ( i - k1 ) * ABS( incx ) - 1] );
+        }
         float* a_t = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
@@ -60,12 +64,12 @@ lapack_int LAPACKE_slaswp_work( int matrix_layout, lapack_int n, float* a,
             goto exit_level_0;
         }
         /* Transpose input matrices */
-        LAPACKE_sge_trans( matrix_layout, lda, n, a, lda, a_t, lda_t );
+        LAPACKE_sge_trans( matrix_layout, lda_t, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_slaswp( &n, a_t, &lda_t, &k1, &k2, ipiv, &incx );
         info = 0;  /* LAPACK call is ok! */
         /* Transpose output matrices */
-        LAPACKE_sge_trans( LAPACK_COL_MAJOR, lda, n, a_t, lda_t, a, lda );
+        LAPACKE_sge_trans( LAPACK_COL_MAJOR, lda_t, n, a_t, lda_t, a, lda );
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_sormlq_work.c
+++ b/LAPACKE/src/lapacke_sormlq_work.c
@@ -41,8 +41,6 @@ lapack_int LAPACKE_sormlq_work( int matrix_layout, char side, char trans,
 {
     lapack_int info = 0;
     lapack_int r;
-    lapack_int lda_t, ldc_t;
-    float *a_t = NULL, *c_t = NULL;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_sormlq( &side, &trans, &m, &n, &k, a, &lda, tau, c, &ldc, work,
@@ -52,8 +50,10 @@ lapack_int LAPACKE_sormlq_work( int matrix_layout, char side, char trans,
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         r = LAPACKE_lsame( side, 'l' ) ? m : n;
-        lda_t = MAX(1,k);
-        ldc_t = MAX(1,m);
+        lapack_int lda_t = MAX(1,k);
+        lapack_int ldc_t = MAX(1,m);
+        float *a_t = NULL;
+        float *c_t = NULL;
         /* Check leading dimension(s) */
         if( lda < r ) {
             info = -8;

--- a/LAPACKE/src/lapacke_sstemr_work.c
+++ b/LAPACKE/src/lapacke_sstemr_work.c
@@ -55,7 +55,7 @@ lapack_int LAPACKE_sstemr_work( int matrix_layout, char jobz, char range,
         lapack_int ldz_t = MAX(1,n);
         float* z_t = NULL;
         /* Check leading dimension(s) */
-        if( ldz < n ) {
+        if( ldz < 1 || ( LAPACKE_lsame( jobz, 'v' ) && ldz < n ) ) {
             info = -14;
             LAPACKE_xerbla( "LAPACKE_sstemr_work", info );
             return info;

--- a/LAPACKE/src/lapacke_ssyevr_work.c
+++ b/LAPACKE/src/lapacke_ssyevr_work.c
@@ -52,8 +52,9 @@ lapack_int LAPACKE_ssyevr_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_ssyevx_work.c
+++ b/LAPACKE/src/lapacke_ssyevx_work.c
@@ -51,8 +51,9 @@ lapack_int LAPACKE_ssyevx_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_ssytrs_aa.c
+++ b/LAPACKE/src/lapacke_ssytrs_aa.c
@@ -60,7 +60,7 @@ lapack_int LAPACKE_ssytrs_aa( int matrix_layout, char uplo, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-	lwork = (lapack_int)work_query;
+    lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     work = (float*)
         LAPACKE_malloc( sizeof(float) * lwork );

--- a/LAPACKE/src/lapacke_zgejsv.c
+++ b/LAPACKE/src/lapacke_zgejsv.c
@@ -41,22 +41,22 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
 {
     lapack_int info = 0;
     lapack_int lwork = (
-    			// 1.1
-    	(	     LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
+                // 1.1
+        (        LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? 2*n+1 :
 
                 //1.2
-     (   (        LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
+     (   (       LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? n*n+3*n :
 
                 //2.1
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
-              (!( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) )&&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+             (!( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) )&&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 3*n :
 
 
                 //2.2
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
               !( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 3*n :
 
@@ -81,8 +81,8 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 4*n*n:
                        1) ) ) ) ) ) ) ) );
     lapack_int lrwork = (
-    			// 1.1
-    	(	     LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
+                // 1.1
+        (        LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? MAX(7,n+2*m) :
 
                 //1.2
@@ -90,13 +90,13 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) )) ? MAX(7,2*n) :
 
                 //2.1
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
-              (!( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) ) &&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+             (!( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? MAX( 7, n+ 2*m ) :
 
 
                 //2.2
-    (	(	   ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
+    (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
               !( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
               !( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? MAX(7,2*n) :
 

--- a/LAPACKE/src/lapacke_zgejsv.c
+++ b/LAPACKE/src/lapacke_zgejsv.c
@@ -51,7 +51,7 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
 
                 //2.1
     (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
-             (!( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) )&&
+              !( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) )&&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 3*n :
 
 
@@ -79,7 +79,7 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
      (  (       ( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
                ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? 4*n*n:
-                       1) ) ) ) ) ) ) ) );
+                       1) ) ) ) ) ) ) );
     lapack_int lrwork = (
                 // 1.1
         (        LAPACKE_lsame( jobu, 'n' ) &&  LAPACKE_lsame( jobv, 'n' ) &&
@@ -91,7 +91,7 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
 
                 //2.1
     (   (      ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) )  &&
-             (!( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) ) &&
+              !( LAPACKE_lsame( jobu, 'u') ||  LAPACKE_lsame( jobu, 'f' ) ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? MAX( 7, n+ 2*m ) :
 
 
@@ -119,7 +119,7 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
      (  (       ( LAPACKE_lsame( jobu, 'u' ) ||  LAPACKE_lsame( jobu, 'f' ) ) &&
                ( LAPACKE_lsame( jobv, 'v' ) ||  LAPACKE_lsame( jobv, 'j' ) ) &&
                ( LAPACKE_lsame( jobt, 't' ) ||  LAPACKE_lsame( joba, 'f' ) || LAPACKE_lsame( joba, 'g' ) ))? MAX(7,2*n) :
-                       7) ) ) ) ) ) ) ) );
+                       7) ) ) ) ) ) ) );
     lapack_int* iwork = NULL;
     double* rwork = NULL;
     lapack_complex_double* cwork = NULL;

--- a/LAPACKE/src/lapacke_zgelq.c
+++ b/LAPACKE/src/lapacke_zgelq.c
@@ -33,9 +33,9 @@
 
 #include "lapacke_utils.h"
 
-lapack_int LAPACKE_zgelq_work( int matrix_layout, lapack_int m, lapack_int n,
-                               lapack_complex_double* a, lapack_int lda,
-                               lapack_complex_double* t, lapack_int tsize )
+lapack_int LAPACKE_zgelq( int matrix_layout, lapack_int m, lapack_int n,
+                          lapack_complex_double* a, lapack_int lda,
+                          lapack_complex_double* t, lapack_int tsize )
 {
     lapack_int info = 0;
     lapack_int lwork = -1;

--- a/LAPACKE/src/lapacke_zgemlq.c
+++ b/LAPACKE/src/lapacke_zgemlq.c
@@ -55,7 +55,7 @@ lapack_int LAPACKE_zgemlq( int matrix_layout, char side, char trans,
     if( LAPACKE_zge_nancheck( matrix_layout, m, n, c, ldc ) ) {
         return -10;
     }
-    if( LAPACKE_d_nancheck( tsize, t, 1 ) ) {
+    if( LAPACKE_z_nancheck( tsize, t, 1 ) ) {
         return -9;
     }
 #endif

--- a/LAPACKE/src/lapacke_zgesdd.c
+++ b/LAPACKE/src/lapacke_zgesdd.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_zgesdd( int matrix_layout, char jobz, lapack_int m,
     if( LAPACKE_lsame( jobz, 'n' ) ) {
         lrwork = MAX(1,7*MIN(m,n));
     } else {
-        lrwork = (size_t)MIN(m,n)*MAX(5*MIN(m,n)+7,2*MAX(m,n)+2*MIN(m,n)+1);
+        lrwork = (size_t)MAX(1,MIN(m,n)*MAX(5*MIN(m,n)+7,2*MAX(m,n)+2*MIN(m,n)+1));
     }
     /* Allocate memory for working array(s) */
     iwork = (lapack_int*)

--- a/LAPACKE/src/lapacke_zgesvdx.c
+++ b/LAPACKE/src/lapacke_zgesvdx.c
@@ -34,12 +34,12 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_zgesvdx( int matrix_layout, char jobu, char jobvt, char range,
-                           lapack_int m, lapack_int n, lapack_complex_double* a,
-                           lapack_int lda, double vl, double vu,
-                           lapack_int il, lapack_int iu, lapack_int* ns,
-                           double* s, lapack_complex_double* u, lapack_int ldu,
-                           lapack_complex_double* vt, lapack_int ldvt,
-                           lapack_int* superb )
+                            lapack_int m, lapack_int n, lapack_complex_double* a,
+                            lapack_int lda, double vl, double vu,
+                            lapack_int il, lapack_int iu, lapack_int* ns,
+                            double* s, lapack_complex_double* u, lapack_int ldu,
+                            lapack_complex_double* vt, lapack_int ldvt,
+                            lapack_int* superb )
 {
     lapack_int info = 0;
     lapack_int lwork = -1;
@@ -61,7 +61,7 @@ lapack_int LAPACKE_zgesvdx( int matrix_layout, char jobu, char jobvt, char range
 #endif
     /* Query optimal working array(s) size */
     info = LAPACKE_zgesvdx_work( matrix_layout, jobu, jobvt, range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
                                  ldu, vt, ldvt, &work_query, lwork, rwork, iwork );
     if( info != 0 ) {
         goto exit_level_0;
@@ -69,7 +69,7 @@ lapack_int LAPACKE_zgesvdx( int matrix_layout, char jobu, char jobvt, char range
     lwork = LAPACK_Z2INT (work_query);
     /* Allocate memory for work arrays */
     work = (lapack_complex_double*)
-    	LAPACKE_malloc( sizeof(lapack_complex_double) * lwork );
+        LAPACKE_malloc( sizeof(lapack_complex_double) * lwork );
     if( work == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
         goto exit_level_1;
@@ -86,8 +86,8 @@ lapack_int LAPACKE_zgesvdx( int matrix_layout, char jobu, char jobvt, char range
     }
     /* Call middle-level interface */
     info = LAPACKE_zgesvdx_work( matrix_layout, jobu, jobvt,  range,
-    							 m, n, a, lda, vl, vu, il, iu, ns, s, u,
-                                ldu, vt, ldvt, work, lwork, rwork, iwork );
+                                 m, n, a, lda, vl, vu, il, iu, ns, s, u,
+                                 ldu, vt, ldvt, work, lwork, rwork, iwork );
     /* Backup significant data from working array(s) */
     for( i=0; i<12*MIN(m,n)-1; i++ ) {
         superb[i] = iwork[i+1];

--- a/LAPACKE/src/lapacke_zgesvdx_work.c
+++ b/LAPACKE/src/lapacke_zgesvdx_work.c
@@ -34,19 +34,19 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_zgesvdx_work( int matrix_layout, char jobu, char jobvt, char range,
-                           		lapack_int m, lapack_int n, lapack_complex_double* a,
-                          		lapack_int lda, double vl, double vu,
-                           		lapack_int il, lapack_int iu, lapack_int* ns,
-                           		double* s, lapack_complex_double* u, lapack_int ldu,
-                           		lapack_complex_double* vt, lapack_int ldvt,
-                                lapack_complex_double* work, lapack_int lwork,
-                                double* rwork, lapack_int* iwork )
+                                 lapack_int m, lapack_int n, lapack_complex_double* a,
+                                 lapack_int lda, double vl, double vu,
+                                 lapack_int il, lapack_int iu, lapack_int* ns,
+                                 double* s, lapack_complex_double* u, lapack_int ldu,
+                                 lapack_complex_double* vt, lapack_int ldvt,
+                                 lapack_complex_double* work, lapack_int lwork,
+                                 double* rwork, lapack_int* iwork )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_zgesvdx( &jobu, &jobvt,  &range, &m, &n, a, &lda, &vl, &vu,
-            			&il, &iu, ns, s, u, &ldu, vt, &ldvt,
+                        &il, &iu, ns, s, u, &ldu, vt, &ldvt,
                         work, &lwork, rwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;
@@ -85,7 +85,7 @@ lapack_int LAPACKE_zgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {
             LAPACK_zgesvdx( &jobu, &jobvt, &range, &m, &n, a, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u, &ldu_t, vt,
+                            &il, &iu, ns, s, u, &ldu_t, vt,
                             &ldvt_t, work, &lwork, rwork, iwork, &info );
             return (info < 0) ? (info - 1) : info;
         }
@@ -116,7 +116,7 @@ lapack_int LAPACKE_zgesvdx_work( int matrix_layout, char jobu, char jobvt, char 
         LAPACKE_zge_trans( matrix_layout, m, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_zgesvdx( &jobu, &jobvt, &range, &m, &n, a_t, &lda_t, &vl, &vu,
-            				&il, &iu, ns, s, u_t, &ldu_t, vt_t,
+                            &il, &iu, ns, s, u_t, &ldu_t, vt_t,
                             &ldvt_t, work, &lwork, rwork, iwork, &info );
         if( info < 0 ) {
             info = info - 1;

--- a/LAPACKE/src/lapacke_zgesvj_work.c
+++ b/LAPACKE/src/lapacke_zgesvj_work.c
@@ -76,7 +76,7 @@ lapack_int LAPACKE_zgesvj_work( int matrix_layout, char joba, char jobu,
         }
         if( LAPACKE_lsame( jobv, 'a' ) || LAPACKE_lsame( jobv, 'v' ) ) {
             v_t = (lapack_complex_double*)
-            	LAPACKE_malloc( sizeof(lapack_complex_double) * ldv_t * MAX(1,n) );
+               LAPACKE_malloc( sizeof(lapack_complex_double) * ldv_t * MAX(1,n) );
             if( v_t == NULL ) {
                 info = LAPACK_TRANSPOSE_MEMORY_ERROR;
                 goto exit_level_1;

--- a/LAPACKE/src/lapacke_zheevr_work.c
+++ b/LAPACKE/src/lapacke_zheevr_work.c
@@ -54,8 +54,9 @@ lapack_int LAPACKE_zheevr_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_zheevx_work.c
+++ b/LAPACKE/src/lapacke_zheevx_work.c
@@ -53,8 +53,9 @@ lapack_int LAPACKE_zheevx_work( int matrix_layout, char jobz, char range,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ncols_z = ( LAPACKE_lsame( range, 'a' ) ||
-                             LAPACKE_lsame( range, 'v' ) ) ? n :
+        lapack_int ncols_z = ( !LAPACKE_lsame( jobz, 'v' ) ) ? 1 :
+                             ( LAPACKE_lsame( range, 'a' ) ||
+                               LAPACKE_lsame( range, 'v' ) ) ? n :
                              ( LAPACKE_lsame( range, 'i' ) ? (iu-il+1) : 1);
         lapack_int lda_t = MAX(1,n);
         lapack_int ldz_t = MAX(1,n);

--- a/LAPACKE/src/lapacke_zhetrf_rk_work.c
+++ b/LAPACKE/src/lapacke_zhetrf_rk_work.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_zhetrf_rk_work( int matrix_layout, char uplo, lapack_int n,
                                 lapack_complex_double* a, lapack_int lda,
-                                lapack_complex_double* e, 
+                                lapack_complex_double* e,
                                 lapack_int* ipiv, lapack_complex_double* work,
                                 lapack_int lwork )
 {

--- a/LAPACKE/src/lapacke_zhetrs_3.c
+++ b/LAPACKE/src/lapacke_zhetrs_3.c
@@ -56,5 +56,5 @@ lapack_int LAPACKE_zhetrs_3( int matrix_layout, char uplo, lapack_int n,
     }
 #endif
     return LAPACKE_zhetrs_3_work( matrix_layout, uplo, n, nrhs, a, lda,
-    							  e, ipiv, b, ldb );
+                                  e, ipiv, b, ldb );
 }

--- a/LAPACKE/src/lapacke_zlacp2_work.c
+++ b/LAPACKE/src/lapacke_zlacp2_work.c
@@ -31,7 +31,6 @@
 * Generated January, 2013
 *****************************************************************************/
 
-#include "lapacke.h"
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_zlacp2_work( int matrix_layout, char uplo, lapack_int m,

--- a/LAPACKE/src/lapacke_zlange.c
+++ b/LAPACKE/src/lapacke_zlange.c
@@ -38,7 +38,7 @@ double LAPACKE_zlange( int matrix_layout, char norm, lapack_int m,
                            lapack_int lda )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     double* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_zlange", -1 );

--- a/LAPACKE/src/lapacke_zlange_work.c
+++ b/LAPACKE/src/lapacke_zlange_work.c
@@ -38,7 +38,7 @@ double LAPACKE_zlange_work( int matrix_layout, char norm, lapack_int m,
                                 lapack_int lda, double* work )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_zlange( &norm, &m, &n, a, &lda, work );

--- a/LAPACKE/src/lapacke_zlanhe.c
+++ b/LAPACKE/src/lapacke_zlanhe.c
@@ -37,7 +37,7 @@ double LAPACKE_zlanhe( int matrix_layout, char norm, char uplo, lapack_int n,
                            const lapack_complex_double* a, lapack_int lda )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     double* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_zlanhe", -1 );

--- a/LAPACKE/src/lapacke_zlanhe_work.c
+++ b/LAPACKE/src/lapacke_zlanhe_work.c
@@ -38,7 +38,7 @@ double LAPACKE_zlanhe_work( int matrix_layout, char norm, char uplo,
                                 lapack_int lda, double* work )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_zlanhe( &norm, &uplo, &n, a, &lda, work );

--- a/LAPACKE/src/lapacke_zlansy.c
+++ b/LAPACKE/src/lapacke_zlansy.c
@@ -37,7 +37,7 @@ double LAPACKE_zlansy( int matrix_layout, char norm, char uplo, lapack_int n,
                            const lapack_complex_double* a, lapack_int lda )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     double* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_zlansy", -1 );

--- a/LAPACKE/src/lapacke_zlansy_work.c
+++ b/LAPACKE/src/lapacke_zlansy_work.c
@@ -38,7 +38,7 @@ double LAPACKE_zlansy_work( int matrix_layout, char norm, char uplo,
                                 lapack_int lda, double* work )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_zlansy( &norm, &uplo, &n, a, &lda, work );

--- a/LAPACKE/src/lapacke_zlantr.c
+++ b/LAPACKE/src/lapacke_zlantr.c
@@ -38,7 +38,7 @@ double LAPACKE_zlantr( int matrix_layout, char norm, char uplo, char diag,
                            const lapack_complex_double* a, lapack_int lda )
 {
     lapack_int info = 0;
-	double res = 0.;
+    double res = 0.;
     double* work = NULL;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_zlantr", -1 );

--- a/LAPACKE/src/lapacke_zlarfb.c
+++ b/LAPACKE/src/lapacke_zlarfb.c
@@ -41,7 +41,7 @@ lapack_int LAPACKE_zlarfb( int matrix_layout, char side, char trans, char direct
                            lapack_int ldc )
 {
     lapack_int info = 0;
-    lapack_int ldwork = ( side=='l')?n:(( side=='r')?m:1);
+    lapack_int ldwork;
     lapack_complex_double* work = NULL;
     lapack_int ncols_v, nrows_v;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
@@ -100,6 +100,13 @@ lapack_int LAPACKE_zlarfb( int matrix_layout, char side, char trans, char direct
             return -9;
     }
 #endif
+    if( LAPACKE_lsame( side, 'l' ) ) {
+        ldwork = n;
+    } else if( LAPACKE_lsame( side, 'r' ) ) {
+        ldwork = m;
+    } else {
+        ldwork = 1;
+    }
     /* Allocate memory for working array(s) */
     work = (lapack_complex_double*)
         LAPACKE_malloc( sizeof(lapack_complex_double) * ldwork * MAX(1,k) );

--- a/LAPACKE/src/lapacke_zlaswp_work.c
+++ b/LAPACKE/src/lapacke_zlaswp_work.c
@@ -46,7 +46,11 @@ lapack_int LAPACKE_zlaswp_work( int matrix_layout, lapack_int n,
             info = info - 1;
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int lda_t = MAX(1,lda);
+        lapack_int lda_t = MAX(1,k2);
+        lapack_int i;
+        for( i = k1; i <= k2; i++ ) {
+            lda_t = MAX( lda_t, ipiv[k1 + ( i - k1 ) * ABS( incx ) - 1] );
+        }
         lapack_complex_double* a_t = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
@@ -62,12 +66,12 @@ lapack_int LAPACKE_zlaswp_work( int matrix_layout, lapack_int n,
             goto exit_level_0;
         }
         /* Transpose input matrices */
-        LAPACKE_zge_trans( matrix_layout, lda, n, a, lda, a_t, lda_t );
+        LAPACKE_zge_trans( matrix_layout, lda_t, n, a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         LAPACK_zlaswp( &n, a_t, &lda_t, &k1, &k2, ipiv, &incx );
         info = 0;  /* LAPACK call is ok! */
         /* Transpose output matrices */
-        LAPACKE_zge_trans( LAPACK_COL_MAJOR, lda, n, a_t, lda_t, a, lda );
+        LAPACKE_zge_trans( LAPACK_COL_MAJOR, lda_t, n, a_t, lda_t, a, lda );
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zstemr_work.c
+++ b/LAPACKE/src/lapacke_zstemr_work.c
@@ -56,7 +56,7 @@ lapack_int LAPACKE_zstemr_work( int matrix_layout, char jobz, char range,
         lapack_int ldz_t = MAX(1,n);
         lapack_complex_double* z_t = NULL;
         /* Check leading dimension(s) */
-        if( ldz < n ) {
+        if( ldz < 1 || ( LAPACKE_lsame( jobz, 'v' ) && ldz < n ) ) {
             info = -14;
             LAPACKE_xerbla( "LAPACKE_zstemr_work", info );
             return info;

--- a/LAPACKE/src/lapacke_zsytrs_3.c
+++ b/LAPACKE/src/lapacke_zsytrs_3.c
@@ -56,5 +56,5 @@ lapack_int LAPACKE_zsytrs_3( int matrix_layout, char uplo, lapack_int n,
     }
 #endif
     return LAPACKE_zsytrs_3_work( matrix_layout, uplo, n, nrhs, a, lda,
-    							  e, ipiv, b, ldb );
+                                  e, ipiv, b, ldb );
 }

--- a/LAPACKE/src/lapacke_zunmlq_work.c
+++ b/LAPACKE/src/lapacke_zunmlq_work.c
@@ -42,9 +42,6 @@ lapack_int LAPACKE_zunmlq_work( int matrix_layout, char side, char trans,
 {
     lapack_int info = 0;
     lapack_int r;
-    lapack_int lda_t, ldc_t;
-    lapack_complex_double* a_t = NULL;
-    lapack_complex_double* c_t = NULL;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         LAPACK_zunmlq( &side, &trans, &m, &n, &k, a, &lda, tau, c, &ldc, work,
@@ -54,8 +51,10 @@ lapack_int LAPACKE_zunmlq_work( int matrix_layout, char side, char trans,
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         r = LAPACKE_lsame( side, 'l' ) ? m : n;
-        lda_t = MAX(1,k);
-        ldc_t = MAX(1,m);
+        lapack_int lda_t = MAX(1,k);
+        lapack_int ldc_t = MAX(1,m);
+        lapack_complex_double* a_t = NULL;
+        lapack_complex_double* c_t = NULL;
         /* Check leading dimension(s) */
         if( lda < r ) {
             info = -8;

--- a/LAPACKE/utils/lapacke_ctp_trans.c
+++ b/LAPACKE/utils/lapacke_ctp_trans.c
@@ -69,7 +69,7 @@ void LAPACKE_ctp_trans( int matrix_layout, char uplo, char diag,
      * and col_major lower and row_major upper are equals too -
      * using one code for equal cases. XOR( colmaj, upper )
      */
-    if( ( colmaj || upper ) && !( colmaj && upper ) ) {
+    if( !( colmaj || upper ) || ( colmaj && upper ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < j+1-st; i++ ) {
                 out[ j-i + (i*(2*n-i+1))/2 ] = in[ ((j+1)*j)/2 + i ];

--- a/LAPACKE/utils/lapacke_dtp_trans.c
+++ b/LAPACKE/utils/lapacke_dtp_trans.c
@@ -69,7 +69,7 @@ void LAPACKE_dtp_trans( int matrix_layout, char uplo, char diag,
      * and col_major lower and row_major upper are equals too -
      * using one code for equal cases. XOR( colmaj, upper )
      */
-    if( ( colmaj || upper ) && !( colmaj && upper ) ) {
+    if( !( colmaj || upper ) || ( colmaj && upper ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < j+1-st; i++ ) {
                 out[ j-i + (i*(2*n-i+1))/2 ] = in[ ((j+1)*j)/2 + i ];

--- a/LAPACKE/utils/lapacke_stp_trans.c
+++ b/LAPACKE/utils/lapacke_stp_trans.c
@@ -69,7 +69,7 @@ void LAPACKE_stp_trans( int matrix_layout, char uplo, char diag,
      * and col_major lower and row_major upper are equals too -
      * using one code for equal cases. XOR( colmaj, upper )
      */
-    if( ( colmaj || upper ) && !( colmaj && upper ) ) {
+    if( !( colmaj || upper ) || ( colmaj && upper ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < j+1-st; i++ ) {
                 out[ j-i + (i*(2*n-i+1))/2 ] = in[ ((j+1)*j)/2 + i ];

--- a/LAPACKE/utils/lapacke_ztp_trans.c
+++ b/LAPACKE/utils/lapacke_ztp_trans.c
@@ -69,7 +69,7 @@ void LAPACKE_ztp_trans( int matrix_layout, char uplo, char diag,
      * and col_major lower and row_major upper are equals too -
      * using one code for equal cases. XOR( colmaj, upper )
      */
-    if( ( colmaj || upper ) && !( colmaj && upper ) ) {
+    if( !( colmaj || upper ) || ( colmaj && upper ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < j+1-st; i++ ) {
                 out[ j-i + (i*(2*n-i+1))/2 ] = in[ ((j+1)*j)/2 + i ];


### PR DESCRIPTION
Here are fixes for a number of bugs discovered in LAPACKE interfaces.

The most important changes:
1. Enabling LAPACKE_*geqr, LAPACKE_*gelq and LAPACKE_*gemlq functions. They were missing in Makefiles and contained some errors.
2. Fix for LAPACK_*larfb: it didn't work for uppercase side char parameter because chars have been compared directly - LAPACKE_lsame was added.
3. Fix for issue #110 
4. Fix for LAPACKE_*tp_trans. Conditions for two loops were swapped so it seems it worked in reverse way.
