### PR TITLE
Fix error report about illegal argument

### DIFF
--- a/CBLAS/src/cblas_sgemm.c
+++ b/CBLAS/src/cblas_sgemm.c
@@ -91,7 +91,7 @@ void cblas_sgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
       else
       {
          cblas_xerbla(2, "cblas_sgemm",
-                       "Illegal TransA setting, %d\n", TransA);
+                       "Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;


### PR DESCRIPTION
It looks like this typo comes from copy-pasting.