### PR TITLE
Fix -Wunused-variable in lapacke_*_aa_2stage_work.c

### DIFF
--- a/LAPACKE/src/lapacke_dsytrf_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_dsytrf_aa_2stage_work.c
@@ -50,7 +50,6 @@ lapack_int LAPACKE_dsytrf_aa_2stage_work( int matrix_layout, char uplo, lapack_i
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,n);
-        lapack_int ldb_t = MAX(1,n);
         double* a_t = NULL;
         double* tb_t = NULL;
         /* Check leading dimension(s) */

--- a/LAPACKE/src/lapacke_zhetrf_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_zhetrf_aa_2stage_work.c
@@ -50,7 +50,6 @@ lapack_int LAPACKE_zhetrf_aa_2stage_work( int matrix_layout, char uplo, lapack_i
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,n);
-        lapack_int ldb_t = MAX(1,n);
         lapack_complex_double* a_t = NULL;
         lapack_complex_double* tb_t = NULL;
         /* Check leading dimension(s) */

--- a/LAPACKE/src/lapacke_zsytrf_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_zsytrf_aa_2stage_work.c
@@ -50,7 +50,6 @@ lapack_int LAPACKE_zsytrf_aa_2stage_work( int matrix_layout, char uplo, lapack_i
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,n);
-        lapack_int ldb_t = MAX(1,n);
         lapack_complex_double* a_t = NULL;
         lapack_complex_double* tb_t = NULL;
         /* Check leading dimension(s) */


### PR DESCRIPTION
This commit fixes warning like the following:

```
[703/2112] Building C object LAPACKE\C...s\lapacke.dir\src\lapacke_dsytri.c.obj
D:\T\lapack\LAPACKE\src\lapacke_dsytrf_aa_2stage_work.c(53,20):  warning: unused
 variable 'ldb_t' [-Wunused-variable]
        lapack_int ldb_t = MAX(1,n);
                   ^
1 warning generated.
[1589/2112] Building C object LAPACKE\...dir\src\lapacke_zhetrf_rook_work.c.obj
D:\T\lapack\LAPACKE\src\lapacke_zhetrf_aa_2stage_work.c(53,20):  warning: unused
 variable 'ldb_t' [-Wunused-variable]
        lapack_int ldb_t = MAX(1,n);
                   ^
1 warning generated.
[1827/2112] Building C object LAPACKE\...e.dir\src\lapacke_zsytrf_rk_work.c.obj
D:\T\lapack\LAPACKE\src\lapacke_zsytrf_aa_2stage_work.c(53,20):  warning: unused
 variable 'ldb_t' [-Wunused-variable]
        lapack_int ldb_t = MAX(1,n);
                   ^
1 warning generated.
```