### PR TITLE
Recursive option for ifort configuration

### DIFF
--- a/INSTALL/make.inc.ifort
+++ b/INSTALL/make.inc.ifort
@@ -16,9 +16,9 @@ CFLAGS = -O3
 #  the compiler options desired when NO OPTIMIZATION is selected.
 #
 FC = ifort
-FFLAGS = -O3 -fp-model strict -assume protect_parens
+FFLAGS = -O3 -fp-model strict -assume protect_parens -recursive
 FFLAGS_DRV = $(FFLAGS)
-FFLAGS_NOOPT = -O0 -fp-model strict -assume protect_parens
+FFLAGS_NOOPT = -O0 -fp-model strict -assume protect_parens -recursive
 
 #  Define LDFLAGS to the desired linker options for your machine.
 #

--- a/INSTALL/make.inc.pgf95
+++ b/INSTALL/make.inc.pgf95
@@ -16,9 +16,9 @@ CFLAGS =
 #  the compiler options desired when NO OPTIMIZATION is selected.
 #
 FC = pgf95
-FFLAGS = -O3
+FFLAGS = -O3 -Mrecursive
 FFLAGS_DRV = $(FFLAGS)
-FFLAGS_NOOPT = -O0
+FFLAGS_NOOPT = -O0 -Mrecursive
 
 #  Define LDFLAGS to the desired linker options for your machine.
 #


### PR DESCRIPTION
(see issue #401)

I don't about similar options for other compilers though, like  the Portland group and Sun compilers. But at least Intel Fortran is covered with this small change (the corresponding "-frecursive" option was already added to the GNU Fortran configuration file).