### PR TITLE
Incorrect behaviour in real ?LACN2 under Fortran 95 SIGN semantics. Improved some ?COPY testing.

### DIFF
--- a/BLAS/TESTING/cblat1.f
+++ b/BLAS/TESTING/cblat1.f
@@ -344,7 +344,8 @@
       LOGICAL           PASS
 *     .. Local Scalars ..
       COMPLEX           CA
-      INTEGER           I, J, KI, KN, KSIZE, LENX, LENY, MX, MY
+      INTEGER           I, J, KI, KN, KSIZE, LENX, LENY, LINCX, LINCY,
+     +                  MX, MY
 *     .. Local Arrays ..
       COMPLEX           CDOT(1), CSIZE1(4), CSIZE2(7,2), CSIZE3(14),
      +                  CT10X(7,4,4), CT10Y(7,4,4), CT6(4,4), CT7(4,4),
@@ -564,15 +565,23 @@
 *              .. CCOPY ..
                CALL CCOPY(N,CX,INCX,CY,INCY)
                CALL CTEST(LENY,CY,CT10Y(1,KN,KI),CSIZE3,1.0E0)
-               CX0(1) = (42.0E0,43.0E0)
-               CY0(1) = (44.0E0,45.0E0)
-               IF (N.EQ.0) THEN
-                  CTY0(1) = CY0(1)
-               ELSE
-                  CTY0(1) = CX0(1)
+               IF (KI.EQ.1) THEN
+                  CX0(1) = (42.0E0,43.0E0)
+                  CY0(1) = (44.0E0,45.0E0)
+                  IF (N.EQ.0) THEN
+                     CTY0(1) = CY0(1)
+                  ELSE
+                     CTY0(1) = CX0(1)
+                  END IF
+                  LINCX = INCX
+                  INCX = 0
+                  LINCY = INCY
+                  INCY = 0
+                  CALL CCOPY(N,CX0,INCX,CY0,INCY)
+                  CALL CTEST(1,CY0,CTY0,CSIZE3,1.0E0)
+                  INCX = LINCX
+                  INCY = LINCY
                END IF
-               CALL CCOPY(N,CX0,0,CY0,0)
-               CALL CTEST(1,CY0,CTY0,CSIZE3,1.0E0)
             ELSE IF (ICASE.EQ.5) THEN
 *              .. CSWAP ..
                CALL CSWAP(N,CX,INCX,CY,INCY)

--- a/BLAS/TESTING/dblat1.f
+++ b/BLAS/TESTING/dblat1.f
@@ -362,7 +362,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION  SA
       INTEGER           I, J, KI, KN, KNI, KPAR, KSIZE, LENX, LENY,
-     $                  MX, MY
+     $                  LINCX, LINCY, MX, MY
 *     .. Local Arrays ..
       DOUBLE PRECISION  DT10X(7,4,4), DT10Y(7,4,4), DT7(4,4),
      $                  DT8(7,4,4), DX1(7),
@@ -646,15 +646,23 @@
    60          CONTINUE
                CALL DCOPY(N,SX,INCX,SY,INCY)
                CALL STEST(LENY,SY,STY,SSIZE2(1,1),1.0D0)
-               SX0(1) = 42.0D0
-               SY0(1) = 43.0D0
-               IF (N.EQ.0) THEN
-                  STY0(1) = SY0(1)
-               ELSE
-                  STY0(1) = SX0(1)
+               IF (KI.EQ.1) THEN
+                  SX0(1) = 42.0D0
+                  SY0(1) = 43.0D0
+                  IF (N.EQ.0) THEN
+                     STY0(1) = SY0(1)
+                  ELSE
+                     STY0(1) = SX0(1)
+                  END IF
+                  LINCX = INCX
+                  INCX = 0
+                  LINCY = INCY
+                  INCY = 0
+                  CALL DCOPY(N,SX0,INCX,SY0,INCY)
+                  CALL STEST(1,SY0,STY0,SSIZE2(1,1),1.0D0)
+                  INCX = LINCX
+                  INCY = LINCY
                END IF
-               CALL DCOPY(N,SX0,0,SY0,0)
-               CALL STEST(1,SY0,STY0,SSIZE2(1,1),1.0D0)
             ELSE IF (ICASE.EQ.6) THEN
 *              .. DSWAP ..
                CALL DSWAP(N,SX,INCX,SY,INCY)

