### PR TITLE
Obey Fortran fixed-form limit to fix missing 'xerbl'

### DIFF
--- a/SRC/sorhr_col.f
+++ b/SRC/sorhr_col.f
@@ -282,7 +282,8 @@
      $                   NPLUSONE
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           SCOPY, SLAORHR_COL_GETRFNP, SSCAL, STRSM, XERBLA
+      EXTERNAL           SCOPY, SLAORHR_COL_GETRFNP, SSCAL, STRSM,
+     $                   XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN


### PR DESCRIPTION
There isn't enough room on the punch card to fit the trailing 'A' in
'XERBLA', leading to an undefined symbol reference to 'XERBL_' in the
stricter Intel compilers. Fixes https://github.com/Reference-LAPACK/lapack/issues/394, will fix an issue on https://github.com/xianyi/OpenBLAS/issues/2386#issuecomment-582096592 and will fix https://github.com/spack/spack/issues/15385 when it's merged upstream into OpenBLAS.