### PR TITLE
[BLAS] Remove unused NCOLA variable

### DIFF
--- a/BLAS/SRC/cgemm.f
+++ b/BLAS/SRC/cgemm.f
@@ -215,7 +215,7 @@
 *     ..
 *     .. Local Scalars ..
       COMPLEX TEMP
-      INTEGER I,INFO,J,L,NCOLA,NROWA,NROWB
+      INTEGER I,INFO,J,L,NROWA,NROWB
       LOGICAL CONJA,CONJB,NOTA,NOTB
 *     ..
 *     .. Parameters ..
@@ -228,8 +228,7 @@
 *     Set  NOTA  and  NOTB  as  true if  A  and  B  respectively are not
 *     conjugated or transposed, set  CONJA and CONJB  as true if  A  and
 *     B  respectively are to be  transposed but  not conjugated  and set
-*     NROWA, NCOLA and  NROWB  as the number of rows and  columns  of  A
-*     and the number of rows of  B  respectively.
+*     NROWA and  NROWB  as the number of rows of  A  and  B  respectively.
 *
       NOTA = LSAME(TRANSA,'N')
       NOTB = LSAME(TRANSB,'N')
@@ -237,10 +236,8 @@
       CONJB = LSAME(TRANSB,'C')
       IF (NOTA) THEN
           NROWA = M
-          NCOLA = K
       ELSE
           NROWA = K
-          NCOLA = M
       END IF
       IF (NOTB) THEN
           NROWB = K

--- a/BLAS/SRC/dgemm.f
+++ b/BLAS/SRC/dgemm.f
@@ -215,7 +215,7 @@
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION TEMP
-      INTEGER I,INFO,J,L,NCOLA,NROWA,NROWB
+      INTEGER I,INFO,J,L,NROWA,NROWB
       LOGICAL NOTA,NOTB
 *     ..
 *     .. Parameters ..
@@ -224,17 +224,15 @@
 *     ..
 *
 *     Set  NOTA  and  NOTB  as  true if  A  and  B  respectively are not
-*     transposed and set  NROWA, NCOLA and  NROWB  as the number of rows
-*     and  columns of  A  and the  number of  rows  of  B  respectively.
+*     transposed and set  NROWA and NROWB  as the number of rows of  A
+*     and  B  respectively.
 *
       NOTA = LSAME(TRANSA,'N')
       NOTB = LSAME(TRANSB,'N')
       IF (NOTA) THEN
           NROWA = M
-          NCOLA = K
       ELSE
           NROWA = K
-          NCOLA = M
       END IF
       IF (NOTB) THEN
           NROWB = K

--- a/BLAS/SRC/sgemm.f
+++ b/BLAS/SRC/sgemm.f
@@ -215,7 +215,7 @@
 *     ..
 *     .. Local Scalars ..
       REAL TEMP
-      INTEGER I,INFO,J,L,NCOLA,NROWA,NROWB
+      INTEGER I,INFO,J,L,NROWA,NROWB
       LOGICAL NOTA,NOTB
 *     ..
 *     .. Parameters ..
@@ -224,17 +224,15 @@
 *     ..
 *
 *     Set  NOTA  and  NOTB  as  true if  A  and  B  respectively are not
-*     transposed and set  NROWA, NCOLA and  NROWB  as the number of rows
-*     and  columns of  A  and the  number of  rows  of  B  respectively.
+*     transposed and set  NROWA and NROWB  as the number of rows of  A
+*     and  B  respectively.
 *
       NOTA = LSAME(TRANSA,'N')
       NOTB = LSAME(TRANSB,'N')
       IF (NOTA) THEN
           NROWA = M
-          NCOLA = K
       ELSE
           NROWA = K
-          NCOLA = M
       END IF
       IF (NOTB) THEN
           NROWB = K

--- a/BLAS/SRC/zgemm.f
+++ b/BLAS/SRC/zgemm.f
@@ -215,7 +215,7 @@
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16 TEMP
-      INTEGER I,INFO,J,L,NCOLA,NROWA,NROWB
+      INTEGER I,INFO,J,L,NROWA,NROWB
       LOGICAL CONJA,CONJB,NOTA,NOTB
 *     ..
 *     .. Parameters ..
@@ -228,8 +228,7 @@
 *     Set  NOTA  and  NOTB  as  true if  A  and  B  respectively are not
 *     conjugated or transposed, set  CONJA and CONJB  as true if  A  and
 *     B  respectively are to be  transposed but  not conjugated  and set
-*     NROWA, NCOLA and  NROWB  as the number of rows and  columns  of  A
-*     and the number of rows of  B  respectively.
+*     NROWA and NROWB  as the number of rows  of  A  and  B  respectively.
 *
       NOTA = LSAME(TRANSA,'N')
       NOTB = LSAME(TRANSB,'N')
@@ -237,10 +236,8 @@
       CONJB = LSAME(TRANSB,'C')
       IF (NOTA) THEN
           NROWA = M
-          NCOLA = K
       ELSE
           NROWA = K
-          NCOLA = M
       END IF
       IF (NOTB) THEN
           NROWB = K


### PR DESCRIPTION
The variable `NCOLA` was computed but not used in the files `*gemm.f`, This PR removes this variable and updates the appropriate comments.