### PR TITLE
Update LAPACKE Makefile - missing functions and conditional invocation of ar

### DIFF
--- a/LAPACKE/src/Makefile
+++ b/LAPACKE/src/Makefile
@@ -2457,9 +2457,15 @@ all: ../../$(LAPACKELIB)
 ../../$(LAPACKELIB): $(OBJ_A) $(OBJ_B) $(DEPRECATED) $(EXTENDED) $(MATGEN)
 	$(ARCH) $(ARCHFLAGS) $@ $(OBJ_A)
 	$(ARCH) $(ARCHFLAGS) $@ $(OBJ_B)
+ifdef BUILD_DEPRECATED
 	$(ARCH) $(ARCHFLAGS) $@ $(DEPRECATED)
+endif
+ifdef (USEXBLAS)
 	$(ARCH) $(ARCHFLAGS) $@ $(EXTENDED)
+endif
+ifdef LAPACKE_WITH_TMG
 	$(ARCH) $(ARCHFLAGS) $@ $(MATGEN)
+endif
 	$(RANLIB) $@
 
 clean: cleanobj

--- a/LAPACKE/src/Makefile
+++ b/LAPACKE/src/Makefile
@@ -254,6 +254,8 @@ lapacke_chesv.o \
 lapacke_chesv_work.o \
 lapacke_chesv_aa.o \
 lapacke_chesv_aa_work.o \
+lapacke_chesv_aa_2stage.o \
+lapacke_chesv_aa_2stage_work.o \
 lapacke_chesv_rk.o \
 lapacke_chesv_rk_work.o \
 lapacke_chesvx.o \
@@ -490,6 +492,8 @@ lapacke_csysv_rook_work.o \
 lapacke_csysv_work.o \
 lapacke_csysv_aa.o \
 lapacke_csysv_aa_work.o \
+lapacke_csysv_aa_2stage.o \
+lapacke_csysv_aa_2stage_work.o \
 lapacke_csysv_rk.o \
 lapacke_csysv_rk_work.o \
 lapacke_csysvx.o \
@@ -1088,6 +1092,8 @@ lapacke_dsysv_rook_work.o \
 lapacke_dsysv_work.o \
 lapacke_dsysv_aa.o \
 lapacke_dsysv_aa_work.o \
+lapacke_dsysv_aa_2stage.o \
+lapacke_dsysv_aa_2stage_work.o \
 lapacke_dsysv_rk.o \
 lapacke_dsysv_rk_work.o \
 lapacke_dsysvx.o \
@@ -1977,6 +1983,8 @@ lapacke_zhesv.o \
 lapacke_zhesv_work.o \
 lapacke_zhesv_aa.o \
 lapacke_zhesv_aa_work.o \
+lapacke_zhesv_aa_2stage.o \
+lapacke_zhesv_aa_2stage_work.o \
 lapacke_zhesv_rk.o \
 lapacke_zhesv_rk_work.o \
 lapacke_zhesvx.o \
@@ -2213,6 +2221,8 @@ lapacke_zsysv_rook_work.o \
 lapacke_zsysv_work.o \
 lapacke_zsysv_aa.o \
 lapacke_zsysv_aa_work.o \
+lapacke_zsysv_aa_2stage.o \
+lapacke_zsysv_aa_2stage_work.o \
 lapacke_zsysv_rk.o \
 lapacke_zsysv_rk_work.o \
 lapacke_zsysvx.o \

--- a/LAPACKE/src/Makefile
+++ b/LAPACKE/src/Makefile
@@ -1101,6 +1101,7 @@ lapacke_dsytrf_work.o \
 lapacke_dsytrf_rook.o \
 lapacke_dsytrf_rook_work.o \
 lapacke_dsytrf_aa.o \
+lapacke_dsytrf_aa_work.o \
 lapacke_dsytrf_aa_2stage.o \
 lapacke_dsytrf_aa_2stage_work.o \
 lapacke_dsytrf_rk.o \
@@ -1661,6 +1662,7 @@ lapacke_ssytrf_work.o \
 lapacke_ssytrf_rook.o \
 lapacke_ssytrf_rook_work.o \
 lapacke_ssytrf_aa.o \
+lapacke_ssytrf_aa_work.o \
 lapacke_ssytrf_aa_2stage.o \
 lapacke_ssytrf_aa_2stage_work.o \
 lapacke_ssytrf_rk.o \


### PR DESCRIPTION
Seems the new two-stage Aasen codes and some work functions were missed in the Makefile for 3.8.0
Also the changed archiver invocation from PR #114 broke compilation on macOS, its ar does not handle empty input gracefully.