### PR TITLE
fix workspace query in xgelq and xgetsls

### DIFF
--- a/SRC/cgelq.f
+++ b/SRC/cgelq.f
@@ -187,7 +187,7 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, LMINWS, MINT, MINW
-      INTEGER            MB, NB, MINTSZ, NBLCKS
+      INTEGER            MB, NB, MINTSZ, NBLCKS, LWMIN, LWOPT, LWREQ
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -243,19 +243,31 @@
 *
 *     Determine if the workspace size satisfies minimal size
 *
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWMIN = MAX( 1, N )
+         LWOPT = MAX( 1, MB*N )
+      ELSE
+         LWMIN = MAX( 1, M )
+         LWOPT = MAX( 1, MB*M )
+      END IF
       LMINWS = .FALSE.
-      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.MB*M )
-     $    .AND. ( LWORK.GE.M ) .AND. ( TSIZE.GE.MINTSZ )
+      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.LWOPT )
+     $    .AND. ( LWORK.GE.LWMIN ) .AND. ( TSIZE.GE.MINTSZ )
      $    .AND. ( .NOT.LQUERY ) ) THEN
         IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) ) THEN
           LMINWS = .TRUE.
           MB = 1
           NB = N
         END IF
-        IF( LWORK.LT.MB*M ) THEN
+        IF( LWORK.LT.LWOPT ) THEN
           LMINWS = .TRUE.
           MB = 1
         END IF
+      END IF
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWREQ = MAX( 1, MB*N )
+      ELSE
+         LWREQ = MAX( 1, MB*M )
       END IF
 *
       IF( M.LT.0 ) THEN
@@ -267,7 +279,7 @@
       ELSE IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 )
      $   .AND. ( .NOT.LQUERY ) .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -6
-      ELSE IF( ( LWORK.LT.MAX( 1, M*MB ) ) .AND .( .NOT.LQUERY )
+      ELSE IF( ( LWORK.LT.LWREQ ) .AND .( .NOT.LQUERY )
      $   .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -8
       END IF
@@ -281,9 +293,9 @@
         T( 2 ) = MB
         T( 3 ) = NB
         IF( MINW ) THEN
-          WORK( 1 ) = MAX( 1, N )
+          WORK( 1 ) = LWMIN
         ELSE
-          WORK( 1 ) = MAX( 1, MB*M )
+          WORK( 1 ) = LWREQ
         END IF
       END IF
       IF( INFO.NE.0 ) THEN
@@ -308,7 +320,7 @@
      $                LWORK, INFO )
       END IF
 *
-      WORK( 1 ) = MAX( 1, MB*M )
+      WORK( 1 ) = LWREQ
 *
       RETURN
 *

--- a/SRC/cgetsls.f
+++ b/SRC/cgetsls.f
@@ -261,7 +261,7 @@
          TSZM = INT( TQ( 1 ) )
          LWM  = INT( WORKQ( 1 ) )
          CALL CGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
-     $                TSZO, B, LDB, WORKQ, -1, INFO2 )
+     $                TSZM, B, LDB, WORKQ, -1, INFO2 )
          LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM

--- a/SRC/dgelq.f
+++ b/SRC/dgelq.f
@@ -187,7 +187,7 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, LMINWS, MINT, MINW
-      INTEGER            MB, NB, MINTSZ, NBLCKS
+      INTEGER            MB, NB, MINTSZ, NBLCKS, LWMIN, LWOPT, LWREQ
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -243,19 +243,31 @@
 *
 *     Determine if the workspace size satisfies minimal size
 *
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWMIN = MAX( 1, N )
+         LWOPT = MAX( 1, MB*N )
+      ELSE
+         LWMIN = MAX( 1, M )
+         LWOPT = MAX( 1, MB*M )
+      END IF
       LMINWS = .FALSE.
-      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.MB*M )
-     $    .AND. ( LWORK.GE.M ) .AND. ( TSIZE.GE.MINTSZ )
+      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.LWOPT )
+     $    .AND. ( LWORK.GE.LWMIN ) .AND. ( TSIZE.GE.MINTSZ )
      $    .AND. ( .NOT.LQUERY ) ) THEN
         IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) ) THEN
             LMINWS = .TRUE.
             MB = 1
             NB = N
         END IF
-        IF( LWORK.LT.MB*M ) THEN
+        IF( LWORK.LT.LWOPT ) THEN
             LMINWS = .TRUE.
             MB = 1
         END IF
