### PR TITLE
Add more tests for edge cases in level-1 BLAS.

### DIFF
--- a/BLAS/TESTING/cblat1.f
+++ b/BLAS/TESTING/cblat1.f
@@ -132,7 +132,7 @@
       COMPLEX           CTRUE5(8,5,2), CTRUE6(8,5,2), CV(8,5,2), CX(8),
      +                  MWPCS(5), MWPCT(5)
       REAL              STRUE2(5), STRUE4(5)
-      INTEGER           ITRUE3(5)
+      INTEGER           ITRUE3(5), ITRUEC(5)
 *     .. External Functions ..
       REAL              SCASUM, SCNRM2
       INTEGER           ICAMAX
@@ -238,6 +238,7 @@
      +                  (0.15E0,0.00E0), (6.0E0,9.0E0), (0.00E0,0.15E0),
      +                  (8.0E0,3.0E0), (0.00E0,0.06E0), (9.0E0,4.0E0)/
       DATA              ITRUE3/0, 1, 2, 2, 2/
+      DATA              ITRUEC/0, 1, 1, 1, 1/
 *     .. Executable Statements ..
       DO 60 INCX = 1, 2
          DO 40 NP1 = 1, 5
@@ -268,6 +269,10 @@
             ELSE IF (ICASE.EQ.10) THEN
 *              .. ICAMAX ..
                CALL ITEST1(ICAMAX(N,CX,INCX),ITRUE3(NP1))
+               DO 160 I = 1, LEN
+                  CX(I) = (42.0E0,43.0E0)
+  160          CONTINUE
+               CALL ITEST1(ICAMAX(N,CX,INCX),ITRUEC(NP1))
             ELSE
                WRITE (NOUT,*) ' Shouldn''t be here in CHECK1'
                STOP
@@ -331,7 +336,8 @@
 *     .. Local Arrays ..
       COMPLEX           CDOT(1), CSIZE1(4), CSIZE2(7,2), CSIZE3(14),
      +                  CT10X(7,4,4), CT10Y(7,4,4), CT6(4,4), CT7(4,4),
-     +                  CT8(7,4,4), CX(7), CX1(7), CY(7), CY1(7)
+     +                  CT8(7,4,4), CTY0(1), CX(7), CX0(1), CX1(7),
+     +                  CY(7), CY0(1), CY1(7)
       INTEGER           INCXS(4), INCYS(4), LENS(4,2), NS(4)
 *     .. External Functions ..
       COMPLEX           CDOTC, CDOTU
@@ -546,6 +552,15 @@
 *              .. CCOPY ..
                CALL CCOPY(N,CX,INCX,CY,INCY)
                CALL CTEST(LENY,CY,CT10Y(1,KN,KI),CSIZE3,1.0E0)
+               CX0(1) = (42.0E0,43.0E0)
+               CY0(1) = (44.0E0,45.0E0)
+               IF (N.EQ.0) THEN
+                  CTY0(1) = CY0(1)
+               ELSE
+                  CTY0(1) = CX0(1)
+               END IF
+               CALL CCOPY(N,CX0,0,CY0,0)
+               CALL CTEST(1,CY0,CTY0,CSIZE3,1.0E0)
             ELSE IF (ICASE.EQ.5) THEN
 *              .. CSWAP ..
                CALL CSWAP(N,CX,INCX,CY,INCY)

--- a/BLAS/TESTING/dblat1.f
+++ b/BLAS/TESTING/dblat1.f
@@ -253,7 +253,7 @@
 *     .. Local Arrays ..
       DOUBLE PRECISION  DTRUE1(5), DTRUE3(5), DTRUE5(8,5,2), DV(8,5,2),
      +                  SA(10), STEMP(1), STRUE(8), SX(8)
-      INTEGER           ITRUE2(5)
+      INTEGER           ITRUE2(5), ITRUEC(5)
 *     .. External Functions ..
       DOUBLE PRECISION  DASUM, DNRM2
       INTEGER           IDAMAX
@@ -297,6 +297,7 @@
      +                  0.03D0, 4.0D0, -0.09D0, 6.0D0, -0.15D0, 7.0D0,
      +                  -0.03D0, 3.0D0/
       DATA              ITRUE2/0, 1, 2, 2, 3/
+      DATA              ITRUEC/0, 1, 1, 1, 1/
 *     .. Executable Statements ..
       DO 80 INCX = 1, 2
          DO 60 NP1 = 1, 5
