### PR TITLE
CMake generates faulty commandlines when invoking ifort or xlf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,10 @@ include(PreventInBuildInstalls)
 
 if(UNIX)
   if(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
-    list(APPEND CMAKE_Fortran_FLAGS -fp-model strict)
+    list(APPEND CMAKE_Fortran_FLAGS "-fp-model strict")
   endif()
   if(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
-    list(APPEND CMAKE_Fortran_FLAGS -qnosave -qstrict=none)
+    list(APPEND CMAKE_Fortran_FLAGS "-qnosave -qstrict=none")
   endif()
 # Delete libmtsk in linking sequence for Sun/Oracle Fortran Compiler.
 # This library is not present in the Sun package SolarisStudio12.3-linux-x86-bin


### PR DESCRIPTION
Adding compiler flags to ifort (or xlf) using

    list(APPEND CMAKE_Fortran_FLAGS -fp-model strict)

adds two semicolon separated commandline flags which results in things like:

    /software/compiler/intel-2018u1/bin/ifort  -I/root/setup/build-scripts/work/lapack-3.9.0/build/CMakeFiles/FortranCInterface/VerifyC  -fp-model;strict -O2 ...

where `-fp-model;strict ` let the compiler fail.  Correct will be 

    list(APPEND CMAKE_Fortran_FLAGS "-fp-model strict")

A similar bug is in the IBM XLF settings, also fixed with the patch. 