### PR TITLE
Lapacke fixes

### DIFF
--- a/LAPACKE/include/lapacke.h
+++ b/LAPACKE/include/lapacke.h
@@ -10582,11 +10582,11 @@ lapack_int LAPACKE_csytri2x_work( int matrix_layout, char uplo, lapack_int n,
                                   const lapack_int* ipiv,
                                   lapack_complex_float* work, lapack_int nb );
 lapack_int LAPACKE_csytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const lapack_complex_float* a,
+                            lapack_int nrhs, lapack_complex_float* a,
                             lapack_int lda, const lapack_int* ipiv,
                             lapack_complex_float* b, lapack_int ldb );
 lapack_int LAPACKE_csytrs2_work( int matrix_layout, char uplo, lapack_int n,
-                                 lapack_int nrhs, const lapack_complex_float* a,
+                                 lapack_int nrhs, lapack_complex_float* a,
                                  lapack_int lda, const lapack_int* ipiv,
                                  lapack_complex_float* b, lapack_int ldb,
                                  lapack_complex_float* work );
@@ -10747,10 +10747,10 @@ lapack_int LAPACKE_dsytri2x_work( int matrix_layout, char uplo, lapack_int n,
                                   const lapack_int* ipiv, double* work,
                                   lapack_int nb );
 lapack_int LAPACKE_dsytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const double* a, lapack_int lda,
+                            lapack_int nrhs, double* a, lapack_int lda,
                             const lapack_int* ipiv, double* b, lapack_int ldb );
 lapack_int LAPACKE_dsytrs2_work( int matrix_layout, char uplo, lapack_int n,
-                                 lapack_int nrhs, const double* a,
+                                 lapack_int nrhs, double* a,
                                  lapack_int lda, const lapack_int* ipiv,
                                  double* b, lapack_int ldb, double* work );
 lapack_int LAPACKE_sbbcsd( int matrix_layout, char jobu1, char jobu2,
@@ -10842,10 +10842,10 @@ lapack_int LAPACKE_ssytri2x_work( int matrix_layout, char uplo, lapack_int n,
                                   const lapack_int* ipiv, float* work,
                                   lapack_int nb );
 lapack_int LAPACKE_ssytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const float* a, lapack_int lda,
+                            lapack_int nrhs, float* a, lapack_int lda,
                             const lapack_int* ipiv, float* b, lapack_int ldb );
 lapack_int LAPACKE_ssytrs2_work( int matrix_layout, char uplo, lapack_int n,
-                                 lapack_int nrhs, const float* a,
+                                 lapack_int nrhs, float* a,
                                  lapack_int lda, const lapack_int* ipiv,
                                  float* b, lapack_int ldb, float* work );
 lapack_int LAPACKE_zbbcsd( int matrix_layout, char jobu1, char jobu2,
@@ -10927,11 +10927,11 @@ lapack_int LAPACKE_zsytri2x_work( int matrix_layout, char uplo, lapack_int n,
                                   const lapack_int* ipiv,
                                   lapack_complex_double* work, lapack_int nb );
 lapack_int LAPACKE_zsytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const lapack_complex_double* a,
+                            lapack_int nrhs, lapack_complex_double* a,
                             lapack_int lda, const lapack_int* ipiv,
                             lapack_complex_double* b, lapack_int ldb );
 lapack_int LAPACKE_zsytrs2_work( int matrix_layout, char uplo, lapack_int n,
-                                 lapack_int nrhs, const lapack_complex_double* a,
+                                 lapack_int nrhs, lapack_complex_double* a,
                                  lapack_int lda, const lapack_int* ipiv,
                                  lapack_complex_double* b, lapack_int ldb,
                                  lapack_complex_double* work );

