### PR TITLE
sgeqrf: documentation of WORK without MAX(1,...)

### DIFF
--- a/SRC/sgeqrf.f
+++ b/SRC/sgeqrf.f
@@ -79,7 +79,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          WORK is REAL array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>


### PR DESCRIPTION
Documentation of WORK: removed MAX(1,...) because LWORK>=1 is required in the description of LWORK anyway.
MAX(1,...) is still correct but confusing.