### PR TITLE
Replace last occurrences of `include` install paths

### DIFF
--- a/BLAS/blas.pc.in
+++ b/BLAS/blas.pc.in
@@ -1,5 +1,5 @@
-prefix=@prefix@
-libdir=@libdir@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: BLAS
 Description: FORTRAN reference implementation of BLAS Basic Linear Algebra Subprograms

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -28,7 +28,7 @@ endforeach()
 endmacro()
 
 append_subdir_files(CBLAS_INCLUDE "include")
-install(FILES ${CBLAS_INCLUDE} ${LAPACK_BINARY_DIR}/include/cblas_mangling.h DESTINATION include)
+install(FILES ${CBLAS_INCLUDE} ${LAPACK_BINARY_DIR}/include/cblas_mangling.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # --------------------------------------------------
 if(BUILD_TESTING)

--- a/CBLAS/cblas.pc.in
+++ b/CBLAS/cblas.pc.in
@@ -1,9 +1,10 @@
-prefix=@prefix@
-libdir=@libdir@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: CBLAS
 Description: C Standard Interface to BLAS Basic Linear Algebra Subprograms
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/blas/#_cblas
 Libs: -L${libdir} -lcblas
+Cflags: -I${includedir}
 Requires.private: blas

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,12 +108,6 @@ macro(lapack_install_library lib)
 endmacro()
 
 set(PKG_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-set(prefix ${CMAKE_INSTALL_PREFIX})
-if(NOT IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
-  set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
-else()
-  set(libdir "${CMAKE_INSTALL_LIBDIR}")
-endif()
 
 # --------------------------------------------------
 # Testing

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 target_link_libraries(lapacke PRIVATE ${LAPACK_LIBRARIES})
 
 lapack_install_library(lapacke)
-install(FILES ${LAPACKE_INCLUDE} ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h DESTINATION include)
+install(FILES ${LAPACKE_INCLUDE} ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(BUILD_TESTING)
   add_subdirectory(example)

--- a/LAPACKE/lapacke.pc.in
+++ b/LAPACKE/lapacke.pc.in
@@ -1,9 +1,10 @@
-prefix=@prefix@
-libdir=@libdir@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: LAPACKE
 Description: C Standard Interface to LAPACK Linear Algebra PACKage
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/lapack/#_standard_c_language_apis_for_lapack
 Libs: -L${libdir} -llapacke
+Cflags: -I${includedir}
 Requires.private: lapack

--- a/lapack.pc.in
+++ b/lapack.pc.in
@@ -1,5 +1,5 @@
-prefix=@prefix@
-libdir=@libdir@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: LAPACK
 Description: FORTRAN reference implementation of LAPACK Linear Algebra PACKage


### PR DESCRIPTION
* Distributions might need to change the header dir
* Also change the template paths in the `.pc` files to
  the idiomatic CMake `GNUInstallDirs` full paths,
  which are always correct, regardless of whether the
  user specified relative or absolute paths. This makes
  the build system somewhat easier and more idiomatic.