@@ -325,6 +326,10 @@
             ELSE IF (ICASE.EQ.10) THEN
 *              .. IDAMAX ..
                CALL ITEST1(IDAMAX(N,SX,INCX),ITRUE2(NP1))
+               DO 100 I = 1, LEN
+                  SX(I) = 42.0D0
+  100          CONTINUE
+               CALL ITEST1(IDAMAX(N,SX,INCX),ITRUEC(NP1))
             ELSE
                WRITE (NOUT,*) ' Shouldn''t be here in CHECK1'
                STOP
@@ -354,7 +359,8 @@
      $                  DPAR(5,4), DT19X(7,4,16),DT19XA(7,4,4),
      $                  DT19XB(7,4,4), DT19XC(7,4,4),DT19XD(7,4,4),
      $                  DT19Y(7,4,16), DT19YA(7,4,4),DT19YB(7,4,4),
-     $                  DT19YC(7,4,4), DT19YD(7,4,4), DTEMP(5)
+     $                  DT19YC(7,4,4), DT19YD(7,4,4), DTEMP(5),
+     $                  STY0(1), SX0(1), SY0(1)
       INTEGER           INCXS(4), INCYS(4), LENS(4,2), NS(4)
 *     .. External Functions ..
       DOUBLE PRECISION  DDOT, DSDOT
@@ -628,6 +634,15 @@
    60          CONTINUE
                CALL DCOPY(N,SX,INCX,SY,INCY)
                CALL STEST(LENY,SY,STY,SSIZE2(1,1),1.0D0)
+               SX0(1) = 42.0D0
+               SY0(1) = 43.0D0
+               IF (N.EQ.0) THEN
+                  STY0(1) = SY0(1)
+               ELSE
+                  STY0(1) = SX0(1)
+               END IF
+               CALL DCOPY(N,SX0,0,SY0,0)
+               CALL STEST(1,SY0,STY0,SSIZE2(1,1),1.0D0)
             ELSE IF (ICASE.EQ.6) THEN
 *              .. DSWAP ..
                CALL DSWAP(N,SX,INCX,SY,INCY)

--- a/BLAS/TESTING/sblat1.f
+++ b/BLAS/TESTING/sblat1.f
@@ -253,7 +253,7 @@
 *     .. Local Arrays ..
       REAL              DTRUE1(5), DTRUE3(5), DTRUE5(8,5,2), DV(8,5,2),
      +                  SA(10), STEMP(1), STRUE(8), SX(8)
-      INTEGER           ITRUE2(5)
+      INTEGER           ITRUE2(5), ITRUEC(5)
 *     .. External Functions ..
       REAL              SASUM, SNRM2
       INTEGER           ISAMAX
@@ -297,6 +297,7 @@
      +                  0.03E0, 4.0E0, -0.09E0, 6.0E0, -0.15E0, 7.0E0,
      +                  -0.03E0, 3.0E0/
       DATA              ITRUE2/0, 1, 2, 2, 3/
+      DATA              ITRUEC/0, 1, 1, 1, 1/
 *     .. Executable Statements ..
       DO 80 INCX = 1, 2
          DO 60 NP1 = 1, 5
@@ -325,6 +326,10 @@
             ELSE IF (ICASE.EQ.10) THEN
 *              .. ISAMAX ..
                CALL ITEST1(ISAMAX(N,SX,INCX),ITRUE2(NP1))
+               DO 100 I = 1, LEN
+                  SX(I) = 42.0E0
+  100          CONTINUE
+               CALL ITEST1(ISAMAX(N,SX,INCX),ITRUEC(NP1))
             ELSE
                WRITE (NOUT,*) ' Shouldn''t be here in CHECK1'
                STOP
@@ -355,7 +360,7 @@
      $                  DT19XB(7,4,4), DT19XC(7,4,4),DT19XD(7,4,4),
      $                  DT19Y(7,4,16), DT19YA(7,4,4),DT19YB(7,4,4),
      $                  DT19YC(7,4,4), DT19YD(7,4,4), DTEMP(5),
-     $                  ST7B(4,4)
+     $                  ST7B(4,4), STY0(1), SX0(1), SY0(1)
       INTEGER           INCXS(4), INCYS(4), LENS(4,2), NS(4)
 *     .. External Functions ..
       REAL              SDOT, SDSDOT
