### PR TITLE
README: Add Repology badge showing package in downstream repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/Reference-LAPACK/lapack.svg?branch=master)](https://travis-ci.org/Reference-LAPACK/lapack)
 [![Appveyor](https://ci.appveyor.com/api/projects/status/bh38iin398msrbtr?svg=true)](https://ci.appveyor.com/project/langou/lapack/)
 [![codecov](https://codecov.io/gh/Reference-LAPACK/lapack/branch/master/graph/badge.svg)](https://codecov.io/gh/Reference-LAPACK/lapack)
+[![Packaging status](https://repology.org/badge/tiny-repos/lapack.svg)](https://repology.org/metapackage/lapack/versions)
 
 
 * VERSION 1.0   :  February 29, 1992
@@ -69,7 +70,7 @@ CBLAS, a C interface to the BLAS, and (5) LAPACKE, a C interface to LAPACK.
    the `INSTALL` directory.
  - LAPACK includes also the CMake build. You will need to have CMake installed
    on your machine (CMake is available at http://www.cmake.org/). CMake will
-   allow an easy installation on a Windows Machine. 
+   allow an easy installation on a Windows Machine.
    An example CMake build is:
    ```sh
    mkdir build
@@ -107,7 +108,7 @@ You can also contact directly the LAPACK team at lapack@icl.utk.edu.
 ## Testing
 
 LAPACK includes a thorough test suite. We recommend that, after compilation,
-you run the test suite. 
+you run the test suite.
 
 For complete information on the LAPACK Testing please consult LAPACK Working
 Note 41 "Installation Guide for LAPACK".
@@ -123,4 +124,3 @@ LAPACK now includes the LAPACKE package.  LAPACKE is a Standard C language API
 for LAPACK This was born from a collaboration of the LAPACK and INTEL Math
 Kernel Library teams. See:
 http://www.netlib.org/lapack/#_standard_c_language_apis_for_lapack.
-


### PR DESCRIPTION
> Repology monitors a huge number of package repositories and other sources comparing packages versions across them and gathering other information. Repology shows you in which repositories a given project is packaged, which version is the latest and which needs updating, who maintains the package, and other related information.


To preview the PR change check out https://github.com/luzpaz/lapack/blob/README-repology/README.md