### PR TITLE
Fix some build warnings due to signature inconsistencies

### DIFF
--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -3640,45 +3640,58 @@ void LAPACK_zggrqf(
     lapack_int* info );
 
 #define LAPACK_sggsvd LAPACK_GLOBAL(sggsvd,SGGSVD)
-lapack_int LAPACKE_sggsvd( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int n, lapack_int p,
-                           lapack_int* k, lapack_int* l, float* a,
-                           lapack_int lda, float* b, lapack_int ldb,
-                           float* alpha, float* beta, float* u, lapack_int ldu,
-                           float* v, lapack_int ldv, float* q, lapack_int ldq,
-                           lapack_int* iwork );
+lapack_int LAPACK_sggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    float* a, lapack_int const* lda,
+    float* b, lapack_int const* ldb,
+    float* alpha, float* beta,
+    float* u, lapack_int const* ldu,
+    float* v, lapack_int const* ldv,
+    float* q, lapack_int const* ldq,
+    float* work, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
-lapack_int LAPACKE_dggsvd( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int n, lapack_int p,
-                           lapack_int* k, lapack_int* l, double* a,
-                           lapack_int lda, double* b, lapack_int ldb,
-                           double* alpha, double* beta, double* u,
-                           lapack_int ldu, double* v, lapack_int ldv, double* q,
-                           lapack_int ldq, lapack_int* iwork );
+lapack_int LAPACK_dggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    double* a, lapack_int const* lda,
+    double* b, lapack_int const* ldb,
+    double* alpha, double* beta,
+    double* u, lapack_int const* ldu,
+    double* v, lapack_int const* ldv,
+    double* q, lapack_int const* ldq,
+    double* work, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
-lapack_int LAPACKE_cggsvd( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int n, lapack_int p,
-                           lapack_int* k, lapack_int* l,
-                           lapack_complex_float* a, lapack_int lda,
-                           lapack_complex_float* b, lapack_int ldb,
-                           float* alpha, float* beta, lapack_complex_float* u,
-                           lapack_int ldu, lapack_complex_float* v,
-                           lapack_int ldv, lapack_complex_float* q,
-                           lapack_int ldq, lapack_int* iwork );
+lapack_int LAPACK_cggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    lapack_complex_float* a, lapack_int const* lda,
+    lapack_complex_float* b, lapack_int const* ldb,
+    float* alpha, float* beta,
+    lapack_complex_float* u, lapack_int const* ldu,
+    lapack_complex_float* v, lapack_int const* ldv,
+    lapack_complex_float* q, lapack_int const* ldq,
+    lapack_complex_float* work, float* rwork,
+    lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
-lapack_int LAPACKE_zggsvd( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int n, lapack_int p,
-                           lapack_int* k, lapack_int* l,
-                           lapack_complex_double* a, lapack_int lda,
-                           lapack_complex_double* b, lapack_int ldb,
-                           double* alpha, double* beta,
-                           lapack_complex_double* u, lapack_int ldu,
-                           lapack_complex_double* v, lapack_int ldv,
-                           lapack_complex_double* q, lapack_int ldq,
-                           lapack_int* iwork );
+lapack_int LAPACK_zggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    lapack_complex_double* a, lapack_int const* lda,
+    lapack_complex_double* b, lapack_int const* ldb,
+    double* alpha, double* beta,
+    lapack_complex_double* u, lapack_int const* ldu,
+    lapack_complex_double* v, lapack_int const* ldv,
+    lapack_complex_double* q, lapack_int const* ldq,
+    lapack_complex_double* work, double* rwork,
+    lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd3 LAPACK_GLOBAL(cggsvd3,CGGSVD3)
 void LAPACK_cggsvd3(
@@ -3743,41 +3756,58 @@ void LAPACK_zggsvd3(
     lapack_int* info );
 
 #define LAPACK_sggsvp LAPACK_GLOBAL(sggsvp,SGGSVP)
-lapack_int LAPACKE_sggsvp( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int p, lapack_int n, float* a,
-                           lapack_int lda, float* b, lapack_int ldb, float tola,
-                           float tolb, lapack_int* k, lapack_int* l, float* u,
-                           lapack_int ldu, float* v, lapack_int ldv, float* q,
-                           lapack_int ldq );
+lapack_int LAPACK_sggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    float* a, lapack_int const* lda,
+    float* b, lapack_int const* ldb,
+    float* tola, float* tolb,
+    lapack_int* k, lapack_int* l,
+    float* u, lapack_int const* ldu,
+    float* v, lapack_int const* ldv,
+    float* q, lapack_int const* ldq,
+    lapack_int* iwork, float* tau,
+    float* work, lapack_int* info );
 
 #define LAPACK_dggsvp LAPACK_GLOBAL(dggsvp,DGGSVP)
