### PR TITLE
reverting incorrect changes made to syntax for CMAKE_Fortran_FLAGS with Intel/XL compilers

### DIFF
--- a/BLAS/SRC/cdotc.f
+++ b/BLAS/SRC/cdotc.f
@@ -39,7 +39,7 @@
 *>
 *> \param[in] CX
 *> \verbatim
-*>          CX is REAL array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
+*>          CX is COMPLEX array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
 *> \endverbatim
 *>
 *> \param[in] INCX
@@ -50,7 +50,7 @@
 *>
 *> \param[in] CY
 *> \verbatim
-*>          CY is REAL array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
+*>          CY is COMPLEX array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/cdotu.f
+++ b/BLAS/SRC/cdotu.f
@@ -39,7 +39,7 @@
 *>
 *> \param[in] CX
 *> \verbatim
-*>          CX is REAL array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
+*>          CX is COMPLEX array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
 *> \endverbatim
 *>
 *> \param[in] INCX
@@ -50,7 +50,7 @@
 *>
 *> \param[in] CY
 *> \verbatim
-*>          CY is REAL array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
+*>          CY is COMPLEX array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/zdotc.f
+++ b/BLAS/SRC/zdotc.f
@@ -39,7 +39,7 @@
 *>
 *> \param[in] ZX
 *> \verbatim
-*>          ZX is REAL array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
+*>          ZX is COMPLEX*16 array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
 *> \endverbatim
 *>
 *> \param[in] INCX
@@ -50,7 +50,7 @@
 *>
 *> \param[in] ZY
 *> \verbatim
-*>          ZY is REAL array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
+*>          ZY is COMPLEX*16 array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/zdotu.f
+++ b/BLAS/SRC/zdotu.f
@@ -39,7 +39,7 @@
 *>
 *> \param[in] ZX
 *> \verbatim
-*>          ZX is REAL array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
+*>          ZX is COMPLEX*16 array, dimension ( 1 + ( N - 1 )*abs( INCX ) )
 *> \endverbatim
 *>
 *> \param[in] INCX
@@ -50,7 +50,7 @@
 *>
 *> \param[in] ZY
 *> \verbatim
