### PR TITLE
?ggsv? followup to #434 & #409

### DIFF
--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -3651,43 +3651,43 @@ void LAPACK_zggrqf(
 
 #define LAPACK_sggsvd LAPACK_GLOBAL(sggsvd,SGGSVD)
 lapack_int LAPACK_sggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* n, lapack_int* p,
+                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
                            lapack_int* k, lapack_int* l, float* a,
-                           lapack_int* lda, float* b, lapack_int* ldb,
-                           float* alpha, float* beta, float* u, lapack_int* ldu,
-                           float* v, lapack_int* ldv, float* q, lapack_int* ldq,
+                           lapack_int const* lda, float* b, lapack_int const* ldb,
+                           float* alpha, float* beta, float* u, lapack_int const* ldu,
+                           float* v, lapack_int const* ldv, float* q, lapack_int const* ldq,
                            float* work, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
 lapack_int LAPACK_dggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* n, lapack_int* p,
+                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
                            lapack_int* k, lapack_int* l, double* a,
-                           lapack_int* lda, double* b, lapack_int* ldb,
+                           lapack_int const* lda, double* b, lapack_int const* ldb,
                            double* alpha, double* beta, double* u,
-                           lapack_int* ldu, double* v, lapack_int* ldv, double* q,
-                           lapack_int* ldq, double* work, lapack_int* iwork, lapack_int* info );
+                           lapack_int const* ldu, double* v, lapack_int const* ldv, double* q,
+                           lapack_int const* ldq, double* work, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
 lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* n, lapack_int* p,
+                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
                            lapack_int* k, lapack_int* l,
-                           lapack_complex_float* a, lapack_int* lda,
-                           lapack_complex_float* b, lapack_int* ldb,
+                           lapack_complex_float* a, lapack_int const* lda,
+                           lapack_complex_float* b, lapack_int const* ldb,
                            float* alpha, float* beta, lapack_complex_float* u,
-                           lapack_int* ldu, lapack_complex_float* v,
-                           lapack_int* ldv, lapack_complex_float* q,
-                           lapack_int* ldq, lapack_complex_float* work, float* rwork, lapack_int* iwork, lapack_int* info );
+                           lapack_int const* ldu, lapack_complex_float* v,
+                           lapack_int const* ldv, lapack_complex_float* q,
+                           lapack_int const* ldq, lapack_complex_float* work, float* rwork, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
 lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* n, lapack_int* p,
+                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
                            lapack_int* k, lapack_int* l,
-                           lapack_complex_double* a, lapack_int* lda,
-                           lapack_complex_double* b, lapack_int* ldb,
+                           lapack_complex_double* a, lapack_int const* lda,
+                           lapack_complex_double* b, lapack_int const* ldb,
                            double* alpha, double* beta,
-                           lapack_complex_double* u, lapack_int* ldu,
-                           lapack_complex_double* v, lapack_int* ldv,
-                           lapack_complex_double* q, lapack_int* ldq,
+                           lapack_complex_double* u, lapack_int const* ldu,
+                           lapack_complex_double* v, lapack_int const* ldv,
+                           lapack_complex_double* q, lapack_int const* ldq,
                            lapack_complex_double* work, double* rwork, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd3 LAPACK_GLOBAL(cggsvd3,CGGSVD3)
@@ -3754,46 +3754,46 @@ void LAPACK_zggsvd3(
 
 #define LAPACK_sggsvp LAPACK_GLOBAL(sggsvp,SGGSVP)
 lapack_int LAPACK_sggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* p, lapack_int* n, float* a,
-                           lapack_int* lda, float* b, lapack_int* ldb, float* tola,
+                           lapack_int const* m, lapack_int const* p, lapack_int const* n, float* a,
+                           lapack_int const* lda, float* b, lapack_int const* ldb, float* tola,
                            float* tolb, lapack_int* k, lapack_int* l, float* u,
-                           lapack_int* ldu, float* v, lapack_int* ldv, float* q,
-                           lapack_int* ldq, lapack_int* iwork, float* tau, 
+                           lapack_int const* ldu, float* v, lapack_int const* ldv, float* q,
+                           lapack_int const* ldq, lapack_int* iwork, float* tau,
                            float* work, lapack_int* info);
 
 #define LAPACK_dggsvp LAPACK_GLOBAL(dggsvp,DGGSVP)
 lapack_int LAPACK_dggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* p, lapack_int* n, double* a,