-lapack_int LAPACKE_dggsvp( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int p, lapack_int n, double* a,
-                           lapack_int lda, double* b, lapack_int ldb,
-                           double tola, double tolb, lapack_int* k,
-                           lapack_int* l, double* u, lapack_int ldu, double* v,
-                           lapack_int ldv, double* q, lapack_int ldq );
+lapack_int LAPACK_dggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    double* a, lapack_int const* lda,
+    double* b, lapack_int const* ldb,
+    double* tola, double* tolb,
+    lapack_int* k, lapack_int* l,
+    double* u, lapack_int const* ldu,
+    double* v, lapack_int const* ldv,
+    double* q, lapack_int const* ldq,
+    lapack_int* iwork, double* tau,
+    double* work, lapack_int* info );
 
 #define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
-lapack_int LAPACKE_cggsvp( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int p, lapack_int n,
-                           lapack_complex_float* a, lapack_int lda,
-                           lapack_complex_float* b, lapack_int ldb, float tola,
-                           float tolb, lapack_int* k, lapack_int* l,
-                           lapack_complex_float* u, lapack_int ldu,
-                           lapack_complex_float* v, lapack_int ldv,
-                           lapack_complex_float* q, lapack_int ldq );
+lapack_int LAPACK_cggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    lapack_complex_float* a, lapack_int const* lda,
+    lapack_complex_float* b, lapack_int const* ldb,
+    float* tola, float* tolb, lapack_int* k, lapack_int* l,
+    lapack_complex_float* u, lapack_int const* ldu,
+    lapack_complex_float* v, lapack_int const* ldv,
+    lapack_complex_float* q, lapack_int const* ldq,
+    lapack_int* iwork, float* rwork, lapack_complex_float* tau,
+    lapack_complex_float* work, lapack_int* info );
 
 #define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
