### PR TITLE
Changing the transposition in some symmetric eigensolvers

### DIFF
--- a/LAPACKE/src/lapacke_cheev_work.c
+++ b/LAPACKE/src/lapacke_cheev_work.c
@@ -78,7 +78,11 @@ lapack_int LAPACKE_cheev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_cge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_cheevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_cheevd_2stage_work.c
@@ -79,7 +79,11 @@ lapack_int LAPACKE_cheevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_cge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda ); 
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_cheevd_work.c
+++ b/LAPACKE/src/lapacke_cheevd_work.c
@@ -79,8 +79,11 @@ lapack_int LAPACKE_cheevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
-
+        if ( jobz == 'V') {
+            LAPACKE_cge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else { 
+            LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dsyev_work.c
+++ b/LAPACKE/src/lapacke_dsyev_work.c
@@ -72,7 +72,11 @@ lapack_int LAPACKE_dsyev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_dge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dsyevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_dsyevd_2stage_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_dsyevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_dge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dsyevd_work.c
+++ b/LAPACKE/src/lapacke_dsyevd_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_dsyevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_dge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_ssyev_work.c
+++ b/LAPACKE/src/lapacke_ssyev_work.c
@@ -72,7 +72,11 @@ lapack_int LAPACKE_ssyev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_sge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_ssyevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_ssyevd_2stage_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_ssyevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_sge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda ); 
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_ssyevd_work.c
+++ b/LAPACKE/src/lapacke_ssyevd_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_ssyevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_sge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zheev_work.c
+++ b/LAPACKE/src/lapacke_zheev_work.c
@@ -78,7 +78,11 @@ lapack_int LAPACKE_zheev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_zge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zheevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_zheevd_2stage_work.c
@@ -79,7 +79,11 @@ lapack_int LAPACKE_zheevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_zge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zheevd_work.c
+++ b/LAPACKE/src/lapacke_zheevd_work.c
@@ -79,7 +79,11 @@ lapack_int LAPACKE_zheevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_zge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else { 
+            LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:


### PR DESCRIPTION
My last commit contained some errors. LAPACKE interfaces typically handle row-major 
layout by transposing the matrix into a temporary array, and then transposing the
result back into the originally matrix after the computations have completed. So,
in the case where eigenvectors are requested, the entire matrix will be overwritten
with the eigenvectors, meaning that we need to copy the entire result back after
computations have completed. We changed the interface to copy the entire result
back after the computation is done when eigenvectors are requested.