### PR TITLE
small fixes in doc of xlatmr

### DIFF
--- a/TESTING/MATGEN/clatmr.f
+++ b/TESTING/MATGEN/clatmr.f
@@ -316,20 +316,6 @@
 *>           Not referenced if PIVTNG = 'N'. Not modified.
 *> \endverbatim
 *>
-*> \param[in] SPARSE
-*> \verbatim
-*>          SPARSE is REAL
-*>           On entry specifies the sparsity of the matrix if a sparse
-*>           matrix is to be generated. SPARSE should lie between
-*>           0 and 1. To generate a sparse matrix, for each matrix entry
-*>           a uniform ( 0, 1 ) random number x is generated and
-*>           compared to SPARSE; if x is larger the matrix entry
-*>           is unchanged and if x is smaller the entry is set
-*>           to zero. Thus on the average a fraction SPARSE of the
-*>           entries will be set to zero.
-*>           Not modified.
-*> \endverbatim
-*>
 *> \param[in] KL
 *> \verbatim
 *>          KL is INTEGER
@@ -347,6 +333,20 @@
 *>           example, KU=0 implies lower triangular, KU=1 implies lower
 *>           Hessenberg, and KU at least N-1 implies the matrix is not
 *>           banded. Must equal KL if matrix is symmetric or Hermitian.
+*>           Not modified.
+*> \endverbatim
+*>
+*> \param[in] SPARSE
+*> \verbatim
+*>          SPARSE is REAL
+*>           On entry specifies the sparsity of the matrix if a sparse
+*>           matrix is to be generated. SPARSE should lie between
+*>           0 and 1. To generate a sparse matrix, for each matrix entry
+*>           a uniform ( 0, 1 ) random number x is generated and
+*>           compared to SPARSE; if x is larger the matrix entry
+*>           is unchanged and if x is smaller the entry is set
+*>           to zero. Thus on the average a fraction SPARSE of the
+*>           entries will be set to zero.
 *>           Not modified.
 *> \endverbatim
 *>
@@ -416,7 +416,7 @@
 *>           If PACK='C' or 'R', LDA must be at least 1.
 *>           If PACK='B', or 'Q', LDA must be MIN ( KU+1, N )
 *>           If PACK='Z', LDA must be at least KUU+KLL+1, where
-*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, N-1 )
+*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, M-1 )
 *>           Not modified.
 *> \endverbatim
 *>

--- a/TESTING/MATGEN/dlatmr.f
+++ b/TESTING/MATGEN/dlatmr.f
@@ -303,20 +303,6 @@
 *>           Not referenced if PIVTNG = 'N'. Not modified.
 *> \endverbatim
 *>
-*> \param[in] SPARSE
-*> \verbatim
-*>          SPARSE is DOUBLE PRECISION
-*>           On entry specifies the sparsity of the matrix if a sparse
-*>           matrix is to be generated. SPARSE should lie between
-*>           0 and 1. To generate a sparse matrix, for each matrix entry
-*>           a uniform ( 0, 1 ) random number x is generated and
-*>           compared to SPARSE; if x is larger the matrix entry
-*>           is unchanged and if x is smaller the entry is set
-*>           to zero. Thus on the average a fraction SPARSE of the
-*>           entries will be set to zero.
-*>           Not modified.
-*> \endverbatim
-*>
 *> \param[in] KL
 *> \verbatim
 *>          KL is INTEGER
@@ -334,6 +320,20 @@
 *>           example, KU=0 implies lower triangular, KU=1 implies lower
 *>           Hessenberg, and KU at least N-1 implies the matrix is not
 *>           banded. Must equal KL if matrix is symmetric.
+*>           Not modified.
+*> \endverbatim
+*>
+*> \param[in] SPARSE
+*> \verbatim
+*>          SPARSE is DOUBLE PRECISION
+*>           On entry specifies the sparsity of the matrix if a sparse
+*>           matrix is to be generated. SPARSE should lie between
+*>           0 and 1. To generate a sparse matrix, for each matrix entry
+*>           a uniform ( 0, 1 ) random number x is generated and
+*>           compared to SPARSE; if x is larger the matrix entry
+*>           is unchanged and if x is smaller the entry is set
+*>           to zero. Thus on the average a fraction SPARSE of the
+*>           entries will be set to zero.
 *>           Not modified.
 *> \endverbatim
 *>
@@ -398,7 +398,7 @@
 *>           If PACK='C' or 'R', LDA must be at least 1.
 *>           If PACK='B', or 'Q', LDA must be MIN ( KU+1, N )
 *>           If PACK='Z', LDA must be at least KUU+KLL+1, where
-*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, N-1 )
+*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, M-1 )
 *>           Not modified.
 *> \endverbatim
 *>