-                           lapack_int* lda, double* b, lapack_int* ldb,
+                           lapack_int const* m, lapack_int const* p, lapack_int const* n, double* a,
+                           lapack_int const* lda, double* b, lapack_int const* ldb,
                            double* tola, double* tolb, lapack_int* k,
-                           lapack_int* l, double* u, lapack_int* ldu, double* v,
-                           lapack_int* ldv, double* q, lapack_int* ldq,
+                           lapack_int* l, double* u, lapack_int const* ldu, double* v,
+                           lapack_int const* ldv, double* q, lapack_int const* ldq,
                            lapack_int* iwork, double* tau, double* work,
                            lapack_int* info);
 
 #define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
 lapack_int LAPACK_cggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* p, lapack_int* n,
-                           lapack_complex_float* a, lapack_int* lda,
-                           lapack_complex_float* b, lapack_int* ldb, float* tola,
+                           lapack_int const* m, lapack_int const* p, lapack_int const* n,
+                           lapack_complex_float* a, lapack_int const* lda,
+                           lapack_complex_float* b, lapack_int const* ldb, float* tola,
                            float* tolb, lapack_int* k, lapack_int* l,
-                           lapack_complex_float* u, lapack_int* ldu,
-                           lapack_complex_float* v, lapack_int* ldv,
-                           lapack_complex_float* q, lapack_int* ldq,
+                           lapack_complex_float* u, lapack_int const* ldu,
+                           lapack_complex_float* v, lapack_int const* ldv,
+                           lapack_complex_float* q, lapack_int const* ldq,
                            lapack_int* iwork, float* rwork,
                            lapack_complex_float* tau, lapack_complex_float* work,
                            lapack_int* info);
 
 #define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
 lapack_int LAPACK_zggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int* m, lapack_int* p, lapack_int* n,
-                           lapack_complex_double* a, lapack_int* lda,
-                           lapack_complex_double* b, lapack_int* ldb,
+                           lapack_int const* m, lapack_int const* p, lapack_int const* n,
+                           lapack_complex_double* a, lapack_int const* lda,
+                           lapack_complex_double* b, lapack_int const* ldb,
                            double* tola, double* tolb, lapack_int* k,
                            lapack_int* l, lapack_complex_double* u,
-                           lapack_int* ldu, lapack_complex_double* v,
-                           lapack_int* ldv, lapack_complex_double* q,
-                           lapack_int* ldq, lapack_int* iwork, double* rwork,
+                           lapack_int const* ldu, lapack_complex_double* v,
+                           lapack_int const* ldv, lapack_complex_double* q,
+                           lapack_int const* ldq, lapack_int* iwork, double* rwork,
                            lapack_complex_double* tau, lapack_complex_double* work,
                            lapack_int* info);
 

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -3665,7 +3665,7 @@ lapack_int LAPACK_dggsvd( char const* jobu, char const* jobv, char const* jobq,
                            lapack_int* lda, double* b, lapack_int* ldb,
                            double* alpha, double* beta, double* u,
                            lapack_int* ldu, double* v, lapack_int* ldv, double* q,
-                           lapack_int* ldq, float* work, lapack_int* iwork, lapack_int* info );
+                           lapack_int* ldq, double* work, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
 lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
@@ -3676,7 +3676,7 @@ lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
                            float* alpha, float* beta, lapack_complex_float* u,
                            lapack_int* ldu, lapack_complex_float* v,
                            lapack_int* ldv, lapack_complex_float* q,
-                           lapack_int* ldq, float* work, lapack_int* rwork, lapack_int* iwork, lapack_int *info );
+                           lapack_int* ldq, lapack_complex_float* work, float* rwork, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
 lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
@@ -3688,7 +3688,7 @@ lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
                            lapack_complex_double* u, lapack_int* ldu,
                            lapack_complex_double* v, lapack_int* ldv,
                            lapack_complex_double* q, lapack_int* ldq,
