### PR TITLE
Correcting doxygen warning messages

### DIFF
--- a/SRC/checon_3.f
+++ b/SRC/checon_3.f
@@ -129,11 +129,6 @@
 *>          WORK is COMPLEX array, dimension (2*N)
 *> \endverbatim
 *>
-*> \param[out] IWORK
-*> \verbatim
-*>          IWORK is INTEGER array, dimension (N)
-*> \endverbatim
-*>
 *> \param[out] INFO
 *> \verbatim
 *>          INFO is INTEGER

--- a/SRC/chetrd_hb2st.F
+++ b/SRC/chetrd_hb2st.F
@@ -50,9 +50,9 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] STAGE
+*> \param[in] STAGE1
 *> \verbatim
-*>          STAGE is CHARACTER*1
+*>          STAGE1 is CHARACTER*1
 *>          = 'N':  "No": to mention that the stage 1 of the reduction  
 *>                  from dense to band using the chetrd_he2hb routine
 *>                  was not called before this routine to reproduce AB. 

--- a/SRC/chetrs_aa.f
+++ b/SRC/chetrs_aa.f
@@ -105,6 +105,7 @@
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER, LWORK >= MAX(1,3*N-2).
+*> \endverbatim
 *>
 *> \param[out] INFO
 *> \verbatim

--- a/SRC/csycon_3.f
+++ b/SRC/csycon_3.f
@@ -19,7 +19,7 @@
 *  ===========
 *
 *       SUBROUTINE CSYCON_3( UPLO, N, A, LDA, E, IPIV, ANORM, RCOND,
-*                            WORK, IWORK, INFO )
+*                            WORK, INFO )
 *
 *       .. Scalar Arguments ..
 *       CHARACTER          UPLO
@@ -27,7 +27,7 @@
 *       REAL               ANORM, RCOND
 *       ..
 *       .. Array Arguments ..
-*       INTEGER            IPIV( * ), IWORK( * )
+*       INTEGER            IPIV( * )
 *       COMPLEX            A( LDA, * ), E ( * ), WORK( * )
 *       ..
 *
@@ -127,11 +127,6 @@
 *> \param[out] WORK
 *> \verbatim
 *>          WORK is COMPLEX array, dimension (2*N)
-*> \endverbatim
-*>
-*> \param[out] IWORK
-*> \verbatim
-*>          IWORK is INTEGER array, dimension (N)
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/csytrs_aa.f
+++ b/SRC/csytrs_aa.f
@@ -105,6 +105,7 @@
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER, LWORK >= MAX(1,3*N-2).
+*> \endverbatim
 *>
 *> \param[out] INFO
 *> \verbatim

--- a/SRC/dsytrd_sb2st.F
+++ b/SRC/dsytrd_sb2st.F
@@ -50,9 +50,9 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] STAGE
+*> \param[in] STAGE1
 *> \verbatim
-*>          STAGE is CHARACTER*1
+*>          STAGE1 is CHARACTER*1
 *>          = 'N':  "No": to mention that the stage 1 of the reduction  
 *>                  from dense to band using the dsytrd_sy2sb routine
 *>                  was not called before this routine to reproduce AB. 

--- a/SRC/dsytrs_aa.f
+++ b/SRC/dsytrs_aa.f
@@ -105,6 +105,7 @@
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER, LWORK >= MAX(1,3*N-2).
+*> \endverbatim
 *>
 *> \param[out] INFO
 *> \verbatim

--- a/SRC/ssytrd_sb2st.F
+++ b/SRC/ssytrd_sb2st.F
@@ -50,9 +50,9 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] STAGE
+*> \param[in] STAGE1
 *> \verbatim
-*>          STAGE is CHARACTER*1
+*>          STAGE1 is CHARACTER*1
 *>          = 'N':  "No": to mention that the stage 1 of the reduction  
 *>                  from dense to band using the ssytrd_sy2sb routine
 *>                  was not called before this routine to reproduce AB. 

--- a/SRC/ssytrs_aa.f
+++ b/SRC/ssytrs_aa.f
@@ -105,6 +105,7 @@
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER, LWORK >= MAX(1,3*N-2).
+*> \endverbatim
 *>
 *> \param[out] INFO
 *> \verbatim

--- a/SRC/zhecon_3.f
+++ b/SRC/zhecon_3.f
@@ -19,7 +19,7 @@
 *  ===========
 *
 *       SUBROUTINE ZHECON_3( UPLO, N, A, LDA, E, IPIV, ANORM, RCOND,
-*                            WORK, IWORK, INFO )
+*                            WORK, INFO )
 *
 *       .. Scalar Arguments ..
 *       CHARACTER          UPLO
@@ -27,7 +27,7 @@
 *       DOUBLE PRECISION   ANORM, RCOND
 *       ..
 *       .. Array Arguments ..
-*       INTEGER            IPIV( * ), IWORK( * )
+*       INTEGER            IPIV( * )
 *       COMPLEX*16         A( LDA, * ), E ( * ), WORK( * )
 *       ..
 *
@@ -127,11 +127,6 @@
 *> \param[out] WORK
 *> \verbatim
 *>          WORK is COMPLEX*16 array, dimension (2*N)
