### PR TITLE
?gesvdq.f: fix typo in documentation

### DIFF
--- a/SRC/cgesvdq.f
+++ b/SRC/cgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *>
 *>          If LIWORK, LCWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK

--- a/SRC/dgesvdq.f
+++ b/SRC/dgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *>
 *>          If LIWORK, LWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK

--- a/SRC/sgesvdq.f
+++ b/SRC/sgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *>
 *>          If LIWORK, LWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *
 *>          If LIWORK, LCWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK


### PR DESCRIPTION
The estimated length of `IWORK` seems to be given in `IWORK(1)` rather than `LIWORK(1)`.