--- a/LAPACKE/include/lapacke.h
+++ b/LAPACKE/include/lapacke.h
@@ -1935,11 +1935,11 @@ lapack_int LAPACKE_zheevx( int matrix_layout, char jobz, char range, char uplo,
 
 lapack_int LAPACKE_chegst( int matrix_layout, lapack_int itype, char uplo,
                            lapack_int n, lapack_complex_float* a,
-                           lapack_int lda, const lapack_complex_float* b,
+                           lapack_int lda, lapack_complex_float* b,
                            lapack_int ldb );
 lapack_int LAPACKE_zhegst( int matrix_layout, lapack_int itype, char uplo,
                            lapack_int n, lapack_complex_double* a,
-                           lapack_int lda, const lapack_complex_double* b,
+                           lapack_int lda, lapack_complex_double* b,
                            lapack_int ldb );
 
 lapack_int LAPACKE_chegv( int matrix_layout, lapack_int itype, char jobz,
@@ -6961,11 +6961,11 @@ lapack_int LAPACKE_zheevx_work( int matrix_layout, char jobz, char range,
 
 lapack_int LAPACKE_chegst_work( int matrix_layout, lapack_int itype, char uplo,
                                 lapack_int n, lapack_complex_float* a,
-                                lapack_int lda, const lapack_complex_float* b,
+                                lapack_int lda, lapack_complex_float* b,
                                 lapack_int ldb );
 lapack_int LAPACKE_zhegst_work( int matrix_layout, lapack_int itype, char uplo,
                                 lapack_int n, lapack_complex_double* a,
-                                lapack_int lda, const lapack_complex_double* b,
+                                lapack_int lda, lapack_complex_double* b,
                                 lapack_int ldb );
 
 lapack_int LAPACKE_chegv_work( int matrix_layout, lapack_int itype, char jobz,

--- a/LAPACKE/src/lapacke_cgejsv.c
+++ b/LAPACKE/src/lapacke_cgejsv.c
@@ -124,7 +124,6 @@ lapack_int LAPACKE_cgejsv( int matrix_layout, char joba, char jobu, char jobv,
     float* rwork = NULL;
     lapack_complex_float* cwork = NULL;
     lapack_int i;
-    lapack_int nu, nv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_cgejsv", -1 );
         return -1;
@@ -132,8 +131,6 @@ lapack_int LAPACKE_cgejsv( int matrix_layout, char joba, char jobu, char jobv,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        nu = LAPACKE_lsame( jobu, 'n' ) ? 1 : m;
-        nv = LAPACKE_lsame( jobv, 'n' ) ? 1 : n;
         if( LAPACKE_cge_nancheck( matrix_layout, m, n, a, lda ) ) {
             return -10;
         }

--- a/LAPACKE/src/lapacke_chegst.c
+++ b/LAPACKE/src/lapacke_chegst.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_chegst( int matrix_layout, lapack_int itype, char uplo,
                            lapack_int n, lapack_complex_float* a,
-                           lapack_int lda, const lapack_complex_float* b,
+                           lapack_int lda, lapack_complex_float* b,
                            lapack_int ldb )
 {
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {

--- a/LAPACKE/src/lapacke_chegst_work.c
+++ b/LAPACKE/src/lapacke_chegst_work.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_chegst_work( int matrix_layout, lapack_int itype, char uplo,
                                 lapack_int n, lapack_complex_float* a,
-                                lapack_int lda, const lapack_complex_float* b,
+                                lapack_int lda, lapack_complex_float* b,
                                 lapack_int ldb )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_csytrs2.c
+++ b/LAPACKE/src/lapacke_csytrs2.c
@@ -34,7 +34,7 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_csytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const lapack_complex_float* a,
+                            lapack_int nrhs, lapack_complex_float* a,
                             lapack_int lda, const lapack_int* ipiv,
                             lapack_complex_float* b, lapack_int ldb )
 {

--- a/LAPACKE/src/lapacke_csytrs2_work.c
+++ b/LAPACKE/src/lapacke_csytrs2_work.c
@@ -34,7 +34,7 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_csytrs2_work( int matrix_layout, char uplo, lapack_int n,
-                                 lapack_int nrhs, const lapack_complex_float* a,
+                                 lapack_int nrhs, lapack_complex_float* a,
                                  lapack_int lda, const lapack_int* ipiv,
                                  lapack_complex_float* b, lapack_int ldb,
                                  lapack_complex_float* work )

--- a/LAPACKE/src/lapacke_dgejsv.c
+++ b/LAPACKE/src/lapacke_dgejsv.c
@@ -74,7 +74,6 @@ lapack_int LAPACKE_dgejsv( int matrix_layout, char joba, char jobu, char jobv,
     lapack_int* iwork = NULL;
     double* work = NULL;
     lapack_int i;
-    lapack_int nu, nv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_dgejsv", -1 );
         return -1;
@@ -82,8 +81,6 @@ lapack_int LAPACKE_dgejsv( int matrix_layout, char joba, char jobu, char jobv,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        nu = LAPACKE_lsame( jobu, 'n' ) ? 1 : m;
-        nv = LAPACKE_lsame( jobv, 'n' ) ? 1 : n;
         if( LAPACKE_dge_nancheck( matrix_layout, m, n, a, lda ) ) {
             return -10;
         }

--- a/LAPACKE/src/lapacke_dsytrs2.c
+++ b/LAPACKE/src/lapacke_dsytrs2.c
@@ -34,7 +34,7 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_dsytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const double* a, lapack_int lda,
+                            lapack_int nrhs, double* a, lapack_int lda,
                             const lapack_int* ipiv, double* b, lapack_int ldb )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_dsytrs2_work.c
+++ b/LAPACKE/src/lapacke_dsytrs2_work.c
@@ -34,7 +34,7 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_dsytrs2_work( int matrix_layout, char uplo, lapack_int n,
-                                 lapack_int nrhs, const double* a,
+                                 lapack_int nrhs, double* a,
                                  lapack_int lda, const lapack_int* ipiv,
                                  double* b, lapack_int ldb, double* work )
 {

--- a/LAPACKE/src/lapacke_sgejsv.c
+++ b/LAPACKE/src/lapacke_sgejsv.c
@@ -74,7 +74,6 @@ lapack_int LAPACKE_sgejsv( int matrix_layout, char joba, char jobu, char jobv,
     lapack_int* iwork = NULL;
     float* work = NULL;
     lapack_int i;
-    lapack_int nu, nv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_sgejsv", -1 );
         return -1;
@@ -82,8 +81,6 @@ lapack_int LAPACKE_sgejsv( int matrix_layout, char joba, char jobu, char jobv,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        nu = LAPACKE_lsame( jobu, 'n' ) ? 1 : m;
-        nv = LAPACKE_lsame( jobv, 'n' ) ? 1 : n;
         if( LAPACKE_sge_nancheck( matrix_layout, m, n, a, lda ) ) {
             return -10;
         }

--- a/LAPACKE/src/lapacke_ssytrs2.c
+++ b/LAPACKE/src/lapacke_ssytrs2.c
@@ -34,7 +34,7 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_ssytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const float* a, lapack_int lda,
+                            lapack_int nrhs, float* a, lapack_int lda,
                             const lapack_int* ipiv, float* b, lapack_int ldb )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_ssytrs2_work.c
+++ b/LAPACKE/src/lapacke_ssytrs2_work.c
@@ -34,7 +34,7 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_ssytrs2_work( int matrix_layout, char uplo, lapack_int n,
-                                 lapack_int nrhs, const float* a,
+                                 lapack_int nrhs, float* a,
                                  lapack_int lda, const lapack_int* ipiv,
                                  float* b, lapack_int ldb, float* work )
 {

--- a/LAPACKE/src/lapacke_zgejsv.c
+++ b/LAPACKE/src/lapacke_zgejsv.c
@@ -124,7 +124,6 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
     double* rwork = NULL;
     lapack_complex_double* cwork = NULL;
     lapack_int i;
-    lapack_int nu, nv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_zgejsv", -1 );
         return -1;
@@ -132,8 +131,6 @@ lapack_int LAPACKE_zgejsv( int matrix_layout, char joba, char jobu, char jobv,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        nu = LAPACKE_lsame( jobu, 'n' ) ? 1 : m;
-        nv = LAPACKE_lsame( jobv, 'n' ) ? 1 : n;
         if( LAPACKE_zge_nancheck( matrix_layout, m, n, a, lda ) ) {
             return -10;
         }

--- a/LAPACKE/src/lapacke_zhegst.c
+++ b/LAPACKE/src/lapacke_zhegst.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_zhegst( int matrix_layout, lapack_int itype, char uplo,
                            lapack_int n, lapack_complex_double* a,
-                           lapack_int lda, const lapack_complex_double* b,
+                           lapack_int lda, lapack_complex_double* b,
                            lapack_int ldb )
 {
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {

--- a/LAPACKE/src/lapacke_zhegst_work.c
+++ b/LAPACKE/src/lapacke_zhegst_work.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_zhegst_work( int matrix_layout, lapack_int itype, char uplo,
                                 lapack_int n, lapack_complex_double* a,
-                                lapack_int lda, const lapack_complex_double* b,
+                                lapack_int lda, lapack_complex_double* b,
                                 lapack_int ldb )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_zsytrs2.c
+++ b/LAPACKE/src/lapacke_zsytrs2.c
@@ -34,7 +34,7 @@
 #include "lapacke_utils.h"
 
 lapack_int LAPACKE_zsytrs2( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, const lapack_complex_double* a,
+                            lapack_int nrhs, lapack_complex_double* a,
                             lapack_int lda, const lapack_int* ipiv,
                             lapack_complex_double* b, lapack_int ldb )
 {

--- a/LAPACKE/src/lapacke_zsytrs2_work.c
+++ b/LAPACKE/src/lapacke_zsytrs2_work.c
@@ -35,7 +35,7 @@
 
 lapack_int LAPACKE_zsytrs2_work( int matrix_layout, char uplo, lapack_int n,
                                  lapack_int nrhs,
-                                 const lapack_complex_double* a, lapack_int lda,
+                                 lapack_complex_double* a, lapack_int lda,
                                  const lapack_int* ipiv,
                                  lapack_complex_double* b, lapack_int ldb,
                                  lapack_complex_double* work )

--- a/SRC/dsytrf_aa_2stage.f
+++ b/SRC/dsytrf_aa_2stage.f
@@ -103,6 +103,22 @@
 *>          no error message related to LTB is issued by XERBLA.
 *> \endverbatim
 *>
+*> \param[out] IPIV
+*> \verbatim
+*>          IPIV is INTEGER array, dimension (N)
+*>          On exit, it contains the details of the interchanges, i.e.,
+*>          the row and column k of A were interchanged with the
+*>          row and column IPIV(k).
+*> \endverbatim
+*>
+*> \param[out] IPIV2
+*> \verbatim
+*>          IPIV2 is INTEGER array, dimension (N)
+*>          On exit, it contains the details of the interchanges, i.e.,
+*>          the row and column k of T were interchanged with the
+*>          row and column IPIV2(k).
+*> \endverbatim
+*>
 *> \param[out] WORK
 *> \verbatim
 *>          WORK is DOUBLE PRECISION workspace of size LWORK
@@ -118,22 +134,6 @@
 *>          routine only calculates the optimal size of the WORK array,
 *>          returns this value as the first entry of the WORK array, and
 *>          no error message related to LWORK is issued by XERBLA.
-*> \endverbatim
-*>
-*> \param[out] IPIV
-*> \verbatim
-*>          IPIV is INTEGER array, dimension (N)
-*>          On exit, it contains the details of the interchanges, i.e.,
-*>          the row and column k of A were interchanged with the
-*>          row and column IPIV(k).
-*> \endverbatim
-*>
-*> \param[out] IPIV2
-*> \verbatim
-*>          IPIV2 is INTEGER array, dimension (N)
-*>          On exit, it contains the details of the interchanges, i.e.,
-*>          the row and column k of T were interchanged with the
-*>          row and column IPIV2(k).
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/zhetrf_aa_2stage.f
+++ b/SRC/zhetrf_aa_2stage.f
@@ -66,7 +66,7 @@
 *>
 *> \param[in,out] A
 *> \verbatim
-*>          A is COMPLEX array, dimension (LDA,N)
+*>          A is COMPLEX*16 array, dimension (LDA,N)
 *>          On entry, the hermitian matrix A.  If UPLO = 'U', the leading
 *>          N-by-N upper triangular part of A contains the upper
 *>          triangular part of the matrix A, and the strictly lower
@@ -87,7 +87,7 @@
 *>
 *> \param[out] TB
 *> \verbatim
-*>          TB is COMPLEX array, dimension (LTB)
+*>          TB is COMPLEX*16 array, dimension (LTB)
 *>          On exit, details of the LU factorization of the band matrix.
 *> \endverbatim
 *>
@@ -121,7 +121,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX workspace of size LWORK
+*>          WORK is COMPLEX*16 workspace of size LWORK
 *> \endverbatim
 *>
 *> \param[in] LWORK


### PR DESCRIPTION
Fixes a few minor issues (const, unused params) in LAPACKE and minor documentation issues. These were causing errors when using LAPACK++ lapack.h header, which has correct const.