### PR TITLE
2-by-1 CS decomposition fixes

### DIFF
--- a/SRC/cuncsd2by1.f
+++ b/SRC/cuncsd2by1.f
@@ -190,9 +190,10 @@
 *>          The dimension of the array WORK.
 *>
 *>          If LWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the WORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LWORK is issued by XERBLA.
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *>
 *> \param[out] RWORK
@@ -211,10 +212,11 @@
 *>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>
-*>          If LRWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the RWORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LRWORK is issued by XERBLA.
+*>          If LRWORK=-1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *
 *> \param[out] IWORK
@@ -313,7 +315,7 @@
       WANTU1 = LSAME( JOBU1, 'Y' )
       WANTU2 = LSAME( JOBU2, 'Y' )
       WANTV1T = LSAME( JOBV1T, 'Y' )
-      LQUERY = LWORK .EQ. -1
+      LQUERY = ( LWORK.EQ.-1 ) .OR. ( LRWORK.EQ.-1 )
 *
       IF( M .LT. 0 ) THEN
          INFO = -4

--- a/SRC/cuncsd2by1.f
+++ b/SRC/cuncsd2by1.f
@@ -711,6 +711,10 @@
 *
 *        Accumulate Householder reflectors
 *
+
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL CCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL CCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -722,7 +726,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL CCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO

--- a/SRC/cuncsd2by1.f
+++ b/SRC/cuncsd2by1.f
@@ -513,6 +513,9 @@
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
             INFO = -19
          END IF
+         IF( LRWORK .LT. LRWORKMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -21
+         END IF
       END IF
       IF( INFO .NE. 0 ) THEN
          CALL XERBLA( 'CUNCSD2BY1', -INFO )
@@ -566,8 +569,8 @@
      $                RWORK(IPHI), U1, LDU1, U2, LDU2, V1T, LDV1T, CDUM,
      $                1, RWORK(IB11D), RWORK(IB11E), RWORK(IB12D),
      $                RWORK(IB12E), RWORK(IB21D), RWORK(IB21E),
-     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD), LBBCSD,
-     $                CHILDINFO )
+     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD),
+     $                LRWORK-IBBCSD+1, CHILDINFO )
 *
 *        Permute rows and columns to place zero submatrices in
 *        preferred positions

--- a/SRC/dorcsd2by1.f
+++ b/SRC/dorcsd2by1.f
@@ -674,6 +674,9 @@
 *
 *        Accumulate Householder reflectors
 *
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL DCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL DCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -685,7 +688,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL DCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO

--- a/SRC/sorcsd2by1.f
+++ b/SRC/sorcsd2by1.f
@@ -674,6 +674,9 @@
 *
 *        Accumulate Householder reflectors
 *
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL SCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL SCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -685,7 +688,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL SCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO

--- a/SRC/zuncsd2by1.f
+++ b/SRC/zuncsd2by1.f
@@ -511,6 +511,9 @@
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
             INFO = -19
          END IF
+         IF( LRWORK .LT. LRWORKMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -21
+         END IF
       END IF
       IF( INFO .NE. 0 ) THEN
          CALL XERBLA( 'ZUNCSD2BY1', -INFO )
@@ -564,8 +567,8 @@
      $                RWORK(IPHI), U1, LDU1, U2, LDU2, V1T, LDV1T, CDUM,
      $                1, RWORK(IB11D), RWORK(IB11E), RWORK(IB12D),
      $                RWORK(IB12E), RWORK(IB21D), RWORK(IB21E),
-     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD), LBBCSD,
-     $                CHILDINFO )
+     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD),
+     $                LRWORK-IBBCSD+1, CHILDINFO )
 *
 *        Permute rows and columns to place zero submatrices in
 *        preferred positions

--- a/SRC/zuncsd2by1.f
+++ b/SRC/zuncsd2by1.f
@@ -189,9 +189,10 @@
 *>          The dimension of the array WORK.
 *>
 *>          If LWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the WORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LWORK is issued by XERBLA.
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *>
 *> \param[out] RWORK
@@ -210,10 +211,11 @@
 *>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>
-*>          If LRWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the RWORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LRWORK is issued by XERBLA.
+*>          If LRWORK=-1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *
 *> \param[out] IWORK
@@ -312,7 +314,7 @@
       WANTU1 = LSAME( JOBU1, 'Y' )
       WANTU2 = LSAME( JOBU2, 'Y' )
       WANTV1T = LSAME( JOBV1T, 'Y' )
-      LQUERY = LWORK .EQ. -1
+      LQUERY = ( LWORK.EQ.-1 ) .OR. ( LRWORK.EQ.-1 )
 *
       IF( M .LT. 0 ) THEN
          INFO = -4

--- a/SRC/zuncsd2by1.f
+++ b/SRC/zuncsd2by1.f
@@ -709,6 +709,9 @@
 *
 *        Accumulate Householder reflectors
 *
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL ZCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL ZCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -720,7 +723,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL ZCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO


### PR DESCRIPTION
This pull request improves `xUNCSD2BY1` and `xORCSD2BY1`.

* The `LRWORK` argument to `xUNCSD2BY()` is checked.
* The actual `LRWORK` value is passed to `xBBCSD()` inside `xUNCSD2BY()` instead of passing the minimum allowed `LRWORK` value.
* `U2` may be obviously not orthogonal or unitary, respectively, for certain input matrix dimension because `xORGQR()` and `xUNGQR()` may overwrite the scalar factors of the elementary reflectors when assembling `U1`. On the author's computer, this happens, e.g., with `m=260`, `q=131`, and `p=130` (these values may be dependent on the blocking size).
* `xUNCSD2BY1` assume workspace queries when `LRWORK = -1`. This is also the behavior exhibited by, e.g., `xHEEVD`.

The `U2` orthogonality issue is caused by `xORGQR()` / `xUNGQR()` using more than the minimum workspace available. The issue can be either fixed by
* restricting the available workspace to the required minimum (here: `P`) or
* copying the scalar factors.

The patch choses the latter approach.