+      END IF
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWREQ = MAX( 1, MB*N )
+      ELSE
+         LWREQ = MAX( 1, MB*M )
       END IF
 *
       IF( M.LT.0 ) THEN
@@ -267,7 +279,7 @@
       ELSE IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 )
      $   .AND. ( .NOT.LQUERY ) .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -6
-      ELSE IF( ( LWORK.LT.MAX( 1, M*MB ) ) .AND .( .NOT.LQUERY )
+      ELSE IF( ( LWORK.LT.LWREQ ) .AND .( .NOT.LQUERY )
      $   .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -8
       END IF
@@ -281,9 +293,9 @@
         T( 2 ) = MB
         T( 3 ) = NB
         IF( MINW ) THEN
-          WORK( 1 ) = MAX( 1, N )
+          WORK( 1 ) = LWMIN
         ELSE
-          WORK( 1 ) = MAX( 1, MB*M )
+          WORK( 1 ) = LWREQ
         END IF
       END IF
       IF( INFO.NE.0 ) THEN
@@ -308,7 +320,7 @@
      $                LWORK, INFO )
       END IF
 *
-      WORK( 1 ) = MAX( 1, MB*M )
+      WORK( 1 ) = LWREQ
 *
       RETURN
 *

--- a/SRC/dgetsls.f
+++ b/SRC/dgetsls.f
@@ -258,7 +258,7 @@
          TSZM = INT( TQ( 1 ) )
          LWM  = INT( WORKQ( 1 ) )
          CALL DGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
-     $                TSZO, B, LDB, WORKQ, -1, INFO2 )
+     $                TSZM, B, LDB, WORKQ, -1, INFO2 )
          LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM

--- a/SRC/sgelq.f
+++ b/SRC/sgelq.f
@@ -187,7 +187,7 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, LMINWS, MINT, MINW
-      INTEGER            MB, NB, MINTSZ, NBLCKS
+      INTEGER            MB, NB, MINTSZ, NBLCKS, LWMIN, LWOPT, LWREQ
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -243,19 +243,31 @@
 *
 *     Determine if the workspace size satisfies minimal size
 *
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWMIN = MAX( 1, N )
+         LWOPT = MAX( 1, MB*N )
+      ELSE
+         LWMIN = MAX( 1, M )
+         LWOPT = MAX( 1, MB*M )
+      END IF
       LMINWS = .FALSE.
-      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.MB*M )
-     $    .AND. ( LWORK.GE.M ) .AND. ( TSIZE.GE.MINTSZ )
+      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.LWOPT )
+     $    .AND. ( LWORK.GE.LWMIN ) .AND. ( TSIZE.GE.MINTSZ )
      $    .AND. ( .NOT.LQUERY ) ) THEN
         IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) ) THEN
           LMINWS = .TRUE.
           MB = 1
           NB = N
         END IF
-        IF( LWORK.LT.MB*M ) THEN
+        IF( LWORK.LT.LWOPT ) THEN
           LMINWS = .TRUE.
           MB = 1
         END IF
+      END IF
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWREQ = MAX( 1, MB*N )
+      ELSE
+         LWREQ = MAX( 1, MB*M )
       END IF
 *
       IF( M.LT.0 ) THEN
@@ -267,7 +279,7 @@
       ELSE IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 )
      $   .AND. ( .NOT.LQUERY ) .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -6
-      ELSE IF( ( LWORK.LT.MAX( 1, M*MB ) ) .AND .( .NOT.LQUERY )
+      ELSE IF( ( LWORK.LT.LWREQ ) .AND .( .NOT.LQUERY )
      $   .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -8
       END IF
@@ -281,9 +293,9 @@
         T( 2 ) = MB
         T( 3 ) = NB
         IF( MINW ) THEN
-          WORK( 1 ) = MAX( 1, N )
+          WORK( 1 ) = LWMIN
         ELSE
-          WORK( 1 ) = MAX( 1, MB*M )
+          WORK( 1 ) = LWREQ
         END IF
       END IF
       IF( INFO.NE.0 ) THEN
@@ -308,7 +320,7 @@
      $                LWORK, INFO )
       END IF
 *
-      WORK( 1 ) = MAX( 1, MB*M )
+      WORK( 1 ) = LWREQ
       RETURN
 *
 *     End of SGELQ

--- a/SRC/sgetsls.f
+++ b/SRC/sgetsls.f
@@ -258,7 +258,7 @@
          TSZM = INT( TQ( 1 ) )
          LWM  = INT( WORKQ( 1 ) )
          CALL SGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
-     $                TSZO, B, LDB, WORKQ, -1, INFO2 )
+     $                TSZM, B, LDB, WORKQ, -1, INFO2 )
          LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM

--- a/SRC/zgelq.f
+++ b/SRC/zgelq.f
@@ -187,7 +187,7 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, LMINWS, MINT, MINW
-      INTEGER            MB, NB, MINTSZ, NBLCKS
+      INTEGER            MB, NB, MINTSZ, NBLCKS, LWMIN, LWOPT, LWREQ
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -243,19 +243,31 @@
 *
 *     Determine if the workspace size satisfies minimal size
 *
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWMIN = MAX( 1, N )
+         LWOPT = MAX( 1, MB*N )
+      ELSE
+         LWMIN = MAX( 1, M )
+         LWOPT = MAX( 1, MB*M )
+      END IF
       LMINWS = .FALSE.
-      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.MB*M )
-     $    .AND. ( LWORK.GE.M ) .AND. ( TSIZE.GE.MINTSZ )
+      IF( ( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) .OR. LWORK.LT.LWOPT )
+     $    .AND. ( LWORK.GE.LWMIN ) .AND. ( TSIZE.GE.MINTSZ )
      $    .AND. ( .NOT.LQUERY ) ) THEN
         IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 ) ) THEN
             LMINWS = .TRUE.
             MB = 1
             NB = N
         END IF
-        IF( LWORK.LT.MB*M ) THEN
+        IF( LWORK.LT.LWOPT ) THEN
             LMINWS = .TRUE.
             MB = 1
         END IF
+      END IF
+      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
+         LWREQ = MAX( 1, MB*N )
+      ELSE
+         LWREQ = MAX( 1, MB*M )
       END IF
 *
       IF( M.LT.0 ) THEN
@@ -267,7 +279,7 @@
       ELSE IF( TSIZE.LT.MAX( 1, MB*M*NBLCKS + 5 )
      $   .AND. ( .NOT.LQUERY ) .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -6
-      ELSE IF( ( LWORK.LT.MAX( 1, M*MB ) ) .AND .( .NOT.LQUERY )
+      ELSE IF( ( LWORK.LT.LWREQ ) .AND .( .NOT.LQUERY )
      $   .AND. ( .NOT.LMINWS ) ) THEN
         INFO = -8
       END IF
@@ -281,9 +293,9 @@
         T( 2 ) = MB
         T( 3 ) = NB
         IF( MINW ) THEN
-          WORK( 1 ) = MAX( 1, N )
+          WORK( 1 ) = LWMIN
         ELSE
-          WORK( 1 ) = MAX( 1, MB*M )
+          WORK( 1 ) = LWREQ
         END IF
       END IF
       IF( INFO.NE.0 ) THEN
@@ -308,7 +320,7 @@
      $                LWORK, INFO )
       END IF
 *
-      WORK( 1 ) = MAX( 1, MB*M )
+      WORK( 1 ) = LWREQ
 *
       RETURN
 *

--- a/SRC/zgetsls.f
+++ b/SRC/zgetsls.f
@@ -261,7 +261,7 @@
          TSZM = INT( TQ( 1 ) )
          LWM  = INT( WORKQ( 1 ) )
          CALL ZGEMLQ( 'L', TRANS, N, NRHS, M, A, LDA, TQ,
-     $                TSZO, B, LDB, WORKQ, -1, INFO2 )
+     $                TSZM, B, LDB, WORKQ, -1, INFO2 )
          LWM  = MAX( LWM, INT( WORKQ( 1 ) ) )
          WSIZEO = TSZO + LWO
          WSIZEM = TSZM + LWM


### PR DESCRIPTION
XGELQ has two main branches:

      IF( ( N.LE.M ) .OR. ( NB.LE.M ) .OR. ( NB.GE.N ) ) THEN
          CALL DGELQT( M, N, MB, A, LDA, T( 6 ), MB, WORK, INFO )
      ELSE
          CALL DLASWLQ( M, N, MB, NB, A, LDA, T( 6 ), MB, WORK,
     $                LWORK, INFO )
      END IF

XGELQT requires a workspace of MB\*N, while XLASWLQ requires a workspace of MB\*M. But this was not correctly split up in the workspace query.

additionally fixes a small typo in XGETSLS (didn't cause any problems for as far as i can tell, but at least the code is cleaner now)

Closes #415 i've confirmed that the provided example no longer errors out.