-                           float* work, lapack_int* rwork, lapack_int* iwork, lapack_int* info );
+                           lapack_complex_double* work, double* rwork, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd3 LAPACK_GLOBAL(cggsvd3,CGGSVD3)
 void LAPACK_cggsvd3(
@@ -3780,7 +3780,7 @@ lapack_int LAPACK_cggsvp(  char const* jobu, char const* jobv, char const* jobq,
                            lapack_complex_float* u, lapack_int* ldu,
                            lapack_complex_float* v, lapack_int* ldv,
                            lapack_complex_float* q, lapack_int* ldq,
-                           lapack_int* iwork, lapack_int* rwork,
+                           lapack_int* iwork, float* rwork,
                            lapack_complex_float* tau, lapack_complex_float* work,
                            lapack_int* info);
 
@@ -3793,7 +3793,7 @@ lapack_int LAPACK_zggsvp(  char const* jobu, char const* jobv, char const* jobq,
                            lapack_int* l, lapack_complex_double* u,
                            lapack_int* ldu, lapack_complex_double* v,
                            lapack_int* ldv, lapack_complex_double* q,
-                           lapack_int* ldq, lapack_int* iwork, lapack_int* rwork,
+                           lapack_int* ldq, lapack_int* iwork, double* rwork,
                            lapack_complex_double* tau, lapack_complex_double* work,
                            lapack_int* info);
 

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -3650,45 +3650,58 @@ void LAPACK_zggrqf(
     lapack_int* info );
 
 #define LAPACK_sggsvd LAPACK_GLOBAL(sggsvd,SGGSVD)
-lapack_int LAPACK_sggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
-                           lapack_int* k, lapack_int* l, float* a,
-                           lapack_int const* lda, float* b, lapack_int const* ldb,
-                           float* alpha, float* beta, float* u, lapack_int const* ldu,
-                           float* v, lapack_int const* ldv, float* q, lapack_int const* ldq,
-                           float* work, lapack_int* iwork, lapack_int* info );
+lapack_int LAPACK_sggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    float* a, lapack_int const* lda,
+    float* b, lapack_int const* ldb,
+    float* alpha, float* beta,
+    float* u, lapack_int const* ldu,
+    float* v, lapack_int const* ldv,
+    float* q, lapack_int const* ldq,
+    float* work, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
-lapack_int LAPACK_dggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
-                           lapack_int* k, lapack_int* l, double* a,
-                           lapack_int const* lda, double* b, lapack_int const* ldb,
-                           double* alpha, double* beta, double* u,
-                           lapack_int const* ldu, double* v, lapack_int const* ldv, double* q,
-                           lapack_int const* ldq, double* work, lapack_int* iwork, lapack_int* info );
+lapack_int LAPACK_dggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    double* a, lapack_int const* lda,
+    double* b, lapack_int const* ldb,
+    double* alpha, double* beta,
+    double* u, lapack_int const* ldu,
+    double* v, lapack_int const* ldv,
+    double* q, lapack_int const* ldq,
+    double* work, lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
-lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
-                           lapack_int* k, lapack_int* l,
-                           lapack_complex_float* a, lapack_int const* lda,
-                           lapack_complex_float* b, lapack_int const* ldb,
-                           float* alpha, float* beta, lapack_complex_float* u,
-                           lapack_int const* ldu, lapack_complex_float* v,
-                           lapack_int const* ldv, lapack_complex_float* q,
-                           lapack_int const* ldq, lapack_complex_float* work, float* rwork, lapack_int* iwork, lapack_int* info );
+lapack_int LAPACK_cggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    lapack_complex_float* a, lapack_int const* lda,
+    lapack_complex_float* b, lapack_int const* ldb,
+    float* alpha, float* beta,
+    lapack_complex_float* u, lapack_int const* ldu,
+    lapack_complex_float* v, lapack_int const* ldv,
+    lapack_complex_float* q, lapack_int const* ldq,
+    lapack_complex_float* work, float* rwork,
+    lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
-lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* n, lapack_int const* p,
-                           lapack_int* k, lapack_int* l,
-                           lapack_complex_double* a, lapack_int const* lda,
-                           lapack_complex_double* b, lapack_int const* ldb,
-                           double* alpha, double* beta,
-                           lapack_complex_double* u, lapack_int const* ldu,
-                           lapack_complex_double* v, lapack_int const* ldv,
-                           lapack_complex_double* q, lapack_int const* ldq,
-                           lapack_complex_double* work, double* rwork, lapack_int* iwork, lapack_int* info );
+lapack_int LAPACK_zggsvd(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    lapack_complex_double* a, lapack_int const* lda,
+    lapack_complex_double* b, lapack_int const* ldb,
+    double* alpha, double* beta,
+    lapack_complex_double* u, lapack_int const* ldu,
+    lapack_complex_double* v, lapack_int const* ldv,
+    lapack_complex_double* q, lapack_int const* ldq,
+    lapack_complex_double* work, double* rwork,
+    lapack_int* iwork, lapack_int* info );
 
 #define LAPACK_cggsvd3 LAPACK_GLOBAL(cggsvd3,CGGSVD3)
 void LAPACK_cggsvd3(
@@ -3753,49 +3766,58 @@ void LAPACK_zggsvd3(
     lapack_int* info );
 
 #define LAPACK_sggsvp LAPACK_GLOBAL(sggsvp,SGGSVP)
-lapack_int LAPACK_sggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* p, lapack_int const* n, float* a,
-                           lapack_int const* lda, float* b, lapack_int const* ldb, float* tola,
-                           float* tolb, lapack_int* k, lapack_int* l, float* u,
-                           lapack_int const* ldu, float* v, lapack_int const* ldv, float* q,
-                           lapack_int const* ldq, lapack_int* iwork, float* tau,
-                           float* work, lapack_int* info);
+lapack_int LAPACK_sggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    float* a, lapack_int const* lda,
+    float* b, lapack_int const* ldb,
+    float* tola, float* tolb,
+    lapack_int* k, lapack_int* l,
+    float* u, lapack_int const* ldu,
+    float* v, lapack_int const* ldv,
+    float* q, lapack_int const* ldq,
+    lapack_int* iwork, float* tau,
+    float* work, lapack_int* info );
 
 #define LAPACK_dggsvp LAPACK_GLOBAL(dggsvp,DGGSVP)
