### PR TITLE
cmake: Fix windows build against lapacke due to undefined lapack_complex_double

### DIFF
--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -16,13 +16,6 @@ if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
                  ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h)
 endif()
 
-if(WIN32 AND NOT UNIX)
-  add_definitions(-DHAVE_LAPACK_CONFIG_H -DLAPACK_COMPLEX_STRUCTURE)
-  message(STATUS "Windows BUILD")
-endif()
-
-get_directory_property(DirDefs COMPILE_DEFINITIONS)
-
 include_directories(include ${LAPACK_BINARY_DIR}/include)
 add_subdirectory(include)
 add_subdirectory(src)
@@ -64,6 +57,10 @@ target_include_directories(lapacke PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+if(WIN32 AND NOT UNIX)
+  target_compile_definitions(lapacke PUBLIC HAVE_LAPACK_CONFIG_H LAPACK_COMPLEX_STRUCTURE)
+  message(STATUS "Windows BUILD")
+endif()
 
 if(LAPACKE_WITH_TMG)
   target_link_libraries(lapacke PRIVATE tmglib)


### PR DESCRIPTION


Since on windows, the lapacke target is unconditionally associated with
the definitions HAVE_LAPACK_CONFIG_H and LAPACK_COMPLEX_STRUCTURE, this
commit makes sure the projects building against lapacke also use the
same definitions.

This commit also removes the setting of "DirDefs" variable which became
obsolete in 13d22f2 (lean CMAKE build for includes)

Build errors fixed by this commit are similar to:

```
1> D:\T\lapack\LAPACKE\include\lapacke.h(89): error C2146: syntax error: missing ';' before identifier 'lapack_make_complex_float'
1> D:\T\lapack\LAPACKE\include\lapacke.h(89): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
1> D:\T\lapack\LAPACKE\include\lapacke.h(109): error C2371: '_Complex': redefinition; different basic types
1> D:\T\lapack\LAPACKE\include\lapacke.h(89): note: see declaration of '_Complex'

[...]
```