### PR TITLE
Install lapack.h in addition to other C headers

### DIFF
--- a/LAPACKE/include/CMakeLists.txt
+++ b/LAPACKE/include/CMakeLists.txt
@@ -1,3 +1,3 @@
-set(LAPACKE_INCLUDE lapacke.h lapacke_config.h lapacke_utils.h)
+set(LAPACKE_INCLUDE lapacke.h lapack.h lapacke_config.h lapacke_utils.h)
 
 file(COPY ${LAPACKE_INCLUDE} DESTINATION ${LAPACK_BINARY_DIR}/include)


### PR DESCRIPTION
PR #294 split lapack.h out of lapacke.h but forgot to copy this file to the install directory