-lapack_int LAPACK_dggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* p, lapack_int const* n, double* a,
-                           lapack_int const* lda, double* b, lapack_int const* ldb,
-                           double* tola, double* tolb, lapack_int* k,
-                           lapack_int* l, double* u, lapack_int const* ldu, double* v,
-                           lapack_int const* ldv, double* q, lapack_int const* ldq,
-                           lapack_int* iwork, double* tau, double* work,
-                           lapack_int* info);
+lapack_int LAPACK_dggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    double* a, lapack_int const* lda,
+    double* b, lapack_int const* ldb,
+    double* tola, double* tolb,
+    lapack_int* k, lapack_int* l,
+    double* u, lapack_int const* ldu,
+    double* v, lapack_int const* ldv,
+    double* q, lapack_int const* ldq,
+    lapack_int* iwork, double* tau,
+    double* work, lapack_int* info );
 
 #define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
-lapack_int LAPACK_cggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* p, lapack_int const* n,
-                           lapack_complex_float* a, lapack_int const* lda,
-                           lapack_complex_float* b, lapack_int const* ldb, float* tola,
-                           float* tolb, lapack_int* k, lapack_int* l,
-                           lapack_complex_float* u, lapack_int const* ldu,
-                           lapack_complex_float* v, lapack_int const* ldv,
-                           lapack_complex_float* q, lapack_int const* ldq,
-                           lapack_int* iwork, float* rwork,
-                           lapack_complex_float* tau, lapack_complex_float* work,
-                           lapack_int* info);
+lapack_int LAPACK_cggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    lapack_complex_float* a, lapack_int const* lda,
+    lapack_complex_float* b, lapack_int const* ldb,
+    float* tola, float* tolb, lapack_int* k, lapack_int* l,
+    lapack_complex_float* u, lapack_int const* ldu,
+    lapack_complex_float* v, lapack_int const* ldv,
+    lapack_complex_float* q, lapack_int const* ldq,
+    lapack_int* iwork, float* rwork, lapack_complex_float* tau,
+    lapack_complex_float* work, lapack_int* info );
 
 #define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