-lapack_int LAPACKE_zggsvp( int matrix_layout, char jobu, char jobv, char jobq,
-                           lapack_int m, lapack_int p, lapack_int n,
-                           lapack_complex_double* a, lapack_int lda,
-                           lapack_complex_double* b, lapack_int ldb,
-                           double tola, double tolb, lapack_int* k,
-                           lapack_int* l, lapack_complex_double* u,
-                           lapack_int ldu, lapack_complex_double* v,
-                           lapack_int ldv, lapack_complex_double* q,
-                           lapack_int ldq );
+lapack_int LAPACK_zggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    lapack_complex_double* a, lapack_int const* lda,
+    lapack_complex_double* b, lapack_int const* ldb,
+    double* tola, double* tolb, lapack_int* k, lapack_int* l,
+    lapack_complex_double* u, lapack_int const* ldu,
+    lapack_complex_double* v, lapack_int const* ldv,
+    lapack_complex_double* q, lapack_int const* ldq,
+    lapack_int* iwork, double* rwork, lapack_complex_double* tau,
+    lapack_complex_double* work, lapack_int* info );
 
 #define LAPACK_cggsvp3 LAPACK_GLOBAL(cggsvp3,CGGSVP3)
 void LAPACK_cggsvp3(

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -2503,7 +2503,7 @@ void LAPACK_zgesvdq(
     lapack_complex_double* U, lapack_int const* ldu,
     lapack_complex_double* V, lapack_int const* ldv, lapack_int* numrank,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_complex_float* cwork, lapack_int* lcwork,
+    lapack_complex_double* cwork, lapack_int* lcwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* info );
 

--- a/LAPACKE/src/lapacke_cgesvdq.c
+++ b/LAPACKE/src/lapacke_cgesvdq.c
@@ -47,8 +47,8 @@ lapack_int LAPACKE_cgesvdq( int matrix_layout, char joba, char jobp,
     lapack_complex_float* cwork = NULL;
     lapack_complex_float cwork_query;
     lapack_int lrwork = -1;
-    double* rwork = NULL;
-    double rwork_query;
+    float* rwork = NULL;
+    float rwork_query;
     lapack_int i;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_cgesvdq", -1 );
@@ -84,7 +84,7 @@ lapack_int LAPACKE_cgesvdq( int matrix_layout, char joba, char jobp,
         info = LAPACK_WORK_MEMORY_ERROR;
         goto exit_level_0;
     }
-    rwork = (double*)LAPACKE_malloc( sizeof(double) * lrwork );
+    rwork = (float*)LAPACKE_malloc( sizeof(float) * lrwork );
     if( rwork == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
         goto exit_level_0;


### PR DESCRIPTION
The following problems were encountered by working on https://github.com/conda-forge/lapack-feedstock/pull/32, trying to package lapack 3.9.0 for conda-forge. I had some missing symbols when I tried initially, and after some investigation, found that the solution lay in #367. After some more problems (mainly build errors on windows), I found I had effectively recreated https://github.com/Reference-LAPACK/lapack/commit/e0bddb25787a1fd6103572a2304af4490ceb5f38.

In the process of fixing the build errors (mainly windows) and warnings, I also came up with the two following commits. Things *do* compile without them, but AFAIS they are needless inconsistencies, and can easily be resolved.

The second commit is somewhat bigger, where @isuruf pointed out to me in that the `lapack.h` header was defining several of the deprecated functions being reintroduced by #367 to be defined as LAPACKE functions. Some [discussion](https://github.com/Reference-LAPACK/lapack/pull/367/files#r415098565) on the original PR made it clear that I don't understand the codebase well, but I'm still baffled how that completely divergent function signature in the header is being swallowed by the compiler, which apparently cannot locate the function.

I haven't investigated if the resulting functions are tested (being deprecated, it seems like a possibility that they're not). In any case, through trial and error (and getting some context from the surrounding declarations in the header), I came up with the second commit. With this, we were able to eliminate the build warnings (and pass the test suite), but I'm happy to accept if what I came up with is wrong.

Some more details in the commit messages.

Build warnings without first commit:

<details>

```
[ 75%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cgesvdq.c.o
[...]/LAPACKE/src/lapacke_cgesvdq.c: In function 'LAPACKE_cgesvdq':
[...]/LAPACKE/src/lapacke_cgesvdq.c:69:34: warning: passing argument 21 of 'LAPACKE_cgesvdq_work' from incompatible pointer type [-Wincompatible-pointer-types]
                                  &rwork_query, lrwork );
                                  ^
In file included from [...]/LAPACKE/include/lapacke_utils.h:37:0,
                 from [...]/LAPACKE/src/lapacke_cgesvdq.c:34:
[...]/LAPACKE/include/lapacke.h:5769:12: note: expected 'float *' but argument is of type 'double *'
 lapack_int LAPACKE_cgesvdq_work( int matrix_layout, char joba, char jobp,
            ^~~~~~~~~~~~~~~~~~~~
[...]/LAPACKE/src/lapacke_cgesvdq.c:95:64: warning: passing argument 21 of 'LAPACKE_cgesvdq_work' from incompatible pointer type [-Wincompatible-pointer-types]
                                  iwork, liwork, cwork, lcwork, rwork, lrwork );
                                                                ^~~~~
In file included from [...]/LAPACKE/include/lapacke_utils.h:37:0,
                 from [...]/LAPACKE/src/lapacke_cgesvdq.c:34:
[...]/LAPACKE/include/lapacke.h:5769:12: note: expected 'float *' but argument is of type 'double *'
 lapack_int LAPACKE_cgesvdq_work( int matrix_layout, char joba, char jobp,
            ^~~~~~~~~~~~~~~~~~~~
[ 75%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cgesvdq_work.c.o
```

```
[ 89%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zgesvdx.c.o
[...]/LAPACKE/src/lapacke_zgesvdq_work.c: In function 'LAPACKE_zgesvdq_work':
[...]/LAPACKE/src/lapacke_zgesvdq_work.c:49:49: warning: passing argument 18 of 'zgesvdq_' from incompatible pointer type [-Wincompatible-pointer-types]
                        numrank, iwork, &liwork, cwork, &lcwork, rwork, &lrwork, &info );
                                                 ^~~~~
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_zgesvdq_work.c:34:
[...]/LAPACKE/include/lapack.h:2497:38: note: expected '_Complex float *' but argument is of type '_Complex double *'
 #define LAPACK_zgesvdq LAPACK_GLOBAL(zgesvdq,ZGESVDQ)
                                      ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/include/lapack.h:2498:6: note: in expansion of macro 'LAPACK_zgesvdq'
 void LAPACK_zgesvdq(
      ^~~~~~~~~~~~~~
[...]/LAPACKE/src/lapacke_zgesvdq_work.c:86:30: warning: passing argument 18 of 'zgesvdq_' from incompatible pointer type [-Wincompatible-pointer-types]
                              cwork, &lcwork, rwork, &lrwork, &info );
[...]/LAPACKE/include/lapack.h:2498:6: note: in expansion of macro 'LAPACK_zgesvdq'
 void LAPACK_zgesvdq(
      ^~~~~~~~~~~~~~
[ 89%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zgesvdx_work.c.o
```

</details>

Build warnings without second patch:

<details>

```
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvp.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_cggsvp_work.c:34:
[...]/LAPACKE/src/lapacke_cggsvp_work.c: In function 'LAPACKE_cggsvp_work':
[...]/LAPACKE/include/lapack.h:3761:37: warning: implicit declaration of function 'cggsvp_'; did you mean 'cggsvp3_'? [-Wimplicit-function-declaration]
 #define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_cggsvp_work.c:52:9: note: in expansion of macro 'LAPACK_cggsvp'
         LAPACK_cggsvp( &jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvp_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvp.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_dggsvp_work.c:34:
[...]/LAPACKE/src/lapacke_dggsvp_work.c: In function 'LAPACKE_dggsvp_work':
[...]/LAPACKE/include/lapack.h:3753:37: warning: implicit declaration of function 'dggsvp_'; did you mean 'dggsvp3_'? [-Wimplicit-function-declaration]
 #define LAPACK_dggsvp LAPACK_GLOBAL(dggsvp,DGGSVP)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_dggsvp_work.c:48:9: note: in expansion of macro 'LAPACK_dggsvp'
         LAPACK_dggsvp( &jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvp_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvp.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_sggsvp_work.c:34:
[...]/LAPACKE/src/lapacke_sggsvp_work.c: In function 'LAPACKE_sggsvp_work':
[...]/LAPACKE/include/lapack.h:3745:37: warning: implicit declaration of function 'sggsvp_'; did you mean 'sggsvp3_'? [-Wimplicit-function-declaration]
 #define LAPACK_sggsvp LAPACK_GLOBAL(sggsvp,SGGSVP)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_sggsvp_work.c:48:9: note: in expansion of macro 'LAPACK_sggsvp'
         LAPACK_sggsvp( &jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvp_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cggsvd.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_zggsvp_work.c:34:
[...]/LAPACKE/src/lapacke_zggsvp_work.c: In function 'LAPACKE_zggsvp_work':
[...]/LAPACKE/include/lapack.h:3771:37: warning: implicit declaration of function 'zggsvp_'; did you mean 'zggsvp3_'? [-Wimplicit-function-declaration]
 #define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_zggsvp_work.c:52:9: note: in expansion of macro 'LAPACK_zggsvp'
         LAPACK_zggsvp( &jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvd.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_cggsvd_work.c:34:
[...]/LAPACKE/src/lapacke_cggsvd_work.c: In function 'LAPACKE_cggsvd_work':
[...]/LAPACKE/include/lapack.h:3660:37: warning: implicit declaration of function 'cggsvd_'; did you mean 'cggsvd3_'? [-Wimplicit-function-declaration]
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_cggsvd_work.c:51:9: note: in expansion of macro 'LAPACK_cggsvd'
         LAPACK_cggsvd( &jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvd.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_dggsvd_work.c:34:
[...]/LAPACKE/src/lapacke_dggsvd_work.c: In function 'LAPACKE_dggsvd_work':
[...]/LAPACKE/include/lapack.h:3651:37: warning: implicit declaration of function 'dggsvd_'; did you mean 'dggsvd3_'? [-Wimplicit-function-declaration]
 #define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_dggsvd_work.c:48:9: note: in expansion of macro 'LAPACK_dggsvd'
         LAPACK_dggsvd( &jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvd.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_sggsvd_work.c:34:
[...]/LAPACKE/src/lapacke_sggsvd_work.c: In function 'LAPACKE_sggsvd_work':
[...]/LAPACKE/include/lapack.h:3642:37: warning: implicit declaration of function 'sggsvd_'; did you mean 'sggsvd3_'? [-Wimplicit-function-declaration]
 #define LAPACK_sggsvd LAPACK_GLOBAL(sggsvd,SGGSVD)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_sggsvd_work.c:48:9: note: in expansion of macro 'LAPACK_sggsvd'
         LAPACK_sggsvd( &jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cgeqpf.c.o
In file included from [...]/LAPACKE/include/lapack.h:11:0,
                 from [...]/LAPACKE/include/lapacke.h:37,
                 from [...]/LAPACKE/include/lapacke_utils.h:37,
                 from [...]/LAPACKE/src/lapacke_zggsvd_work.c:34:
[...]/LAPACKE/src/lapacke_zggsvd_work.c: In function 'LAPACKE_zggsvd_work':
[...]/LAPACKE/include/lapack.h:3671:37: warning: implicit declaration of function 'zggsvd_'; did you mean 'zggsvd3_'? [-Wimplicit-function-declaration]
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
                                     ^
[...]/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
[...]/LAPACKE/src/lapacke_zggsvd_work.c:51:9: note: in expansion of macro 'LAPACK_zggsvd'
         LAPACK_zggsvd( &jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb,
         ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cgeqpf_work.c.o
```

</details>