### PR TITLE
Fixes CMake builds and documentation in [sz]laorhr_getrfnp2

### DIFF
--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -343,7 +343,7 @@ set(DLASRC
    dgetsls.f dgeqr.f dlatsqr.f dlamtsqr.f dgemqr.f
    dgelq.f dlaswlq.f dlamswlq.f dgemlq.f
    dtplqt.f dtplqt2.f dtpmlqt.f
-   dorhr.f dlaorhr.f dlaorhr_getrfnp.f dlaorhr_getrfnp2.f
+   dorhr.f dlaorhr_getrfnp.f dlaorhr_getrfnp2.f
    dsytrd_2stage.f dsytrd_sy2sb.f dsytrd_sb2st.F dsb2st_kernels.f
    dsyevd_2stage.f dsyev_2stage.f dsyevx_2stage.f dsyevr_2stage.f
    dsbev_2stage.f dsbevx_2stage.f dsbevd_2stage.f dsygv_2stage.f

--- a/SRC/slaorhr_getrfnp2.f
+++ b/SRC/slaorhr_getrfnp2.f
@@ -6,7 +6,7 @@
 *            http://www.netlib.org/lapack/explore-html/
 *
 *> \htmlonly
-*> Download DLAORHR_GETRF2NP + dependencies
+*> Download SLAORHR_GETRF2NP + dependencies
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/slaorhr_getrfnp2.f">
 *> [TGZ]</a>
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/slaorhr_getrfnp2.f">

--- a/SRC/zlaorhr_getrfnp2.f
+++ b/SRC/zlaorhr_getrfnp2.f
@@ -6,7 +6,7 @@
 *            http://www.netlib.org/lapack/explore-html/
 *
 *> \htmlonly
-*> Download DLAORHR_GETRF2NP + dependencies
+*> Download ZLAORHR_GETRF2NP + dependencies
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/zlaorhr_getrfnp2.f">
 *> [TGZ]</a>
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/zlaorhr_getrfnp2.f">


### PR DESCRIPTION
A recent commit 8189dae5acf59ba4da35f06c4c2c5e88ee0f7147 forgot
to remove the deleted file from SRC/CMakeLists.txt.

NOTE: The commit referenced above changed alot in cmake builds. Are all these things tested? It seems the CI was broken by the changes.