### PR TITLE
style: Fix typo in docstrings

### DIFF
--- a/SRC/VARIANTS/README
+++ b/SRC/VARIANTS/README
@@ -34,7 +34,7 @@ References:For a more detailed description please refer to
 =========
 
 These variants are compiled by default in the build process but they are not tested by default.
-The build process creates one new library per variants in the four arithmetics (single real/double real/single complex/double complex).
+The build process creates one new library per variants in the four arithmetic (single real/double real/single complex/double complex).
 The libraries are in the SRC/VARIANTS directory.
 
 Corresponding libraries created in SRC/VARIANTS:

--- a/SRC/cgejsv.f
+++ b/SRC/cgejsv.f
@@ -1763,7 +1763,7 @@
             ELSE
 *
 *              .. ill-conditioned case: second QRF with pivoting
-*              Note that windowed pivoting would be equaly good
+*              Note that windowed pivoting would be equally good
 *              numerically, and more run-time efficient. So, in
 *              an optimal implementation, the next call to CGEQP3
 *              should be replaced with eg. CALL CGEQPX (ACM TOMS #782)
@@ -1821,7 +1821,7 @@
 *
                IF ( CONDR2 .GE. COND_OK ) THEN
 *                 .. save the Householder vectors used for Q3
-*                 (this overwrittes the copy of R2, as it will not be
+*                 (this overwrites the copy of R2, as it will not be
 *                 needed in this branch, but it does not overwritte the
 *                 Huseholder vectors of Q2.).
                   CALL CLACPY( 'U', NR, NR, V, LDV, CWORK(2*N+1), N )

--- a/SRC/cgesc2.f
+++ b/SRC/cgesc2.f
@@ -91,7 +91,7 @@
 *> \verbatim
 *>          SCALE is REAL
 *>           On exit, SCALE contains the scale factor. SCALE is chosen
-*>           0 <= SCALE <= 1 to prevent owerflow in the solution.
+*>           0 <= SCALE <= 1 to prevent overflow in the solution.
 *> \endverbatim
 *
 *  Authors:

--- a/SRC/cgesvdq.f
+++ b/SRC/cgesvdq.f
@@ -717,7 +717,7 @@
 *
 *        Standard absolute error bound suffices. All sigma_i with
 *        sigma_i < N*EPS*||A||_F are flushed to zero. This is an
-*        agressive enforcement of lower numerical rank by introducing a
+*        aggressive enforcement of lower numerical rank by introducing a
 *        backward error of the order of N*EPS*||A||_F.
          NR = 1  
          RTMP = SQRT(REAL(N))*EPSLN
@@ -728,7 +728,7 @@
  3002    CONTINUE          
 *
       ELSEIF ( ACCLM ) THEN 
-*        .. similarly as above, only slightly more gentle (less agressive).
+*        .. similarly as above, only slightly more gentle (less aggressive).
 *        Sudden drop on the diagonal of R is used as the criterion for being
 *        close-to-rank-deficient. The threshold is set to EPSLN=SLAMCH('E').
 *        [[This can be made more flexible by replacing this hard-coded value
@@ -1039,7 +1039,7 @@
 *            vectors of R**H  
 *               [[The optimal ratio N/NR for using QRF instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'CGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                 OPTRATIO = 2 
@@ -1156,7 +1156,7 @@
 *               is then N1 (N or M)
 *               [[The optimal ratio N/NR for using LQ instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'CGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                OPTRATIO = 2 

--- a/SRC/cgsvj1.f
+++ b/SRC/cgsvj1.f
@@ -61,7 +61,7 @@
 *> In terms of the columns of A, the first N1 columns are rotated 'against'
 *> the remaining N-N1 columns, trying to increase the angle between the
 *> corresponding subspaces. The off-diagonal block is N1-by(N-N1) and it is
-*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parmeter.
+*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parameter.
 *> The number of sweeps is given in NSWEEP and the orthogonality threshold
 *> is given in TOL.
 *> \endverbatim

--- a/SRC/chetrd_he2hb.f
+++ b/SRC/chetrd_he2hb.f
@@ -363,7 +363,7 @@
 *
 *
 *     Set the workspace of the triangular matrix T to zero once such a
-*     way everytime T is generated the upper/lower portion will be always zero  
+*     way every time T is generated the upper/lower portion will be always zero
 *   
       CALL CLASET( "A", LDT, KD, ZERO, ZERO, WORK( TPOS ), LDT )
 *

--- a/SRC/chetrf_aa.f
+++ b/SRC/chetrf_aa.f
@@ -256,7 +256,7 @@
      $                      A( MAX(1, J), J+1 ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J
@@ -376,7 +376,7 @@
      $                      A( J+1, MAX(1, J) ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J

--- a/SRC/chseqr.f
+++ b/SRC/chseqr.f
@@ -139,7 +139,7 @@
 *> \verbatim
 *>          LDZ is INTEGER
 *>           The leading dimension of the array Z.  if COMPZ = 'I' or
-*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwize, LDZ >= 1.
+*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwise, LDZ >= 1.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/cla_wwaddw.f
+++ b/SRC/cla_wwaddw.f
@@ -36,7 +36,7 @@
 *>    CLA_WWADDW adds a vector W into a doubled-single vector (X, Y).
 *>
 *>    This works for all extant IBM's hex and binary floating point
-*>    arithmetics, but not for decimal.
+*>    arithmetic, but not for decimal.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/clahqr.f
+++ b/SRC/clahqr.f
@@ -148,7 +148,7 @@
 *>                  If INFO > 0 and WANTT is .FALSE., then on exit,
 *>                  the remaining unconverged eigenvalues are the
 *>                  eigenvalues of the upper Hessenberg matrix
-*>                  rows and columns ILO thorugh INFO of the final,
+*>                  rows and columns ILO through INFO of the final,
 *>                  output value of H.
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit

--- a/SRC/csyconvf.f
+++ b/SRC/csyconvf.f
@@ -294,7 +294,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -347,7 +347,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -438,7 +438,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where k increases from 1 to N
 *
             I = 1
@@ -491,7 +491,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/csyconvf_rook.f
+++ b/SRC/csyconvf_rook.f
@@ -285,7 +285,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -336,7 +336,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -426,7 +426,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where i increases from 1 to N
 *
             I = 1
@@ -477,7 +477,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/csytrf_aa.f
+++ b/SRC/csytrf_aa.f
@@ -256,7 +256,7 @@
      $                   A( MAX(1, J), J+1 ), LDA,
      $                   IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J
@@ -375,7 +375,7 @@
      $                   A( J+1, MAX(1, J) ), LDA,
      $                   IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J

--- a/SRC/dgejsv.f
+++ b/SRC/dgejsv.f
@@ -1335,7 +1335,7 @@
             ELSE
 *
 *              .. ill-conditioned case: second QRF with pivoting
-*              Note that windowed pivoting would be equaly good
+*              Note that windowed pivoting would be equally good
 *              numerically, and more run-time efficient. So, in
 *              an optimal implementation, the next call to DGEQP3
 *              should be replaced with eg. CALL SGEQPX (ACM TOMS #782)
@@ -1388,7 +1388,7 @@
 *
                IF ( CONDR2 .GE. COND_OK ) THEN
 *                 .. save the Householder vectors used for Q3
-*                 (this overwrittes the copy of R2, as it will not be
+*                 (this overwrites the copy of R2, as it will not be
 *                 needed in this branch, but it does not overwritte the
 *                 Huseholder vectors of Q2.).
                   CALL DLACPY( 'U', NR, NR, V, LDV, WORK(2*N+1), N )

--- a/SRC/dgesc2.f
+++ b/SRC/dgesc2.f
@@ -90,7 +90,7 @@
 *> \verbatim
 *>          SCALE is DOUBLE PRECISION
 *>          On exit, SCALE contains the scale factor. SCALE is chosen
-*>          0 <= SCALE <= 1 to prevent owerflow in the solution.
+*>          0 <= SCALE <= 1 to prevent overflow in the solution.
 *> \endverbatim
 *
 *  Authors:
@@ -151,7 +151,7 @@
 *     ..
 *     .. Executable Statements ..
 *
-*      Set constant to control owerflow
+*      Set constant to control overflow
 *
       EPS = DLAMCH( 'P' )
       SMLNUM = DLAMCH( 'S' ) / EPS

--- a/SRC/dgesvdq.f
+++ b/SRC/dgesvdq.f
@@ -717,7 +717,7 @@
 *
 *        Standard absolute error bound suffices. All sigma_i with
 *        sigma_i < N*EPS*||A||_F are flushed to zero. This is an
-*        agressive enforcement of lower numerical rank by introducing a
+*        aggressive enforcement of lower numerical rank by introducing a
 *        backward error of the order of N*EPS*||A||_F.
          NR = 1  
          RTMP = SQRT(DBLE(N))*EPSLN
@@ -728,7 +728,7 @@
  3002    CONTINUE          
 *
       ELSEIF ( ACCLM ) THEN 
-*        .. similarly as above, only slightly more gentle (less agressive).
+*        .. similarly as above, only slightly more gentle (less aggressive).
 *        Sudden drop on the diagonal of R is used as the criterion for being
 *        close-to-rank-deficient. The threshold is set to EPSLN=DLAMCH('E').
 *        [[This can be made more flexible by replacing this hard-coded value
@@ -1032,7 +1032,7 @@
 *            vectors of R**T 
 *               [[The optimal ratio N/NR for using QRF instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'DGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                 OPTRATIO = 2 
@@ -1147,7 +1147,7 @@
 *               is then N1 (N or M)
 *               [[The optimal ratio N/NR for using LQ instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'DGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                OPTRATIO = 2 

--- a/SRC/dgetc2.f
+++ b/SRC/dgetc2.f
@@ -85,7 +85,7 @@
 *> \verbatim
 *>          INFO is INTEGER
 *>           = 0: successful exit
-*>           > 0: if INFO = k, U(k, k) is likely to produce owerflow if
+*>           > 0: if INFO = k, U(k, k) is likely to produce overflow if
 *>                we try to solve for x in Ax = b. So U is perturbed to
 *>                avoid the overflow.
 *> \endverbatim

--- a/SRC/dgsvj0.f
+++ b/SRC/dgsvj0.f
@@ -1045,7 +1045,7 @@
 
  1993 CONTINUE
 *     end i=1:NSWEEP loop
-* #:) Reaching this point means that the procedure has comleted the given
+* #:) Reaching this point means that the procedure has completed the given
 *     number of iterations.
       INFO = NSWEEP - 1
       GO TO 1995

--- a/SRC/dgsvj1.f
+++ b/SRC/dgsvj1.f
@@ -61,7 +61,7 @@
 *> In terms of the columns of A, the first N1 columns are rotated 'against'
 *> the remaining N-N1 columns, trying to increase the angle between the
 *> corresponding subspaces. The off-diagonal block is N1-by(N-N1) and it is
-*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parmeter.
+*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parameter.
 *> The number of sweeps is given in NSWEEP and the orthogonality threshold
 *> is given in TOL.
 *> \endverbatim

--- a/SRC/dhseqr.f
+++ b/SRC/dhseqr.f
@@ -156,7 +156,7 @@
 *> \verbatim
 *>          LDZ is INTEGER
 *>           The leading dimension of the array Z.  if COMPZ = 'I' or
-*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwize, LDZ >= 1.
+*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwise, LDZ >= 1.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/dla_wwaddw.f
+++ b/SRC/dla_wwaddw.f
@@ -36,7 +36,7 @@
 *>    DLA_WWADDW adds a vector W into a doubled-single vector (X, Y).
 *>
 *>    This works for all extant IBM's hex and binary floating point
-*>    arithmetics, but not for decimal.
+*>    arithmetic, but not for decimal.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/dlahqr.f
+++ b/SRC/dlahqr.f
@@ -160,7 +160,7 @@
 *>                  If INFO > 0 and WANTT is .FALSE., then on exit,
 *>                  the remaining unconverged eigenvalues are the
 *>                  eigenvalues of the upper Hessenberg matrix rows
-*>                  and columns ILO thorugh INFO of the final, output
+*>                  and columns ILO through INFO of the final, output
 *>                  value of H.
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit

--- a/SRC/dlatdf.f
+++ b/SRC/dlatdf.f
@@ -85,7 +85,7 @@
 *>          RHS is DOUBLE PRECISION array, dimension (N)
 *>          On entry, RHS contains contributions from other subsystems.
 *>          On exit, RHS contains the solution of the subsystem with
-*>          entries acoording to the value of IJOB (see above).
+*>          entries according to the value of IJOB (see above).
 *> \endverbatim
 *>
 *> \param[in,out] RDSUM

--- a/SRC/dsyconvf.f
+++ b/SRC/dsyconvf.f
@@ -291,7 +291,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -344,7 +344,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -435,7 +435,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where k increases from 1 to N
 *
             I = 1
@@ -488,7 +488,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/dsyconvf_rook.f
+++ b/SRC/dsyconvf_rook.f
@@ -282,7 +282,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -333,7 +333,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -423,7 +423,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where i increases from 1 to N
 *
             I = 1
@@ -474,7 +474,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/dsytrd_sy2sb.f
+++ b/SRC/dsytrd_sy2sb.f
@@ -363,7 +363,7 @@
 *
 *
 *     Set the workspace of the triangular matrix T to zero once such a
-*     way everytime T is generated the upper/lower portion will be always zero  
+*     way every time T is generated the upper/lower portion will be always zero
 *   
       CALL DLASET( "A", LDT, KD, ZERO, ZERO, WORK( TPOS ), LDT )
 *

--- a/SRC/dsytrf_aa.f
+++ b/SRC/dsytrf_aa.f
@@ -256,7 +256,7 @@
      $                      A( MAX(1, J), J+1 ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J
@@ -375,7 +375,7 @@
      $                      A( J+1, MAX(1, J) ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J

--- a/SRC/sgejsv.f
+++ b/SRC/sgejsv.f
@@ -1335,7 +1335,7 @@
             ELSE
 *
 *              .. ill-conditioned case: second QRF with pivoting
-*              Note that windowed pivoting would be equaly good
+*              Note that windowed pivoting would be equally good
 *              numerically, and more run-time efficient. So, in
 *              an optimal implementation, the next call to SGEQP3
 *              should be replaced with eg. CALL SGEQPX (ACM TOMS #782)
@@ -1388,7 +1388,7 @@
 *
                IF ( CONDR2 .GE. COND_OK ) THEN
 *                 .. save the Householder vectors used for Q3
-*                 (this overwrittes the copy of R2, as it will not be
+*                 (this overwrites the copy of R2, as it will not be
 *                 needed in this branch, but it does not overwritte the
 *                 Huseholder vectors of Q2.).
                   CALL SLACPY( 'U', NR, NR, V, LDV, WORK(2*N+1), N )

--- a/SRC/sgesc2.f
+++ b/SRC/sgesc2.f
@@ -90,7 +90,7 @@
 *> \verbatim
 *>          SCALE is REAL
 *>           On exit, SCALE contains the scale factor. SCALE is chosen
-*>           0 <= SCALE <= 1 to prevent owerflow in the solution.
+*>           0 <= SCALE <= 1 to prevent overflow in the solution.
 *> \endverbatim
 *
 *  Authors:
@@ -151,7 +151,7 @@
 *     ..
 *     .. Executable Statements ..
 *
-*      Set constant to control owerflow
+*      Set constant to control overflow
 *
       EPS = SLAMCH( 'P' )
       SMLNUM = SLAMCH( 'S' ) / EPS

--- a/SRC/sgesvdq.f
+++ b/SRC/sgesvdq.f
@@ -717,7 +717,7 @@
 *
 *        Standard absolute error bound suffices. All sigma_i with
 *        sigma_i < N*EPS*||A||_F are flushed to zero. This is an
-*        agressive enforcement of lower numerical rank by introducing a
+*        aggressive enforcement of lower numerical rank by introducing a
 *        backward error of the order of N*EPS*||A||_F.
          NR = 1  
          RTMP = SQRT(REAL(N))*EPSLN
@@ -728,7 +728,7 @@
  3002    CONTINUE          
 *
       ELSEIF ( ACCLM ) THEN 
-*        .. similarly as above, only slightly more gentle (less agressive).
+*        .. similarly as above, only slightly more gentle (less aggressive).
 *        Sudden drop on the diagonal of R is used as the criterion for being
 *        close-to-rank-deficient. The threshold is set to EPSLN=SLAMCH('E').
 *        [[This can be made more flexible by replacing this hard-coded value
@@ -1032,7 +1032,7 @@
 *            vectors of R**T  
 *               [[The optimal ratio N/NR for using QRF instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'SGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                 OPTRATIO = 2 
@@ -1147,7 +1147,7 @@
 *               is then N1 (N or M)
 *               [[The optimal ratio N/NR for using LQ instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'SGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                OPTRATIO = 2 

--- a/SRC/sgetc2.f
+++ b/SRC/sgetc2.f
@@ -85,7 +85,7 @@
 *> \verbatim
 *>          INFO is INTEGER
 *>           = 0: successful exit
-*>           > 0: if INFO = k, U(k, k) is likely to produce owerflow if
+*>           > 0: if INFO = k, U(k, k) is likely to produce overflow if
 *>                we try to solve for x in Ax = b. So U is perturbed to
 *>                avoid the overflow.
 *> \endverbatim

--- a/SRC/sgsvj0.f
+++ b/SRC/sgsvj0.f
@@ -1045,7 +1045,7 @@
 
  1993 CONTINUE
 *     end i=1:NSWEEP loop
-* #:) Reaching this point means that the procedure has comleted the given
+* #:) Reaching this point means that the procedure has completed the given
 *     number of iterations.
       INFO = NSWEEP - 1
       GO TO 1995

--- a/SRC/sgsvj1.f
+++ b/SRC/sgsvj1.f
@@ -61,7 +61,7 @@
 *> In terms of the columns of A, the first N1 columns are rotated 'against'
 *> the remaining N-N1 columns, trying to increase the angle between the
 *> corresponding subspaces. The off-diagonal block is N1-by(N-N1) and it is
-*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parmeter.
+*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parameter.
 *> The number of sweeps is given in NSWEEP and the orthogonality threshold
 *> is given in TOL.
 *> \endverbatim

--- a/SRC/shseqr.f
+++ b/SRC/shseqr.f
@@ -156,7 +156,7 @@
 *> \verbatim
 *>          LDZ is INTEGER
 *>           The leading dimension of the array Z.  if COMPZ = 'I' or
-*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwize, LDZ >= 1.
+*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwise, LDZ >= 1.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/sla_wwaddw.f
+++ b/SRC/sla_wwaddw.f
@@ -36,7 +36,7 @@
 *>    SLA_WWADDW adds a vector W into a doubled-single vector (X, Y).
 *>
 *>    This works for all extant IBM's hex and binary floating point
-*>    arithmetics, but not for decimal.
+*>    arithmetic, but not for decimal.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/slahqr.f
+++ b/SRC/slahqr.f
@@ -160,7 +160,7 @@
 *>                  If INFO > 0 and WANTT is .FALSE., then on exit,
 *>                  the remaining unconverged eigenvalues are the
 *>                  eigenvalues of the upper Hessenberg matrix rows
-*>                  and columns ILO thorugh INFO of the final, output
+*>                  and columns ILO through INFO of the final, output
 *>                  value of H.
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit

--- a/SRC/slatdf.f
+++ b/SRC/slatdf.f
@@ -85,7 +85,7 @@
 *>          RHS is REAL array, dimension N.
 *>          On entry, RHS contains contributions from other subsystems.
 *>          On exit, RHS contains the solution of the subsystem with
-*>          entries acoording to the value of IJOB (see above).
+*>          entries according to the value of IJOB (see above).
 *> \endverbatim
 *>
 *> \param[in,out] RDSUM

--- a/SRC/ssyconvf.f
+++ b/SRC/ssyconvf.f
@@ -291,7 +291,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -344,7 +344,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -435,7 +435,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where k increases from 1 to N
 *
             I = 1
@@ -488,7 +488,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/ssyconvf_rook.f
+++ b/SRC/ssyconvf_rook.f
@@ -282,7 +282,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -333,7 +333,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -423,7 +423,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where i increases from 1 to N
 *
             I = 1
@@ -474,7 +474,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/ssytrd_sy2sb.f
+++ b/SRC/ssytrd_sy2sb.f
@@ -363,7 +363,7 @@
 *
 *
 *     Set the workspace of the triangular matrix T to zero once such a
-*     way everytime T is generated the upper/lower portion will be always zero  
+*     way every time T is generated the upper/lower portion will be always zero
 *   
       CALL SLASET( "A", LDT, KD, ZERO, ZERO, WORK( TPOS ), LDT )
 *

--- a/SRC/ssytrf_aa.f
+++ b/SRC/ssytrf_aa.f
@@ -256,7 +256,7 @@
      $                      A( MAX(1, J), J+1 ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J
@@ -375,7 +375,7 @@
      $                      A( J+1, MAX(1, J) ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J

--- a/SRC/zgejsv.f
+++ b/SRC/zgejsv.f
@@ -1765,7 +1765,7 @@
             ELSE
 *
 *              .. ill-conditioned case: second QRF with pivoting
-*              Note that windowed pivoting would be equaly good
+*              Note that windowed pivoting would be equally good
 *              numerically, and more run-time efficient. So, in
 *              an optimal implementation, the next call to ZGEQP3
 *              should be replaced with eg. CALL ZGEQPX (ACM TOMS #782)
@@ -1823,7 +1823,7 @@
 *
                IF ( CONDR2 .GE. COND_OK ) THEN
 *                 .. save the Householder vectors used for Q3
-*                 (this overwrittes the copy of R2, as it will not be
+*                 (this overwrites the copy of R2, as it will not be
 *                 needed in this branch, but it does not overwritte the
 *                 Huseholder vectors of Q2.).
                   CALL ZLACPY( 'U', NR, NR, V, LDV, CWORK(2*N+1), N )

--- a/SRC/zgesc2.f
+++ b/SRC/zgesc2.f
@@ -91,7 +91,7 @@
 *> \verbatim
 *>          SCALE is DOUBLE PRECISION
 *>           On exit, SCALE contains the scale factor. SCALE is chosen
-*>           0 <= SCALE <= 1 to prevent owerflow in the solution.
+*>           0 <= SCALE <= 1 to prevent overflow in the solution.
 *> \endverbatim
 *
 *  Authors:

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -717,7 +717,7 @@
 *
 *        Standard absolute error bound suffices. All sigma_i with
 *        sigma_i < N*EPS*||A||_F are flushed to zero. This is an
-*        agressive enforcement of lower numerical rank by introducing a
+*        aggressive enforcement of lower numerical rank by introducing a
 *        backward error of the order of N*EPS*||A||_F.
          NR = 1  
          RTMP = SQRT(DBLE(N))*EPSLN
@@ -728,7 +728,7 @@
  3002    CONTINUE          
 *
       ELSEIF ( ACCLM ) THEN 
-*        .. similarly as above, only slightly more gentle (less agressive).
+*        .. similarly as above, only slightly more gentle (less aggressive).
 *        Sudden drop on the diagonal of R is used as the criterion for being
 *        close-to-rank-deficient. The threshold is set to EPSLN=DLAMCH('E').
 *        [[This can be made more flexible by replacing this hard-coded value
@@ -1039,7 +1039,7 @@
 *            vectors of R**H  
 *               [[The optimal ratio N/NR for using QRF instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'ZGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                 OPTRATIO = 2 
@@ -1156,7 +1156,7 @@
 *               is then N1 (N or M)
 *               [[The optimal ratio N/NR for using LQ instead of padding 
 *                 with zeros. Here hard coded to 2; it must be at least 
-*                 two due to work space contraints.]]
+*                 two due to work space constraints.]]
 *               OPTRATIO = ILAENV(6, 'ZGESVD', 'S' // 'O', NR,N,0,0)
 *               OPTRATIO = MAX( OPTRATIO, 2 ) 
                OPTRATIO = 2 

--- a/SRC/zgsvj1.f
+++ b/SRC/zgsvj1.f
@@ -61,7 +61,7 @@
 *> In terms of the columns of A, the first N1 columns are rotated 'against'
 *> the remaining N-N1 columns, trying to increase the angle between the
 *> corresponding subspaces. The off-diagonal block is N1-by(N-N1) and it is
-*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parmeter.
+*> tiled using quadratic tiles of side KBL. Here, KBL is a tunning parameter.
 *> The number of sweeps is given in NSWEEP and the orthogonality threshold
 *> is given in TOL.
 *> \endverbatim

--- a/SRC/zhetrd_he2hb.f
+++ b/SRC/zhetrd_he2hb.f
@@ -363,7 +363,7 @@
 *
 *
 *     Set the workspace of the triangular matrix T to zero once such a
-*     way everytime T is generated the upper/lower portion will be always zero  
+*     way every time T is generated the upper/lower portion will be always zero
 *   
       CALL ZLASET( "A", LDT, KD, ZERO, ZERO, WORK( TPOS ), LDT )
 *

--- a/SRC/zhetrf_aa.f
+++ b/SRC/zhetrf_aa.f
@@ -256,7 +256,7 @@
      $                      A( MAX(1, J), J+1 ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J
@@ -376,7 +376,7 @@
      $                      A( J+1, MAX(1, J) ), LDA,
      $                      IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J

--- a/SRC/zhseqr.f
+++ b/SRC/zhseqr.f
@@ -139,7 +139,7 @@
 *> \verbatim
 *>          LDZ is INTEGER
 *>           The leading dimension of the array Z.  if COMPZ = 'I' or
-*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwize, LDZ >= 1.
+*>           COMPZ = 'V', then LDZ >= MAX(1,N).  Otherwise, LDZ >= 1.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/zla_wwaddw.f
+++ b/SRC/zla_wwaddw.f
@@ -36,7 +36,7 @@
 *>    ZLA_WWADDW adds a vector W into a doubled-single vector (X, Y).
 *>
 *>    This works for all extant IBM's hex and binary floating point
-*>    arithmetics, but not for decimal.
+*>    arithmetic, but not for decimal.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/zlahqr.f
+++ b/SRC/zlahqr.f
@@ -148,7 +148,7 @@
 *>                  If INFO > 0 and WANTT is .FALSE., then on exit,
 *>                  the remaining unconverged eigenvalues are the
 *>                  eigenvalues of the upper Hessenberg matrix
-*>                  rows and columns ILO thorugh INFO of the final,
+*>                  rows and columns ILO through INFO of the final,
 *>                  output value of H.
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit

--- a/SRC/zsyconvf.f
+++ b/SRC/zsyconvf.f
@@ -294,7 +294,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -347,7 +347,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -438,7 +438,7 @@
 *
 *           Convert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where k increases from 1 to N
 *
             I = 1
@@ -491,7 +491,7 @@
 *
 *           Revert PERMUTATIONS and IPIV
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/zsyconvf_rook.f
+++ b/SRC/zsyconvf_rook.f
@@ -285,7 +285,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in factorization order where i decreases from N to 1
 *
             I = N
@@ -336,7 +336,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of upper part of A
+*           Apply permutations to submatrices of upper part of A
 *           in reverse factorization order where i increases from 1 to N
 *
             I = 1
@@ -426,7 +426,7 @@
 *
 *           Convert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in factorization order where i increases from 1 to N
 *
             I = 1
@@ -477,7 +477,7 @@
 *
 *           Revert PERMUTATIONS
 *
-*           Apply permutaions to submatrices of lower part of A
+*           Apply permutations to submatrices of lower part of A
 *           in reverse factorization order where i decreases from N to 1
 *
             I = N

--- a/SRC/zsytrf_aa.f
+++ b/SRC/zsytrf_aa.f
@@ -256,7 +256,7 @@
      $                   A( MAX(1, J), J+1 ), LDA,
      $                   IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J
@@ -375,7 +375,7 @@
      $                   A( J+1, MAX(1, J) ), LDA,
      $                   IPIV( J+1 ), WORK, N, WORK( N*NB+1 ) )
 *
-*        Ajust IPIV and apply it back (J-th step picks (J+1)-th pivot)
+*        Adjust IPIV and apply it back (J-th step picks (J+1)-th pivot)
 *
          DO J2 = J+2, MIN(N, J+JB+1)
             IPIV( J2 ) = IPIV( J2 ) + J

--- a/TESTING/EIG/cchkst.f
+++ b/TESTING/EIG/cchkst.f
@@ -167,7 +167,7 @@
 *>                                              CSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because CSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z* | / ( |S| n ulp )    CSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/cchkst2stg.f
+++ b/TESTING/EIG/cchkst2stg.f
@@ -188,7 +188,7 @@
 *>                                              CSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because CSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z* | / ( |S| n ulp )    CSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/dchkst.f
+++ b/TESTING/EIG/dchkst.f
@@ -166,7 +166,7 @@
 *>                                              DSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because DSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z' | / ( |S| n ulp )    DSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/dchkst2stg.f
+++ b/TESTING/EIG/dchkst2stg.f
@@ -187,7 +187,7 @@
 *>                                              DSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because DSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z' | / ( |S| n ulp )    DSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/schkst.f
+++ b/TESTING/EIG/schkst.f
@@ -166,7 +166,7 @@
 *>                                              SSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because SSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z' | / ( |S| n ulp )    SSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/schkst2stg.f
+++ b/TESTING/EIG/schkst2stg.f
@@ -187,7 +187,7 @@
 *>                                              SSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because SSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z' | / ( |S| n ulp )    SSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/zchkst.f
+++ b/TESTING/EIG/zchkst.f
@@ -167,7 +167,7 @@
 *>                                              ZSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because ZSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z* | / ( |S| n ulp )    ZSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/zchkst2stg.f
+++ b/TESTING/EIG/zchkst2stg.f
@@ -188,7 +188,7 @@
 *>                                              ZSTEMR('V', 'I')
 *>
 *> Tests 29 through 34 are disable at present because ZSTEMR
-*> does not handle partial specturm requests.
+*> does not handle partial spectrum requests.
 *>
 *> (29)    | S - Z D Z* | / ( |S| n ulp )    ZSTEMR('V', 'I')
 *>

--- a/TESTING/EIG/zdrgev3.f
+++ b/TESTING/EIG/zdrgev3.f
@@ -389,7 +389,7 @@
 *> \author Univ. of Colorado Denver
 *> \author NAG Ltd.
 *
-*> \date Febuary 2015
+*> \date February 2015
 *
 *> \ingroup complex16_eig
 *

--- a/TESTING/MATGEN/clatm2.f
+++ b/TESTING/MATGEN/clatm2.f
@@ -186,7 +186,7 @@
 *>          SPARSE is REAL
 *>           Value between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry

--- a/TESTING/MATGEN/clatm3.f
+++ b/TESTING/MATGEN/clatm3.f
@@ -202,7 +202,7 @@
 *> \verbatim
 *>          SPARSE is REAL between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry

--- a/TESTING/MATGEN/dlatm2.f
+++ b/TESTING/MATGEN/dlatm2.f
@@ -182,7 +182,7 @@
 *> \verbatim
 *>          SPARSE is DOUBLE PRECISION between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry

--- a/TESTING/MATGEN/dlatm3.f
+++ b/TESTING/MATGEN/dlatm3.f
@@ -199,7 +199,7 @@
 *> \verbatim
 *>          SPARSE is DOUBLE PRECISION between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry

--- a/TESTING/MATGEN/slatm2.f
+++ b/TESTING/MATGEN/slatm2.f
@@ -182,7 +182,7 @@
 *> \verbatim
 *>          SPARSE is REAL between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry

--- a/TESTING/MATGEN/slatm3.f
+++ b/TESTING/MATGEN/slatm3.f
@@ -199,7 +199,7 @@
 *> \verbatim
 *>          SPARSE is REAL between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry

--- a/TESTING/MATGEN/zlatm2.f
+++ b/TESTING/MATGEN/zlatm2.f
@@ -185,7 +185,7 @@
 *> \verbatim
 *>          SPARSE is DOUBLE PRECISION between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry

--- a/TESTING/MATGEN/zlatm3.f
+++ b/TESTING/MATGEN/zlatm3.f
@@ -202,7 +202,7 @@
 *> \verbatim
 *>          SPARSE is DOUBLE PRECISION between 0. and 1.
 *>           On entry specifies the sparsity of the matrix
-*>           if sparse matix is to be generated.
+*>           if sparse matrix is to be generated.
 *>           SPARSE should lie between 0 and 1.
 *>           A uniform ( 0, 1 ) random number x is generated and
 *>           compared to SPARSE; if x is larger the matrix entry


### PR DESCRIPTION
Issues were identified using the open-source tool codespell [1]
running the following command from the source directory:

[1] https://github.com/codespell-project/codespell#readme

```
$ codespell -q6 \
  --skip=".git,Doxyfile,Doxyfile_man,CMakeLists.txt,Makefile" \
  --regex="\w[a-z\-\_]+" \
  --ignore-words-list="fro,ith,nd,noe,numer" \
  --summary

[...]

-------8<-------
SUMMARY:
acoording     2
agressive     8
ajust        12
arithmetics   5
comleted      2
contraints    8
equaly        4
everytime     4
febuary       1
matix         8
otherwize     4
overwrittes   4
owerflow      8
parmeter      4
permutaions  32
specturm      8
```