-lapack_int LAPACK_zggsvp(  char const* jobu, char const* jobv, char const* jobq,
-                           lapack_int const* m, lapack_int const* p, lapack_int const* n,
-                           lapack_complex_double* a, lapack_int const* lda,
-                           lapack_complex_double* b, lapack_int const* ldb,
-                           double* tola, double* tolb, lapack_int* k,
-                           lapack_int* l, lapack_complex_double* u,
-                           lapack_int const* ldu, lapack_complex_double* v,
-                           lapack_int const* ldv, lapack_complex_double* q,
-                           lapack_int const* ldq, lapack_int* iwork, double* rwork,
-                           lapack_complex_double* tau, lapack_complex_double* work,
-                           lapack_int* info);
+lapack_int LAPACK_zggsvp(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* p, lapack_int const* n,
+    lapack_complex_double* a, lapack_int const* lda,
+    lapack_complex_double* b, lapack_int const* ldb,
+    double* tola, double* tolb, lapack_int* k, lapack_int* l,
+    lapack_complex_double* u, lapack_int const* ldu,
+    lapack_complex_double* v, lapack_int const* ldv,
+    lapack_complex_double* q, lapack_int const* ldq,
+    lapack_int* iwork, double* rwork, lapack_complex_double* tau,
+    lapack_complex_double* work, lapack_int* info );
 
 #define LAPACK_cggsvp3 LAPACK_GLOBAL(cggsvp3,CGGSVP3)
 void LAPACK_cggsvp3(


### PR DESCRIPTION
After #434 got merged, I retried building lapack for conda-forge in https://github.com/conda-forge/lapack-feedstock/pull/32 based on `tags/v3.9.0` + #367, #370, #390, #408, #427, #431, #434, #436, but still got [build warnings](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=204180&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d) for the ?ggsv?-functions affected by #367, #409 & #434:

<details>

```
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cggsvp.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cggsvp_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvp.c.o
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvp_work.c: In function 'LAPACKE_cggsvp_work':
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvp_work.c:53:71: warning: passing argument 22 of 'cggsvp_' from incompatible pointer type [-Wincompatible-pointer-types]
                        &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork, rwork,
                                                                       ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvp_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3774:37: note: expected 'int *' but argument is of type 'float *'
 #define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3775:12: note: in expansion of macro 'LAPACK_cggsvp'
 lapack_int LAPACK_cggsvp(  char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvp_work.c:141:44: warning: passing argument 22 of 'cggsvp_' from incompatible pointer type [-Wincompatible-pointer-types]
                        q_t, &ldq_t, iwork, rwork, tau, work, &info );
                                            ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvp_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3774:37: note: expected 'int *' but argument is of type 'float *'
 #define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3775:12: note: in expansion of macro 'LAPACK_cggsvp'
 lapack_int LAPACK_cggsvp(  char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvp_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvp.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvp_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvp.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvp_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cggsvd.c.o
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvp_work.c: In function 'LAPACKE_zggsvp_work':
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvp_work.c:53:71: warning: passing argument 22 of 'zggsvp_' from incompatible pointer type [-Wincompatible-pointer-types]
                        &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork, rwork,
                                                                       ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvp_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3787:37: note: expected 'int *' but argument is of type 'double *'
 #define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3788:12: note: in expansion of macro 'LAPACK_zggsvp'
 lapack_int LAPACK_zggsvp(  char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvp_work.c:141:44: warning: passing argument 22 of 'zggsvp_' from incompatible pointer type [-Wincompatible-pointer-types]
                        q_t, &ldq_t, iwork, rwork, tau, work, &info );
                                            ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvp_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3787:37: note: expected 'int *' but argument is of type 'double *'
 #define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3788:12: note: in expansion of macro 'LAPACK_zggsvp'
 lapack_int LAPACK_zggsvp(  char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvd.c.o
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c: In function 'LAPACKE_cggsvd_work':
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:52:64: warning: passing argument 21 of 'cggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        alpha, beta, u, &ldu, v, &ldv, q, &ldq, work, rwork,
                                                                ^~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3670:37: note: expected 'float *' but argument is of type '_Complex float *'
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3671:12: note: in expansion of macro 'LAPACK_cggsvd'
 lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:52:70: warning: passing argument 22 of 'cggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        alpha, beta, u, &ldu, v, &ldv, q, &ldq, work, rwork,
                                                                      ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3670:37: note: expected 'int *' but argument is of type 'float *'
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3671:12: note: in expansion of macro 'LAPACK_cggsvd'
 lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:140:32: warning: passing argument 21 of 'cggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        &ldq_t, work, rwork, iwork, &info );
                                ^~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3670:37: note: expected 'float *' but argument is of type '_Complex float *'
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3671:12: note: in expansion of macro 'LAPACK_cggsvd'
 lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:140:38: warning: passing argument 22 of 'cggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        &ldq_t, work, rwork, iwork, &info );
                                      ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_cggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3670:37: note: expected 'int *' but argument is of type 'float *'
 #define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3671:12: note: in expansion of macro 'LAPACK_cggsvd'
 lapack_int LAPACK_cggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvd.c.o
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_dggsvd_work.c: In function 'LAPACKE_dggsvd_work':
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_dggsvd_work.c:49:64: warning: passing argument 21 of 'dggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        alpha, beta, u, &ldu, v, &ldv, q, &ldq, work, iwork,
                                                                ^~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_dggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3661:37: note: expected 'float *' but argument is of type 'double *'
 #define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3662:12: note: in expansion of macro 'LAPACK_dggsvd'
 lapack_int LAPACK_dggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_dggsvd_work.c:129:32: warning: passing argument 21 of 'dggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        &ldq_t, work, iwork, &info );
                                ^~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_dggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3661:37: note: expected 'float *' but argument is of type 'double *'
 #define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3662:12: note: in expansion of macro 'LAPACK_dggsvd'
 lapack_int LAPACK_dggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_sggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvd.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_zggsvd_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cgeqpf.c.o
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c: In function 'LAPACKE_zggsvd_work':
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:52:64: warning: passing argument 21 of 'zggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        alpha, beta, u, &ldu, v, &ldv, q, &ldq, work, rwork,
                                                                ^~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3681:37: note: expected 'float *' but argument is of type '_Complex double *'
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3682:12: note: in expansion of macro 'LAPACK_zggsvd'
 lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:52:70: warning: passing argument 22 of 'zggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        alpha, beta, u, &ldu, v, &ldv, q, &ldq, work, rwork,
                                                                      ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3681:37: note: expected 'int *' but argument is of type 'double *'
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3682:12: note: in expansion of macro 'LAPACK_zggsvd'
 lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:140:32: warning: passing argument 21 of 'zggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        &ldq_t, work, rwork, iwork, &info );
                                ^~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3681:37: note: expected 'float *' but argument is of type '_Complex double *'
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3682:12: note: in expansion of macro 'LAPACK_zggsvd'
 lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:140:38: warning: passing argument 22 of 'zggsvd_' from incompatible pointer type [-Wincompatible-pointer-types]
                        &ldq_t, work, rwork, iwork, &info );
                                      ^~~~~
In file included from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:11:0,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_utils.h:37,
                 from /home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/src/lapacke_zggsvd_work.c:34:
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3681:37: note: expected 'int *' but argument is of type 'double *'
 #define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
                                     ^
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapacke_mangling.h:12:39: note: in definition of macro 'LAPACK_GLOBAL'
 #define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
                                       ^~~~~~
/home/conda/feedstock_root/build_artifacts/blas-split_1599076138671/work/LAPACKE/include/lapack.h:3682:12: note: in expansion of macro 'LAPACK_zggsvd'
 lapack_int LAPACK_zggsvd( char const* jobu, char const* jobv, char const* jobq,
            ^~~~~~~~~~~~~
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cgeqpf_work.c.o
[ 98%] Building C object LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_dgeqpf.c.o
```

</details>

Based on this, I compared what I had done in #409 with the implementation from #434, and ended up splitting the differences into three separate commits, for ease of reviewing/choosing:
1. Commit https://github.com/Reference-LAPACK/lapack/commit/d470f435d26e4fa71930cb23da3429ce268099f7 deals with some signature mismatches that should be fixed - with this commit, the build warnings [disappear](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=204297&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97)
1. Commit https://github.com/Reference-LAPACK/lapack/commit/cc04b61950d01058163b45ae98b7452900d0f179 adds a couple of `const` qualifiers that I had had in #409, based on what I had seen from the surrounding functions, and particularly the ?ggsv?3-variants of the deprecated functions - this compiles without warnings [as well](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=204411&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97). This should be double-checked for correctness, as I'm not 100% sure why which parameters should be const or not. I tracked the original addition of the `const` modifiers back to #294, but there's not much reasoning to go on for me.
1. Commit https://github.com/Reference-LAPACK/lapack/commit/5ae1561e8e8be1720a1a05c7b3c705441c137412 does not change any code, just matches the indentation & formatting to rest of `lapack.h`

I think the first commit should be included, the second and third are matters of choice & style, but here for completeness.