### PR TITLE
Add GSVD with QR factorizations, 2-by-1 CS decomposition

### DIFF
--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -370,7 +370,7 @@ set(ZLASRC
    zgetri.f zgetrs.f
    zggbak.f zggbal.f
    zgges.f  zgges3.f zggesx.f zggev.f  zggev3.f zggevx.f
-   zggglm.f zgghrd.f zgghd3.f zgglse.f zggqrf.f zggrqf.f
+   zggglm.f zgghrd.f zgghd3.f zgglse.f zggqrf.f zggrqf.f zggqrcs.f
    zggsvd3.f zggsvp3.f
    zgtcon.f zgtrfs.f zgtsv.f  zgtsvx.f zgttrf.f zgttrs.f zgtts2.f zhbev.f
    zhbevd.f zhbevx.f zhbgst.f zhbgv.f  zhbgvd.f zhbgvx.f zhbtrd.f

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -177,7 +177,7 @@ set(CLASRC
    cgetri.f
    cggbak.f cggbal.f
    cgges.f  cgges3.f cggesx.f cggev.f  cggev3.f cggevx.f
-   cggglm.f cgghrd.f cgghd3.f cgglse.f cggqrf.f cggrqf.f
+   cggglm.f cgghrd.f cgghd3.f cgglse.f cggqrf.f cggrqf.f cggqrcs.f
    cggsvd3.f cggsvp3.f
    cgtcon.f cgtrfs.f cgtsv.f  cgtsvx.f cgttrf.f cgttrs.f cgtts2.f chbev.f
    chbevd.f chbevx.f chbgst.f chbgv.f  chbgvd.f chbgvx.f chbtrd.f

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -280,7 +280,7 @@ set(DLASRC
    dgetrf.f dgetrf2.f dgetri.f
    dgetrs.f dggbak.f dggbal.f
    dgges.f  dgges3.f dggesx.f dggev.f  dggev3.f dggevx.f
-   dggglm.f dgghrd.f dgghd3.f dgglse.f dggqrf.f
+   dggglm.f dgghrd.f dgghd3.f dgglse.f dggqrf.f dggqrcs.f
    dggrqf.f dggsvd3.f dggsvp3.f dgtcon.f dgtrfs.f dgtsv.f
    dgtsvx.f dgttrf.f dgttrs.f dgtts2.f dhgeqz.f
    dhsein.f dhseqr.f dlabrd.f dlacon.f dlacn2.f

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -87,7 +87,7 @@ set(SLASRC
    sgetrf2.f sgetri.f
    sggbak.f sggbal.f
    sgges.f  sgges3.f sggesx.f sggev.f  sggev3.f sggevx.f
-   sggglm.f sgghrd.f sgghd3.f sgglse.f sggqrf.f
+   sggglm.f sgghrd.f sgghd3.f sgglse.f sggqrf.f sggqrcs.f
    sggrqf.f sggsvd3.f sggsvp3.f sgtcon.f sgtrfs.f sgtsv.f
    sgtsvx.f sgttrf.f sgttrs.f sgtts2.f shgeqz.f
    shsein.f shseqr.f slabrd.f slacon.f slacn2.f

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -1,0 +1,665 @@
+*> \brief <b> CGGQRCS computes the singular value decomposition (SVD) for OTHER matrices</b>
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download CGGQRCS + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE CGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+*                           A, LDA, B, LDB,
+*                           THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+*                           WORK, LWORK, RWORK, LRWORK, IWORK, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          JOBU1, JOB2, JOBQT
+*       INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+*      $                   M, N, P, L, LWORK, LRWORK
+*       REAL               W
+*       ..
+*       .. Array Arguments ..
+*       INTEGER            IWORK( * ), RWORK( * )
+*       COMPLEX            A( LDA, * ), B( LDB, * ), THETA( * ),
+*      $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQ, * ),
+*      $                   WORK( * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> CGGQRCS computes the generalized singular value decomposition (GSVD)
+*> of an M-by-N real matrix A and P-by-N real matrix B:
+*>
+*>       U1**T*A*Q = D1*( 0 R ),    U2**T*B*Q = D2*( 0 R )
+*>
+*> where U1, U2, and Q are orthogonal matrices. CGGQRCS uses the QR
+*> factorization with column pivoting and the 2-by-1 CS decomposition to
+*> compute the GSVD.
+*>
+*> Let L be the effective numerical rank of the matrix (A**T,B**T)**T,
+*> then R is a L-by-L nonsingular upper triangular matrix, D1 and
+*> D2 are M-by-L and P-by-L "diagonal" matrices and of the
+*> following structures, respectively:
+*>
+*>                        K   K1
+*>        D1 =     (  0   0   0 )
+*>              K  (  0   S   0 )
+*>              K1 (  0   0   I )
+*>
+*>                    K2  K
+*>        D2 =  K2 (  I   0   0 )
+*>              K  (  0   C   0 )
+*>                 (  0   0   0 )
+*>
+*>                 N-L  L
+*>   ( 0 R ) = L (  0   R )
+*>
+*> where
+*>
+*>   K  = MIN(M, P, L, M + P - L),
+*>   K1 = MAX(L - P, 0),
+*>   K2 = MAX(L - M, 0),
+*>   C  = diag( COS(THETA(1)), ..., COS(THETA(K)) ),
+*>   S  = diag( SIN(THETA(1)), ..., SIN(THETA(K)) ), and
+*>   C^2 + S^2 = I.
+*>
+*> The routine computes C, S, R, and optionally the orthogonal
+*> transformation matrices U, V and Q. If L <= M, then R is stored in
+*> A(1:L, 1:L) on exit. Otherwise, the first M rows of R are stored in
+*> A(:, 1:L) and R( M+1:, M+1: ) is stored in B(1:L-M, 1:L-M). In both
+*> cases, only the upper triangular part is stored.
+*>
+*> In particular, if B is an N-by-N nonsingular matrix, then the GSVD of
+*> A and B implicitly gives the SVD of A*inv(B):
+*>                      A*inv(B) = U1*(D1*inv(D2))*U2**T.
+*> If (A**T,B**T)**T  has orthonormal columns, then the GSVD of A and B
+*> is also equal to the CS decomposition of A and B. Furthermore, the
+*> GSVD can be used to derive the solution of the eigenvalue problem:
+*>                      A**T*A x = lambda * B**T*B x.
+*> In some literature, the GSVD of A and B is presented in the form
+*>                  U1**T*A*X = ( 0 D1 ),   U2**T*B*X = ( 0 D2 )
+*> where U1 and U2 are orthogonal and X is nonsingular, D1 and D2 are
+*> ``diagonal''.  The former GSVD form can be converted to the latter
+*> form by taking the nonsingular matrix X as
+*>
+*>                      X = Q*( I   0    )
+*>                            ( 0 inv(R) ).
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] JOBU1
+*> \verbatim
+*>          JOBU1 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U1 is computed;
+*>          = 'N':  U1 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBU2
+*> \verbatim
+*>          JOBU2 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U2 is computed;
+*>          = 'N':  U2 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBQT
+*> \verbatim
+*>          JOBQT is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix Q is computed;
+*>          = 'N':  Q is not computed.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.  M >= 0.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] P
+*> \verbatim
+*>          P is INTEGER
+*>          The number of rows of the matrix B.  P >= 0.
+*> \endverbatim
+*>
+*> \param[out] W
+*> \verbatim
+*>          W is REAL
+*>
+*>          On exit, W is a radix power chosen such that the Frobenius
+*>          norm of A and W*B are within sqrt(radix) and 1/sqrt(radix)
+*>          of each other.
+*> \endverbatim
+*>
+*> \param[out] L
+*> \verbatim
+*>          L is INTEGER
+*>          On exit, the effective numerical rank of the matrix
+*>          (A**T, B**T)**T.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension (LDA,N)
+*>          On entry, the M-by-N matrix A.
+*>          On exit, A contains the triangular matrix R or the first M
+*>          rows of R, respectively. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A. LDA >= max(1,M).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX array, dimension (LDB,N)
+*>          On entry, the P-by-N matrix B.
+*>          On exit, if L > M, then B contains the last L - M rows of
+*>          the triangular matrix R. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B. LDB >= max(1,P).
+*> \endverbatim
+*>
+*> \param[out] THETA
+*> \verbatim
+*>          THETA is REAL array, dimension (N)
+*>
+*>          On exit, THETA contains K = MIN(M, P, L, M + P - L) values
+*>          in radians in ascending order.
+*> \endverbatim
+*>
+*> \param[out] U1
+*> \verbatim
+*>          U1 is COMPLEX array, dimension (LDU1,M)
+*>          If JOBU1 = 'Y', U1 contains the M-by-M orthogonal matrix U1.
+*>          If JOBU1 = 'N', U1 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU1
+*> \verbatim
+*>          LDU1 is INTEGER
+*>          The leading dimension of the array U1. LDU1 >= max(1,M) if
+*>          JOBU1 = 'Y'; LDU1 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] U2
+*> \verbatim
+*>          U2 is COMPLEX array, dimension (LDU2,P)
+*>          If JOBU2 = 'Y', U2 contains the P-by-P orthogonal matrix U2.
+*>          If JOBU2 = 'N', U2 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU2
+*> \verbatim
+*>          LDU2 is INTEGER
+*>          The leading dimension of the array U2. LDU2 >= max(1,P) if
+*>          JOBU2 = 'Y'; LDU2 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] QT
+*> \verbatim
+*>          QT is COMPLEX array, dimension (LDQT,N)
+*>          If JOBQT = 'Y', QT contains the N-by-N orthogonal matrix
+*>          Q**T.
+*> \endverbatim
+*>
+*> \param[in] LDQT
+*> \verbatim
+*>          LDQT is INTEGER
+*>          The leading dimension of the array QT. LDQT >= max(1,N) if
+*>          JOBQT = 'Y'; LDQT >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>
+*>          If LWORK = -1, then a workspace query is assumed; the
+*>          routine only calculates the optimal size of the WORK array,
+*>          returns this value as the first entry of the WORK array, and
+*>          no error message related to LWORK is issued by XERBLA.
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is REAL array, dimension (MAX(1,LRWORK))
+*> \endverbatim
+*>
+*> \param[in] LRWORK
+*> \verbatim
+*>          LRWORK is INTEGER
+*>          The dimension of the array RWORK.
+*>
+*>          If LRWORK = -1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the RWORK array, returns
+*>          this value as the first entry of the work array, and no error
+*>          message related to LRWORK is issued by XERBLA.
+*> \endverbatim
+*>
+*> \param[out] IWORK
+*> \verbatim
+*>          IWORK is INTEGER array, dimension (M + N + P)
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  CBBCSD did not converge. For further details, see
+*>                subroutine CUNCSDBY1.
+*> \endverbatim
+*
+*> \par Internal Parameters:
+*  =========================
+*>
+*> \verbatim
+*>  TOL     REAL
+*>          Let G = (A**T,B**T)**T. TOL is the threshold to determine
+*>          the effective rank of G. Generally, it is set to
+*>                   TOL = MAX(M,P,N) * norm(G) * MACHEPS,
+*>          where norm(G) is the Frobenius norm of G.
+*>          The size of TOL may affect the size of backward error of the
+*>          decomposition.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Christoph Conrads (https://christoph-conrads.name)
+*
+*> \date October 2019
+*
+*> \ingroup realGEsing
+*
+*> \par Contributors:
+*  ==================
+*>
+*>     Christoph Conrads (https://christoph-conrads.name)
+*>
+*
+*> \par Further Details:
+*  =====================
+*>
+*>  CGGQRCS should be significantly faster than CGGSVD and CGGSVD3 for
+*>  large matrices because the matrices A and B are reduced to a pair of
+*>  well-conditioned bidiagonal matrices instead of pairs of upper
+*>  triangular matrices. On the downside, CGGQRCS requires a much larger
+*>  workspace whose dimension must be queried at run-time.
+*>
+*  =====================================================================
+      SUBROUTINE CGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+     $                    A, LDA, B, LDB,
+     $                    THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+     $                    WORK, LWORK, RWORK, LRWORK, IWORK, INFO )
+*
+*  -- LAPACK driver routine (version 3.X.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd. --
+*     <DATE>
+*
+      IMPLICIT NONE
+*     .. Scalar Arguments ..
+      CHARACTER          JOBU1, JOBU2, JOBQT
+      INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+     $                   L, M, N, P, LWORK, LRWORK
+      COMPLEX            W
+*     ..
+*     .. Array Arguments ..
+      INTEGER            IWORK( * )
+      REAL               RWORK( * )
+      COMPLEX            A( LDA, * ), B( LDB, * ), THETA( * ),
+     $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQT, * ),
+     $                   WORK( * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Local Scalars ..
+      LOGICAL            WANTU1, WANTU2, WANTQT, LQUERY
+      INTEGER            I, J, Z, R, LDG, LWKOPT, LRWKOPT
+      REAL               GNORM, TOL, ULP, UNFL, NORMA, NORMB, BASE, NAN
+      COMPLEX            ZERO, ONE, CNAN
+*     .. Local Arrays ..
+      COMPLEX            G( M + P, N ), TAU( MIN( M + P, N ) )
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      REAL               SLAMCH, CLANGE
+      EXTERNAL           LSAME, SLAMCH, SLANGE
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           CLACPY, CLASCL, CGEQP3, CUNGQR, CGERQF, CUNGRQ,
+     $                   CUNCSD2BY1, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX, MIN
+*     ..
+*     .. Executable Statements ..
+*
+*     Decode and test the input parameters
+*
+      WANTU1 = LSAME( JOBU1, 'Y' )
+      WANTU2 = LSAME( JOBU2, 'Y' )
+      WANTQT = LSAME( JOBQT, 'Y' )
+      LQUERY = ( LWORK.EQ.-1 ) .OR. ( LRWORK.EQ.-1 )
+      LWKOPT = 1
+      LRWKOPT = 2*N
+*
+*     Initialize variables
+*
+      L = MIN( M + P, N )
+      Z = ( M + P ) * N
+      IF ( LQUERY ) THEN
+         G = 0
+      ELSE
+         G = RESHAPE( WORK(1:Z), (/ M + P, N /) )
+      END IF
+      TAU = WORK( Z + 1 )
+      LDG = M + P
+      ZERO = (0.0E0, 0.0E0)
+      ONE = (1.0E0, 0.0E0)
+*     Computing 0.0 / 0.0 directly causes compiler errors
+      NAN = 1.0E0
+      NAN = 0.0 / (NAN - 1.0E0)
+      CNAN = CMPLX(NAN,NAN)
+*
+*     Test the input arguments
+*
+      INFO = 0
+      IF( .NOT.( WANTU1 .OR. LSAME( JOBU1, 'N' ) ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.( WANTU2 .OR. LSAME( JOBU2, 'N' ) ) ) THEN
+         INFO = -2
+      ELSE IF( .NOT.( WANTQT .OR. LSAME( JOBQT, 'N' ) ) ) THEN
+         INFO = -3
+      ELSE IF( M.LT.0 ) THEN
+         INFO = -4
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -5
+      ELSE IF( P.LT.0 ) THEN
+         INFO = -6
+      ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
+         INFO = -10
+      ELSE IF( LDB.LT.MAX( 1, P ) ) THEN
+         INFO = -12
+      ELSE IF( LDU1.LT.1 .OR. ( WANTU1 .AND. LDU1.LT.M ) ) THEN
+         INFO = -15
+      ELSE IF( LDU2.LT.1 .OR. ( WANTU2 .AND. LDU2.LT.P ) ) THEN
+         INFO = -17
+      ELSE IF( LDQT.LT.1 .OR. ( WANTQT .AND. LDQT.LT.N ) ) THEN
+         INFO = -19
+      ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
+         INFO = -23
+      ELSE IF( LRWORK.LT.2*N .AND. .NOT.LQUERY ) THEN
+         INFO = -25
+      END IF
+*
+*     Compute workspace
+*
+      IF( INFO.EQ.0 ) THEN
+         CALL CGEQP3( M+P, N, G, LDG, IWORK, TAU,
+     $                WORK, -1, RWORK, INFO )
+         LWKOPT = INT( WORK( 1 ) )
+
+         CALL CUNGQR( M + P, L, L, G, LDG, TAU, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+
+         CALL CUNCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, L,
+     $                    G, LDG, G, LDG,
+     $                    THETA, U2, LDU2, U1, LDU1, QT, LDQT,
+     $                    WORK, -1, RWORK, LRWORK, IWORK, INFO )
+*        Add L to LWKOPT for xGEQP3, xUNGQR because of array TAU
+         LWKOPT = MAX( LWKOPT + L, INT( WORK( 1 ) ) )
+         LWKOPT = Z + LWKOPT
+         LRWKOPT = MAX( 2*N, INT( RWORK( 1 ) ) )
+
+*        DGERQF stores L scalar factors for the elementary reflectors
+         CALL CGERQF( L, N, QT, LDQT, TAU, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + L )
+
+         CALL CUNGRQ( N, N, L, QT, LDQT, TAU, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + L )
+
+         WORK( 1 ) = CMPLX( REAL( LWKOPT ), 0.0E0 )
+         RWORK( 1 ) = REAL( LRWKOPT )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'CGGQRCS', -INFO )
+         RETURN
+      END IF
+      IF( LQUERY ) THEN
+         RETURN
+      ENDIF
+*
+*     Scale matrix B such that norm(A) \approx norm(B)
+*
+      NORMA = CLANGE( 'F', M, N, A, LDA, RWORK )
+      NORMB = CLANGE( 'F', P, N, B, LDB, RWORK )
+*
+      IF ( NORMB.EQ.0 ) THEN
+         W = 1.0E0
+      ELSE
+         BASE = SLAMCH( 'B' )
+         W = BASE ** INT( LOG( NORMA / NORMB ) / LOG( BASE ) )
+*
+         CALL CLASCL( 'G', -1, -1, 1.0E0, W, P, N, B, LDB, INFO )
+         IF ( INFO.NE.0 ) THEN
+            RETURN
+         END IF
+      END IF
+*
+*     Copy matrices A, B into the (M+P) x n matrix G
+*
+      CALL CLACPY( 'A', M, N, A, LDA, G( P + 1, 1 ), LDG )
+      CALL CLACPY( 'A', P, N, B, LDB, G( 1, 1 ), LDG )
+*
+*     DEBUG
+*
+      CALL CLASET( 'A', M, N, CNAN, CNAN, A, LDA )
+      CALL CLASET( 'A', P, N, CNAN, CNAN, B, LDB )
+*
+*     Compute the Frobenius norm of matrix G
+*
+      GNORM = CLANGE( 'F', M + P, N, G, LDG, WORK( Z + 1 ) )
+*
+*     Get machine precision and set up threshold for determining
+*     the effective numerical rank of the matrix G.
+*
+      ULP = SLAMCH( 'Precision' )
+      UNFL = SLAMCH( 'Safe Minimum' )
+      TOL = MAX( M + P, N ) * MAX( GNORM, UNFL ) * ULP
+*
+*     IWORK stores the column permutations computed by CGEQP3.
+*     Columns J where IWORK( J ) is non-zero are permuted to the front
+*     so we set the all entries to zero here.
+*
+      DO 10 J = 1, N
+         IWORK( J ) = 0
+   10 CONTINUE
+*
+*     Compute the QR factorization with column pivoting GΠ = Q1 R1
+*
+      CALL CGEQP3( M + P, N, G, LDG, IWORK, TAU,
+     $             WORK( Z + 1 ), LWORK - Z, RWORK, INFO )
+      IF( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Determine the rank of G
+*
+      R = 0
+      DO 20 I = 1, MIN( M + P, N )
+         IF( ABS( G( I, I ) ).LE.TOL ) THEN
+            EXIT
+         END IF
+         R = R + 1
+   20 CONTINUE
+*
+*     Handle rank=0 case
+*
+      IF( R.EQ.0 ) THEN
+         IF( WANTU1 ) THEN
+            CALL SLASET( 'A', M, M, ZERO, ONE, U1, LDU1 )
+         END IF
+         IF( WANTU2 ) THEN
+            CALL SLASET( 'A', P, P, ZERO, ONE, U2, LDU2 )
+         END IF
+         IF( WANTQT ) THEN
+            CALL SLASET( 'A', N, N, ZERO, ONE, QT, LDQT )
+         END IF
+*
+         WORK( 1 ) = CMPLX( REAL(LWKOPT), 0.0E0 )
+         RWORK( 1 ) = REAL(LRWKOPT)
+         RETURN
+      END IF
+*
+*     Copy R1( 1:R, : ) into A, B and set lower triangular part to zero
+*
+      IF( R.LE.M ) THEN
+          CALL CLACPY( 'U', R, N, G, LDG, A, LDA )
+          CALL CLASET( 'L', R - 1, N, ZERO, ZERO, A( 2, 1 ), LDA )
+      ELSE
+          CALL CLACPY( 'U', M, N, G, LDG, A, LDA )
+          CALL CLACPY( 'U', R - M, N - M, G( M+1, M+1 ), LDG, B, LDB )
+*
+          CALL CLASET( 'L', M - 1, N, ZERO, ZERO, A( 2, 1 ), LDA )
+          CALL CLASET( 'L', R-M-1, N, ZERO, ZERO, B( 2, 1 ), LDB )
+      END IF
+*
+*     Explicitly form Q1 so that we can compute the CS decomposition
+*
+      CALL CUNGQR( M + P, R, R, G, LDG, TAU,
+     $             WORK( Z + 1 ), LWORK - Z, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     DEBUG
+*
+      TAU(:) = CNAN
+*
+*     Compute the CS decomposition of Q1( :, 1:R )
+*
+      CALL CUNCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, R,
+     $                 G( 1, 1 ), LDG, G( P + 1, 1 ), LDG, THETA,
+     $                 U2, LDU2, U1, LDU1, QT, LDQT,
+     $                 WORK( Z + 1 ), LWORK - Z,
+     $                 RWORK, LRWORK, IWORK( N + 1 ), INFO )
+      IF( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     DEBUG
+*
+      WORK(1:LWORK) = CNAN
+      RWORK(1:LRWORK) = NAN
+*
+*     Copy V^T from QT to G
+*
+      CALL CLACPY( 'A', R, R, QT, LDQT, G, LDG )
+*
+*     DEBUG
+*
+      CALL CLASET( 'A', N, N, CNAN, CNAN, QT, LDQT )
+*
+*     Compute V^T R1( 1:R, : ) in the last R rows of QT
+*
+      IF ( R.LE.M ) THEN
+         CALL CGEMM( 'N', 'N', R, N, R, ONE, G, LDG,
+     $               A, LDA, ZERO, QT( N-R+1, 1 ), LDQT )
+      ELSE
+         CALL CGEMM( 'N', 'N', R, N, M, ONE, G( 1, 1 ), LDG,
+     $               A, LDA, ZERO, QT( N-R+1, 1 ), LDQT )
+         CALL CGEMM( 'N', 'N', R, N - M, R - M, ONE,
+     $               G( 1, M + 1 ), LDG, B, LDB,
+     $               ONE, QT( N-R+1, M+1 ), LDQT )
+      END IF
+*
+*     DEBUG
+*
+      CALL CLASET( 'A', M, N, CNAN, CNAN, A, LDA )
+      CALL CLASET( 'A', P, N, CNAN, CNAN, B, LDB )
+      WORK(1:LWORK) = CNAN
+*
+*     Compute the RQ decomposition of V^T R1( 1:R, : )
+*
+      TAU = WORK(1:L)
+      CALL CGERQF( R, N, QT( N-R+1, 1 ), LDQT, TAU,
+     $             WORK( L + 1 ), LWORK - L, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Copy matrix R from QT( N-R+1:N, N-R+1:N ) to A, B
+*
+      IF ( R.LE.M ) THEN
+         CALL CLACPY( 'U', R, R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
+      ELSE
+         CALL CLACPY( 'U', M,     R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
+         CALL CLACPY( 'U', R - M, R - M, QT( N-R+M+1, N-R+M+1 ), LDQT,
+     $                B, LDB )
+      END IF
+*
+*     DEBUG
+*
+      CALL CLASET( 'U', R, R, CNAN, CNAN, QT( 1, N-R+1 ), LDQT )
+      WORK( L+1:LWORK ) = CNAN
+*
+*     Explicitly form Q^T
+*
+      IF( WANTQT ) THEN
+         CALL CUNGRQ( N, N, R, QT, LDQT, TAU,
+     $                WORK( L + 1 ), LWORK - L, INFO )
+         IF ( INFO.NE.0 ) THEN
+            RETURN
+         END IF
+*
+*     Revert column permutation Π by permuting the rows of Q^T
+*
+         CALL CLAPMT( .FALSE., N, N, QT, LDQT, IWORK )
+      END IF
+*
+      WORK( 1 ) = CMPLX( REAL(LWKOPT), 0.0E0 )
+      RWORK( 1 ) = REAL(LRWKOPT)
+
+      RETURN
+*
+*     End of CGGQRCS
+*
+      END

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -353,7 +353,7 @@
 *     .. Local Scalars ..
       LOGICAL            WANTU1, WANTU2, WANTQT, LQUERY
       INTEGER            I, J, LMAX, Z, LDG, LWKOPT, LRWKOPT,
-     $                   LRWORK2BY1, K2BY1
+     $                   LRWORK2BY1
       REAL               GNORM, TOL, ULP, UNFL, NORMA, NORMB, BASE, NAN
       COMPLEX            ZERO, ONE, CNAN
 *     .. Local Arrays ..
@@ -451,8 +451,13 @@
          LWKOPT = Z + LWKOPT
 *        Adjust CUNCSD2BY1 LRWORK for case with maximum memory
 *        consumption
-         K2BY1 = MIN( m, p, n, MAX( 0, M+P-N) )
-         LRWORK2BY1 = INT( RWORK(1) ) - 16 * K2BY1 + 16 * MIN( M,P,N )
+         LRWORK2BY1 = INT( RWORK(1) )
+*        Select safe xUNCSD2BY1 IBBCSD value
+     $                - 9 * MAX( 0, MIN( M, P, N, M+P-N-1 ) )
+     $                + 9 * MAX( 1, MIN( M, P, N ) )
+*        Select safe xUNCSD2BY1 LBBCSD value
+     $                - 8 * MAX( 0, MIN( M, P, N, M+P-N ) )
+     $                + 8 * MIN( M, P, N )
          LRWKOPT = MAX( 2*N, LRWORK2BY1 )
 
 *        CGERQF, CUNGRQ read/store up to LMAX scalar factors

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -44,7 +44,7 @@
 *> \verbatim
 *>
 *> CGGQRCS computes the generalized singular value decomposition (GSVD)
-*> of an M-by-N real matrix A and P-by-N real matrix B:
+*> of an M-by-N complex matrix A and P-by-N complex matrix B:
 *>
 *>       U1**T*A*Q = D1*( 0 R ),    U2**T*B*Q = D2*( 0 R )
 *>
@@ -53,7 +53,7 @@
 *> compute the GSVD.
 *>
 *> Let L be the effective numerical rank of the matrix (A**T,B**T)**T,
-*> then R is a L-by-L nonsingular upper triangular matrix, D1 and
+*> then R is an L-by-L nonsingular upper triangular matrix, D1 and
 *> D2 are M-by-L and P-by-L "diagonal" matrices and of the
 *> following structures, respectively:
 *>

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -514,9 +514,7 @@
 *     Columns J where IWORK( J ) is non-zero are permuted to the front
 *     so we set the all entries to zero here.
 *
-      DO 10 J = 1, N
-         IWORK( J ) = 0
-   10 CONTINUE
+      IWORK( 1:N ) = 0
 *
 *     Compute the QR factorization with column pivoting GΠ = Q1 R1
 *

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -360,7 +360,7 @@
 *     .. External Functions ..
       LOGICAL            LSAME
       REAL               SLAMCH, CLANGE
-      EXTERNAL           LSAME, SLAMCH, SLANGE
+      EXTERNAL           LSAME, SLAMCH, CLANGE
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CLACPY, CLASCL, CGEQP3, CUNGQR, CGERQF, CUNGRQ,

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -337,7 +337,7 @@
       CHARACTER          JOBU1, JOBU2, JOBQT
       INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
      $                   L, M, N, P, LWORK, LRWORK
-      COMPLEX            W
+      REAL               W
 *     ..
 *     .. Array Arguments ..
       INTEGER            IWORK( * )

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -352,7 +352,8 @@
 *
 *     .. Local Scalars ..
       LOGICAL            WANTU1, WANTU2, WANTQT, LQUERY
-      INTEGER            I, J, LMAX, Z, LDG, LWKOPT, LRWKOPT
+      INTEGER            I, J, LMAX, Z, LDG, LWKOPT, LRWKOPT,
+     $                   LRWORK2BY1, K2BY1
       REAL               GNORM, TOL, ULP, UNFL, NORMA, NORMB, BASE, NAN
       COMPLEX            ZERO, ONE, CNAN
 *     .. Local Arrays ..
@@ -448,7 +449,11 @@
          LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
 *        The matrix (A, B) must be stored sequentially for xUNCSD2BY1
          LWKOPT = Z + LWKOPT
-         LRWKOPT = MAX( 2*N, INT( RWORK( 1 ) ) )
+*        Adjust CUNCSD2BY1 LRWORK for case with maximum memory
+*        consumption
+         K2BY1 = MIN( m, p, n, MAX( 0, M+P-N) )
+         LRWORK2BY1 = INT( RWORK(1) ) - 16 * K2BY1 + 16 * MIN( M,P,N )
+         LRWKOPT = MAX( 2*N, LRWORK2BY1 )
 
 *        CGERQF, CUNGRQ read/store up to LMAX scalar factors
          CALL CGERQF( LMAX, N, QT, LDQT, WORK, WORK, -1, INFO )

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -129,19 +129,19 @@
 *> \param[in] M
 *> \verbatim
 *>          M is INTEGER
-*>          The number of rows of the matrix A.  M >= 0.
+*>          The number of rows of the matrix A.  M >= 1.
 *> \endverbatim
 *>
 *> \param[in] N
 *> \verbatim
 *>          N is INTEGER
-*>          The number of columns of the matrices A and B.  N >= 0.
+*>          The number of columns of the matrices A and B.  N >= 1.
 *> \endverbatim
 *>
 *> \param[in] P
 *> \verbatim
 *>          P is INTEGER
-*>          The number of rows of the matrix B.  P >= 0.
+*>          The number of rows of the matrix B.  P >= 1.
 *> \endverbatim
 *>
 *> \param[out] W
@@ -390,7 +390,7 @@
       IF ( LQUERY ) THEN
          G = 0
       ELSE
-         G = RESHAPE( WORK(1:Z), (/ M + P, N /) )
+         G = WORK( 1 )
       END IF
       LDG = M + P
       ZERO = (0.0E0, 0.0E0)
@@ -409,11 +409,11 @@
          INFO = -2
       ELSE IF( .NOT.( WANTQT .OR. LSAME( JOBQT, 'N' ) ) ) THEN
          INFO = -3
-      ELSE IF( M.LT.0 ) THEN
+      ELSE IF( M.LT.1 ) THEN
          INFO = -4
-      ELSE IF( N.LT.0 ) THEN
+      ELSE IF( N.LT.1 ) THEN
          INFO = -5
-      ELSE IF( P.LT.0 ) THEN
+      ELSE IF( P.LT.1 ) THEN
          INFO = -6
       ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
          INFO = -10

--- a/SRC/cggqrcs.f
+++ b/SRC/cggqrcs.f
@@ -365,8 +365,8 @@
       EXTERNAL           LSAME, SLAMCH, CLANGE
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           CLACPY, CLASCL, CGEQP3, CUNGQR, CGERQF, CUNGRQ,
-     $                   CUNCSD2BY1, XERBLA
+      EXTERNAL           CGEMM, CGEQP3, CGERQF, CLACPY, CLAPMT, CLASCL,
+     $                   CLASET, CUNGQR, CUNGRQ, CUNCSD2BY1, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN

--- a/SRC/cuncsd2by1.f
+++ b/SRC/cuncsd2by1.f
@@ -190,9 +190,10 @@
 *>          The dimension of the array WORK.
 *>
 *>          If LWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the WORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LWORK is issued by XERBLA.
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *>
 *> \param[out] RWORK
@@ -211,10 +212,11 @@
 *>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>
-*>          If LRWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the RWORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LRWORK is issued by XERBLA.
+*>          If LRWORK=-1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *
 *> \param[out] IWORK
@@ -313,7 +315,7 @@
       WANTU1 = LSAME( JOBU1, 'Y' )
       WANTU2 = LSAME( JOBU2, 'Y' )
       WANTV1T = LSAME( JOBV1T, 'Y' )
-      LQUERY = LWORK .EQ. -1
+      LQUERY = ( LWORK.EQ.-1 ) .OR. ( LRWORK.EQ.-1 )
 *
       IF( M .LT. 0 ) THEN
          INFO = -4

--- a/SRC/cuncsd2by1.f
+++ b/SRC/cuncsd2by1.f
@@ -711,6 +711,10 @@
 *
 *        Accumulate Householder reflectors
 *
+
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL CCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL CCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -722,7 +726,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL CCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO

--- a/SRC/cuncsd2by1.f
+++ b/SRC/cuncsd2by1.f
@@ -513,6 +513,9 @@
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
             INFO = -19
          END IF
+         IF( LRWORK .LT. LRWORKMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -21
+         END IF
       END IF
       IF( INFO .NE. 0 ) THEN
          CALL XERBLA( 'CUNCSD2BY1', -INFO )
@@ -566,8 +569,8 @@
      $                RWORK(IPHI), U1, LDU1, U2, LDU2, V1T, LDV1T, CDUM,
      $                1, RWORK(IB11D), RWORK(IB11E), RWORK(IB12D),
      $                RWORK(IB12E), RWORK(IB21D), RWORK(IB21E),
-     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD), LBBCSD,
-     $                CHILDINFO )
+     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD),
+     $                LRWORK-IBBCSD+1, CHILDINFO )
 *
 *        Permute rows and columns to place zero submatrices in
 *        preferred positions

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -507,6 +507,8 @@
          IF( WANTQT ) THEN
             CALL DLASET( 'A', N, N, 0.0D0, 1.0D0, QT, LDQT )
          END IF
+*
+         WORK( 1 ) = DBLE( LWKOPT )
          RETURN
       END IF
 *

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -410,7 +410,7 @@
          CALL DORGQR( M + P, L, L, G, LDG, THETA, WORK, -1, INFO )
          LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
 
-         CALL DORCSD2BY1( JOBU1, JOBU2, JOBQT, M + P, P, N,
+         CALL DORCSD2BY1( JOBU1, JOBU2, JOBQT, M + P, P, L,
      $                    G, LDG, G, LDG,
      $                    THETA, U2, LDU2, U1, LDU1, QT, LDQT,
      $                    WORK, -1, IWORK, INFO )

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -80,8 +80,9 @@
 *>
 *> The routine computes C, S, R, and optionally the orthogonal
 *> transformation matrices U, V and Q. If L <= M, then R is stored in
-*> A(1:L, :) on exit. Otherwise, the first M rows of R are stored in A
-*> and the last L-M rows are stored in B(1:L-M, :).
+*> A(1:L, 1:L) on exit. Otherwise, the first M rows of R are stored in
+*> A(:, 1:L) and R( M+1:, M+1: ) is stored in B(1:L-M, 1:L-M). In both
+*> cases, only the upper triangular part is stored.
 *>
 *> In particular, if B is an N-by-N nonsingular matrix, then the GSVD of
 *> A and B implicitly gives the SVD of A*inv(B):
@@ -570,10 +571,11 @@
 *     Copy matrix R from QT( 1:R, N-R+1: ) to A, B
 *
       IF ( R.LE.M ) THEN
-         CALL DLACPY( 'U', R, R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
+         CALL DLACPY( 'U', R, R, QT( 1, N-R+1 ), LDQT, A, LDA )
       ELSE
-         CALL DLACPY( 'U', M,     R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
-         CALL DLACPY( 'U', R - M, R, QT( N-R+M+1, N-R+1 ), LDQT, B, LDB)
+         CALL DLACPY( 'U', M,     R, QT( 1, N-R+1 ), LDQT, A, LDA )
+         CALL DLACPY( 'U', R - M, R - M, QT( M + 1, N-R+M+1 ), LDQT,
+     $                B, LDB )
       END IF
 *
 *     Explicitly form Q^T

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -540,7 +540,7 @@
 *
 *     DEBUG
 *
-      THETA(1:L) = NAN
+      THETA(1:N) = NAN
 *
 *     Compute the CS decomposition of Q1( :, 1:L )
 *

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -365,7 +365,11 @@
 *
       L = MIN( M + P, N )
       Z = ( M + P ) * N
-      G = RESHAPE( WORK(1:Z), (/ M + P, N /) )
+      IF ( LQUERY ) THEN
+         G = 0
+      ELSE
+         G = RESHAPE( WORK(1:Z), (/ M + P, N /) )
+      END IF
       LDG = M + P
 *
 *     Test the input arguments

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -562,7 +562,7 @@
 *
 *     Copy V^T from QT to G
 *
-      CALL DLACPY( 'A', R, R, QT, LDQT, G, R )
+      CALL DLACPY( 'A', R, R, QT, LDQT, G, LDG )
 *
 *     DEBUG
 *
@@ -571,12 +571,12 @@
 *     Compute V^T R1( 1:R, : ) in the last R rows of QT
 *
       IF ( R.LE.M ) THEN
-         CALL DGEMM( 'N', 'N', R, N, R, 1.0D0, G, R,
+         CALL DGEMM( 'N', 'N', R, N, R, 1.0D0, G, LDG,
      $               A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
       ELSE
-         CALL DGEMM( 'N', 'N', R, N, M, 1.0D0, G( 1, 1 ), R,
+         CALL DGEMM( 'N', 'N', R, N, M, 1.0D0, G( 1, 1 ), LDG,
      $               A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
-         CALL DGEMM( 'N', 'N', R, N, R - M, 1.0D0, G( 1, M + 1 ), R,
+         CALL DGEMM( 'N', 'N', R, N, R - M, 1.0D0, G( 1, M + 1 ), LDG,
      $               B, LDB, 1.0D0, QT( N-R+1, 1 ), LDQT )
       END IF
 *

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -547,12 +547,12 @@
 *
       IF ( R.LE.M ) THEN
          CALL DGEMM( 'N', 'N', R, N, R, 1.0D0, G, R,
-     $          A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
+     $               A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
       ELSE
          CALL DGEMM( 'N', 'N', R, N, M, 1.0D0, G( 1, 1 ), R,
-     $          A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
+     $               A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
          CALL DGEMM( 'N', 'N', R, N, R - M, 1.0D0, G( 1, M + 1 ), R,
-     $          B, LDB, 1.0D0, QT( N-R+1, 1 ), LDQT )
+     $               B, LDB, 1.0D0, QT( N-R+1, 1 ), LDQT )
       END IF
 *
 *     Compute the RQ decomposition of V^T R1( 1:R, : )

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -334,8 +334,7 @@
 *     .. Local Scalars ..
       LOGICAL            WANTU1, WANTU2, WANTQT, LQUERY
       INTEGER            I, J, Z, R, LDG, LWKOPT
-      DOUBLE PRECISION   GNORM, FACTOR, TOL, ULP, UNFL, NORMA, NORMB,
-     $                   BASE
+      DOUBLE PRECISION   GNORM, TOL, ULP, UNFL, NORMA, NORMB, BASE
 *     .. Local Arrays ..
       DOUBLE PRECISION   G( M + P, N )
 *     ..
@@ -444,8 +443,7 @@
          W = 1.0D0
       ELSE
          BASE = DLAMCH( 'B' )
-         FACTOR = -0.5D0 / LOG ( BASE )
-         W = BASE ** INT( FACTOR * LOG( NORMA / NORMB ) )
+         W = BASE ** INT( LOG( NORMA / NORMB ) / LOG( BASE ) )
 *
          CALL DLASCL( 'G', -1, -1, 1.0D0, W, P, N, B, LDB, INFO )
          IF ( INFO.NE.0 ) THEN

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -128,19 +128,19 @@
 *> \param[in] M
 *> \verbatim
 *>          M is INTEGER
-*>          The number of rows of the matrix A.  M >= 0.
+*>          The number of rows of the matrix A.  M >= 1.
 *> \endverbatim
 *>
 *> \param[in] N
 *> \verbatim
 *>          N is INTEGER
-*>          The number of columns of the matrices A and B.  N >= 0.
+*>          The number of columns of the matrices A and B.  N >= 1.
 *> \endverbatim
 *>
 *> \param[in] P
 *> \verbatim
 *>          P is INTEGER
-*>          The number of rows of the matrix B.  P >= 0.
+*>          The number of rows of the matrix B.  P >= 1.
 *> \endverbatim
 *>
 *> \param[out] W
@@ -369,7 +369,7 @@
       IF ( LQUERY ) THEN
          G = 0
       ELSE
-         G = RESHAPE( WORK(1:Z), (/ M + P, N /) )
+         G = WORK( 1 )
       END IF
       LDG = M + P
 *     Computing 0.0 / 0.0 directly causes compiler errors
@@ -385,11 +385,11 @@
          INFO = -2
       ELSE IF( .NOT.( WANTQT .OR. LSAME( JOBQT, 'N' ) ) ) THEN
          INFO = -3
-      ELSE IF( M.LT.0 ) THEN
+      ELSE IF( M.LT.1 ) THEN
          INFO = -4
-      ELSE IF( N.LT.0 ) THEN
+      ELSE IF( N.LT.1 ) THEN
          INFO = -5
-      ELSE IF( P.LT.0 ) THEN
+      ELSE IF( P.LT.1 ) THEN
          INFO = -6
       ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
          INFO = -10

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -409,7 +409,7 @@
          CALL DORGQR( M + P, L, L, G, LDG, THETA, WORK, -1, INFO )
          LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
 
-         CALL DORCSD2BY1( JOBU1, JOBU2, JOBQT, M + P, P, L,
+         CALL DORCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, L,
      $                    G, LDG, G, LDG,
      $                    THETA, U2, LDU2, U1, LDU1, QT, LDQT,
      $                    WORK, -1, IWORK, INFO )
@@ -529,7 +529,7 @@
 *
 *     Compute the CS decomposition of Q1( :, 1:R )
 *
-      CALL DORCSD2BY1( JOBU1, JOBU2, JOBQT, M + P, P, R,
+      CALL DORCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, R,
      $                 G( 1, 1 ), LDG, G( P + 1, 1 ), LDG, THETA,
      $                 U2, LDU2, U1, LDU1, QT, LDQT,
      $                 WORK( Z + 1 ), LWORK - Z, IWORK( N + 1 ), INFO )
@@ -572,15 +572,17 @@
 *
 *     Explicitly form Q^T
 *
-      CALL DORGRQ( N, N, R, QT, LDQT, WORK,
-     $             WORK( L + 1 ), LWORK - L, INFO )
-      IF ( INFO.NE.0 ) THEN
-         RETURN
-      END IF
+      IF( WANTQT ) THEN
+         CALL DORGRQ( N, N, R, QT, LDQT, WORK,
+     $                WORK( L + 1 ), LWORK - L, INFO )
+         IF ( INFO.NE.0 ) THEN
+            RETURN
+         END IF
 *
 *     Revert column permutation Π by permuting the rows of Q^T
 *
-      CALL DLAPMT( .FALSE., N, N, QT, LDQT, IWORK )
+         CALL DLAPMT( .FALSE., N, N, QT, LDQT, IWORK )
+      END IF
 *
       WORK( 1 ) = DBLE( LWKOPT )
       RETURN

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -521,7 +521,7 @@
          RETURN
       END IF
 *
-*     Copy R1 into A and set lower triangular part of A to zero
+*     Copy R1( 1:R, : ) into A, B and set lower triangular part to zero
 *
       IF( R.LE.M ) THEN
           CALL DLACPY( 'U', R, N, G, LDG, A, LDA )
@@ -595,7 +595,7 @@
          RETURN
       END IF
 *
-*     Copy matrix R from QT( 1:R, N-R+1: ) to A, B
+*     Copy matrix R from QT( N-R+1:N, N-R+1:N ) to A, B
 *
       IF ( R.LE.M ) THEN
          CALL DLACPY( 'U', R, R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -512,13 +512,17 @@
          RETURN
       END IF
 *
-*     Copy R1 into A
+*     Copy R1 into A and set lower triangular part of A to zero
 *
       IF( R.LE.M ) THEN
           CALL DLACPY( 'U', R, N, G, LDG, A, LDA )
+          CALL DLASET( 'L', R - 1, N, 0.0D0, 0.0D0, A( 2, 1 ), LDA )
       ELSE
           CALL DLACPY( 'U', M, N, G, LDG, A, LDA )
-          CALL DLACPY( 'A', R - M, N, G( M + 1, 1 ), LDG, B, LDB )
+          CALL DLACPY( 'U', R - M, N, G( M + 1, 1 ), LDG, B, LDB )
+*
+          CALL DLASET( 'L', M - 1, N, 0.0D0, 0.0D0, A( 2, 1 ), LDA )
+          CALL DLASET( 'L', R-M-1, N, 0.0D0, 0.0D0, B( 2, 1 ), LDB )
       END IF
 *
 *     Explicitly form Q1 so that we can compute the CS decomposition

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -528,7 +528,7 @@
           CALL DLASET( 'L', R - 1, N, 0.0D0, 0.0D0, A( 2, 1 ), LDA )
       ELSE
           CALL DLACPY( 'U', M, N, G, LDG, A, LDA )
-          CALL DLACPY( 'U', R - M, N, G( M + 1, 1 ), LDG, B, LDB )
+          CALL DLACPY( 'U', R - M, N - M, G( M+1, M+1 ), LDG, B, LDB )
 *
           CALL DLASET( 'L', M - 1, N, 0.0D0, 0.0D0, A( 2, 1 ), LDA )
           CALL DLASET( 'L', R-M-1, N, 0.0D0, 0.0D0, B( 2, 1 ), LDB )
@@ -576,8 +576,9 @@
       ELSE
          CALL DGEMM( 'N', 'N', R, N, M, 1.0D0, G( 1, 1 ), LDG,
      $               A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
-         CALL DGEMM( 'N', 'N', R, N, R - M, 1.0D0, G( 1, M + 1 ), LDG,
-     $               B, LDB, 1.0D0, QT( N-R+1, 1 ), LDQT )
+         CALL DGEMM( 'N', 'N', R, N - M, R - M, 1.0D0,
+     $               G( 1, M + 1 ), LDG, B, LDB,
+     $               1.0D0, QT( N-R+1, M+1 ), LDQT )
       END IF
 *
 *     DEBUG

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -539,21 +539,21 @@
 *
       CALL DLACPY( 'A', R, R, QT, LDQT, G, R )
 *
-*     Compute V^T R1( 1:R, : )
+*     Compute V^T R1( 1:R, : ) in the last R rows of QT
 *
       IF ( R.LE.M ) THEN
          CALL DGEMM( 'N', 'N', R, N, R, 1.0D0, G, R,
-     $          A, LDA, 0.0D0, QT, LDQT )
+     $          A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
       ELSE
          CALL DGEMM( 'N', 'N', R, N, M, 1.0D0, G( 1, 1 ), R,
-     $          A, LDA, 0.0D0, QT, LDQT )
+     $          A, LDA, 0.0D0, QT( N-R+1, 1 ), LDQT )
          CALL DGEMM( 'N', 'N', R, N, R - M, 1.0D0, G( 1, M + 1 ), R,
-     $          B, LDB, 1.0D0, QT, LDQT )
+     $          B, LDB, 1.0D0, QT( N-R+1, 1 ), LDQT )
       END IF
 *
 *     Compute the RQ decomposition of V^T R1( 1:R, : )
 *
-      CALL DGERQF( R, N, QT, LDQT, WORK,
+      CALL DGERQF( R, N, QT( N-R+1, 1 ), LDQT, WORK,
      $             WORK( L + 1 ), LWORK - L, INFO )
       IF ( INFO.NE.0 ) THEN
          RETURN
@@ -562,10 +562,10 @@
 *     Copy matrix R from QT( 1:R, N-R+1: ) to A, B
 *
       IF ( R.LE.M ) THEN
-         CALL DLACPY( 'U', R, R, QT( 1, N-R+1 ), LDQT, A, LDA )
+         CALL DLACPY( 'U', R, R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
       ELSE
-         CALL DLACPY( 'U', M,     R, QT(     1, N-R+1 ), LDQT, A, LDA )
-         CALL DLACPY( 'U', R - M, R, QT( M + 1, N-R+1 ), LDQT, B, LDB )
+         CALL DLACPY( 'U', M,     R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
+         CALL DLACPY( 'U', R - M, R, QT( N-R+M+1, N-R+1 ), LDQT, B, LDB)
       END IF
 *
 *     Explicitly form Q^T

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -1,0 +1,564 @@
+*> \brief <b> DGGQRCS computes the singular value decomposition (SVD) for OTHER matrices</b>
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download DGGQRCS + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/dggqrcs.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/dggqrcs.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/dggqrcs.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE DGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+*                           A, LDA, B, LDB,
+*                           THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+*                           WORK, LWORK, IWORK, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          JOBU1, JOB2, JOBQT
+*       INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+*      $                   M, N, P, L, LWORK
+*       DOUBLE PRECISION   W
+*       ..
+*       .. Array Arguments ..
+*       INTEGER            IWORK( * )
+*       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), THETA( * ),
+*      $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQ, * ),
+*      $                   WORK( * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> DGGQRCS computes the generalized singular value decomposition (GSVD)
+*> of an M-by-N real matrix A and P-by-N real matrix B:
+*>
+*>       U1**T*A*Q = D1*( 0 R ),    U2**T*B*Q = D2*( 0 R )
+*>
+*> where U1, U2, and Q are orthogonal matrices. DGGQRCS uses the QR
+*> factorization with column pivoting and the 2-by-1 CS decomposition to
+*> compute the GSVD.
+*>
+*> Let L be the effective numerical rank of the matrix (A**T,B**T)**T,
+*> then R is a L-by-L nonsingular upper triangular matrix, D1 and
+*> D2 are M-by-L and P-by-L "diagonal" matrices and of the
+*> following structures, respectively:
+*>
+*>                        K   K1
+*>        D1 =     (  0   0   0 )
+*>              K  (  0   S   0 )
+*>              K1 (  0   0   I )
+*>
+*>                    K2  K
+*>        D2 =  K2 (  I   0   0 )
+*>              K  (  0   C   0 )
+*>                 (  0   0   0 )
+*>
+*>                 N-L  L
+*>   ( 0 R ) = L (  0   R )
+*>
+*> where
+*>
+*>   K  = MIN(M, P, L, M + P - L),
+*>   K1 = MAX(L - P, 0),
+*>   K2 = MAX(L - M, 0),
+*>   C  = diag( COS(THETA(1)), ..., COS(THETA(K)) ),
+*>   S  = diag( SIN(THETA(1)), ..., SIN(THETA(K)) ), and
+*>   C^2 + S^2 = I.
+*
+*> The routine computes C, S, R, and optionally the orthogonal
+*> transformation matrices U, V and Q. If L <= M, then R is stored in
+*> A(1:L, :) on exit. Otherwise, the first M rows of R are stored in A
+*> and the last L-M rows are stored in B(1:L-M, :).
+*>
+*> In particular, if B is an N-by-N nonsingular matrix, then the GSVD of
+*> A and B implicitly gives the SVD of A*inv(B):
+*>                      A*inv(B) = U1*(D1*inv(D2))*U2**T.
+*> If (A**T,B**T)**T  has orthonormal columns, then the GSVD of A and B
+*> is also equal to the CS decomposition of A and B. Furthermore, the
+*> GSVD can be used to derive the solution of the eigenvalue problem:
+*>                      A**T*A x = lambda* B**T*B x.
+*> In some literature, the GSVD of A and B is presented in the form
+*>                  U1**T*A*X = ( 0 D1 ),   U2**T*B*X = ( 0 D2 )
+*> where U1 and U2 are orthogonal and X is nonsingular, D1 and D2 are
+*> ``diagonal''.  The former GSVD form can be converted to the latter
+*> form by taking the nonsingular matrix X as
+*>
+*>                      X = Q*( I   0    )
+*>                            ( 0 inv(R) ).
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] JOBU1
+*> \verbatim
+*>          JOBU1 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U1 is computed;
+*>          = 'N':  U1 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBU2
+*> \verbatim
+*>          JOBU2 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U2 is computed;
+*>          = 'N':  U2 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBQT
+*> \verbatim
+*>          JOBQT is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix Q is computed;
+*>          = 'N':  Q is not computed.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.  M >= 0.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] P
+*> \verbatim
+*>          P is INTEGER
+*>          The number of rows of the matrix B.  P >= 0.
+*> \endverbatim
+*>
+*> \param[out] W
+*> \verbatim
+*>          W in DOUBLE PRECISION
+*>
+*>          On exit, W is a radix power chosen such that the Frobenius
+*>          norm of A and W*B are within sqrt(radix) and 1/sqrt(radix)
+*>          of each other.
+*> \endverbatim
+*>
+*> \param[out] L
+*> \verbatim
+*>          L is INTEGER
+*>          On exit, the effective numerical rank of the matrix
+*>          (A**T, B**T)**T.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA,N)
+*>          On entry, the M-by-N matrix A.
+*>          On exit, A contains the triangular matrix R or the first M
+*>          rows of R, respectively. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A. LDA >= max(1,M).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is DOUBLE PRECISION array, dimension (LDB,N)
+*>          On entry, the P-by-N matrix B.
+*>          On exit, if L > M, then B contains the last L - M rows of
+*>          the triangular matrix R. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B. LDB >= max(1,P).
+*> \endverbatim
+*>
+*> \param[out] THETA
+*> \verbatim
+*>          THETA is DOUBLE PRECISION array, dimension (N)
+*>
+*>          On exit, THETA contains K = MIN(M, P, L, M + P - L) values
+*>          in radians in ascending order.
+*> \endverbatim
+*>
+*> \param[out] U1
+*> \verbatim
+*>          U1 is DOUBLE PRECISION array, dimension (LDU1,M)
+*>          If JOBU1 = 'Y', U1 contains the M-by-M orthogonal matrix U1.
+*>          If JOBU1 = 'N', U1 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU1
+*> \verbatim
+*>          LDU1 is INTEGER
+*>          The leading dimension of the array U1. LDU1 >= max(1,M) if
+*>          JOBU1 = 'Y'; LDU1 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] U2
+*> \verbatim
+*>          U2 is DOUBLE PRECISION array, dimension (LDU2,P)
+*>          If JOBU2 = 'Y', U2 contains the P-by-P orthogonal matrix U2.
+*>          If JOBU2 = 'N', U2 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU2
+*> \verbatim
+*>          LDU2 is INTEGER
+*>          The leading dimension of the array U2. LDU2 >= max(1,P) if
+*>          JOBU2 = 'Y'; LDU2 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] QT
+*> \verbatim
+*>          QT is DOUBLE PRECISION array, dimension (LDQT,N)
+*>          If JOBQT = 'Y', QT contains the N-by-N orthogonal matrix
+*>          Q**T.
+*> \endverbatim
+*>
+*> \param[in] LDQT
+*> \verbatim
+*>          LDQT is INTEGER
+*>          The leading dimension of the array QT. LDQT >= max(1,N) if
+*>          JOBQT = 'Y'; LDQT >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>
+*>          If LWORK = -1, then a workspace query is assumed; the
+*>          routine only calculates the optimal size of the WORK array,
+*>          returns this value as the first entry of the WORK array, and
+*>          no error message related to LWORK is issued by XERBLA.
+*> \endverbatim
+*>
+*> \param[out] IWORK
+*> \verbatim
+*>          IWORK is INTEGER array, dimension (M + N + P)
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  DBBCSD did not converge. For further details, see
+*>                subroutine DORCSDBY1.
+*> \endverbatim
+*
+*> \par Internal Parameters:
+*  =========================
+*>
+*> \verbatim
+*>  TOL     DOUBLE PRECISION
+*>          Let G = (A**T,B**T)**T. TOL is the threshold to determine
+*>          the effective rank of G. Generally, it is set to
+*>                   TOL = MAX(M,P,N) * norm(G) * MACHEPS,
+*>          where norm(G) is the Frobenius norm of G.
+*>          The size of TOL may affect the size of backward error of the
+*>          decomposition.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Christoph Conrads (https://christoph-conrads.name)
+*
+*> \date September 2016
+*
+*> \ingroup doubleGEsing
+*
+*> \par Contributors:
+*  ==================
+*>
+*>     Christoph Conrads (https://christoph-conrads.name)
+*>
+*
+*> \par Further Details:
+*  =====================
+*>
+*>  DGGQRCS should be significantly faster than DGGSVD and DGGSVD3 for
+*>  large matrices because the matrices A and B are reduced to a pair of
+*>  well-conditioned bidiagonal matrices instead of pairs of upper
+*>  triangular matrices. On the downside, DGGQRCS requires a much larger
+*>  workspace whose dimension must be queried at run-time.
+*>
+*  =====================================================================
+      SUBROUTINE DGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+     $                    A, LDA, B, LDB
+     $                    THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+     $                    WORK, LWORK, IWORK, INFO )
+*
+*  -- LAPACK driver routine (version 3.7.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd. --
+*     September 2016
+*
+*     .. Scalar Arguments ..
+      CHARACTER          JOBU1, JOBU2, JOBQT
+      INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+     $                   L, M, N, P, LWORK
+      DOUBLE PRECISION   W
+*     ..
+*     .. Array Arguments ..
+      INTEGER            IWORK( * )
+      DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), THETA( * ),
+     $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQT, * ),
+     $                   WORK( * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Local Scalars ..
+      LOGICAL            WANTU1, WANTU2, WANTQT, LQUERY
+      INTEGER            I, J, Z, R, LWKOPT
+      DOUBLE PRECISION   GNORM, FACTOR, TOL, ULP, UNFL
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      DOUBLE PRECISION   DLAMCH, DLANGE
+      EXTERNAL           LSAME, DLAMCH, DLANGE
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           DCOPY, DGEQP3, DORGQR, DGERQF, QORGRQ,
+     $                   DORCSD2BY1, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX, MIN
+*     ..
+*     .. Executable Statements ..
+*
+*     Decode and test the input parameters
+*
+      WANTU1 = LSAME( JOBU1, 'Y' )
+      WANTU2 = LSAME( JOBU2, 'Y' )
+      WANTQT = LSAME( JOBQT, 'Y' )
+      LQUERY = ( LWORK.EQ.-1 )
+      LWKOPT = 1
+*
+*     Initialize variables
+*
+      G = WORK
+      TAU = WORK
+      L = MIN( M + P, N )
+      LDG = M + P
+      Z = ( M + P ) * N
+*
+*     Test the input arguments
+*
+      INFO = 0
+      IF( .NOT.( WANTU1 .OR. LSAME( JOBU1, 'N' ) ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.( WANTU2 .OR. LSAME( JOBU2, 'N' ) ) ) THEN
+         INFO = -2
+      ELSE IF( .NOT.( WANTQT .OR. LSAME( JOBQT, 'N' ) ) ) THEN
+         INFO = -3
+      ELSE IF( M.LT.0 ) THEN
+         INFO = -4
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -5
+      ELSE IF( P.LT.0 ) THEN
+         INFO = -6
+      ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
+         INFO = -10
+      ELSE IF( LDB.LT.MAX( 1, P ) ) THEN
+         INFO = -12
+      ELSE IF( LDU1.LT.1 .OR. ( WANTU1 .AND. LDU1.LT.M ) ) THEN
+         INFO = -15
+      ELSE IF( LDU2.LT.1 .OR. ( WANTU2 .AND. LDU2.LT.P ) ) THEN
+         INFO = -17
+      ELSE IF( LDQT.LT.1 .OR. ( WANTQT .AND. LDQT.LT.N ) ) THEN
+         INFO = -19
+      ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
+         INFO = -23
+      END IF
+*
+*     Compute workspace
+*
+      IF( INFO.EQ.0 ) THEN
+         CALL DGEQP3( M+P, N, G, LDG, IWORK,
+     $                THETA, WORK( Z + 1 ), LWORK - Z, -1 )
+         LWKOPT = INT( WORK( 1 ) )
+
+         CALL DORGQR( M + P, L, L, G, LDG, THETA, WORK( Z + 1 ), -1 )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+
+         CALL DORCSD2BY1( JOBU1, JOBU2, JOBQT, M + P, M, N,
+     $                    G, LDG, G, LDG,
+     $                    THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+     $                    WORK( Z + 1 ), LWORK - Z, IWORK, -1 )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         LWKOPT = (M + P)*N + LWKOPT
+
+*        DGERQF stores L scalar factors for the elementary reflectors
+         CALL DGERQF( L, N, QT, LDQT, TAU, WORK( L ), LWORK, -1 )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + L )
+
+         CALL DORGRQ( N, N, L, QT, LDQT, TAU, WORK( L ), LWORK, -1 )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + L )
+
+         WORK( 1 ) = DBLE( LWKOPT )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DGGQRCS', -INFO )
+         RETURN
+      END IF
+      IF( LQUERY ) THEN
+         RETURN
+      ENDIF
+*
+*     Scale matrix B such that norm(A) \approx norm(B)
+*
+      NORMA = DLANGE( 'F', M, N, A, LDA, NULL )
+      NORMB = DLANGE( 'F', P, N, B, LDB, NULL )
+*
+      BASE = DLAMCH( 'B' )
+      FACTOR = -0.5D0 / LOG ( BASE )
+      W = BASE ** INT( FACTOR * LOG( NORMA / NORMB ) )
+*
+      DLASCL( 'G', -1, -1, ONE, W, P, N, B, LDB, INFO )
+      IF ( INFO.NE.0 )
+         RETURN
+      END IF
+*
+*     Copy matrices A, B into the (M+P) x n matrix G
+*
+      DLACPY( 'A', M, N, A, LDA, G( P + 1, 1 ), LDG )
+      DLACPY( 'A', P, N, B, LDB, G( 1, 1 ), LDG )
+*
+*     Compute the Frobenius norm of matrix G
+*
+      GNORM = DLANGE( 'F', M + P, N, G, LDG, NULL )
+*
+*     Get machine precision and set up threshold for determining
+*     the effective numerical rank of the matrix G.
+*
+      ULP = DLAMCH( 'Precision' )
+      UNFL = DLAMCH( 'Safe Minimum' )
+      TOL = MAX( M + P, N )*MAX( NORM, UNFL )*ULP
+*
+*     IWORK stores the column permutations computed by DGEQP3.
+*     Columns J where IWORK( J ) is non-zero are permuted to the front
+*     so we set the all entries to zero here.
+*
+      DO 10 J = 1, N
+         IWORK( J ) = 0
+   10 CONTINUE
+*
+*     Compute the QR factorization with column pivoting GΠ = Q1 R1
+*
+      CALL DGEQP3( M + P, N, G, LDG, IWORK, THETA, WORK2, LWORK2, INFO )
+      IF( INFO.NE.0 ) THEN
+         ERROR
+      END IF
+*
+*     Determine the rank of G
+*
+      R = 0
+      DO 20 I = 1, MIN( M + P, N )
+         IF( ABS( G( I, I ) ).LE.TOL ) THEN
+            EXIT
+         END IF
+         R = R + 1
+   20 CONTINUE
+*
+      L = R
+*
+*     Copy R1 into A
+*
+      IF( R.LE.M ) THEN
+          DLACPY( 'U', R, N, G, LDG, A, LDA )
+      ELSE
+          DLACPY( 'U', M, N, G, LDG, A, LDA )
+          DLACPY( 'A', R - M, N, G( M + 1, 1 ), LDG, B, LDB )
+      END IF
+*
+*     Explicitly form Q1 so that we can compute the CS decomposition
+*
+      DORGQR( M + P, R, R, G, LDG, THETA, WORK2, LWORK2, INFO )
+*
+*     Compute the CS decomposition of Q1( :, 1:R )
+*
+      DORCSD2BY1( JOBU1, JOBU2, JOBQT, M + P, M, R,
+     $            G( 1, 1 ), LDG, G( M + 1, 1 ), LDG, THETA,
+     $            U2, LDU2, U1, LDU1, QT, LDQT,
+     $            WORK2, LWORK2, IWORK( N + 1 ), INFO )
+      IF( INFO.NE.0 )
+         RETURN
+      END IF
+*
+*     Copy V^T from QT to G
+*
+      DLACPY( 'A', R, R, QT, LDQT, G, R )
+*
+*     Compute V^T R1( 1:R, : )
+*
+      IF ( R.LE.M ) THEN
+         DGEMM( 'N', 'N', R, N, R, 1.0D0, G, R,
+     $          A, LDA, 0.0D0, QT, LDQT )
+      ELSE
+         DGEMM( 'N', 'N', R, N, M, 1.0D0, G( 1, 1 ), R,
+     $          A, LDA, 0.0D0, QT, LDQT )
+         DGEMM( 'N', 'N', R, N, R - M, 1.0D0, G( 1, M+1: ), R,
+     $          B, LDB, 1.0D0, QT, LDQT )
+      END IF
+*
+*     Copy V^T R1( 1:R, : ) from G to QT
+*
+      DLACPY
+*
+*     Compute the RQ decomposition of V^T R1( 1:R, : )
+*
+      DGERQF( R, N, QT, LDQT, TAU, WORK2, LWORK2, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Copy matrix R from QT( 1:R, N-R+1: ) to A, B
+*
+      IF ( R.LE.M ) THEN
+         DLACPY( 'U', R, R, QT( 1, N-R+1: ), LDQT, A, LDA )
+      ELSE
+         DLACPY( 'U', M,     R, QT(     1, N-R+1: ), LDQT, A, LDA )
+         DLACPY( 'U', R - M, R, QT( M + 1, N-R+1: ), LDQT, B, LDB )
+      END IF
+*
+*     Explicitly form Q^T
+*
+      DORGRQ( N, N, R, QT, LDQT, TAU, WORK2, LWORK2, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Revert column permutation Π by permuting the rows of Q^T
+*
+      DLAPMT( .FALSE., N, N, QT, LDQT, IWORK )
+*
+      WORK( 1 ) = DBLE( LWKOPT )
+      RETURN
+*
+*     End of DGGQRCS
+*
+      END

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -145,7 +145,7 @@
 *>
 *> \param[out] W
 *> \verbatim
-*>          W in DOUBLE PRECISION
+*>          W is DOUBLE PRECISION
 *>
 *>          On exit, W is a radix power chosen such that the Frobenius
 *>          norm of A and W*B are within sqrt(radix) and 1/sqrt(radix)
@@ -544,7 +544,7 @@
 *
 *     DEBUG
 *
-      THETA(1:N) = NAN
+      THETA(1:L) = NAN
 *
 *     Compute the CS decomposition of Q1( :, 1:R )
 *

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -345,8 +345,8 @@
       EXTERNAL           LSAME, DLAMCH, DLANGE
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           DLACPY, DLASCL, DGEQP3, DORGQR, DGERQF, QORGRQ,
-     $                   DORCSD2BY1, XERBLA
+      EXTERNAL           DGEMM, DGEQP3, DGERQF, DLACPY, DLAPMT, DLASCL,
+     $                   DLASET, DORGQR, DORGRQ, DORCSD2BY1, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -480,9 +480,7 @@
 *     Columns J where IWORK( J ) is non-zero are permuted to the front
 *     so we set the all entries to zero here.
 *
-      DO 10 J = 1, N
-         IWORK( J ) = 0
-   10 CONTINUE
+      IWORK( 1:N ) = 0
 *
 *     Compute the QR factorization with column pivoting GΠ = Q1 R1
 *

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -597,10 +597,10 @@
 *     Copy matrix R from QT( 1:R, N-R+1: ) to A, B
 *
       IF ( R.LE.M ) THEN
-         CALL DLACPY( 'U', R, R, QT( 1, N-R+1 ), LDQT, A, LDA )
+         CALL DLACPY( 'U', R, R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
       ELSE
-         CALL DLACPY( 'U', M,     R, QT( 1, N-R+1 ), LDQT, A, LDA )
-         CALL DLACPY( 'U', R - M, R - M, QT( M + 1, N-R+M+1 ), LDQT,
+         CALL DLACPY( 'U', M,     R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
+         CALL DLACPY( 'U', R - M, R - M, QT( N-R+M+1, N-R+M+1 ), LDQT,
      $                B, LDB )
       END IF
 *

--- a/SRC/dggqrcs.f
+++ b/SRC/dggqrcs.f
@@ -458,7 +458,7 @@
 *
 *     Compute the Frobenius norm of matrix G
 *
-      GNORM = DLANGE( 'F', M + P, N, G, LDG, WORK( Z ) )
+      GNORM = DLANGE( 'F', M + P, N, G, LDG, WORK( Z + 1 ) )
 *
 *     Get machine precision and set up threshold for determining
 *     the effective numerical rank of the matrix G.

--- a/SRC/dorcsd2by1.f
+++ b/SRC/dorcsd2by1.f
@@ -674,6 +674,9 @@
 *
 *        Accumulate Householder reflectors
 *
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL DCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL DCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -685,7 +688,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL DCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO

--- a/SRC/sggqrcs.f
+++ b/SRC/sggqrcs.f
@@ -299,7 +299,7 @@
 *> \par Further Details:
 *  =====================
 *>
-*>  SGGQRCS should be significantly faster than DGGSVD and DGGSVD3 for
+*>  SGGQRCS should be significantly faster than SGGSVD and SGGSVD3 for
 *>  large matrices because the matrices A and B are reduced to a pair of
 *>  well-conditioned bidiagonal matrices instead of pairs of upper
 *>  triangular matrices. On the downside, SGGQRCS requires a much larger
@@ -418,9 +418,10 @@
      $                    THETA, U2, LDU2, U1, LDU1, QT, LDQT,
      $                    WORK, -1, IWORK, INFO )
          LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+*        The matrix (A, B) must be stored sequentially for SORCSD2BY1
          LWKOPT = Z + LWKOPT
 
-*        DGERQF stores L scalar factors for the elementary reflectors
+*        SGERQF stores L scalar factors for the elementary reflectors
          CALL SGERQF( L, N, QT, LDQT, WORK, WORK, -1, INFO )
          LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + L )
 
@@ -476,7 +477,7 @@
       UNFL = SLAMCH( 'Safe Minimum' )
       TOL = MAX( M + P, N ) * MAX( GNORM, UNFL ) * ULP
 *
-*     IWORK stores the column permutations computed by DGEQP3.
+*     IWORK stores the column permutations computed by SGEQP3.
 *     Columns J where IWORK( J ) is non-zero are permuted to the front
 *     so we set the all entries to zero here.
 *

--- a/SRC/sggqrcs.f
+++ b/SRC/sggqrcs.f
@@ -525,7 +525,7 @@
 *
       IF( R.LE.M ) THEN
           CALL SLACPY( 'U', R, N, G, LDG, A, LDA )
-          IF( M.GT.2 ) THEN
+          IF( M.GT.1 ) THEN
              CALL SLASET( 'L', R - 1, N, 0.0E0, 0.0E0, A( 2, 1 ), LDA )
           END IF
       ELSE

--- a/SRC/sggqrcs.f
+++ b/SRC/sggqrcs.f
@@ -525,7 +525,9 @@
 *
       IF( R.LE.M ) THEN
           CALL SLACPY( 'U', R, N, G, LDG, A, LDA )
-          CALL SLASET( 'L', R - 1, N, 0.0E0, 0.0E0, A( 2, 1 ), LDA )
+          IF( M.GT.2 ) THEN
+             CALL SLASET( 'L', R - 1, N, 0.0E0, 0.0E0, A( 2, 1 ), LDA )
+          END IF
       ELSE
           CALL SLACPY( 'U', M, N, G, LDG, A, LDA )
           CALL SLACPY( 'U', R - M, N - M, G( M+1, M+1 ), LDG, B, LDB )

--- a/SRC/sggqrcs.f
+++ b/SRC/sggqrcs.f
@@ -128,19 +128,19 @@
 *> \param[in] M
 *> \verbatim
 *>          M is INTEGER
-*>          The number of rows of the matrix A.  M >= 0.
+*>          The number of rows of the matrix A.  M >= 1.
 *> \endverbatim
 *>
 *> \param[in] N
 *> \verbatim
 *>          N is INTEGER
-*>          The number of columns of the matrices A and B.  N >= 0.
+*>          The number of columns of the matrices A and B.  N >= 1.
 *> \endverbatim
 *>
 *> \param[in] P
 *> \verbatim
 *>          P is INTEGER
-*>          The number of rows of the matrix B.  P >= 0.
+*>          The number of rows of the matrix B.  P >= 1.
 *> \endverbatim
 *>
 *> \param[out] W
@@ -369,7 +369,7 @@
       IF ( LQUERY ) THEN
          G = 0
       ELSE
-         G = RESHAPE( WORK(1:Z), (/ M + P, N /) )
+         G = WORK( 1 )
       END IF
       LDG = M + P
 *     Computing 0.0 / 0.0 directly causes compiler errors
@@ -385,11 +385,11 @@
          INFO = -2
       ELSE IF( .NOT.( WANTQT .OR. LSAME( JOBQT, 'N' ) ) ) THEN
          INFO = -3
-      ELSE IF( M.LT.0 ) THEN
+      ELSE IF( M.LT.1 ) THEN
          INFO = -4
-      ELSE IF( N.LT.0 ) THEN
+      ELSE IF( N.LT.1 ) THEN
          INFO = -5
-      ELSE IF( P.LT.0 ) THEN
+      ELSE IF( P.LT.1 ) THEN
          INFO = -6
       ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
          INFO = -10

--- a/SRC/sggqrcs.f
+++ b/SRC/sggqrcs.f
@@ -481,9 +481,7 @@
 *     Columns J where IWORK( J ) is non-zero are permuted to the front
 *     so we set the all entries to zero here.
 *
-      DO 10 J = 1, N
-         IWORK( J ) = 0
-   10 CONTINUE
+      IWORK( 1:N ) = 0
 *
 *     Compute the QR factorization with column pivoting GΠ = Q1 R1
 *

--- a/SRC/sggqrcs.f
+++ b/SRC/sggqrcs.f
@@ -345,8 +345,8 @@
       EXTERNAL           LSAME, SLAMCH, SLANGE
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           SLACPY, SLASCL, SGEQP3, SORGQR, SGERQF, SORGRQ,
-     $                   SORCSD2BY1, XERBLA
+      EXTERNAL           SGEMM, SGEQP3, SGERQF, SLACPY, SLAPMT, SLASCL,
+     $                   SLASET, SORGQR, SORGRQ, SORCSD2BY1, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN

--- a/SRC/sggqrcs.f
+++ b/SRC/sggqrcs.f
@@ -1,0 +1,632 @@
+*> \brief <b> SGGQRCS computes the singular value decomposition (SVD) for OTHER matrices</b>
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download SGGQRCS + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE SGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+*                           A, LDA, B, LDB,
+*                           THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+*                           WORK, LWORK, IWORK, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          JOBU1, JOB2, JOBQT
+*       INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+*      $                   M, N, P, L, LWORK
+*       REAL               W
+*       ..
+*       .. Array Arguments ..
+*       INTEGER            IWORK( * )
+*       REAL               A( LDA, * ), B( LDB, * ), THETA( * ),
+*      $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQ, * ),
+*      $                   WORK( * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> SGGQRCS computes the generalized singular value decomposition (GSVD)
+*> of an M-by-N real matrix A and P-by-N real matrix B:
+*>
+*>       U1**T*A*Q = D1*( 0 R ),    U2**T*B*Q = D2*( 0 R )
+*>
+*> where U1, U2, and Q are orthogonal matrices. SGGQRCS uses the QR
+*> factorization with column pivoting and the 2-by-1 CS decomposition to
+*> compute the GSVD.
+*>
+*> Let L be the effective numerical rank of the matrix (A**T,B**T)**T,
+*> then R is a L-by-L nonsingular upper triangular matrix, D1 and
+*> D2 are M-by-L and P-by-L "diagonal" matrices and of the
+*> following structures, respectively:
+*>
+*>                        K   K1
+*>        D1 =     (  0   0   0 )
+*>              K  (  0   S   0 )
+*>              K1 (  0   0   I )
+*>
+*>                    K2  K
+*>        D2 =  K2 (  I   0   0 )
+*>              K  (  0   C   0 )
+*>                 (  0   0   0 )
+*>
+*>                 N-L  L
+*>   ( 0 R ) = L (  0   R )
+*>
+*> where
+*>
+*>   K  = MIN(M, P, L, M + P - L),
+*>   K1 = MAX(L - P, 0),
+*>   K2 = MAX(L - M, 0),
+*>   C  = diag( COS(THETA(1)), ..., COS(THETA(K)) ),
+*>   S  = diag( SIN(THETA(1)), ..., SIN(THETA(K)) ), and
+*>   C^2 + S^2 = I.
+*>
+*> The routine computes C, S, R, and optionally the orthogonal
+*> transformation matrices U, V and Q. If L <= M, then R is stored in
+*> A(1:L, 1:L) on exit. Otherwise, the first M rows of R are stored in
+*> A(:, 1:L) and R( M+1:, M+1: ) is stored in B(1:L-M, 1:L-M). In both
+*> cases, only the upper triangular part is stored.
+*>
+*> In particular, if B is an N-by-N nonsingular matrix, then the GSVD of
+*> A and B implicitly gives the SVD of A*inv(B):
+*>                      A*inv(B) = U1*(D1*inv(D2))*U2**T.
+*> If (A**T,B**T)**T  has orthonormal columns, then the GSVD of A and B
+*> is also equal to the CS decomposition of A and B. Furthermore, the
+*> GSVD can be used to derive the solution of the eigenvalue problem:
+*>                      A**T*A x = lambda * B**T*B x.
+*> In some literature, the GSVD of A and B is presented in the form
+*>                  U1**T*A*X = ( 0 D1 ),   U2**T*B*X = ( 0 D2 )
+*> where U1 and U2 are orthogonal and X is nonsingular, D1 and D2 are
+*> ``diagonal''.  The former GSVD form can be converted to the latter
+*> form by taking the nonsingular matrix X as
+*>
+*>                      X = Q*( I   0    )
+*>                            ( 0 inv(R) ).
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] JOBU1
+*> \verbatim
+*>          JOBU1 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U1 is computed;
+*>          = 'N':  U1 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBU2
+*> \verbatim
+*>          JOBU2 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U2 is computed;
+*>          = 'N':  U2 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBQT
+*> \verbatim
+*>          JOBQT is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix Q is computed;
+*>          = 'N':  Q is not computed.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.  M >= 0.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] P
+*> \verbatim
+*>          P is INTEGER
+*>          The number of rows of the matrix B.  P >= 0.
+*> \endverbatim
+*>
+*> \param[out] W
+*> \verbatim
+*>          W in REAL
+*>
+*>          On exit, W is a radix power chosen such that the Frobenius
+*>          norm of A and W*B are within sqrt(radix) and 1/sqrt(radix)
+*>          of each other.
+*> \endverbatim
+*>
+*> \param[out] L
+*> \verbatim
+*>          L is INTEGER
+*>          On exit, the effective numerical rank of the matrix
+*>          (A**T, B**T)**T.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array, dimension (LDA,N)
+*>          On entry, the M-by-N matrix A.
+*>          On exit, A contains the triangular matrix R or the first M
+*>          rows of R, respectively. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A. LDA >= max(1,M).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is REAL array, dimension (LDB,N)
+*>          On entry, the P-by-N matrix B.
+*>          On exit, if L > M, then B contains the last L - M rows of
+*>          the triangular matrix R. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B. LDB >= max(1,P).
+*> \endverbatim
+*>
+*> \param[out] THETA
+*> \verbatim
+*>          THETA is REAL array, dimension (N)
+*>
+*>          On exit, THETA contains K = MIN(M, P, L, M + P - L) values
+*>          in radians in ascending order.
+*> \endverbatim
+*>
+*> \param[out] U1
+*> \verbatim
+*>          U1 is REAL array, dimension (LDU1,M)
+*>          If JOBU1 = 'Y', U1 contains the M-by-M orthogonal matrix U1.
+*>          If JOBU1 = 'N', U1 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU1
+*> \verbatim
+*>          LDU1 is INTEGER
+*>          The leading dimension of the array U1. LDU1 >= max(1,M) if
+*>          JOBU1 = 'Y'; LDU1 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] U2
+*> \verbatim
+*>          U2 is REAL array, dimension (LDU2,P)
+*>          If JOBU2 = 'Y', U2 contains the P-by-P orthogonal matrix U2.
+*>          If JOBU2 = 'N', U2 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU2
+*> \verbatim
+*>          LDU2 is INTEGER
+*>          The leading dimension of the array U2. LDU2 >= max(1,P) if
+*>          JOBU2 = 'Y'; LDU2 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] QT
+*> \verbatim
+*>          QT is REAL array, dimension (LDQT,N)
+*>          If JOBQT = 'Y', QT contains the N-by-N orthogonal matrix
+*>          Q**T.
+*> \endverbatim
+*>
+*> \param[in] LDQT
+*> \verbatim
+*>          LDQT is INTEGER
+*>          The leading dimension of the array QT. LDQT >= max(1,N) if
+*>          JOBQT = 'Y'; LDQT >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>
+*>          If LWORK = -1, then a workspace query is assumed; the
+*>          routine only calculates the optimal size of the WORK array,
+*>          returns this value as the first entry of the WORK array, and
+*>          no error message related to LWORK is issued by XERBLA.
+*> \endverbatim
+*>
+*> \param[out] IWORK
+*> \verbatim
+*>          IWORK is INTEGER array, dimension (M + N + P)
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  DBBCSD did not converge. For further details, see
+*>                subroutine DORCSDBY1.
+*> \endverbatim
+*
+*> \par Internal Parameters:
+*  =========================
+*>
+*> \verbatim
+*>  TOL     REAL
+*>          Let G = (A**T,B**T)**T. TOL is the threshold to determine
+*>          the effective rank of G. Generally, it is set to
+*>                   TOL = MAX(M,P,N) * norm(G) * MACHEPS,
+*>          where norm(G) is the Frobenius norm of G.
+*>          The size of TOL may affect the size of backward error of the
+*>          decomposition.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Christoph Conrads (https://christoph-conrads.name)
+*
+*> \date October 2019
+*
+*> \ingroup realGEsing
+*
+*> \par Contributors:
+*  ==================
+*>
+*>     Christoph Conrads (https://christoph-conrads.name)
+*>
+*
+*> \par Further Details:
+*  =====================
+*>
+*>  SGGQRCS should be significantly faster than DGGSVD and DGGSVD3 for
+*>  large matrices because the matrices A and B are reduced to a pair of
+*>  well-conditioned bidiagonal matrices instead of pairs of upper
+*>  triangular matrices. On the downside, SGGQRCS requires a much larger
+*>  workspace whose dimension must be queried at run-time.
+*>
+*  =====================================================================
+      SUBROUTINE SGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+     $                    A, LDA, B, LDB,
+     $                    THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+     $                    WORK, LWORK, IWORK, INFO )
+*
+*  -- LAPACK driver routine (version 3.7.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd. --
+*     September 2016
+*
+      IMPLICIT NONE
+*     .. Scalar Arguments ..
+      CHARACTER          JOBU1, JOBU2, JOBQT
+      INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+     $                   L, M, N, P, LWORK
+      REAL               W
+*     ..
+*     .. Array Arguments ..
+      INTEGER            IWORK( * )
+      REAL               A( LDA, * ), B( LDB, * ), THETA( * ),
+     $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQT, * ),
+     $                   WORK( * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Local Scalars ..
+      LOGICAL            WANTU1, WANTU2, WANTQT, LQUERY
+      INTEGER            I, J, Z, R, LDG, LWKOPT
+      REAL               GNORM, TOL, ULP, UNFL, NORMA, NORMB, BASE, NAN
+*     .. Local Arrays ..
+      REAL               G( M + P, N )
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      REAL               SLAMCH, SLANGE
+      EXTERNAL           LSAME, SLAMCH, SLANGE
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           SLACPY, SLASCL, SGEQP3, SORGQR, SGERQF, SORGRQ,
+     $                   SORCSD2BY1, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX, MIN
+*     ..
+*     .. Executable Statements ..
+*
+*     Decode and test the input parameters
+*
+      WANTU1 = LSAME( JOBU1, 'Y' )
+      WANTU2 = LSAME( JOBU2, 'Y' )
+      WANTQT = LSAME( JOBQT, 'Y' )
+      LQUERY = ( LWORK.EQ.-1 )
+      LWKOPT = 1
+*
+*     Initialize variables
+*
+      L = MIN( M + P, N )
+      Z = ( M + P ) * N
+      IF ( LQUERY ) THEN
+         G = 0
+      ELSE
+         G = RESHAPE( WORK(1:Z), (/ M + P, N /) )
+      END IF
+      LDG = M + P
+*     Computing 0.0 / 0.0 directly causes compiler errors
+      NAN = 1.0E0
+      NAN = 0.0 / (NAN - 1.0E0)
+*
+*     Test the input arguments
+*
+      INFO = 0
+      IF( .NOT.( WANTU1 .OR. LSAME( JOBU1, 'N' ) ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.( WANTU2 .OR. LSAME( JOBU2, 'N' ) ) ) THEN
+         INFO = -2
+      ELSE IF( .NOT.( WANTQT .OR. LSAME( JOBQT, 'N' ) ) ) THEN
+         INFO = -3
+      ELSE IF( M.LT.0 ) THEN
+         INFO = -4
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -5
+      ELSE IF( P.LT.0 ) THEN
+         INFO = -6
+      ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
+         INFO = -10
+      ELSE IF( LDB.LT.MAX( 1, P ) ) THEN
+         INFO = -12
+      ELSE IF( LDU1.LT.1 .OR. ( WANTU1 .AND. LDU1.LT.M ) ) THEN
+         INFO = -15
+      ELSE IF( LDU2.LT.1 .OR. ( WANTU2 .AND. LDU2.LT.P ) ) THEN
+         INFO = -17
+      ELSE IF( LDQT.LT.1 .OR. ( WANTQT .AND. LDQT.LT.N ) ) THEN
+         INFO = -19
+      ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
+         INFO = -23
+      END IF
+*
+*     Compute workspace
+*
+      IF( INFO.EQ.0 ) THEN
+         CALL SGEQP3( M+P, N, G, LDG, IWORK, THETA, WORK, -1, INFO )
+         LWKOPT = INT( WORK( 1 ) )
+
+         CALL SORGQR( M + P, L, L, G, LDG, THETA, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+
+         CALL SORCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, L,
+     $                    G, LDG, G, LDG,
+     $                    THETA, U2, LDU2, U1, LDU1, QT, LDQT,
+     $                    WORK, -1, IWORK, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         LWKOPT = Z + LWKOPT
+
+*        DGERQF stores L scalar factors for the elementary reflectors
+         CALL SGERQF( L, N, QT, LDQT, WORK, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + L )
+
+         CALL SORGRQ( N, N, L, QT, LDQT, WORK, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + L )
+
+         WORK( 1 ) = REAL( LWKOPT )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'SGGQRCS', -INFO )
+         RETURN
+      END IF
+      IF( LQUERY ) THEN
+         RETURN
+      ENDIF
+*
+*     Scale matrix B such that norm(A) \approx norm(B)
+*
+      NORMA = SLANGE( 'F', M, N, A, LDA, WORK )
+      NORMB = SLANGE( 'F', P, N, B, LDB, WORK )
+*
+      IF ( NORMB.EQ.0 ) THEN
+         W = 1.0E0
+      ELSE
+         BASE = SLAMCH( 'B' )
+         W = BASE ** INT( LOG( NORMA / NORMB ) / LOG( BASE ) )
+*
+         CALL SLASCL( 'G', -1, -1, 1.0E0, W, P, N, B, LDB, INFO )
+         IF ( INFO.NE.0 ) THEN
+            RETURN
+         END IF
+      END IF
+*
+*     Copy matrices A, B into the (M+P) x n matrix G
+*
+      CALL SLACPY( 'A', M, N, A, LDA, G( P + 1, 1 ), LDG )
+      CALL SLACPY( 'A', P, N, B, LDB, G( 1, 1 ), LDG )
+*
+*     DEBUG
+*
+      CALL SLASET( 'A', M, N, NAN, NAN, A, LDA )
+      CALL SLASET( 'A', P, N, NAN, NAN, B, LDB )
+*
+*     Compute the Frobenius norm of matrix G
+*
+      GNORM = SLANGE( 'F', M + P, N, G, LDG, WORK( Z + 1 ) )
+*
+*     Get machine precision and set up threshold for determining
+*     the effective numerical rank of the matrix G.
+*
+      ULP = SLAMCH( 'Precision' )
+      UNFL = SLAMCH( 'Safe Minimum' )
+      TOL = MAX( M + P, N ) * MAX( GNORM, UNFL ) * ULP
+*
+*     IWORK stores the column permutations computed by DGEQP3.
+*     Columns J where IWORK( J ) is non-zero are permuted to the front
+*     so we set the all entries to zero here.
+*
+      DO 10 J = 1, N
+         IWORK( J ) = 0
+   10 CONTINUE
+*
+*     Compute the QR factorization with column pivoting GΠ = Q1 R1
+*
+      CALL SGEQP3( M + P, N, G, LDG, IWORK, THETA,
+     $             WORK( Z + 1 ), LWORK - Z, INFO )
+      IF( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Determine the rank of G
+*
+      R = 0
+      DO 20 I = 1, MIN( M + P, N )
+         IF( ABS( G( I, I ) ).LE.TOL ) THEN
+            EXIT
+         END IF
+         R = R + 1
+   20 CONTINUE
+*
+      L = R
+*
+*     Handle rank=0 case
+*
+      IF( L.EQ.0 ) THEN
+         IF( WANTU1 ) THEN
+            CALL SLASET( 'A', M, M, 0.0E0, 1.0E0, U1, LDU1 )
+         END IF
+         IF( WANTU2 ) THEN
+            CALL SLASET( 'A', P, P, 0.0E0, 1.0E0, U2, LDU2 )
+         END IF
+         IF( WANTQT ) THEN
+            CALL SLASET( 'A', N, N, 0.0E0, 1.0E0, QT, LDQT )
+         END IF
+*
+         WORK( 1 ) = REAL( LWKOPT )
+         RETURN
+      END IF
+*
+*     Copy R1( 1:R, : ) into A, B and set lower triangular part to zero
+*
+      IF( R.LE.M ) THEN
+          CALL SLACPY( 'U', R, N, G, LDG, A, LDA )
+          CALL SLASET( 'L', R - 1, N, 0.0E0, 0.0E0, A( 2, 1 ), LDA )
+      ELSE
+          CALL SLACPY( 'U', M, N, G, LDG, A, LDA )
+          CALL SLACPY( 'U', R - M, N - M, G( M+1, M+1 ), LDG, B, LDB )
+*
+          CALL SLASET( 'L', M - 1, N, 0.0E0, 0.0E0, A( 2, 1 ), LDA )
+          CALL SLASET( 'L', R-M-1, N, 0.0E0, 0.0E0, B( 2, 1 ), LDB )
+      END IF
+*
+*     Explicitly form Q1 so that we can compute the CS decomposition
+*
+      CALL SORGQR( M + P, R, R, G, LDG, THETA,
+     $             WORK( Z + 1 ), LWORK - Z, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     DEBUG
+*
+      THETA(1:N) = NAN
+*
+*     Compute the CS decomposition of Q1( :, 1:R )
+*
+      CALL SORCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, R,
+     $                 G( 1, 1 ), LDG, G( P + 1, 1 ), LDG, THETA,
+     $                 U2, LDU2, U1, LDU1, QT, LDQT,
+     $                 WORK( Z + 1 ), LWORK - Z, IWORK( N + 1 ), INFO )
+      IF( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     DEBUG
+*
+      WORK(1:LWORK) = NAN
+*
+*     Copy V^T from QT to G
+*
+      CALL SLACPY( 'A', R, R, QT, LDQT, G, LDG )
+*
+*     DEBUG
+*
+      CALL SLASET( 'A', N, N, NAN, NAN, QT, LDQT )
+*
+*     Compute V^T R1( 1:R, : ) in the last R rows of QT
+*
+      IF ( R.LE.M ) THEN
+         CALL SGEMM( 'N', 'N', R, N, R, 1.0E0, G, LDG,
+     $               A, LDA, 0.0E0, QT( N-R+1, 1 ), LDQT )
+      ELSE
+         CALL SGEMM( 'N', 'N', R, N, M, 1.0E0, G( 1, 1 ), LDG,
+     $               A, LDA, 0.0E0, QT( N-R+1, 1 ), LDQT )
+         CALL SGEMM( 'N', 'N', R, N - M, R - M, 1.0E0,
+     $               G( 1, M + 1 ), LDG, B, LDB,
+     $               1.0E0, QT( N-R+1, M+1 ), LDQT )
+      END IF
+*
+*     DEBUG
+*
+      CALL SLASET( 'A', M, N, NAN, NAN, A, LDA )
+      CALL SLASET( 'A', P, N, NAN, NAN, B, LDB )
+      WORK(1:LWORK) = NAN
+*
+*     Compute the RQ decomposition of V^T R1( 1:R, : )
+*
+      CALL SGERQF( R, N, QT( N-R+1, 1 ), LDQT, WORK,
+     $             WORK( L + 1 ), LWORK - L, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Copy matrix R from QT( N-R+1:N, N-R+1:N ) to A, B
+*
+      IF ( R.LE.M ) THEN
+         CALL SLACPY( 'U', R, R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
+      ELSE
+         CALL SLACPY( 'U', M,     R, QT( N-R+1, N-R+1 ), LDQT, A, LDA )
+         CALL SLACPY( 'U', R - M, R - M, QT( N-R+M+1, N-R+M+1 ), LDQT,
+     $                B, LDB )
+      END IF
+*
+*     DEBUG
+*
+      CALL SLASET( 'U', R, R, NAN, NAN, QT( 1, N-R+1 ), LDQT )
+      WORK( L+1:LWORK ) = NAN
+*
+*     Explicitly form Q^T
+*
+      IF( WANTQT ) THEN
+         CALL SORGRQ( N, N, R, QT, LDQT, WORK,
+     $                WORK( L + 1 ), LWORK - L, INFO )
+         IF ( INFO.NE.0 ) THEN
+            RETURN
+         END IF
+*
+*     Revert column permutation Π by permuting the rows of Q^T
+*
+         CALL SLAPMT( .FALSE., N, N, QT, LDQT, IWORK )
+      END IF
+*
+      WORK( 1 ) = REAL( LWKOPT )
+      RETURN
+*
+*     End of SGGQRCS
+*
+      END

--- a/SRC/sorcsd2by1.f
+++ b/SRC/sorcsd2by1.f
@@ -674,6 +674,9 @@
 *
 *        Accumulate Householder reflectors
 *
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL SCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL SCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -685,7 +688,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL SCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO

--- a/SRC/sorcsd2by1.f
+++ b/SRC/sorcsd2by1.f
@@ -520,10 +520,12 @@
                V1T(1,J) = ZERO
                V1T(J,1) = ZERO
             END DO
-            CALL SLACPY( 'U', Q-1, Q-1, X21(1,2), LDX21, V1T(2,2),
+            IF( Q.GT.1 ) THEN
+               CALL SLACPY( 'U', Q-1, Q-1, X21(1,2), LDX21, V1T(2,2),
      $                   LDV1T )
-            CALL SORGLQ( Q-1, Q-1, Q-1, V1T(2,2), LDV1T, WORK(ITAUQ1),
+               CALL SORGLQ( Q-1, Q-1, Q-1, V1T(2,2), LDV1T,WORK(ITAUQ1),
      $                   WORK(IORGLQ), LORGLQ, CHILDINFO )
+            ENDIF
          END IF
 *
 *        Simultaneously diagonalize X11 and X21.

--- a/SRC/zggqrcs.f
+++ b/SRC/zggqrcs.f
@@ -1,0 +1,678 @@
+*> \brief <b> ZGGQRCS computes the singular value decomposition (SVD) for OTHER matrices</b>
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download ZGGQRCS + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/sggqrcs.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE ZGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+*                           A, LDA, B, LDB,
+*                           THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+*                           WORK, LWORK, RWORK, LRWORK, IWORK, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          JOBU1, JOB2, JOBQT
+*       INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+*      $                   M, N, P, L, LWORK, LRWORK
+*       DOUBLE PRECISION   W
+*       ..
+*       .. Array Arguments ..
+*       INTEGER            IWORK( * )
+*       DOUBLE PRECISION   THETA( * ), RWORK( * )
+*       COMPLEX*16         A( LDA, * ), B( LDB, * ),
+*      $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQ, * ),
+*      $                   WORK( * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> ZGGQRCS computes the generalized singular value decomposition (GSVD)
+*> of an M-by-N complex matrix A and P-by-N complex matrix B:
+*>
+*>       U1**T*A*Q = D1*( 0 R ),    U2**T*B*Q = D2*( 0 R )
+*>
+*> where U1, U2, and Q are orthogonal matrices. ZGGQRCS uses the QR
+*> factorization with column pivoting and the 2-by-1 CS decomposition to
+*> compute the GSVD.
+*>
+*> Let L be the effective numerical rank of the matrix (A**T,B**T)**T,
+*> then R is an L-by-L nonsingular upper triangular matrix, D1 and
+*> D2 are M-by-L and P-by-L "diagonal" matrices and of the
+*> following structures, respectively:
+*>
+*>                        K   K1
+*>        D1 =     (  0   0   0 )
+*>              K  (  0   S   0 )
+*>              K1 (  0   0   I )
+*>
+*>                    K2  K
+*>        D2 =  K2 (  I   0   0 )
+*>              K  (  0   C   0 )
+*>                 (  0   0   0 )
+*>
+*>                 N-L  L
+*>   ( 0 R ) = L (  0   R )
+*>
+*> where
+*>
+*>   K  = MIN(M, P, L, M + P - L),
+*>   K1 = MAX(L - P, 0),
+*>   K2 = MAX(L - M, 0),
+*>   C  = diag( COS(THETA(1)), ..., COS(THETA(K)) ),
+*>   S  = diag( SIN(THETA(1)), ..., SIN(THETA(K)) ), and
+*>   C^2 + S^2 = I.
+*>
+*> The routine computes C, S, R, and optionally the orthogonal
+*> transformation matrices U, V and Q. If L <= M, then R is stored in
+*> A(1:L, 1:L) on exit. Otherwise, the first M rows of R are stored in
+*> A(:, 1:L) and R( M+1:, M+1: ) is stored in B(1:L-M, 1:L-M). In both
+*> cases, only the upper triangular part is stored.
+*>
+*> In particular, if B is an N-by-N nonsingular matrix, then the GSVD of
+*> A and B implicitly gives the SVD of A*inv(B):
+*>                      A*inv(B) = U1*(D1*inv(D2))*U2**T.
+*> If (A**T,B**T)**T  has orthonormal columns, then the GSVD of A and B
+*> is also equal to the CS decomposition of A and B. Furthermore, the
+*> GSVD can be used to derive the solution of the eigenvalue problem:
+*>                      A**T*A x = lambda * B**T*B x.
+*> In some literature, the GSVD of A and B is presented in the form
+*>                  U1**T*A*X = ( 0 D1 ),   U2**T*B*X = ( 0 D2 )
+*> where U1 and U2 are orthogonal and X is nonsingular, D1 and D2 are
+*> ``diagonal''.  The former GSVD form can be converted to the latter
+*> form by taking the nonsingular matrix X as
+*>
+*>                      X = Q*( I   0    )
+*>                            ( 0 inv(R) ).
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] JOBU1
+*> \verbatim
+*>          JOBU1 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U1 is computed;
+*>          = 'N':  U1 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBU2
+*> \verbatim
+*>          JOBU2 is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix U2 is computed;
+*>          = 'N':  U2 is not computed.
+*> \endverbatim
+*>
+*> \param[in] JOBQT
+*> \verbatim
+*>          JOBQT is CHARACTER*1
+*>          = 'Y':  Orthogonal matrix Q is computed;
+*>          = 'N':  Q is not computed.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.  M >= 1.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrices A and B.  N >= 1.
+*> \endverbatim
+*>
+*> \param[in] P
+*> \verbatim
+*>          P is INTEGER
+*>          The number of rows of the matrix B.  P >= 1.
+*> \endverbatim
+*>
+*> \param[out] W
+*> \verbatim
+*>          W is DOUBLE PRECISION
+*>
+*>          On exit, W is a radix power chosen such that the Frobenius
+*>          norm of A and W*B are within sqrt(radix) and 1/sqrt(radix)
+*>          of each other.
+*> \endverbatim
+*>
+*> \param[out] L
+*> \verbatim
+*>          L is INTEGER
+*>          On exit, the effective numerical rank of the matrix
+*>          (A**T, B**T)**T.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension (LDA,N)
+*>          On entry, the M-by-N matrix A.
+*>          On exit, A contains the triangular matrix R or the first M
+*>          rows of R, respectively. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A. LDA >= max(1,M).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX*16 array, dimension (LDB,N)
+*>          On entry, the P-by-N matrix B.
+*>          On exit, if L > M, then B contains the last L - M rows of
+*>          the triangular matrix R. See Purpose for details.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B. LDB >= max(1,P).
+*> \endverbatim
+*>
+*> \param[out] THETA
+*> \verbatim
+*>          THETA is DOUBLE PRECISION array, dimension (N)
+*>
+*>          On exit, THETA contains K = MIN(M, P, L, M + P - L) values
+*>          in radians in ascending order.
+*> \endverbatim
+*>
+*> \param[out] U1
+*> \verbatim
+*>          U1 is COMPLEX*16 array, dimension (LDU1,M)
+*>          If JOBU1 = 'Y', U1 contains the M-by-M orthogonal matrix U1.
+*>          If JOBU1 = 'N', U1 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU1
+*> \verbatim
+*>          LDU1 is INTEGER
+*>          The leading dimension of the array U1. LDU1 >= max(1,M) if
+*>          JOBU1 = 'Y'; LDU1 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] U2
+*> \verbatim
+*>          U2 is COMPLEX*16 array, dimension (LDU2,P)
+*>          If JOBU2 = 'Y', U2 contains the P-by-P orthogonal matrix U2.
+*>          If JOBU2 = 'N', U2 is not referenced.
+*> \endverbatim
+*>
+*> \param[in] LDU2
+*> \verbatim
+*>          LDU2 is INTEGER
+*>          The leading dimension of the array U2. LDU2 >= max(1,P) if
+*>          JOBU2 = 'Y'; LDU2 >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] QT
+*> \verbatim
+*>          QT is COMPLEX*16 array, dimension (LDQT,N)
+*>          If JOBQT = 'Y', QT contains the N-by-N orthogonal matrix
+*>          Q**T.
+*> \endverbatim
+*>
+*> \param[in] LDQT
+*> \verbatim
+*>          LDQT is INTEGER
+*>          The leading dimension of the array QT. LDQT >= max(1,N) if
+*>          JOBQT = 'Y'; LDQT >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>
+*>          If LWORK = -1, then a workspace query is assumed; the
+*>          routine only calculates the optimal size of the WORK array,
+*>          returns this value as the first entry of the WORK array, and
+*>          no error message related to LWORK is issued by XERBLA.
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is DOUBLE PRECISION array, dimension (MAX(1,LRWORK))
+*> \endverbatim
+*>
+*> \param[in] LRWORK
+*> \verbatim
+*>          LRWORK is INTEGER
+*>          The dimension of the array RWORK.
+*>
+*>          If LRWORK = -1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the RWORK array, returns
+*>          this value as the first entry of the work array, and no error
+*>          message related to LRWORK is issued by XERBLA.
+*> \endverbatim
+*>
+*> \param[out] IWORK
+*> \verbatim
+*>          IWORK is INTEGER array, dimension (M + N + P)
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  ZBBCSD did not converge. For further details, see
+*>                subroutine ZUNCSDBY1.
+*> \endverbatim
+*
+*> \par Internal Parameters:
+*  =========================
+*>
+*> \verbatim
+*>  TOL     DOUBLE PRECISION
+*>          Let G = (A**T,B**T)**T. TOL is the threshold to determine
+*>          the effective rank of G. Generally, it is set to
+*>                   TOL = MAX(M,P,N) * norm(G) * MACHEPS,
+*>          where norm(G) is the Frobenius norm of G.
+*>          The size of TOL may affect the size of backward error of the
+*>          decomposition.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Christoph Conrads (https://christoph-conrads.name)
+*
+*> \date April 2020
+*
+*> \ingroup complex16OTHERcomputational
+*
+*> \par Contributors:
+*  ==================
+*>
+*>     Christoph Conrads (https://christoph-conrads.name)
+*>
+*
+*> \par Further Details:
+*  =====================
+*>
+*>  ZGGQRCS should be significantly faster than ZGGSVD and ZGGSVD3 for
+*>  large matrices because the matrices A and B are reduced to a pair of
+*>  well-conditioned bidiagonal matrices instead of pairs of upper
+*>  triangular matrices. On the downside, ZGGQRCS requires a much larger
+*>  workspace whose dimension must be queried at run-time.
+*>
+*  =====================================================================
+      SUBROUTINE ZGGQRCS( JOBU1, JOBU2, JOBQT, M, N, P, W, L,
+     $                    A, LDA, B, LDB,
+     $                    THETA, U1, LDU1, U2, LDU2, QT, LDQT,
+     $                    WORK, LWORK, RWORK, LRWORK, IWORK, INFO )
+*
+*  -- LAPACK driver routine (version 3.X.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd. --
+*     <DATE>
+*
+      IMPLICIT NONE
+*     .. Scalar Arguments ..
+      CHARACTER          JOBU1, JOBU2, JOBQT
+      INTEGER            INFO, LDA, LDB, LDU1, LDU2, LDQT,
+     $                   L, M, N, P, LWORK, LRWORK
+      DOUBLE PRECISION   W
+*     ..
+*     .. Array Arguments ..
+      INTEGER            IWORK( * )
+      DOUBLE PRECISION   THETA( * ), RWORK( * )
+      COMPLEX*16         A( LDA, * ), B( LDB, * ),
+     $                   U1( LDU1, * ), U2( LDU2, * ), QT( LDQT, * ),
+     $                   WORK( * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Local Scalars ..
+      LOGICAL            WANTU1, WANTU2, WANTQT, LQUERY
+      INTEGER            I, J, LMAX, Z, LDG, LWKOPT, LRWKOPT,
+     $                   LRWORK2BY1
+      DOUBLE PRECISION   GNORM, TOL, ULP, UNFL, NORMA, NORMB, BASE, NAN
+      COMPLEX*16         ZERO, ONE, ZNAN
+*     .. Local Arrays ..
+      COMPLEX*16         G( M + P, N )
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      DOUBLE PRECISION   DLAMCH, ZLANGE
+      EXTERNAL           LSAME, DLAMCH, ZLANGE
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           ZGEMM, ZGEQP3, ZGERQF, ZLACPY, ZLAPMT, ZLASCL,
+     $                   ZLASET, ZUNGQR, ZUNGRQ, ZUNCSD2BY1, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX, MIN
+*     ..
+*     .. Executable Statements ..
+*
+*     Decode and test the input parameters
+*
+      WANTU1 = LSAME( JOBU1, 'Y' )
+      WANTU2 = LSAME( JOBU2, 'Y' )
+      WANTQT = LSAME( JOBQT, 'Y' )
+      LQUERY = ( LWORK.EQ.-1 ) .OR. ( LRWORK.EQ.-1 )
+      LWKOPT = 1
+      LRWKOPT = 2*N
+*
+*     Initialize variables
+*
+      L = 0
+      LMAX = MIN( M + P, N )
+      Z = ( M + P ) * N
+      IF ( LQUERY ) THEN
+         G = 0
+      ELSE
+         G = WORK( 1 )
+      END IF
+      LDG = M + P
+      ZERO = (0.0D0, 0.0D0)
+      ONE = (1.0D0, 0.0D0)
+*     Computing 0.0 / 0.0 directly causes compiler errors
+      NAN = 1.0D0
+      NAN = 0.0 / (NAN - 1.0D0)
+      ZNAN = DCMPLX(NAN,NAN)
+*
+*     Test the input arguments
+*
+      INFO = 0
+      IF( .NOT.( WANTU1 .OR. LSAME( JOBU1, 'N' ) ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.( WANTU2 .OR. LSAME( JOBU2, 'N' ) ) ) THEN
+         INFO = -2
+      ELSE IF( .NOT.( WANTQT .OR. LSAME( JOBQT, 'N' ) ) ) THEN
+         INFO = -3
+      ELSE IF( M.LT.1 ) THEN
+         INFO = -4
+      ELSE IF( N.LT.1 ) THEN
+         INFO = -5
+      ELSE IF( P.LT.1 ) THEN
+         INFO = -6
+      ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
+         INFO = -10
+      ELSE IF( LDB.LT.MAX( 1, P ) ) THEN
+         INFO = -12
+      ELSE IF( LDU1.LT.1 .OR. ( WANTU1 .AND. LDU1.LT.M ) ) THEN
+         INFO = -15
+      ELSE IF( LDU2.LT.1 .OR. ( WANTU2 .AND. LDU2.LT.P ) ) THEN
+         INFO = -17
+      ELSE IF( LDQT.LT.1 .OR. ( WANTQT .AND. LDQT.LT.N ) ) THEN
+         INFO = -19
+      ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
+         INFO = -23
+      ELSE IF( LRWORK.LT.2*N .AND. .NOT.LQUERY ) THEN
+         INFO = -25
+      END IF
+*
+*     Compute optimal workspace size
+*
+      IF( INFO.EQ.0 ) THEN
+*        ZGEQP3, ZUNGQR read/store LMAX scalar factors
+         CALL ZGEQP3( M+P, N, G, LDG, IWORK, WORK,
+     $                WORK, -1, RWORK, INFO )
+         LWKOPT = INT( WORK( 1 ) ) + LMAX
+
+         CALL ZUNGQR( M + P, LMAX, LMAX, G, LDG, WORK, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + LMAX )
+
+         CALL ZUNCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, LMAX,
+     $                    G, LDG, G, LDG,
+     $                    THETA, U2, LDU2, U1, LDU1, QT, LDQT,
+     $                    WORK, -1, RWORK, LRWORK, IWORK, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+*        The matrix (A, B) must be stored sequentially for xUNCSD2BY1
+         LWKOPT = Z + LWKOPT
+*        Adjust ZUNCSD2BY1 LRWORK for case with maximum memory
+*        consumption
+         LRWORK2BY1 = INT( RWORK(1) )
+*        Select safe xUNCSD2BY1 IBBCSD value
+     $                - 9 * MAX( 0, MIN( M, P, N, M+P-N-1 ) )
+     $                + 9 * MAX( 1, MIN( M, P, N ) )
+*        Select safe xUNCSD2BY1 LBBCSD value
+     $                - 8 * MAX( 0, MIN( M, P, N, M+P-N ) )
+     $                + 8 * MIN( M, P, N )
+         LRWKOPT = MAX( 2*N, LRWORK2BY1 )
+
+*        ZGERQF, ZUNGRQ read/store up to LMAX scalar factors
+         CALL ZGERQF( LMAX, N, QT, LDQT, WORK, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + LMAX )
+
+         CALL ZUNGRQ( N, N, LMAX, QT, LDQT, WORK, WORK, -1, INFO )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) + LMAX )
+
+         WORK( 1 ) = DCMPLX( DBLE( LWKOPT ), 0.0D0 )
+         RWORK( 1 ) = DBLE( LRWKOPT )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'ZGGQRCS', -INFO )
+         RETURN
+      END IF
+      IF( LQUERY ) THEN
+         RETURN
+      ENDIF
+*
+*     DEBUG
+*
+      IWORK( 1:M+N+P ) = -1
+*
+*     Scale matrix B such that norm(A) \approx norm(B)
+*
+      NORMA = ZLANGE( 'F', M, N, A, LDA, RWORK )
+      NORMB = ZLANGE( 'F', P, N, B, LDB, RWORK )
+*
+      IF ( NORMB.EQ.0 ) THEN
+         W = 1.0D0
+      ELSE
+         BASE = DLAMCH( 'B' )
+         W = BASE ** INT( LOG( NORMA / NORMB ) / LOG( BASE ) )
+*
+         CALL ZLASCL( 'G', -1, -1, 1.0D0, W, P, N, B, LDB, INFO )
+         IF ( INFO.NE.0 ) THEN
+            RETURN
+         END IF
+      END IF
+*
+*     Copy matrices A, B into the (M+P) x n matrix G
+*
+      CALL ZLACPY( 'A', M, N, A, LDA, G( P + 1, 1 ), LDG )
+      CALL ZLACPY( 'A', P, N, B, LDB, G( 1, 1 ), LDG )
+*
+*     DEBUG
+*
+      CALL ZLASET( 'A', M, N, ZNAN, ZNAN, A, LDA )
+      CALL ZLASET( 'A', P, N, ZNAN, ZNAN, B, LDB )
+*
+*     Compute the Frobenius norm of matrix G
+*
+      GNORM = ZLANGE( 'F', M + P, N, G, LDG, WORK( Z + 1 ) )
+*
+*     Get machine precision and set up threshold for determining
+*     the effective numerical rank of the matrix G.
+*
+      ULP = DLAMCH( 'Precision' )
+      UNFL = DLAMCH( 'Safe Minimum' )
+      TOL = MAX( M + P, N ) * MAX( GNORM, UNFL ) * ULP
+*
+*     IWORK stores the column permutations computed by ZGEQP3.
+*     Columns J where IWORK( J ) is non-zero are permuted to the front
+*     so we set the all entries to zero here.
+*
+      IWORK( 1:N ) = 0
+*
+*     Compute the QR factorization with column pivoting GΠ = Q1 R1
+*
+      CALL ZGEQP3( M + P, N, G, LDG, IWORK, WORK( Z + 1 ),
+     $             WORK( Z + LMAX + 1 ), LWORK - Z - LMAX, RWORK, INFO )
+      IF( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Determine the rank of G
+*
+      DO 20 I = 1, LMAX
+         IF( ABS( G( I, I ) ).LE.TOL ) THEN
+            EXIT
+         END IF
+         L = L + 1
+   20 CONTINUE
+*
+*     Handle rank=0 case
+*
+      IF( L.EQ.0 ) THEN
+         IF( WANTU1 ) THEN
+            CALL ZLASET( 'A', M, M, ZERO, ONE, U1, LDU1 )
+         END IF
+         IF( WANTU2 ) THEN
+            CALL ZLASET( 'A', P, P, ZERO, ONE, U2, LDU2 )
+         END IF
+         IF( WANTQT ) THEN
+            CALL ZLASET( 'A', N, N, ZERO, ONE, QT, LDQT )
+         END IF
+*
+         WORK( 1 ) = DCMPLX( DBLE(LWKOPT), 0.0D0 )
+         RWORK( 1 ) = DBLE(LRWKOPT)
+         RETURN
+      END IF
+*
+*     Copy R1( 1:L, : ) into A, B and set lower triangular part to zero
+*
+      IF( L.LE.M ) THEN
+          CALL ZLACPY( 'U', L, N, G, LDG, A, LDA )
+          CALL ZLASET( 'L', L - 1, N, ZERO, ZERO, A( 2, 1 ), LDA )
+      ELSE
+          CALL ZLACPY( 'U', M, N, G, LDG, A, LDA )
+          CALL ZLACPY( 'U', L - M, N - M, G( M+1, M+1 ), LDG, B, LDB )
+*
+          CALL ZLASET( 'L', M - 1, N, ZERO, ZERO, A( 2, 1 ), LDA )
+          CALL ZLASET( 'L', L-M-1, N, ZERO, ZERO, B( 2, 1 ), LDB )
+      END IF
+*
+*     Explicitly form Q1 so that we can compute the CS decomposition
+*
+      CALL ZUNGQR( M + P, L, L, G, LDG, WORK( Z + 1 ),
+     $             WORK( Z + L + 1 ), LWORK - Z - L, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     DEBUG
+*
+      RWORK( 1:LRWORK ) = NAN
+      WORK( Z+1:LWORK ) = ZNAN
+*
+*     Compute the CS decomposition of Q1( :, 1:L )
+*
+      CALL ZUNCSD2BY1( JOBU2, JOBU1, 'Y', M + P, P, L,
+     $                 G( 1, 1 ), LDG, G( P + 1, 1 ), LDG, THETA,
+     $                 U2, LDU2, U1, LDU1, QT, LDQT,
+     $                 WORK( Z + 1 ), LWORK - Z,
+     $                 RWORK, LRWORK, IWORK( N + 1 ), INFO )
+      IF( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     DEBUG
+*
+      WORK( 1:LWORK ) = ZNAN
+      RWORK( 1:LRWORK ) = NAN
+*
+*     Copy V^T from QT to G
+*
+      CALL ZLACPY( 'A', L, L, QT, LDQT, G, LDG )
+*
+*     DEBUG
+*
+      CALL ZLASET( 'A', N, N, ZNAN, ZNAN, QT, LDQT )
+*
+*     Compute V^T R1( 1:L, : ) in the last L rows of QT
+*
+      IF ( L.LE.M ) THEN
+         CALL ZGEMM( 'N', 'N', L, N, L, ONE, G, LDG,
+     $               A, LDA, ZERO, QT( N-L+1, 1 ), LDQT )
+      ELSE
+         CALL ZGEMM( 'N', 'N', L, N, M, ONE, G( 1, 1 ), LDG,
+     $               A, LDA, ZERO, QT( N-L+1, 1 ), LDQT )
+         CALL ZGEMM( 'N', 'N', L, N - M, L - M, ONE,
+     $               G( 1, M + 1 ), LDG, B, LDB,
+     $               ONE, QT( N-L+1, M+1 ), LDQT )
+      END IF
+*
+*     DEBUG
+*
+      CALL ZLASET( 'A', M, N, ZNAN, ZNAN, A, LDA )
+      CALL ZLASET( 'A', P, N, ZNAN, ZNAN, B, LDB )
+      WORK(1:LWORK) = ZNAN
+*
+*     Compute the RQ decomposition of V^T R1( 1:L, : )
+*
+      CALL ZGERQF( L, N, QT( N-L+1, 1 ), LDQT, WORK( 1 ),
+     $             WORK( L + 1 ), LWORK - L, INFO )
+      IF ( INFO.NE.0 ) THEN
+         RETURN
+      END IF
+*
+*     Copy matrix L from QT( N-L+1:N, N-L+1:N ) to A, B
+*
+      IF ( L.LE.M ) THEN
+         CALL ZLACPY( 'U', L, L, QT( N-L+1, N-L+1 ), LDQT, A, LDA )
+      ELSE
+         CALL ZLACPY( 'U', M,     L, QT( N-L+1, N-L+1 ), LDQT, A, LDA )
+         CALL ZLACPY( 'U', L - M, L - M, QT( N-L+M+1, N-L+M+1 ), LDQT,
+     $                B, LDB )
+      END IF
+*
+*     DEBUG
+*
+      CALL ZLASET( 'U', L, L, ZNAN, ZNAN, QT( 1, N-L+1 ), LDQT )
+      WORK( L+1:LWORK ) = ZNAN
+*
+*     Explicitly form Q^T
+*
+      IF( WANTQT ) THEN
+         CALL ZUNGRQ( N, N, L, QT, LDQT, WORK,
+     $                WORK( L + 1 ), LWORK - L, INFO )
+         IF ( INFO.NE.0 ) THEN
+            RETURN
+         END IF
+*
+*     Revert column permutation Π by permuting the rows of Q^T
+*
+         CALL ZLAPMT( .FALSE., N, N, QT, LDQT, IWORK )
+      END IF
+*
+      WORK( 1 ) = DCMPLX( DBLE(LWKOPT), 0.0D0 )
+      RWORK( 1 ) = DBLE(LRWKOPT)
+
+      RETURN
+*
+*     End of ZGGQRCS
+*
+      END

--- a/SRC/zuncsd2by1.f
+++ b/SRC/zuncsd2by1.f
@@ -511,6 +511,9 @@
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
             INFO = -19
          END IF
+         IF( LRWORK .LT. LRWORKMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -21
+         END IF
       END IF
       IF( INFO .NE. 0 ) THEN
          CALL XERBLA( 'ZUNCSD2BY1', -INFO )
@@ -564,8 +567,8 @@
      $                RWORK(IPHI), U1, LDU1, U2, LDU2, V1T, LDV1T, CDUM,
      $                1, RWORK(IB11D), RWORK(IB11E), RWORK(IB12D),
      $                RWORK(IB12E), RWORK(IB21D), RWORK(IB21E),
-     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD), LBBCSD,
-     $                CHILDINFO )
+     $                RWORK(IB22D), RWORK(IB22E), RWORK(IBBCSD),
+     $                LRWORK-IBBCSD+1, CHILDINFO )
 *
 *        Permute rows and columns to place zero submatrices in
 *        preferred positions

--- a/SRC/zuncsd2by1.f
+++ b/SRC/zuncsd2by1.f
@@ -189,9 +189,10 @@
 *>          The dimension of the array WORK.
 *>
 *>          If LWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the WORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LWORK is issued by XERBLA.
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *>
 *> \param[out] RWORK
@@ -210,10 +211,11 @@
 *>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>
-*>          If LRWORK = -1, then a workspace query is assumed; the routine
-*>          only calculates the optimal size of the RWORK array, returns
-*>          this value as the first entry of the work array, and no error
-*>          message related to LRWORK is issued by XERBLA.
+*>          If LRWORK=-1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the WORK and RWORK
+*>          arrays, returns this value as the first entry of the WORK
+*>          and RWORK array, respectively, and no error message related
+*>          to LWORK or LRWORK is issued by XERBLA.
 *> \endverbatim
 *
 *> \param[out] IWORK
@@ -312,7 +314,7 @@
       WANTU1 = LSAME( JOBU1, 'Y' )
       WANTU2 = LSAME( JOBU2, 'Y' )
       WANTV1T = LSAME( JOBV1T, 'Y' )
-      LQUERY = LWORK .EQ. -1
+      LQUERY = ( LWORK.EQ.-1 ) .OR. ( LRWORK.EQ.-1 )
 *
       IF( M .LT. 0 ) THEN
          INFO = -4

--- a/SRC/zuncsd2by1.f
+++ b/SRC/zuncsd2by1.f
@@ -709,6 +709,9 @@
 *
 *        Accumulate Householder reflectors
 *
+         IF( WANTU2 .AND. M-P .GT. 0 ) THEN
+            CALL ZCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
+         END IF
          IF( WANTU1 .AND. P .GT. 0 ) THEN
             CALL ZCOPY( P, WORK(IORBDB), 1, U1, 1 )
             DO J = 2, P
@@ -720,7 +723,6 @@
      $                   WORK(IORGQR), LORGQR, CHILDINFO )
          END IF
          IF( WANTU2 .AND. M-P .GT. 0 ) THEN
-            CALL ZCOPY( M-P, WORK(IORBDB+P), 1, U2, 1 )
             DO J = 2, M-P
                U2(1,J) = ZERO
             END DO


### PR DESCRIPTION
This pull request adds a generalized singular value decomposition computed by means of a QR decomposition with column pivoting and the 2-by-1 CS decomposition to LAPACK. The PR requires #405.

Given a pair of matrices `A`, `B` with appropriate dimensions, the GSVD computes a decomposition
* `A = U1 D1 R Q^*`,
* `B = U2 D2 R Q^*`.

I would like to have feedback on the computation of the matrix `R`. Currently it is always computed but this is expensive because of an additional matrix-matrix multiplication followed by an RQ decomposition. Should I make this optional?

The PR is based on #63 but provides all implementations (single-precision real, double-precision real, single-precision complex, and double-precision complex) with tests removed because of the C++ dependency. The tests can be found in fb5dfb3fc87b3707de81dda6ae7ea2043d7cb247.