### PR TITLE
lapacke: add include directory to target

### DIFF
--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -60,6 +60,10 @@ set_target_properties(
   VERSION ${LAPACK_VERSION}
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
+target_include_directories(lapacke PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  $<INSTALL_INTERFACE:include>
+)
 
 if(LAPACKE_WITH_TMG)
   target_link_libraries(lapacke PRIVATE tmglib)


### PR DESCRIPTION
add include directories to target. With this change in a cmake project one can link lapacke with just the following

```
find_package(lapacke CONFIG REQUIRED)
add_executable(foo foo.cpp)
target_link_libraries(foo lapacke)
```
