### PR TITLE
Fix documentation for ?LASWP routine

### DIFF
--- a/SRC/claswp.f
+++ b/SRC/claswp.f
@@ -79,14 +79,15 @@
 *> \verbatim
 *>          IPIV is INTEGER array, dimension (K1+(K2-K1)*abs(INCX))
 *>          The vector of pivot indices. Only the elements in positions
-*>          K1 through K1+(K2-K1)*INCX of IPIV are accessed.
-*>          IPIV(K) = L implies rows K and L are to be interchanged.
+*>          K1 through K1+(K2-K1)*abs(INCX) of IPIV are accessed.
+*>          IPIV(K1+(K-K1)*abs(INCX)) = L implies rows K and L are to be
+*>          interchanged.
 *> \endverbatim
 *>
 *> \param[in] INCX
 *> \verbatim
 *>          INCX is INTEGER
-*>          The increment between successive values of IPIV.  If IPIV
+*>          The increment between successive values of IPIV. If INCX
 *>          is negative, the pivots are applied in reverse order.
 *> \endverbatim
 *
@@ -135,7 +136,8 @@
 *     ..
 *     .. Executable Statements ..
 *
-*     Interchange row I with row IPIV(I) for each of rows K1 through K2.
+*     Interchange row I with row IPIV(K1+(I-K1)*abs(INCX)) for each of rows
+*     K1 through K2.
 *
       IF( INCX.GT.0 ) THEN
          IX0 = K1

--- a/SRC/dlaswp.f
+++ b/SRC/dlaswp.f
@@ -79,14 +79,15 @@
 *> \verbatim
 *>          IPIV is INTEGER array, dimension (K1+(K2-K1)*abs(INCX))
 *>          The vector of pivot indices. Only the elements in positions
-*>          K1 through K1+(K2-K1)*INCX of IPIV are accessed.
-*>          IPIV(K) = L implies rows K and L are to be interchanged.
+*>          K1 through K1+(K2-K1)*abs(INCX) of IPIV are accessed.
+*>          IPIV(K1+(K-K1)*abs(INCX)) = L implies rows K and L are to be
+*>          interchanged.
 *> \endverbatim
 *>
 *> \param[in] INCX
 *> \verbatim
 *>          INCX is INTEGER
-*>          The increment between successive values of IPIV.  If IPIV
+*>          The increment between successive values of IPIV. If INCX
 *>          is negative, the pivots are applied in reverse order.
 *> \endverbatim
 *
@@ -135,7 +136,8 @@
 *     ..
 *     .. Executable Statements ..
 *
-*     Interchange row I with row IPIV(I) for each of rows K1 through K2.
+*     Interchange row I with row IPIV(K1+(I-K1)*abs(INCX)) for each of rows
+*     K1 through K2.
 *
       IF( INCX.GT.0 ) THEN
          IX0 = K1

--- a/SRC/slaswp.f
+++ b/SRC/slaswp.f
@@ -79,14 +79,15 @@
 *> \verbatim
 *>          IPIV is INTEGER array, dimension (K1+(K2-K1)*abs(INCX))
 *>          The vector of pivot indices. Only the elements in positions
-*>          K1 through K1+(K2-K1)*INCX of IPIV are accessed.
-*>          IPIV(K) = L implies rows K and L are to be interchanged.
+*>          K1 through K1+(K2-K1)*abs(INCX) of IPIV are accessed.
+*>          IPIV(K1+(K-K1)*abs(INCX)) = L implies rows K and L are to be
+*>          interchanged.
 *> \endverbatim
 *>
 *> \param[in] INCX
 *> \verbatim
 *>          INCX is INTEGER
-*>          The increment between successive values of IPIV.  If IPIV
+*>          The increment between successive values of IPIV. If INCX
 *>          is negative, the pivots are applied in reverse order.
 *> \endverbatim
 *
@@ -135,7 +136,8 @@
 *     ..
 *     .. Executable Statements ..
 *
-*     Interchange row I with row IPIV(I) for each of rows K1 through K2.
+*     Interchange row I with row IPIV(K1+(I-K1)*abs(INCX)) for each of rows
+*     K1 through K2.
 *
       IF( INCX.GT.0 ) THEN
          IX0 = K1

--- a/SRC/zlaswp.f
+++ b/SRC/zlaswp.f
@@ -79,14 +79,15 @@
 *> \verbatim
 *>          IPIV is INTEGER array, dimension (K1+(K2-K1)*abs(INCX))
 *>          The vector of pivot indices. Only the elements in positions
-*>          K1 through K1+(K2-K1)*INCX of IPIV are accessed.
-*>          IPIV(K) = L implies rows K and L are to be interchanged.
+*>          K1 through K1+(K2-K1)*abs(INCX) of IPIV are accessed.
+*>          IPIV(K1+(K-K1)*abs(INCX)) = L implies rows K and L are to be
+*>          interchanged.
 *> \endverbatim
 *>
 *> \param[in] INCX
 *> \verbatim
 *>          INCX is INTEGER
-*>          The increment between successive values of IPIV.  If IPIV
+*>          The increment between successive values of IPIV. If INCX
 *>          is negative, the pivots are applied in reverse order.
 *> \endverbatim
 *
@@ -135,7 +136,8 @@
 *     ..
 *     .. Executable Statements ..
 *
-*     Interchange row I with row IPIV(I) for each of rows K1 through K2.
+*     Interchange row I with row IPIV(K1+(I-K1)*abs(INCX)) for each of rows
+*     K1 through K2.
 *
       IF( INCX.GT.0 ) THEN
          IX0 = K1


### PR DESCRIPTION
It seems comments in LASWP routine doesn't fully correspond to implementation.

If I understand correctly, ?LASWP routine works as follows:
When INCX > 0:
```
DO I = K1, K2
   swap rows A(I,*) and A(IPIV(K1 + (I - K1)*INCX),*)
END DO
```

When INCX < 0:
```
DO I = K2, K1, -1
   swap rows A(I,*) and A(IPIV(K1 + (K1 - I)*INCX),*)
END DO
```

In both cases row I and `IPIV(K1 + (I - K1)*abs(INCX))` are interchanged. The only difference is that when INCX < 0 the pivots are applied in reverse order: `I = K2, K2-1, ..., K1`
