### PR TITLE
LAPACK: avoid out-of-bound write in ?LANTR

### DIFF
--- a/SRC/clantr.f
+++ b/SRC/clantr.f
@@ -287,7 +287,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/SRC/dlantr.f
+++ b/SRC/dlantr.f
@@ -285,7 +285,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/SRC/slantr.f
+++ b/SRC/slantr.f
@@ -285,7 +285,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/SRC/zlantr.f
+++ b/SRC/zlantr.f
@@ -287,7 +287,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M


### PR DESCRIPTION
The out-of-bound write will happen when computing the inf-norm of wide, lower triangular matrices with "tight" work. It is documented that this case is not supported by ?LANTR but since the change is small and easy, it is worth doing it.

I think the documentation unfortunately cannot be updated to lift the restriction on matrix sizes. 