### PR TITLE
cmake: Fix LAPACKE include directory associated with the build interface

### DIFF
--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -61,7 +61,7 @@ set_target_properties(
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
 target_include_directories(lapacke PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
 


### PR DESCRIPTION
This commit ensures that the <root>/LAPACKE/include directory is associated
with the LAPACKE target and it fixes configuration error when building project
against a build tree of the LAPACK project.

Co-authored-by: Pablo Hernandez <pablo.hernandez@kitware.com>