### PR TITLE
Fix the loop index scalar in ZHEEQUB.f

### DIFF
--- a/SRC/zheequb.f
+++ b/SRC/zheequb.f
@@ -271,7 +271,7 @@
          AVG = AVG / N
 
          STD = 0.0D0
-         DO I = N+1, N
+         DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO
          CALL ZLASSQ( N, WORK( N+1 ), 1, SCALE, SUMSQ )


### PR DESCRIPTION
In #61 one of the files has been missed in terms of the loop index modifications and that in turn causes wildly different results depending on the versions due to the data being not scaled appropriately.

This PR completes the suite.