### PR TITLE
cmake: Tell CMake that our Fortran sources are in fixed format

### DIFF
--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -44,12 +44,6 @@ elseif( (CMAKE_Fortran_COMPILER_ID STREQUAL "VisualAge" ) OR  # CMake 2.6
     set( FPE_EXIT TRUE )
   endif()
 
-  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "-qfixed") )
-    message( STATUS "Enabling fixed format F90/F95 with -qfixed" )
-    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qfixed"
-         CACHE STRING "Flags for Fortran compiler." FORCE )
-  endif()
-
 # HP Fortran
 elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "HP" )
   if( "${CMAKE_Fortran_FLAGS}" MATCHES "\\+fp_exception" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ set(CMAKE_MODULE_PATH "${LAPACK_SOURCE_DIR}/CMAKE" ${CMAKE_MODULE_PATH})
 # Export all symbols on Windows when building shared libraries
 SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
+# Tell CMake that our Fortran sources are written in fixed format.
+set(CMAKE_Fortran_FORMAT FIXED)
+
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")


### PR DESCRIPTION
CMake will automatically generate the proper flag to tell each compiler
that our sources use fixed format.  Drop our manual use of `-qfixed` for
the XL Fortran compiler because it breaks CMake's FortranCInterface
detection (which uses free-format sources).