### PR TITLE
Improvements of CMake (instalL) code for CBLAS, LAPACKE 

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -39,14 +39,9 @@ install(FILES ${CBLAS_INCLUDE} ${LAPACK_BINARY_DIR}/include/cblas_mangling.h
   COMPONENT Development
   )
 
-# --------------------------------------------------
 if(BUILD_TESTING)
   add_subdirectory(testing)
   add_subdirectory(examples)
-endif()
-
-if(NOT BLAS_FOUND)
-  set(ALL_TARGETS ${ALL_TARGETS} ${BLASLIB})
 endif()
 
 # Export cblas targets from the

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -44,28 +44,11 @@ if(BUILD_TESTING)
   add_subdirectory(examples)
 endif()
 
-# Export cblas targets from the
-# install tree, if any.
-set(_cblas_config_install_guard_target "")
-if(ALL_TARGETS)
-  install(EXPORT ${CBLASLIB}-targets
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
-    COMPONENT Development
-    )
-  # Choose one of the cblas targets to use as a guard for
-  # cblas-config.cmake to load targets from the install tree.
-  list(GET ALL_TARGETS 0 _cblas_config_install_guard_target)
-endif()
+install(EXPORT ${CBLASLIB}-targets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
+  COMPONENT Development
+  )
 
-# Export cblas targets from the build tree, if any.
-set(_cblas_config_build_guard_target "")
-if(ALL_TARGETS)
-  export(TARGETS ${ALL_TARGETS} FILE ${CBLASLIB}-targets.cmake)
-
-  # Choose one of the cblas targets to use as a guard
-  # for cblas-config.cmake to load targets from the build tree.
-  list(GET ALL_TARGETS 0 _cblas_config_build_guard_target)
-endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-version.cmake.in
   ${LAPACK_BINARY_DIR}/${CBLASLIB}-config-version.cmake @ONLY)

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -50,17 +50,17 @@ install(EXPORT ${CBLASLIB}-targets
   )
 
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc @ONLY)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc
+  DESTINATION ${PKG_CONFIG_DIR}
+  )
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-version.cmake.in
   ${LAPACK_BINARY_DIR}/${CBLASLIB}-config-version.cmake @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-build.cmake.in
   ${LAPACK_BINARY_DIR}/${CBLASLIB}-config.cmake @ONLY)
-
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc @ONLY)
-  install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc
-  DESTINATION ${PKG_CONFIG_DIR}
-  )
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-install.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${CBLASLIB}-config.cmake @ONLY)

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -49,6 +49,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc
   DESTINATION ${PKG_CONFIG_DIR}
+  COMPONENT Development
   )
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cblas-config-version.cmake.in
@@ -62,6 +63,7 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${CBLASLIB}-config.cmake
   ${LAPACK_BINARY_DIR}/${CBLASLIB}-config-version.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
+  COMPONENT Development
   )
 
 install(EXPORT ${CBLASLIB}-targets

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -44,12 +44,6 @@ if(BUILD_TESTING)
   add_subdirectory(examples)
 endif()
 
-install(EXPORT ${CBLASLIB}-targets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
-  COMPONENT Development
-  )
-
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cblas.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}.pc @ONLY)
 install(FILES
@@ -70,7 +64,7 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
   )
 
-#install(EXPORT ${CBLASLIB}-targets
-#  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
-#  COMPONENT Development
-#  )
+install(EXPORT ${CBLASLIB}-targets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CBLASLIB}-${LAPACK_VERSION}
+  COMPONENT Development
+  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,10 +469,6 @@ if(NOT LATESTLAPACK_FOUND)
   set(ALL_TARGETS ${ALL_TARGETS} ${LAPACKLIB})
 endif()
 
