### PR TITLE
Misc. Typos

### DIFF
--- a/SRC/cgesvdq.f
+++ b/SRC/cgesvdq.f
@@ -354,7 +354,7 @@
 *>   1. The data movement (matrix transpose) is coded using simple nested
 *>   DO-loops because BLAS and LAPACK do not provide corresponding subroutines.
 *>   Those DO-loops are easily identified in this source code - by the CONTINUE
-*>   statements labeled wit 11**. In an optimized version of this code, the
+*>   statements labeled with 11**. In an optimized version of this code, the
 *>   nested DO loops should be replaced with calls to an optimized subroutine.
 *>   2. This code scales A by 1/SQRT(M) if the largest ABS(A(i,j)) could cause
 *>   column norm overflow. This is the minial precaution and it is left to the
@@ -390,7 +390,7 @@
 *
 *> \par Contributors:
 *  ==================
-*> 
+*>
 *> \verbatim
 *> Developed and coded by Zlatko Drmac, Department of Mathematics
 *>  University of Zagreb, Croatia, drmac@math.hr
@@ -953,7 +953,7 @@
      $          CALL CLASET( 'L', NR-1,NR-1, CZERO,CZERO, A(2,1), LDA )
             CALL CGESVD( 'N', 'N', NR, N, A, LDA, S, U, LDU,
      $           V, LDV, CWORK, LCWORK, RWORK, INFO )
-*	
+*
          END IF
 *
       ELSE IF ( LSVEC .AND. ( .NOT. RSVEC) ) THEN

--- a/SRC/clahqr.f
+++ b/SRC/clahqr.f
@@ -153,7 +153,7 @@
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit
 *>          (*)       (initial value of H)*U  = U*(final value of H)
-*>                  where U is an orthognal matrix.    The final
+*>                  where U is an orthogonal matrix.    The final
 *>                  value of H is upper Hessenberg and triangular in
 *>                  rows and columns INFO+1 through IHI.
 *>

--- a/SRC/ctgsy2.f
+++ b/SRC/ctgsy2.f
@@ -67,7 +67,7 @@
 *>             R  * B**H + L  * E**H  = scale * -F
 *>
 *> This case is used to compute an estimate of Dif[(A, D), (B, E)] =
-*> = sigma_min(Z) using reverse communicaton with CLACON.
+*> = sigma_min(Z) using reverse communication with CLACON.
 *>
 *> CTGSY2 also (IJOB >= 1) contributes to the computation in CTGSYL
 *> of an upper bound on the separation between to matrix pairs. Then

--- a/SRC/dgesvdq.f
+++ b/SRC/dgesvdq.f
@@ -356,7 +356,7 @@
 *>   1. The data movement (matrix transpose) is coded using simple nested
 *>   DO-loops because BLAS and LAPACK do not provide corresponding subroutines.
 *>   Those DO-loops are easily identified in this source code - by the CONTINUE
-*>   statements labeled wit 11**. In an optimized version of this code, the
+*>   statements labeled with 11**. In an optimized version of this code, the
 *>   nested DO loops should be replaced with calls to an optimized subroutine.
 *>   2. This code scales A by 1/SQRT(M) if the largest ABS(A(i,j)) could cause
 *>   column norm overflow. This is the minial precaution and it is left to the
@@ -392,7 +392,7 @@
 *
 *> \par Contributors:
 *  ==================
-*> 
+*>
 *> \verbatim
 *> Developed and coded by Zlatko Drmac, Department of Mathematics
 *>  University of Zagreb, Croatia, drmac@math.hr
@@ -955,7 +955,7 @@
      $          CALL DLASET( 'L', NR-1,NR-1, ZERO,ZERO, A(2,1), LDA )
             CALL DGESVD( 'N', 'N', NR, N, A, LDA, S, U, LDU,
      $           V, LDV, WORK, LWORK, INFO )
-*	
+*
          END IF
 *
       ELSE IF ( LSVEC .AND. ( .NOT. RSVEC) ) THEN

--- a/SRC/dlahqr.f
+++ b/SRC/dlahqr.f
@@ -165,7 +165,7 @@
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit
 *>          (*)       (initial value of H)*U  = U*(final value of H)
-*>                  where U is an orthognal matrix.    The final
+*>                  where U is an orthogonal matrix.    The final
 *>                  value of H is upper Hessenberg and triangular in
 *>                  rows and columns INFO+1 through IHI.
 *>

--- a/SRC/dtgsy2.f
+++ b/SRC/dtgsy2.f
@@ -71,7 +71,7 @@
 *>             R  * B**T + L  * E**T  = scale * -F
 *>
 *> This case is used to compute an estimate of Dif[(A, D), (B, E)] =
-*> sigma_min(Z) using reverse communicaton with DLACON.
+*> sigma_min(Z) using reverse communication with DLACON.
 *>
 *> DTGSY2 also (IJOB >= 1) contributes to the computation in DTGSYL
 *> of an upper bound on the separation between to matrix pairs. Then

--- a/SRC/sgesvdq.f
+++ b/SRC/sgesvdq.f
@@ -356,7 +356,7 @@
 *>   1. The data movement (matrix transpose) is coded using simple nested
 *>   DO-loops because BLAS and LAPACK do not provide corresponding subroutines.
 *>   Those DO-loops are easily identified in this source code - by the CONTINUE