-*> \endverbatim
-*>
-*> \param[out] IWORK
-*> \verbatim
-*>          IWORK is INTEGER array, dimension (N)
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/zhetrd_hb2st.F
+++ b/SRC/zhetrd_hb2st.F
@@ -50,9 +50,9 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] STAGE
+*> \param[in] STAGE1
 *> \verbatim
-*>          STAGE is CHARACTER*1
+*>          STAGE1 is CHARACTER*1
 *>          = 'N':  "No": to mention that the stage 1 of the reduction  
 *>                  from dense to band using the zhetrd_he2hb routine
 *>                  was not called before this routine to reproduce AB. 

--- a/SRC/zhetrs_aa.f
+++ b/SRC/zhetrs_aa.f
@@ -106,6 +106,7 @@
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER, LWORK >= MAX(1,3*N-2).
+*> \endverbatim
 *>
 *> \param[out] INFO
 *> \verbatim

--- a/SRC/zsycon_3.f
+++ b/SRC/zsycon_3.f
@@ -19,7 +19,7 @@
 *  ===========
 *
 *       SUBROUTINE ZSYCON_3( UPLO, N, A, LDA, E, IPIV, ANORM, RCOND,
-*                            WORK, IWORK, INFO )
+*                            WORK, INFO )
 *
 *       .. Scalar Arguments ..
 *       CHARACTER          UPLO
@@ -27,7 +27,7 @@
 *       DOUBLE PRECISION   ANORM, RCOND
 *       ..
 *       .. Array Arguments ..
-*       INTEGER            IPIV( * ), IWORK( * )
+*       INTEGER            IPIV( * )
 *       COMPLEX*16         A( LDA, * ), E ( * ), WORK( * )
 *       ..
 *
@@ -127,11 +127,6 @@
 *> \param[out] WORK
 *> \verbatim
 *>          WORK is COMPLEX*16 array, dimension (2*N)
-*> \endverbatim
-*>
-*> \param[out] IWORK
-*> \verbatim
-*>          IWORK is INTEGER array, dimension (N)
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/zsytrs_aa.f
+++ b/SRC/zsytrs_aa.f
@@ -105,6 +105,7 @@
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER, LWORK >= MAX(1,3*N-2).
+*> \endverbatim
 *>
 *> \param[out] INFO
 *> \verbatim

--- a/TESTING/EIG/cbdt05.f
+++ b/TESTING/EIG/cbdt05.f
@@ -52,6 +52,7 @@
 *> \verbatim
 *>          A is COMPLEX array, dimension (LDA,N)
 *>          The m by n matrix A.
+*> \endverbatim
 *>
 *> \param[in] LDA
 *> \verbatim

--- a/TESTING/EIG/dbdt05.f
+++ b/TESTING/EIG/dbdt05.f
@@ -52,6 +52,7 @@
 *> \verbatim
 *>          A is DOUBLE PRECISION array, dimension (LDA,N)
 *>          The m by n matrix A.
+*> \endverbatim
 *>
 *> \param[in] LDA
 *> \verbatim

--- a/TESTING/EIG/sbdt05.f
+++ b/TESTING/EIG/sbdt05.f
@@ -52,6 +52,7 @@
 *> \verbatim
 *>          A is REAL array, dimension (LDA,N)
 *>          The m by n matrix A.
+*> \endverbatim
 *>
 *> \param[in] LDA
 *> \verbatim

--- a/TESTING/EIG/zbdt05.f
+++ b/TESTING/EIG/zbdt05.f
@@ -52,6 +52,7 @@
 *> \verbatim
 *>          A is COMPLEX*16 array, dimension (LDA,N)
 *>          The m by n matrix A.
+*> \endverbatim
 *>
 *> \param[in] LDA
 *> \verbatim

--- a/TESTING/LIN/cdrvsy_rk.f
+++ b/TESTING/LIN/cdrvsy_rk.f
@@ -98,8 +98,9 @@
 *> \param[out] E
 *> \verbatim
 *>          E is COMPLEX array, dimension (NMAX)
-*> \param[out] AINV
+*> \endverbatim
 *>
+*> \param[out] AINV
 *> \verbatim
 *>          AINV is COMPLEX array, dimension (NMAX*NMAX)
 *> \endverbatim

--- a/TESTING/LIN/zdrvhe_rk.f
+++ b/TESTING/LIN/zdrvhe_rk.f
@@ -98,6 +98,7 @@
 *> \param[out] E
 *> \verbatim
 *>          E is COMPLEX*16 array, dimension (NMAX)
+*> \endverbatim
 *>
 *> \param[out] AINV
 *> \verbatim


### PR DESCRIPTION
Building the documentation given messages like:
-  warning: argument 'stage' of command @param is not found in the argument list of
-  warning: The following parameters of chetrd_hb2st(character STAGE1, character VECT, character UPLO, integer N, integer KD, complex, dimension(ldab, \*) AB, integer LDAB, real, dimension(\*) D, real, dimension(\*) E, complex, dimension(\*) HOUS, integer LHOUS, complex, dimension(\*) WORK, integer LWORK, integer INFO) are not documented:
    parameter 'stage1'

this fix sees to it that the messages disappear