@@ -631,6 +636,15 @@
    60          CONTINUE
                CALL SCOPY(N,SX,INCX,SY,INCY)
                CALL STEST(LENY,SY,STY,SSIZE2(1,1),1.0E0)
+               SX0(1) = 42.0E0
+               SY0(1) = 43.0E0
+               IF (N.EQ.0) THEN
+                  STY0(1) = SY0(1)
+               ELSE
+                  STY0(1) = SX0(1)
+               END IF
+               CALL SCOPY(N,SX0,0,SY0,0)
+               CALL STEST(1,SY0,STY0,SSIZE2(1,1),1.0E0)
             ELSE IF (ICASE.EQ.6) THEN
 *              .. SSWAP ..
                CALL SSWAP(N,SX,INCX,SY,INCY)

--- a/BLAS/TESTING/zblat1.f
+++ b/BLAS/TESTING/zblat1.f
@@ -132,7 +132,7 @@
       COMPLEX*16        CTRUE5(8,5,2), CTRUE6(8,5,2), CV(8,5,2), CX(8),
      +                  MWPCS(5), MWPCT(5)
       DOUBLE PRECISION  STRUE2(5), STRUE4(5)
-      INTEGER           ITRUE3(5)
+      INTEGER           ITRUE3(5), ITRUEC(5)
 *     .. External Functions ..
       DOUBLE PRECISION  DZASUM, DZNRM2
       INTEGER           IZAMAX
@@ -238,6 +238,7 @@
      +                  (0.15D0,0.00D0), (6.0D0,9.0D0), (0.00D0,0.15D0),
      +                  (8.0D0,3.0D0), (0.00D0,0.06D0), (9.0D0,4.0D0)/
       DATA              ITRUE3/0, 1, 2, 2, 2/
+      DATA              ITRUEC/0, 1, 1, 1, 1/
 *     .. Executable Statements ..
       DO 60 INCX = 1, 2
          DO 40 NP1 = 1, 5
@@ -268,6 +269,10 @@
             ELSE IF (ICASE.EQ.10) THEN
 *              .. IZAMAX ..
                CALL ITEST1(IZAMAX(N,CX,INCX),ITRUE3(NP1))
+               DO 160 I = 1, LEN
+                  CX(I) = (42.0D0,43.0D0)
+  160          CONTINUE
+               CALL ITEST1(IZAMAX(N,CX,INCX),ITRUEC(NP1))
             ELSE
                WRITE (NOUT,*) ' Shouldn''t be here in CHECK1'
                STOP
@@ -331,7 +336,8 @@
 *     .. Local Arrays ..
       COMPLEX*16        CDOT(1), CSIZE1(4), CSIZE2(7,2), CSIZE3(14),
      +                  CT10X(7,4,4), CT10Y(7,4,4), CT6(4,4), CT7(4,4),
-     +                  CT8(7,4,4), CX(7), CX1(7), CY(7), CY1(7)
+     +                  CT8(7,4,4), CTY0(1), CX(7), CX0(1), CX1(7),
+     +                  CY(7), CY0(1), CY1(7)
       INTEGER           INCXS(4), INCYS(4), LENS(4,2), NS(4)
 *     .. External Functions ..
       COMPLEX*16        ZDOTC, ZDOTU
@@ -546,6 +552,15 @@
 *              .. ZCOPY ..
                CALL ZCOPY(N,CX,INCX,CY,INCY)
                CALL CTEST(LENY,CY,CT10Y(1,KN,KI),CSIZE3,1.0D0)
+               CX0(1) = (42.0D0,43.0D0)
+               CY0(1) = (44.0D0,45.0D0)
+               IF (N.EQ.0) THEN
+                  CTY0(1) = CY0(1)
+               ELSE
+                  CTY0(1) = CX0(1)
+               END IF
+               CALL ZCOPY(N,CX0,0,CY0,0)
+               CALL CTEST(1,CY0,CTY0,CSIZE3,1.0D0)
             ELSE IF (ICASE.EQ.5) THEN
 *              .. ZSWAP ..
                CALL ZSWAP(N,CX,INCX,CY,INCY)


### PR DESCRIPTION
At NAG we've observed issues with the BLIS version of IDAMAX and with the Apple vecLib version of ZCOPY in some edge cases.

We thought it would be useful to have additional test cases in place upstream here:

added test of I*AMAX when the input vector is constant;

added test of *COPY when the source and target have increment 0.