--- a/TESTING/MATGEN/slatmr.f
+++ b/TESTING/MATGEN/slatmr.f
@@ -303,20 +303,6 @@
 *>           Not referenced if PIVTNG = 'N'. Not modified.
 *> \endverbatim
 *>
-*> \param[in] SPARSE
-*> \verbatim
-*>          SPARSE is REAL
-*>           On entry specifies the sparsity of the matrix if a sparse
-*>           matrix is to be generated. SPARSE should lie between
-*>           0 and 1. To generate a sparse matrix, for each matrix entry
-*>           a uniform ( 0, 1 ) random number x is generated and
-*>           compared to SPARSE; if x is larger the matrix entry
-*>           is unchanged and if x is smaller the entry is set
-*>           to zero. Thus on the average a fraction SPARSE of the
-*>           entries will be set to zero.
-*>           Not modified.
-*> \endverbatim
-*>
 *> \param[in] KL
 *> \verbatim
 *>          KL is INTEGER
@@ -334,6 +320,20 @@
 *>           example, KU=0 implies lower triangular, KU=1 implies lower
 *>           Hessenberg, and KU at least N-1 implies the matrix is not
 *>           banded. Must equal KL if matrix is symmetric.
+*>           Not modified.
+*> \endverbatim
+*>
+*> \param[in] SPARSE
+*> \verbatim
+*>          SPARSE is REAL
+*>           On entry specifies the sparsity of the matrix if a sparse
+*>           matrix is to be generated. SPARSE should lie between
+*>           0 and 1. To generate a sparse matrix, for each matrix entry
+*>           a uniform ( 0, 1 ) random number x is generated and
+*>           compared to SPARSE; if x is larger the matrix entry
+*>           is unchanged and if x is smaller the entry is set
+*>           to zero. Thus on the average a fraction SPARSE of the
+*>           entries will be set to zero.
 *>           Not modified.
 *> \endverbatim
 *>
@@ -398,7 +398,7 @@
 *>           If PACK='C' or 'R', LDA must be at least 1.
 *>           If PACK='B', or 'Q', LDA must be MIN ( KU+1, N )
 *>           If PACK='Z', LDA must be at least KUU+KLL+1, where
-*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, N-1 )
+*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, M-1 )
 *>           Not modified.
 *> \endverbatim
 *>

--- a/TESTING/MATGEN/zlatmr.f
+++ b/TESTING/MATGEN/zlatmr.f
@@ -316,20 +316,6 @@
 *>           Not referenced if PIVTNG = 'N'. Not modified.
 *> \endverbatim
 *>
-*> \param[in] SPARSE
-*> \verbatim
-*>          SPARSE is DOUBLE PRECISION
-*>           On entry specifies the sparsity of the matrix if a sparse
-*>           matrix is to be generated. SPARSE should lie between
-*>           0 and 1. To generate a sparse matrix, for each matrix entry
-*>           a uniform ( 0, 1 ) random number x is generated and
-*>           compared to SPARSE; if x is larger the matrix entry
-*>           is unchanged and if x is smaller the entry is set
-*>           to zero. Thus on the average a fraction SPARSE of the
-*>           entries will be set to zero.
-*>           Not modified.
-*> \endverbatim
-*>
 *> \param[in] KL
 *> \verbatim
 *>          KL is INTEGER
@@ -347,6 +333,20 @@
 *>           example, KU=0 implies lower triangular, KU=1 implies lower
 *>           Hessenberg, and KU at least N-1 implies the matrix is not
 *>           banded. Must equal KL if matrix is symmetric or Hermitian.
+*>           Not modified.
+*> \endverbatim
+*>
+*> \param[in] SPARSE
+*> \verbatim
+*>          SPARSE is DOUBLE PRECISION
+*>           On entry specifies the sparsity of the matrix if a sparse
+*>           matrix is to be generated. SPARSE should lie between
+*>           0 and 1. To generate a sparse matrix, for each matrix entry
+*>           a uniform ( 0, 1 ) random number x is generated and
+*>           compared to SPARSE; if x is larger the matrix entry
+*>           is unchanged and if x is smaller the entry is set
+*>           to zero. Thus on the average a fraction SPARSE of the
+*>           entries will be set to zero.
 *>           Not modified.
 *> \endverbatim
 *>
@@ -416,7 +416,7 @@
 *>           If PACK='C' or 'R', LDA must be at least 1.
 *>           If PACK='B', or 'Q', LDA must be MIN ( KU+1, N )
 *>           If PACK='Z', LDA must be at least KUU+KLL+1, where
-*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, N-1 )
+*>           KUU = MIN ( KU, N-1 ) and KLL = MIN ( KL, M-1 )
 *>           Not modified.
 *> \endverbatim
 *>


### PR DESCRIPTION
The `SPARSE` parameter was in the wrong position in the docs, and the setting of `KLL` (as it is written in the code), is maximally `M-1`, not `N-1`.