### PR TITLE
Correcting doxygen warning messages

### DIFF
--- a/BLAS/SRC/sdsdot.f
+++ b/BLAS/SRC/sdsdot.f
@@ -23,13 +23,13 @@
 *>
 *> \verbatim
 *>
-*    Compute the inner product of two vectors with extended
-*    precision accumulation.
-*
-*    Returns S.P. result with dot product accumulated in D.P.
-*    SDSDOT = SB + sum for I = 0 to N-1 of SX(LX+I*INCX)*SY(LY+I*INCY),
-*    where LX = 1 if INCX .GE. 0, else LX = 1+(1-N)*INCX, and LY is
-*    defined in a similar way using INCY.
+*>   Compute the inner product of two vectors with extended
+*>   precision accumulation.
+*>
+*>   Returns S.P. result with dot product accumulated in D.P.
+*>   SDSDOT = SB + sum for I = 0 to N-1 of SX(LX+I*INCX)*SY(LY+I*INCY),
+*>   where LX = 1 if INCX .GE. 0, else LX = 1+(1-N)*INCX, and LY is
+*>   defined in a similar way using INCY.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/ilaenv2stage.f
+++ b/SRC/ilaenv2stage.f
@@ -39,9 +39,9 @@
 *>
 *> ILAENV2STAGE returns an INTEGER
 *> if ILAENV2STAGE >= 0: ILAENV2STAGE returns the value of the parameter
-*                        specified by ISPEC
+*>                       specified by ISPEC
 *> if ILAENV2STAGE < 0:  if ILAENV2STAGE = -k, the k-th argument had an
-*                        illegal value.
+*>                       illegal value.
 *>
 *> This version provides a set of parameters which should give good,
 *> but not optimal, performance on many of the currently available

--- a/SRC/iparam2stage.F
+++ b/SRC/iparam2stage.F
@@ -53,7 +53,7 @@
 *>              return.
 *>
 *>              ISPEC=17: the optimal blocksize nb for the reduction to
-*                         BAND
+*>                        BAND
 *>
 *>              ISPEC=18: the optimal blocksize ib for the eigenvectors
 *>                        singular vectors update routine
@@ -90,14 +90,14 @@
 *> \param[in] NBI
 *> \verbatim
 *>          NBI is INTEGER which is the used in the reduciton, 
-*           (e.g., the size of the band), needed to compute workspace
-*           and LHOUS2.
+*>          (e.g., the size of the band), needed to compute workspace
+*>          and LHOUS2.
 *> \endverbatim
 *>
 *> \param[in] IBI
 *> \verbatim
 *>          IBI is INTEGER which represent the IB of the reduciton,
-*           needed to compute workspace and LHOUS2.
+*>          needed to compute workspace and LHOUS2.
 *> \endverbatim
 *>
 *> \param[in] NXI


### PR DESCRIPTION
Building the documentation given messages like:
BLAS/SRC/sdsdot.f:25: warning: reached end of comment while inside a @verbatim block; check for missing @@endverbatim tag!
- this fix sees to it that the messages disappear
- the doxygen proposed patch in pull request 660 (https://github.com/doxygen/doxygen/pull/660) solves the @@verbatim problem.