-if(BUILD_TESTING)
-  set(ALL_TARGETS ${ALL_TARGETS} ${TMGLIB})
-endif()
-
 # Export lapack targets, not including lapacke, from the
 # install tree, if any.
 set(_lapack_config_install_guard_target "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,9 +353,27 @@ option(LAPACKE_WITH_TMG "Build LAPACKE with tmglib routines" OFF)
 if(LAPACKE_WITH_TMG)
   set(LAPACKE ON)
 endif()
-if(BUILD_TESTING OR LAPACKE_WITH_TMG) #already included, avoid double inclusion
+
+# TMGLIB
+# Cache export target
+set(LAPACK_INSTALL_EXPORT_NAME_CACHE ${LAPACK_INSTALL_EXPORT_NAME})
+if(BUILD_TESTING OR LAPACKE_WITH_TMG)
+  if(LATESTLAPACK_FOUND AND LAPACKE_WITH_TMG)
+    set(CMAKE_REQUIRED_LIBRARIES ${LAPACK_LIBRARIES})
+    # Check if dlatms (part of tmg) is found
+    CHECK_FORTRAN_FUNCTION_EXISTS("dlatms" LAPACK_WITH_TMGLIB_FOUND)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    if(NOT LAPACK_WITH_TMGLIB_FOUND)
+      # Build and install TMG as part of LAPACKE targets (as opposed to LAPACK
+      # targets)
+      set(LAPACK_INSTALL_EXPORT_NAME ${LAPACKELIB}-targets)
+    endif()
+  endif()
   add_subdirectory(TESTING/MATGEN)
 endif()
+# Reset export target
+set(LAPACK_INSTALL_EXPORT_NAME ${LAPACK_INSTALL_EXPORT_NAME_CACHE})
+unset(LAPACK_INSTALL_EXPORT_NAME_CACHE)
 
 if(LAPACKE)
   add_subdirectory(LAPACKE)
@@ -451,7 +469,7 @@ if(NOT LATESTLAPACK_FOUND)
   set(ALL_TARGETS ${ALL_TARGETS} ${LAPACKLIB})
 endif()
 
-if(BUILD_TESTING OR LAPACKE_WITH_TMG)
+if(BUILD_TESTING)
   set(ALL_TARGETS ${ALL_TARGETS} ${TMGLIB})
 endif()
 
@@ -477,6 +495,10 @@ endif()
 # Include lapacke in targets exported from the build tree.
 if(LAPACKE)
   set(ALL_TARGETS ${ALL_TARGETS} ${LAPACKELIB})
+endif()
+
+if(NOT LAPACK_WITH_TMGLIB_FOUND AND LAPACKE_WITH_TMG)
+  set(ALL_TARGETS ${ALL_TARGETS} ${TMGLIB})
 endif()
 
 # Export lapack and lapacke targets from the build tree, if any.


### PR DESCRIPTION
### Introduction
This pull request is my own attempt at fixing issue #410 (which I have created myself).
The main problem was that the created CMake packages for CBLAS/LAPACKE would not be usable when providing preinstalled optimized BLAS/LAPACK.

This is my first attempt at contributing to this repository, so I would greatly appreciate feedback of any kind.

### Changes
The issue stemmed mainly from the CMake code for CBLAS, which differed significantly from that of LAPACKE. 
I was unable to figure out a reason for this difference, and removing it largely fixed the issues I had with the install instructions.
Specifically, checks for the content `ALL_TARGETS` were made inside `CBLAS/CMakeLists.txt` that I do not think were necessary.

While I believe the above to be just fixed, I have also made one significant change.
This concerns the case outlined in the introduction, where intend to build and install LAPACKE using optimized BLAS/LAPACK libraries. 
If we additionally want to use the TMG library content (`LAPACKE_WITH_TMG=ON`), but `tmg` was not built with the optimized LAPACK, then we need to also build (and install) the `tmg` library.
Before the changes made here, the CMake code would build `tmg` as part of the `lapack-targets` (as opposed to the `lapacke-targets`) and attempt to install an additional `lapack-config.cmake` file. 
In this case however, I think it would be better to instead build and install it as part of the `lapacke-targets`, since modifying an already existing package doesn't seem prudent (or might even not be possible, for example for lack of permissions). 

Making this change allowed the library we are developing to build and install CBLAS/LAPACKE (if they are not found) with optimized BLAS/LAPACK, all without caring whether or not `tmg` is included in the optimized libraries on the system. 
At least for our use case, this is a major portability improvement.

### To be done
In the case mainly of interest in this pull request, no targets associated with `lapack-targets` are thus built. Ideally, installing `lapack-config.cmake` would no longer be necessary, and only the CBLAS and LAPACKE CMake packages should be installed.
I have not made this particular change yet, and a (seemingly useless) `lapack-config.cmake` will also be installed. 
This might cause issues, and I would love to get some feedback on how to alleviate this.

### More ideas
While working on this pull request, I had a few ideas for things that could possibly be done in the future, but certainly require more thought.
I won't go into details here, but the gist is:
 - Possibly get rid of the `ALL_TARGETS` part of code (seems obsolete to me)
 - Make CBLAS and LAPACKE separate repositories (with git submodules for BLAS/LAPACK)