### PR TITLE
fixed path in installed package config files for CBLAS and LAPACKE.

### DIFF
--- a/CBLAS/cmake/cblas-config-install.cmake.in
+++ b/CBLAS/cmake/cblas-config-install.cmake.in
@@ -5,7 +5,7 @@ get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
 get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
 
 # Load the LAPACK package with which we were built.
-set(LAPACK_DIR "${_CBLAS_PREFIX}/@{LIBRARY_DIR@/cmake/lapack-@LAPACK_VERSION@")
+set(LAPACK_DIR "${_CBLAS_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/lapack-@LAPACK_VERSION@")
 find_package(LAPACK NO_MODULE)
 
 # Load lapacke targets from the install tree.

--- a/LAPACKE/cmake/lapacke-config-install.cmake.in
+++ b/LAPACKE/cmake/lapacke-config-install.cmake.in
@@ -5,7 +5,7 @@ get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
 get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
 
 # Load the LAPACK package with which we were built.
-set(LAPACK_DIR "${_LAPACKE_PREFIX}/@{LIBRARY_DIR@/cmake/lapack-@LAPACK_VERSION@")
+set(LAPACK_DIR "${_LAPACKE_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/lapack-@LAPACK_VERSION@")
 find_package(LAPACK NO_MODULE)
 
 # Load lapacke targets from the install tree.


### PR DESCRIPTION
These did not get caught in the cleanup of installation directory names (#e64606d). Fixes #21