### PR TITLE
cmake: Help client project by setting LAPACK_Fortran_COMPILER_ID in config

### DIFF
--- a/CMAKE/lapack-config-build.cmake.in
+++ b/CMAKE/lapack-config-build.cmake.in
@@ -5,6 +5,9 @@ if(_LAPACK_TARGET AND NOT TARGET "${_LAPACK_TARGET}")
 endif()
 unset(_LAPACK_TARGET)
 
+# Hint for project building against lapack
+set(LAPACK_Fortran_COMPILER_ID "@CMAKE_Fortran_COMPILER_ID@")
+
 # Report the blas and lapack raw or imported libraries.
 set(LAPACK_blas_LIBRARIES "@BLAS_LIBRARIES@")
 set(LAPACK_lapack_LIBRARIES "@LAPACK_LIBRARIES@")

--- a/CMAKE/lapack-config-install.cmake.in
+++ b/CMAKE/lapack-config-install.cmake.in
@@ -8,6 +8,9 @@ if(_LAPACK_TARGET AND NOT TARGET "${_LAPACK_TARGET}")
 endif()
 unset(_LAPACK_TARGET)
 
+# Hint for project building against lapack
+set(LAPACK_Fortran_COMPILER_ID "@CMAKE_Fortran_COMPILER_ID@")
+
 # Report the blas and lapack raw or imported libraries.
 set(LAPACK_blas_LIBRARIES "@BLAS_LIBRARIES@")
 set(LAPACK_lapack_LIBRARIES "@LAPACK_LIBRARIES@")

--- a/LAPACKE/cmake/lapacke-config-build.cmake.in
+++ b/LAPACKE/cmake/lapacke-config-build.cmake.in
@@ -7,6 +7,9 @@ if(NOT TARGET lapacke)
   include("@LAPACK_BINARY_DIR@/lapack-targets.cmake")
 endif()
 
+# Hint for project building against lapack
+set(LAPACKE_Fortran_COMPILER_ID ${LAPACK_Fortran_COMPILER_ID})
+
 # Report lapacke header search locations from build tree.
 set(LAPACKE_INCLUDE_DIRS "@LAPACK_BINARY_DIR@/include")
 

--- a/LAPACKE/cmake/lapacke-config-install.cmake.in
+++ b/LAPACKE/cmake/lapacke-config-install.cmake.in
@@ -13,6 +13,9 @@ if(NOT TARGET lapacke)
   include(${_LAPACKE_SELF_DIR}/lapacke-targets.cmake)
 endif()
 
+# Hint for project building against lapack
+set(LAPACKE_Fortran_COMPILER_ID ${LAPACK_Fortran_COMPILER_ID})
+
 # Report lapacke header search locations.
 set(LAPACKE_INCLUDE_DIRS ${_LAPACKE_PREFIX}/include)
 


### PR DESCRIPTION
This change may help project building against LAPACK or LAPACKE to lookup
the associated Fortran compiler support libraries.