### PR TITLE
round error

### DIFF
--- a/INSTALL/dlamch.f
+++ b/INSTALL/dlamch.f
@@ -112,7 +112,7 @@
 *           Use SMALL plus a bit, to avoid the possibility of rounding
 *           causing overflow when computing  1/sfmin.
 *
-            SFMIN = SMALL*( ONE+EPS )
+            SFMIN = SMALL*( ONE+EPSILON(ZERO) )
          END IF
          RMACH = SFMIN
       ELSE IF( LSAME( CMACH, 'B' ) ) THEN


### PR DESCRIPTION
ONE+EPS would round to ONE since EPS=EPSILON(ZERO)*0.5, maybe recall EPSILON(ZERO) isn't the optimal solution.