--- a/BLAS/TESTING/sblat1.f
+++ b/BLAS/TESTING/sblat1.f
@@ -362,7 +362,7 @@
 *     .. Local Scalars ..
       REAL              SA
       INTEGER           I, J, KI, KN, KNI, KPAR, KSIZE, LENX, LENY,
-     $                  MX, MY
+     $                  LINCX, LINCY, MX, MY
 *     .. Local Arrays ..
       REAL              DT10X(7,4,4), DT10Y(7,4,4), DT7(4,4),
      $                  DT8(7,4,4), DX1(7),
@@ -648,15 +648,23 @@
    60          CONTINUE
                CALL SCOPY(N,SX,INCX,SY,INCY)
                CALL STEST(LENY,SY,STY,SSIZE2(1,1),1.0E0)
-               SX0(1) = 42.0E0
-               SY0(1) = 43.0E0
-               IF (N.EQ.0) THEN
-                  STY0(1) = SY0(1)
-               ELSE
-                  STY0(1) = SX0(1)
+               IF (KI.EQ.1) THEN
+                  SX0(1) = 42.0E0
+                  SY0(1) = 43.0E0
+                  IF (N.EQ.0) THEN
+                     STY0(1) = SY0(1)
+                  ELSE
+                     STY0(1) = SX0(1)
+                  END IF
+                  LINCX = INCX
+                  INCX = 0
+                  LINCY = INCY
+                  INCY = 0
+                  CALL SCOPY(N,SX0,INCX,SY0,INCY)
+                  CALL STEST(1,SY0,STY0,SSIZE2(1,1),1.0E0)
+                  INCX = LINCX
+                  INCY = LINCY
                END IF
-               CALL SCOPY(N,SX0,0,SY0,0)
-               CALL STEST(1,SY0,STY0,SSIZE2(1,1),1.0E0)
             ELSE IF (ICASE.EQ.6) THEN
 *              .. SSWAP ..
                CALL SSWAP(N,SX,INCX,SY,INCY)

--- a/BLAS/TESTING/zblat1.f
+++ b/BLAS/TESTING/zblat1.f
@@ -344,7 +344,8 @@
       LOGICAL           PASS
 *     .. Local Scalars ..
       COMPLEX*16        CA
-      INTEGER           I, J, KI, KN, KSIZE, LENX, LENY, MX, MY
+      INTEGER           I, J, KI, KN, KSIZE, LENX, LENY, LINCX, LINCY,
+     +                  MX, MY
 *     .. Local Arrays ..
       COMPLEX*16        CDOT(1), CSIZE1(4), CSIZE2(7,2), CSIZE3(14),
      +                  CT10X(7,4,4), CT10Y(7,4,4), CT6(4,4), CT7(4,4),
@@ -564,15 +565,23 @@
 *              .. ZCOPY ..
                CALL ZCOPY(N,CX,INCX,CY,INCY)
                CALL CTEST(LENY,CY,CT10Y(1,KN,KI),CSIZE3,1.0D0)
-               CX0(1) = (42.0D0,43.0D0)
-               CY0(1) = (44.0D0,45.0D0)
-               IF (N.EQ.0) THEN
-                  CTY0(1) = CY0(1)
-               ELSE
-                  CTY0(1) = CX0(1)
+               IF (KI.EQ.1) THEN
+                  CX0(1) = (42.0D0,43.0D0)
+                  CY0(1) = (44.0D0,45.0D0)
+                  IF (N.EQ.0) THEN
+                     CTY0(1) = CY0(1)
+                  ELSE
+                     CTY0(1) = CX0(1)
+                  END IF
+                  LINCX = INCX
+                  INCX = 0
+                  LINCY = INCY
+                  INCY = 0
+                  CALL ZCOPY(N,CX0,INCX,CY0,INCY)
+                  CALL CTEST(1,CY0,CTY0,CSIZE3,1.0D0)
+                  INCX = LINCX
+                  INCY = LINCY
                END IF
-               CALL ZCOPY(N,CX0,0,CY0,0)
-               CALL CTEST(1,CY0,CTY0,CSIZE3,1.0D0)
             ELSE IF (ICASE.EQ.5) THEN
 *              .. ZSWAP ..
                CALL ZSWAP(N,CX,INCX,CY,INCY)

--- a/SRC/dlacn2.f
+++ b/SRC/dlacn2.f
@@ -160,7 +160,7 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, JLAST
-      DOUBLE PRECISION   ALTSGN, ESTOLD, TEMP
+      DOUBLE PRECISION   ALTSGN, ESTOLD, TEMP, XS
 *     ..
 *     .. External Functions ..
       INTEGER            IDAMAX