-*>          ZY is REAL array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
+*>          ZY is COMPLEX*16 array, dimension ( 1 + ( N - 1 )*abs( INCY ) )
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/CBLAS/src/cblas_sgemm.c
+++ b/CBLAS/src/cblas_sgemm.c
@@ -91,7 +91,7 @@ void cblas_sgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
       else
       {
          cblas_xerbla(2, "cblas_sgemm",
-                       "Illegal TransA setting, %d\n", TransA);
+                       "Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,10 @@ include(PreventInBuildInstalls)
 
 if(UNIX)
   if(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
-    list(APPEND CMAKE_Fortran_FLAGS "-fp-model strict")
+    string(APPEND CMAKE_Fortran_FLAGS "-fp-model strict")
   endif()
   if(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
-    list(APPEND CMAKE_Fortran_FLAGS "-qnosave -qstrict=none")
+    string(APPEND CMAKE_Fortran_FLAGS "-qnosave -qstrict=none")
   endif()
 # Delete libmtsk in linking sequence for Sun/Oracle Fortran Compiler.
 # This library is not present in the Sun package SolarisStudio12.3-linux-x86-bin

--- a/LAPACKE/src/lapacke_cgelsd.c
+++ b/LAPACKE/src/lapacke_cgelsd.c
@@ -75,7 +75,7 @@ lapack_int LAPACKE_cgelsd( int matrix_layout, lapack_int m, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_cgesvdq.c
+++ b/LAPACKE/src/lapacke_cgesvdq.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_cgesvdq( int matrix_layout, char joba, char jobp,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lcwork = LAPACK_C2INT(cwork_query);
     lrwork = (lapack_int)rwork_query;
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_cgesvdq.c
+++ b/LAPACKE/src/lapacke_cgesvdq.c
@@ -71,7 +71,7 @@ lapack_int LAPACKE_cgesvdq( int matrix_layout, char joba, char jobp,
         goto exit_level_0;
     }
     liwork = (lapack_int)iwork_query;
-    lcwork = (lapack_int)cwork_query;
+    lcwork = LAPACK_C2INT(cwork_query);
     lrwork = (lapack_int)rwork_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_cggesx.c
+++ b/LAPACKE/src/lapacke_cggesx.c
@@ -91,7 +91,7 @@ lapack_int LAPACKE_cggesx( int matrix_layout, char jobvsl, char jobvsr,
     if( info != 0 ) {
         goto exit_level_2;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_chbevd.c
+++ b/LAPACKE/src/lapacke_chbevd.c
@@ -67,7 +67,7 @@ lapack_int LAPACKE_chbevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_chbevd_2stage.c
+++ b/LAPACKE/src/lapacke_chbevd_2stage.c
@@ -67,7 +67,7 @@ lapack_int LAPACKE_chbevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_chbgvd.c
+++ b/LAPACKE/src/lapacke_chbgvd.c
@@ -71,7 +71,7 @@ lapack_int LAPACKE_chbgvd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_cheev_work.c
+++ b/LAPACKE/src/lapacke_cheev_work.c
@@ -78,7 +78,11 @@ lapack_int LAPACKE_cheev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_cge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_cheevd.c
+++ b/LAPACKE/src/lapacke_cheevd.c
@@ -65,7 +65,7 @@ lapack_int LAPACKE_cheevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_cheevd_2stage.c
+++ b/LAPACKE/src/lapacke_cheevd_2stage.c
@@ -65,7 +65,7 @@ lapack_int LAPACKE_cheevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_cheevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_cheevd_2stage_work.c
@@ -79,7 +79,11 @@ lapack_int LAPACKE_cheevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_cge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda ); 
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_cheevd_work.c
+++ b/LAPACKE/src/lapacke_cheevd_work.c
@@ -79,8 +79,11 @@ lapack_int LAPACKE_cheevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
-
+        if ( jobz == 'V') {
+            LAPACKE_cge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else { 
+            LAPACKE_che_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_cheevr.c
+++ b/LAPACKE/src/lapacke_cheevr.c
@@ -83,7 +83,7 @@ lapack_int LAPACKE_cheevr( int matrix_layout, char jobz, char range, char uplo,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_cheevr_2stage.c
+++ b/LAPACKE/src/lapacke_cheevr_2stage.c
@@ -83,7 +83,7 @@ lapack_int LAPACKE_cheevr_2stage( int matrix_layout, char jobz, char range, char
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_chegvd.c
+++ b/LAPACKE/src/lapacke_chegvd.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_chegvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_chpevd.c
+++ b/LAPACKE/src/lapacke_chpevd.c
@@ -66,7 +66,7 @@ lapack_int LAPACKE_chpevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_chpgvd.c
+++ b/LAPACKE/src/lapacke_chpgvd.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_chpgvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_clantr_work.c
+++ b/LAPACKE/src/lapacke_clantr_work.c
@@ -49,6 +49,7 @@ float LAPACKE_clantr_work( int matrix_layout, char norm, char uplo,
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         lapack_complex_float* a_t = NULL;
+        float* work_lapack = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
             info = -8;
@@ -62,12 +63,24 @@ float LAPACKE_clantr_work( int matrix_layout, char norm, char uplo,
             info = LAPACK_TRANSPOSE_MEMORY_ERROR;
             goto exit_level_0;
         }
+        /* Allocate memory for work array(s) */
+        if( LAPACKE_lsame( norm, 'i' ) ) {
+            work_lapack = (float*)LAPACKE_malloc( sizeof(float) * MAX(1,m) );
+            if( work_lapack == NULL ) {
+                info = LAPACK_WORK_MEMORY_ERROR;
+                goto exit_level_1;
+            }
+        }
         /* Transpose input matrices */
         LAPACKE_ctr_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
-        res = LAPACK_clantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work );
+        res = LAPACK_clantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
         info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
+        if( work_lapack ) {
+            LAPACKE_free( work_lapack );
+        }
+exit_level_1:
         LAPACKE_free( a_t );
 exit_level_0:
         if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {

--- a/LAPACKE/src/lapacke_clantr_work.c
+++ b/LAPACKE/src/lapacke_clantr_work.c
@@ -43,9 +43,6 @@ float LAPACKE_clantr_work( int matrix_layout, char norm, char uplo,
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_clantr( &norm, &uplo, &diag, &m, &n, a, &lda, work );
-        if( info < 0 ) {
-            info = info - 1;
-        }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         lapack_complex_float* a_t = NULL;
@@ -75,7 +72,6 @@ float LAPACKE_clantr_work( int matrix_layout, char norm, char uplo,
         LAPACKE_ctr_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_clantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         if( work_lapack ) {
             LAPACKE_free( work_lapack );

--- a/LAPACKE/src/lapacke_cstedc.c
+++ b/LAPACKE/src/lapacke_cstedc.c
@@ -73,7 +73,7 @@ lapack_int LAPACKE_cstedc( int matrix_layout, char compz, lapack_int n, float* d
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_cstegr.c
+++ b/LAPACKE/src/lapacke_cstegr.c
@@ -81,7 +81,7 @@ lapack_int LAPACKE_cstegr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_cstemr.c
+++ b/LAPACKE/src/lapacke_cstemr.c
@@ -75,7 +75,7 @@ lapack_int LAPACKE_cstemr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ctgsen.c
+++ b/LAPACKE/src/lapacke_ctgsen.c
@@ -84,7 +84,7 @@ lapack_int LAPACKE_ctgsen( int matrix_layout, lapack_int ijob,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */
     if( ijob != 0 ) {

--- a/LAPACKE/src/lapacke_dgeesx.c
+++ b/LAPACKE/src/lapacke_dgeesx.c
@@ -76,7 +76,7 @@ lapack_int LAPACKE_dgeesx( int matrix_layout, char jobvs, char sort,
     if( info != 0 ) {
         goto exit_level_1;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     if( LAPACKE_lsame( sense, 'b' ) || LAPACKE_lsame( sense, 'v' ) ) {

--- a/LAPACKE/src/lapacke_dgelsd.c
+++ b/LAPACKE/src/lapacke_dgelsd.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_dgelsd( int matrix_layout, lapack_int m, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dgesvdq.c
+++ b/LAPACKE/src/lapacke_dgesvdq.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_dgesvdq( int matrix_layout, char joba, char jobp,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     lrwork = (lapack_int)rwork_query;
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_dggesx.c
+++ b/LAPACKE/src/lapacke_dggesx.c
@@ -82,7 +82,7 @@ lapack_int LAPACKE_dggesx( int matrix_layout, char jobvsl, char jobvsr,
     if( info != 0 ) {
         goto exit_level_1;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dlantr_work.c
+++ b/LAPACKE/src/lapacke_dlantr_work.c
@@ -42,9 +42,6 @@ double LAPACKE_dlantr_work( int matrix_layout, char norm, char uplo,
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_dlantr( &norm, &uplo, &diag, &m, &n, a, &lda, work );
-        if( info < 0 ) {
-            info = info - 1;
-        }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         double* a_t = NULL;
@@ -73,7 +70,6 @@ double LAPACKE_dlantr_work( int matrix_layout, char norm, char uplo,
         LAPACKE_dtr_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_dlantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         if( work_lapack ) {
             LAPACKE_free( work_lapack );

--- a/LAPACKE/src/lapacke_dlantr_work.c
+++ b/LAPACKE/src/lapacke_dlantr_work.c
@@ -48,6 +48,7 @@ double LAPACKE_dlantr_work( int matrix_layout, char norm, char uplo,
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         double* a_t = NULL;
+        double* work_lapack = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
             info = -8;
@@ -60,12 +61,24 @@ double LAPACKE_dlantr_work( int matrix_layout, char norm, char uplo,
             info = LAPACK_TRANSPOSE_MEMORY_ERROR;
             goto exit_level_0;
         }
+        /* Allocate memory for work array(s) */
+        if( LAPACKE_lsame( norm, 'i' ) ) {
+            work_lapack = (double*)LAPACKE_malloc( sizeof(double) * MAX(1,m) );
+            if( work_lapack == NULL ) {
+                info = LAPACK_WORK_MEMORY_ERROR;
+                goto exit_level_1;
+            }
+        }
         /* Transpose input matrices */
         LAPACKE_dtr_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
-        res = LAPACK_dlantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work );
+        res = LAPACK_dlantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
         info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
+        if( work_lapack ) {
+            LAPACKE_free( work_lapack );
+        }
+exit_level_1:
         LAPACKE_free( a_t );
 exit_level_0:
         if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {

--- a/LAPACKE/src/lapacke_dsbevd.c
+++ b/LAPACKE/src/lapacke_dsbevd.c
@@ -62,7 +62,7 @@ lapack_int LAPACKE_dsbevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dsbevd_2stage.c
+++ b/LAPACKE/src/lapacke_dsbevd_2stage.c
@@ -62,7 +62,7 @@ lapack_int LAPACKE_dsbevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dsbgvd.c
+++ b/LAPACKE/src/lapacke_dsbgvd.c
@@ -67,7 +67,7 @@ lapack_int LAPACKE_dsbgvd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dspevd.c
+++ b/LAPACKE/src/lapacke_dspevd.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_dspevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dspgvd.c
+++ b/LAPACKE/src/lapacke_dspgvd.c
@@ -66,7 +66,7 @@ lapack_int LAPACKE_dspgvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dstedc.c
+++ b/LAPACKE/src/lapacke_dstedc.c
@@ -69,7 +69,7 @@ lapack_int LAPACKE_dstedc( int matrix_layout, char compz, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dstegr.c
+++ b/LAPACKE/src/lapacke_dstegr.c
@@ -81,7 +81,7 @@ lapack_int LAPACKE_dstegr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dstemr.c
+++ b/LAPACKE/src/lapacke_dstemr.c
@@ -75,7 +75,7 @@ lapack_int LAPACKE_dstemr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dstevd.c
+++ b/LAPACKE/src/lapacke_dstevd.c
@@ -64,7 +64,7 @@ lapack_int LAPACKE_dstevd( int matrix_layout, char jobz, lapack_int n, double* d
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dstevr.c
+++ b/LAPACKE/src/lapacke_dstevr.c
@@ -81,7 +81,7 @@ lapack_int LAPACKE_dstevr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dsyev_work.c
+++ b/LAPACKE/src/lapacke_dsyev_work.c
@@ -72,7 +72,11 @@ lapack_int LAPACKE_dsyev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_dge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dsyevd.c
+++ b/LAPACKE/src/lapacke_dsyevd.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_dsyevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dsyevd_2stage.c
+++ b/LAPACKE/src/lapacke_dsyevd_2stage.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_dsyevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dsyevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_dsyevd_2stage_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_dsyevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_dge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dsyevd_work.c
+++ b/LAPACKE/src/lapacke_dsyevd_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_dsyevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_dge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_dsy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dsyevr.c
+++ b/LAPACKE/src/lapacke_dsyevr.c
@@ -78,7 +78,7 @@ lapack_int LAPACKE_dsyevr( int matrix_layout, char jobz, char range, char uplo,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dsyevr_2stage.c
+++ b/LAPACKE/src/lapacke_dsyevr_2stage.c
@@ -78,7 +78,7 @@ lapack_int LAPACKE_dsyevr_2stage( int matrix_layout, char jobz, char range, char
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dsygvd.c
+++ b/LAPACKE/src/lapacke_dsygvd.c
@@ -66,7 +66,7 @@ lapack_int LAPACKE_dsygvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_dtgsen.c
+++ b/LAPACKE/src/lapacke_dtgsen.c
@@ -81,7 +81,7 @@ lapack_int LAPACKE_dtgsen( int matrix_layout, lapack_int ijob,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     if( ijob != 0 ) {

--- a/LAPACKE/src/lapacke_dtrsen.c
+++ b/LAPACKE/src/lapacke_dtrsen.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_dtrsen( int matrix_layout, char job, char compq,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     if( LAPACKE_lsame( job, 'b' ) || LAPACKE_lsame( job, 'v' ) ) {

--- a/LAPACKE/src/lapacke_sgeesx.c
+++ b/LAPACKE/src/lapacke_sgeesx.c
@@ -76,7 +76,7 @@ lapack_int LAPACKE_sgeesx( int matrix_layout, char jobvs, char sort,
     if( info != 0 ) {
         goto exit_level_1;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     if( LAPACKE_lsame( sense, 'b' ) || LAPACKE_lsame( sense, 'v' ) ) {

--- a/LAPACKE/src/lapacke_sgelsd.c
+++ b/LAPACKE/src/lapacke_sgelsd.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_sgelsd( int matrix_layout, lapack_int m, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sgesvdq.c
+++ b/LAPACKE/src/lapacke_sgesvdq.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_sgesvdq( int matrix_layout, char joba, char jobp,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     lrwork = (lapack_int)rwork_query;
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_sggesx.c
+++ b/LAPACKE/src/lapacke_sggesx.c
@@ -82,7 +82,7 @@ lapack_int LAPACKE_sggesx( int matrix_layout, char jobvsl, char jobvsr,
     if( info != 0 ) {
         goto exit_level_1;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_slantr_work.c
+++ b/LAPACKE/src/lapacke_slantr_work.c
@@ -48,6 +48,7 @@ float LAPACKE_slantr_work( int matrix_layout, char norm, char uplo,
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         float* a_t = NULL;
+        float* work_lapack = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
             info = -8;
@@ -60,12 +61,24 @@ float LAPACKE_slantr_work( int matrix_layout, char norm, char uplo,
             info = LAPACK_TRANSPOSE_MEMORY_ERROR;
             goto exit_level_0;
         }
+        /* Allocate memory for work array(s) */
+        if( LAPACKE_lsame( norm, 'i' ) ) {
+            work_lapack = (float*)LAPACKE_malloc( sizeof(float) * MAX(1,m) );
+            if( work_lapack == NULL ) {
+                info = LAPACK_WORK_MEMORY_ERROR;
+                goto exit_level_1;
+            }
+        }
         /* Transpose input matrices */
         LAPACKE_str_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
-        res = LAPACK_slantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work );
+        res = LAPACK_slantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
         info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
+        if( work_lapack ) {
+            LAPACKE_free( work_lapack );
+        }
+exit_level_1:
         LAPACKE_free( a_t );
 exit_level_0:
         if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {

--- a/LAPACKE/src/lapacke_slantr_work.c
+++ b/LAPACKE/src/lapacke_slantr_work.c
@@ -42,9 +42,6 @@ float LAPACKE_slantr_work( int matrix_layout, char norm, char uplo,
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_slantr( &norm, &uplo, &diag, &m, &n, a, &lda, work );
-        if( info < 0 ) {
-            info = info - 1;
-        }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         float* a_t = NULL;
@@ -73,7 +70,6 @@ float LAPACKE_slantr_work( int matrix_layout, char norm, char uplo,
         LAPACKE_str_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_slantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         if( work_lapack ) {
             LAPACKE_free( work_lapack );

--- a/LAPACKE/src/lapacke_ssbevd.c
+++ b/LAPACKE/src/lapacke_ssbevd.c
@@ -62,7 +62,7 @@ lapack_int LAPACKE_ssbevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ssbevd_2stage.c
+++ b/LAPACKE/src/lapacke_ssbevd_2stage.c
@@ -62,7 +62,7 @@ lapack_int LAPACKE_ssbevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ssbgvd.c
+++ b/LAPACKE/src/lapacke_ssbgvd.c
@@ -67,7 +67,7 @@ lapack_int LAPACKE_ssbgvd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sspevd.c
+++ b/LAPACKE/src/lapacke_sspevd.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_sspevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sspgvd.c
+++ b/LAPACKE/src/lapacke_sspgvd.c
@@ -66,7 +66,7 @@ lapack_int LAPACKE_sspgvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sstedc.c
+++ b/LAPACKE/src/lapacke_sstedc.c
@@ -69,7 +69,7 @@ lapack_int LAPACKE_sstedc( int matrix_layout, char compz, lapack_int n, float* d
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sstegr.c
+++ b/LAPACKE/src/lapacke_sstegr.c
@@ -81,7 +81,7 @@ lapack_int LAPACKE_sstegr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sstemr.c
+++ b/LAPACKE/src/lapacke_sstemr.c
@@ -74,7 +74,7 @@ lapack_int LAPACKE_sstemr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sstevd.c
+++ b/LAPACKE/src/lapacke_sstevd.c
@@ -64,7 +64,7 @@ lapack_int LAPACKE_sstevd( int matrix_layout, char jobz, lapack_int n, float* d,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_sstevr.c
+++ b/LAPACKE/src/lapacke_sstevr.c
@@ -81,7 +81,7 @@ lapack_int LAPACKE_sstevr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ssyev_work.c
+++ b/LAPACKE/src/lapacke_ssyev_work.c
@@ -72,7 +72,11 @@ lapack_int LAPACKE_ssyev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_sge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_ssyevd.c
+++ b/LAPACKE/src/lapacke_ssyevd.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_ssyevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ssyevd_2stage.c
+++ b/LAPACKE/src/lapacke_ssyevd_2stage.c
@@ -61,7 +61,7 @@ lapack_int LAPACKE_ssyevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ssyevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_ssyevd_2stage_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_ssyevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_sge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda ); 
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_ssyevd_work.c
+++ b/LAPACKE/src/lapacke_ssyevd_work.c
@@ -76,7 +76,11 @@ lapack_int LAPACKE_ssyevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_sge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_ssy_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_ssyevr.c
+++ b/LAPACKE/src/lapacke_ssyevr.c
@@ -78,7 +78,7 @@ lapack_int LAPACKE_ssyevr( int matrix_layout, char jobz, char range, char uplo,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ssyevr_2stage.c
+++ b/LAPACKE/src/lapacke_ssyevr_2stage.c
@@ -78,7 +78,7 @@ lapack_int LAPACKE_ssyevr_2stage( int matrix_layout, char jobz, char range, char
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ssygvd.c
+++ b/LAPACKE/src/lapacke_ssygvd.c
@@ -66,7 +66,7 @@ lapack_int LAPACKE_ssygvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_stgsen.c
+++ b/LAPACKE/src/lapacke_stgsen.c
@@ -81,7 +81,7 @@ lapack_int LAPACKE_stgsen( int matrix_layout, lapack_int ijob,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     if( ijob != 0 ) {

--- a/LAPACKE/src/lapacke_strsen.c
+++ b/LAPACKE/src/lapacke_strsen.c
@@ -69,7 +69,7 @@ lapack_int LAPACKE_strsen( int matrix_layout, char job, char compq,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     if( LAPACKE_lsame( job, 'b' ) || LAPACKE_lsame( job, 'v' ) ) {

--- a/LAPACKE/src/lapacke_zgelsd.c
+++ b/LAPACKE/src/lapacke_zgelsd.c
@@ -75,7 +75,7 @@ lapack_int LAPACKE_zgelsd( int matrix_layout, lapack_int m, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zgesvdq.c
+++ b/LAPACKE/src/lapacke_zgesvdq.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_zgesvdq( int matrix_layout, char joba, char jobp,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lcwork = LAPACK_C2INT(cwork_query);
     lrwork = (lapack_int)rwork_query;
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zgesvdq.c
+++ b/LAPACKE/src/lapacke_zgesvdq.c
@@ -71,7 +71,7 @@ lapack_int LAPACKE_zgesvdq( int matrix_layout, char joba, char jobp,
         goto exit_level_0;
     }
     liwork = (lapack_int)iwork_query;
-    lcwork = (lapack_int)cwork_query;
+    lcwork = LAPACK_C2INT(cwork_query);
     lrwork = (lapack_int)rwork_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_zggesx.c
+++ b/LAPACKE/src/lapacke_zggesx.c
@@ -91,7 +91,7 @@ lapack_int LAPACKE_zggesx( int matrix_layout, char jobvsl, char jobvsr,
     if( info != 0 ) {
         goto exit_level_2;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_zhbevd.c
+++ b/LAPACKE/src/lapacke_zhbevd.c
@@ -67,7 +67,7 @@ lapack_int LAPACKE_zhbevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zhbevd_2stage.c
+++ b/LAPACKE/src/lapacke_zhbevd_2stage.c
@@ -67,7 +67,7 @@ lapack_int LAPACKE_zhbevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zhbgvd.c
+++ b/LAPACKE/src/lapacke_zhbgvd.c
@@ -71,7 +71,7 @@ lapack_int LAPACKE_zhbgvd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zheev_work.c
+++ b/LAPACKE/src/lapacke_zheev_work.c
@@ -78,7 +78,11 @@ lapack_int LAPACKE_zheev_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_zge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zheevd.c
+++ b/LAPACKE/src/lapacke_zheevd.c
@@ -65,7 +65,7 @@ lapack_int LAPACKE_zheevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zheevd_2stage.c
+++ b/LAPACKE/src/lapacke_zheevd_2stage.c
@@ -65,7 +65,7 @@ lapack_int LAPACKE_zheevd_2stage( int matrix_layout, char jobz, char uplo, lapac
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zheevd_2stage_work.c
+++ b/LAPACKE/src/lapacke_zheevd_2stage_work.c
@@ -79,7 +79,11 @@ lapack_int LAPACKE_zheevd_2stage_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_zge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else {
+            LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zheevd_work.c
+++ b/LAPACKE/src/lapacke_zheevd_work.c
@@ -79,7 +79,11 @@ lapack_int LAPACKE_zheevd_work( int matrix_layout, char jobz, char uplo,
             info = info - 1;
         }
         /* Transpose output matrices */
-        LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        if ( jobz == 'V') {
+            LAPACKE_zge_trans( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
+        } else { 
+            LAPACKE_zhe_trans( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
+        }
         /* Release memory and exit */
         LAPACKE_free( a_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zheevr.c
+++ b/LAPACKE/src/lapacke_zheevr.c
@@ -83,7 +83,7 @@ lapack_int LAPACKE_zheevr( int matrix_layout, char jobz, char range, char uplo,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zheevr_2stage.c
+++ b/LAPACKE/src/lapacke_zheevr_2stage.c
@@ -83,7 +83,7 @@ lapack_int LAPACKE_zheevr_2stage( int matrix_layout, char jobz, char range, char
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zhegvd.c
+++ b/LAPACKE/src/lapacke_zhegvd.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_zhegvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zhpevd.c
+++ b/LAPACKE/src/lapacke_zhpevd.c
@@ -66,7 +66,7 @@ lapack_int LAPACKE_zhpevd( int matrix_layout, char jobz, char uplo, lapack_int n
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zhpgvd.c
+++ b/LAPACKE/src/lapacke_zhpgvd.c
@@ -70,7 +70,7 @@ lapack_int LAPACKE_zhpgvd( int matrix_layout, lapack_int itype, char jobz,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zlantr_work.c
+++ b/LAPACKE/src/lapacke_zlantr_work.c
@@ -49,6 +49,7 @@ double LAPACKE_zlantr_work( int matrix_layout, char norm, char uplo,
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         lapack_complex_double* a_t = NULL;
+        double* work_lapack = NULL;
         /* Check leading dimension(s) */
         if( lda < n ) {
             info = -8;
@@ -62,12 +63,24 @@ double LAPACKE_zlantr_work( int matrix_layout, char norm, char uplo,
             info = LAPACK_TRANSPOSE_MEMORY_ERROR;
             goto exit_level_0;
         }
+        /* Allocate memory for work array(s) */
+        if( LAPACKE_lsame( norm, 'i' ) ) {
+            work_lapack = (double*)LAPACKE_malloc( sizeof(double) * MAX(1,m) );
+            if( work_lapack == NULL ) {
+                info = LAPACK_WORK_MEMORY_ERROR;
+                goto exit_level_1;
+            }
+        }
         /* Transpose input matrices */
         LAPACKE_ztr_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
-        res = LAPACK_zlantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work );
+        res = LAPACK_zlantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
         info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
+        if( work_lapack ) {
+            LAPACKE_free( work_lapack );
+        }
+exit_level_1:
         LAPACKE_free( a_t );
 exit_level_0:
         if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {

--- a/LAPACKE/src/lapacke_zlantr_work.c
+++ b/LAPACKE/src/lapacke_zlantr_work.c
@@ -43,9 +43,6 @@ double LAPACKE_zlantr_work( int matrix_layout, char norm, char uplo,
     if( matrix_layout == LAPACK_COL_MAJOR ) {
         /* Call LAPACK function and adjust info */
         res = LAPACK_zlantr( &norm, &uplo, &diag, &m, &n, a, &lda, work );
-        if( info < 0 ) {
-            info = info - 1;
-        }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,m);
         lapack_complex_double* a_t = NULL;
@@ -75,7 +72,6 @@ double LAPACKE_zlantr_work( int matrix_layout, char norm, char uplo,
         LAPACKE_ztr_trans( matrix_layout, uplo, diag, MAX(m,n), a, lda, a_t, lda_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_zlantr( &norm, &uplo, &diag, &m, &n, a_t, &lda_t, work_lapack );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         if( work_lapack ) {
             LAPACKE_free( work_lapack );

--- a/LAPACKE/src/lapacke_zstedc.c
+++ b/LAPACKE/src/lapacke_zstedc.c
@@ -74,7 +74,7 @@ lapack_int LAPACKE_zstedc( int matrix_layout, char compz, lapack_int n,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lrwork = (lapack_int)rwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */

--- a/LAPACKE/src/lapacke_zstegr.c
+++ b/LAPACKE/src/lapacke_zstegr.c
@@ -82,7 +82,7 @@ lapack_int LAPACKE_zstegr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_zstemr.c
+++ b/LAPACKE/src/lapacke_zstemr.c
@@ -75,7 +75,7 @@ lapack_int LAPACKE_zstemr( int matrix_layout, char jobz, char range,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );

--- a/LAPACKE/src/lapacke_ztgsen.c
+++ b/LAPACKE/src/lapacke_ztgsen.c
@@ -84,7 +84,7 @@ lapack_int LAPACKE_ztgsen( int matrix_layout, lapack_int ijob,
     if( info != 0 ) {
         goto exit_level_0;
     }
-    liwork = (lapack_int)iwork_query;
+    liwork = iwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */
     if( ijob != 0 ) {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ CBLAS, a C interface to the BLAS, and (5) LAPACKE, a C interface to LAPACK.
    mkdir build
    cd build
    cmake -DCMAKE_INSTALL_LIBDIR=$HOME/.local/lapack ..
-   cmake --build -j . --target install
+   cmake --build . -j --target install
    ```
    That installs the LAPACK library under $HOME/.local/lapack/
  - Specific information to run LAPACK under Windows is available at

--- a/SRC/cgesvdq.f
+++ b/SRC/cgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *>
 *>          If LIWORK, LCWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK

--- a/SRC/clantr.f
+++ b/SRC/clantr.f
@@ -287,7 +287,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/SRC/dgesvdq.f
+++ b/SRC/dgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *>
 *>          If LIWORK, LWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK

--- a/SRC/dlantr.f
+++ b/SRC/dlantr.f
@@ -285,7 +285,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/SRC/sgesvdq.f
+++ b/SRC/sgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *>
 *>          If LIWORK, LWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK

--- a/SRC/slantr.f
+++ b/SRC/slantr.f
@@ -285,7 +285,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -220,7 +220,7 @@
 *>          left singular vectors in the case JOBU = 'F'.
 *
 *>          If LIWORK, LCWORK, or LRWORK = -1, then on exit, if INFO = 0,
-*>          LIWORK(1) returns the minimal LIWORK.
+*>          IWORK(1) returns the minimal LIWORK.
 *> \endverbatim
 *>
 *> \param[in] LIWORK

--- a/SRC/zlantr.f
+++ b/SRC/zlantr.f
@@ -287,7 +287,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M


### PR DESCRIPTION
commits 7c98411 and ac26c7cc introduced an incorrect syntax for setting CMAKE_Fortran_FLAGS. This variable was treated as a list instead of a string and was generating incorrect syntax. Verified fix with a successful Intel 18 configuration on linux.

References issue #336 