### PR TITLE
Bug fix in SLAMSWLQ; fix type mismatches.

### DIFF
--- a/SRC/cgetsls.f
+++ b/SRC/cgetsls.f
@@ -187,8 +187,8 @@
       INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
      $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
-      REAL               ANRM, BIGNUM, BNRM, SMLNUM
-      COMPLEX            TQ( 5 ), WORKQ
+      REAL               ANRM, BIGNUM, BNRM, SMLNUM, DUM( 1 )
+      COMPLEX            TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -236,31 +236,31 @@
        IF( M.GE.N ) THEN
          CALL CGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL CGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL CGEQR( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL CGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZM, B, LDB, WORKQ, -1, INFO2 )
-         LWM = MAX( LWM, INT( WORKQ ) )
+         LWM = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        ELSE
          CALL CGELQ( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL CGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL CGELQ( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL CGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWM  = MAX( LWM, INT( WORKQ ) )
+         LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        END IF
@@ -305,7 +305,7 @@
 *
 *     Scale A, B if max element outside range [SMLNUM,BIGNUM]
 *
-      ANRM = CLANGE( 'M', M, N, A, LDA, WORK )
+      ANRM = CLANGE( 'M', M, N, A, LDA, DUM )
       IASCL = 0
       IF( ANRM.GT.ZERO .AND. ANRM.LT.SMLNUM ) THEN
 *
@@ -331,7 +331,7 @@
       IF ( TRAN ) THEN
         BROW = N
       END IF
-      BNRM = CLANGE( 'M', BROW, NRHS, B, LDB, WORK )
+      BNRM = CLANGE( 'M', BROW, NRHS, B, LDB, DUM )
       IBSCL = 0
       IF( BNRM.GT.ZERO .AND. BNRM.LT.SMLNUM ) THEN
 *

--- a/SRC/dgetsls.f
+++ b/SRC/dgetsls.f
@@ -185,7 +185,7 @@
       INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
      $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
-      DOUBLE PRECISION   ANRM, BIGNUM, BNRM, SMLNUM, TQ( 5 ), WORKQ
+      DOUBLE PRECISION   ANRM, BIGNUM, BNRM, SMLNUM, TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -233,31 +233,31 @@
        IF( M.GE.N ) THEN
          CALL DGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL DGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL DGEQR( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL DGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZM, B, LDB, WORKQ, -1, INFO2 )
-         LWM = MAX( LWM, INT( WORKQ ) )
+         LWM = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        ELSE
          CALL DGELQ( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL DGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL DGELQ( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL DGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWM  = MAX( LWM, INT( WORKQ ) )
+         LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        END IF

--- a/SRC/ilaslc.f
+++ b/SRC/ilaslc.f
@@ -94,7 +94,7 @@
 *
 *     .. Parameters ..
       REAL             ZERO
-      PARAMETER ( ZERO = 0.0D+0 )
+      PARAMETER ( ZERO = 0.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER I

--- a/SRC/iparam2stage.F
+++ b/SRC/iparam2stage.F
@@ -172,7 +172,7 @@
       INTEGER            I, IC, IZ, KD, IB, LHOUS, LWORK, NTHREADS,
      $                   FACTOPTNB, QROPTNB, LQOPTNB
       LOGICAL            RPREC, CPREC
-      CHARACTER          PREC*1, ALGO*3, STAG*5, SUBNAM*12, VECT*3
+      CHARACTER          PREC*1, ALGO*3, STAG*5, SUBNAM*12, VECT*1
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          CHAR, ICHAR, MAX

--- a/SRC/sgelqt3.f
+++ b/SRC/sgelqt3.f
@@ -130,7 +130,7 @@
 *
 *     .. Parameters ..
       REAL   ONE
-      PARAMETER ( ONE = 1.0D+00 )
+      PARAMETER ( ONE = 1.0E+00 )
 *     ..
 *     .. Local Scalars ..
       INTEGER   I, I1, J, J1, M1, M2, N1, N2, IINFO

--- a/SRC/sgetsls.f
+++ b/SRC/sgetsls.f
@@ -185,7 +185,7 @@
       INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
      $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
-      REAL               ANRM, BIGNUM, BNRM, SMLNUM, TQ( 5 ), WORKQ
+      REAL               ANRM, BIGNUM, BNRM, SMLNUM, TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -233,31 +233,31 @@
        IF( M.GE.N ) THEN
          CALL SGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL SGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL SGEQR( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL SGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZM, B, LDB, WORKQ, -1, INFO2 )
-         LWM = MAX( LWM, INT( WORKQ ) )
+         LWM = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        ELSE
          CALL SGELQ( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL SGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL SGELQ( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL SGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWM  = MAX( LWM, INT( WORKQ ) )
+         LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        END IF

--- a/SRC/slamswlq.f
+++ b/SRC/slamswlq.f
@@ -281,7 +281,7 @@
       END IF
 *
       IF((NB.LE.K).OR.(NB.GE.MAX(M,N,K))) THEN
-        CALL DGEMLQT( SIDE, TRANS, M, N, K, MB, A, LDA,
+        CALL SGEMLQT( SIDE, TRANS, M, N, K, MB, A, LDA,
      $        T, LDT, C, LDC, WORK, INFO)
         RETURN
       END IF

--- a/SRC/zgetsls.f
+++ b/SRC/zgetsls.f
@@ -187,8 +187,8 @@
       INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
      $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
-      DOUBLE PRECISION   ANRM, BIGNUM, BNRM, SMLNUM
-      COMPLEX*16         TQ( 5 ), WORKQ
+      DOUBLE PRECISION   ANRM, BIGNUM, BNRM, SMLNUM, DUM( 1 )
+      COMPLEX*16         TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -236,31 +236,31 @@
        IF( M.GE.N ) THEN
          CALL ZGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL ZGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL ZGEQR( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL ZGEMQR( 'L', TRANS, M, NRHS, N, A, LDA, TQ,
      $                TSZM, B, LDB, WORKQ, -1, INFO2 )
-         LWM = MAX( LWM, INT( WORKQ ) )
+         LWM = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        ELSE
          CALL ZGELQ( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
          TSZO = INT( TQ( 1 ) )
-         LWO  = INT( WORKQ )
+         LWO  = INT( WORKQ( 1 ) )
          CALL ZGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWO  = MAX( LWO, INT( WORKQ ) )
+         LWO  = MAX( LWO, INT( WORKQ( 1 ) ) )
          CALL ZGELQ( M, N, A, LDA, TQ, -2, WORKQ, -2, INFO2 )
          TSZM = INT( TQ( 1 ) )
-         LWM  = INT( WORKQ )
+         LWM  = INT( WORKQ( 1 ) )
          CALL ZGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
      $                TSZO, B, LDB, WORKQ, -1, INFO2 )
-         LWM  = MAX( LWM, INT( WORKQ ) )
+         LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM
        END IF
@@ -305,7 +305,7 @@
 *
 *     Scale A, B if max element outside range [SMLNUM,BIGNUM]
 *
-      ANRM = ZLANGE( 'M', M, N, A, LDA, WORK )
+      ANRM = ZLANGE( 'M', M, N, A, LDA, DUM )
       IASCL = 0
       IF( ANRM.GT.ZERO .AND. ANRM.LT.SMLNUM ) THEN
 *
@@ -331,7 +331,7 @@
       IF ( TRAN ) THEN
         BROW = N
       END IF
-      BNRM = ZLANGE( 'M', BROW, NRHS, B, LDB, WORK )
+      BNRM = ZLANGE( 'M', BROW, NRHS, B, LDB, DUM )
       IBSCL = 0
       IF( BNRM.GT.ZERO .AND. BNRM.LT.SMLNUM ) THEN
 *

--- a/SRC/zhecon_3.f
+++ b/SRC/zhecon_3.f
@@ -189,7 +189,7 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
+      DOUBLE PRECISION   ONE, ZERO
       PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
 *     ..
 *     .. Local Scalars ..

--- a/SRC/zhecon_rook.f
+++ b/SRC/zhecon_rook.f
@@ -157,7 +157,7 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
+      DOUBLE PRECISION   ONE, ZERO
       PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
 *     ..
 *     .. Local Scalars ..

--- a/SRC/zhetri2x.f
+++ b/SRC/zhetri2x.f
@@ -137,7 +137,7 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE
+      DOUBLE PRECISION   ONE
       COMPLEX*16            CONE, ZERO
       PARAMETER          ( ONE = 1.0D+0,
      $                   CONE = ( 1.0D+0, 0.0D+0 ),


### PR DESCRIPTION
- Fix: SLAMSWLQ calls DGEMLQT instead of SGEMLQT.
- Use dummy variable for ?LANGE work array argument in [CS]GETSLS.
- Use 1-element array for workspace query in ?GETSLS.
- Fix PARAMETER declaration type mismatches in ILASLC, IPARAM2STAGE,
SGELQT3, ZHECON_3, ZHECON_ROOK, ZHETRI2X.