### PR TITLE
[DOCS] Fix typo in docs of dzasum.f

### DIFF
--- a/BLAS/SRC/dzasum.f
+++ b/BLAS/SRC/dzasum.f
@@ -24,7 +24,7 @@
 *> \verbatim
 *>
 *>    DZASUM takes the sum of the (|Re(.)| + |Im(.)|)'s of a complex vector and
-*>    returns a single precision result.
+*>    returns a double precision result.
 *> \endverbatim
 *
 *  Arguments:


### PR DESCRIPTION
Just a small typo so that the docs match the function signature, which is:

```fortran
DOUBLE PRECISION FUNCTION DZASUM(N,ZX,INCX)
```