-*>   statements labeled wit 11**. In an optimized version of this code, the
+*>   statements labeled with 11**. In an optimized version of this code, the
 *>   nested DO loops should be replaced with calls to an optimized subroutine.
 *>   2. This code scales A by 1/SQRT(M) if the largest ABS(A(i,j)) could cause
 *>   column norm overflow. This is the minial precaution and it is left to the
@@ -392,7 +392,7 @@
 *
 *> \par Contributors:
 *  ==================
-*> 
+*>
 *> \verbatim
 *> Developed and coded by Zlatko Drmac, Department of Mathematics
 *>  University of Zagreb, Croatia, drmac@math.hr
@@ -958,7 +958,7 @@
      $          CALL SLASET( 'L', NR-1,NR-1, ZERO,ZERO, A(2,1), LDA )
             CALL SGESVD( 'N', 'N', NR, N, A, LDA, S, U, LDU,
      $           V, LDV, WORK, LWORK, INFO )
-*	
+*
          END IF
 *
       ELSE IF ( LSVEC .AND. ( .NOT. RSVEC) ) THEN

--- a/SRC/slahqr.f
+++ b/SRC/slahqr.f
@@ -165,7 +165,7 @@
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit
 *>          (*)       (initial value of H)*U  = U*(final value of H)
-*>                  where U is an orthognal matrix.    The final
+*>                  where U is an orthogonal matrix.    The final
 *>                  value of H is upper Hessenberg and triangular in
 *>                  rows and columns INFO+1 through IHI.
 *>

--- a/SRC/stgsy2.f
+++ b/SRC/stgsy2.f
@@ -71,7 +71,7 @@
 *>             R  * B**T + L  * E**T  = scale * -F
 *>
 *> This case is used to compute an estimate of Dif[(A, D), (B, E)] =
-*> sigma_min(Z) using reverse communicaton with SLACON.
+*> sigma_min(Z) using reverse communication with SLACON.
 *>
 *> STGSY2 also (IJOB >= 1) contributes to the computation in STGSYL
 *> of an upper bound on the separation between to matrix pairs. Then

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -354,7 +354,7 @@
 *>   1. The data movement (matrix transpose) is coded using simple nested
 *>   DO-loops because BLAS and LAPACK do not provide corresponding subroutines.
 *>   Those DO-loops are easily identified in this source code - by the CONTINUE
-*>   statements labeled wit 11**. In an optimized version of this code, the
+*>   statements labeled with 11**. In an optimized version of this code, the
 *>   nested DO loops should be replaced with calls to an optimized subroutine.
 *>   2. This code scales A by 1/SQRT(M) if the largest ABS(A(i,j)) could cause
 *>   column norm overflow. This is the minial precaution and it is left to the
@@ -390,7 +390,7 @@
 *
 *> \par Contributors:
 *  ==================
-*> 
+*>
 *> \verbatim
 *> Developed and coded by Zlatko Drmac, Department of Mathematics
 *>  University of Zagreb, Croatia, drmac@math.hr
@@ -951,7 +951,7 @@
      $          CALL ZLASET( 'L', NR-1,NR-1, CZERO,CZERO, A(2,1), LDA )
             CALL ZGESVD( 'N', 'N', NR, N, A, LDA, S, U, LDU,
      $           V, LDV, CWORK, LCWORK, RWORK, INFO )
-*	
+*
          END IF
 *
       ELSE IF ( LSVEC .AND. ( .NOT. RSVEC) ) THEN

--- a/SRC/zlahqr.f
+++ b/SRC/zlahqr.f
@@ -153,7 +153,7 @@
 *>
 *>                  If INFO > 0 and WANTT is .TRUE., then on exit
 *>          (*)       (initial value of H)*U  = U*(final value of H)
-*>                  where U is an orthognal matrix.    The final
+*>                  where U is an orthogonal matrix.    The final
 *>                  value of H is upper Hessenberg and triangular in
 *>                  rows and columns INFO+1 through IHI.
 *>

--- a/SRC/ztgsy2.f
+++ b/SRC/ztgsy2.f
@@ -67,7 +67,7 @@
 *>             R  * B**H + L  * E**H  = scale * -F
 *>
 *> This case is used to compute an estimate of Dif[(A, D), (B, E)] =
-*> = sigma_min(Z) using reverse communicaton with ZLACON.
+*> = sigma_min(Z) using reverse communication with ZLACON.
 *>
 *> ZTGSY2 also (IJOB >= 1) contributes to the computation in ZTGSYL
 *> of an upper bound on the separation between to matrix pairs. Then

--- a/lapack_build.cmake
+++ b/lapack_build.cmake
@@ -169,7 +169,7 @@ endif()
 # dashboard then set this variable to the directory
 # the dashboard should be in
 make_directory("${CTEST_DASHBOARD_ROOT}")
-# these are the the name of the source and binary directory on disk.
+# these are the names of the source and binary directory on disk.
 # They will be appended to DASHBOARD_ROOT
 set(CTEST_SOURCE_DIRECTORY  "${CTEST_DASHBOARD_ROOT}/${CTEST_DIR_NAME}")
 set(CTEST_BINARY_DIRECTORY  "${CTEST_SOURCE_DIRECTORY}-${CTEST_BUILD_NAME}")


### PR DESCRIPTION
Found via `codespell -q 3 -L als,copys,ded,dum,fastr,ist,ith,nd,noe,numer,wit`