@@ -199,7 +199,11 @@
       EST = DASUM( N, X, 1 )
 *
       DO 30 I = 1, N
-         X( I ) = SIGN( ONE, X( I ) )
+         IF( X(I).GE.ZERO ) THEN
+            X(I) = ONE
+         ELSE
+            X(I) = -ONE
+         END IF
          ISGN( I ) = NINT( X( I ) )
    30 CONTINUE
       KASE = 2
@@ -232,7 +236,12 @@
       ESTOLD = EST
       EST = DASUM( N, V, 1 )
       DO 80 I = 1, N
-         IF( NINT( SIGN( ONE, X( I ) ) ).NE.ISGN( I ) )
+         IF( X(I).GE.ZERO ) THEN
+            XS = ONE
+         ELSE
+            XS = -ONE
+         END IF
+         IF( NINT( XS ).NE.ISGN( I ) )
      $      GO TO 90
    80 CONTINUE
 *     REPEATED SIGN VECTOR DETECTED, HENCE ALGORITHM HAS CONVERGED.
@@ -244,7 +253,11 @@
      $   GO TO 120
 *
       DO 100 I = 1, N
-         X( I ) = SIGN( ONE, X( I ) )
+         IF( X(I).GE.ZERO ) THEN
+            X(I) = ONE
+         ELSE
+            X(I) = -ONE
+         END IF
          ISGN( I ) = NINT( X( I ) )
   100 CONTINUE
       KASE = 2

--- a/SRC/dlacn2.f
+++ b/SRC/dlacn2.f
@@ -171,7 +171,7 @@
       EXTERNAL           DCOPY
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, DBLE, NINT, SIGN
+      INTRINSIC          ABS, DBLE, NINT
 *     ..
 *     .. Executable Statements ..
 *

--- a/SRC/slacn2.f
+++ b/SRC/slacn2.f
@@ -160,7 +160,7 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, JLAST
-      REAL               ALTSGN, ESTOLD, TEMP
+      REAL               ALTSGN, ESTOLD, TEMP, XS
 *     ..
 *     .. External Functions ..
       INTEGER            ISAMAX
@@ -171,7 +171,7 @@
       EXTERNAL           SCOPY
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, NINT, REAL, SIGN
+      INTRINSIC          ABS, NINT, REAL
 *     ..
 *     .. Executable Statements ..
 *
@@ -199,7 +199,11 @@
       EST = SASUM( N, X, 1 )
 *
       DO 30 I = 1, N
-         X( I ) = SIGN( ONE, X( I ) )
+         IF( X(I).GE.ZERO ) THEN
+            X(I) = ONE
+         ELSE
+            X(I) = -ONE
+         END IF
          ISGN( I ) = NINT( X( I ) )
    30 CONTINUE
       KASE = 2
@@ -232,7 +236,12 @@
       ESTOLD = EST
       EST = SASUM( N, V, 1 )
       DO 80 I = 1, N
-         IF( NINT( SIGN( ONE, X( I ) ) ).NE.ISGN( I ) )
+         IF( X(I).GE.ZERO ) THEN
+            XS = ONE
+         ELSE
+            XS = -ONE
+         END IF
+         IF( NINT( XS ).NE.ISGN( I ) )
      $      GO TO 90
    80 CONTINUE
 *     REPEATED SIGN VECTOR DETECTED, HENCE ALGORITHM HAS CONVERGED.
@@ -244,7 +253,11 @@
      $   GO TO 120
 *
       DO 100 I = 1, N
-         X( I ) = SIGN( ONE, X( I ) )
+         IF( X(I).GE.ZERO ) THEN
+            X(I) = ONE
+         ELSE
+            X(I) = -ONE
+         END IF
          ISGN( I ) = NINT( X( I ) )
   100 CONTINUE
       KASE = 2


### PR DESCRIPTION
Hi,

My colleague Edvin Hopkins at NAG noticed that SLACN2 and DLACN2 suffers from the change in meaning of SIGN at Fortran 95, with respect to negative zero. With DLACN2 this was manifesting as incorrect results in the DGEEVX example program we distribute with our numerical library.

The intended semantics can be seen in the original paper e.g. at http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.117.4839&rep=rep1&type=pdf (page 384), so we suggest inlining the expression as an IF block in order to uniformly force the correct behaviour.

I have also taken the opportunity to improve the new INCX==INCY=0 testing in ?blat1 in order to run the new tests only once and to display the correct INC values on failure.