### PR TITLE
Correcting doxygen warning message

### DIFF
--- a/BLAS/SRC/sdsdot.f
+++ b/BLAS/SRC/sdsdot.f
@@ -77,8 +77,6 @@
 *> \author Lawson, C. L., (JPL), Hanson, R. J., (SNLA),
 *> \author Kincaid, D. R., (U. of Texas), Krogh, F. T., (JPL)
 *
-*> \ingroup complex_blas_level1
-*
 *> \par Further Details:
 *  =====================
 *>


### PR DESCRIPTION
Correcting message: "BLAS/SRC/sdsdot.f:165: warning: Member sdsdot found in multiple @ingroup groups! The member will be put in group single_blas_level1, and not in group complex_blas_level1" by removing incorrect ingroup command.