### PR TITLE
Mark xrotg() parameters as [in,out]

### DIFF
--- a/BLAS/SRC/crotg.f
+++ b/BLAS/SRC/crotg.f
@@ -27,7 +27,7 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] CA
+*> \param[in,out] CA
 *> \verbatim
 *>          CA is COMPLEX
 *> \endverbatim

--- a/BLAS/SRC/drotg.f
+++ b/BLAS/SRC/drotg.f
@@ -26,12 +26,12 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] DA
+*> \param[in,out] DA
 *> \verbatim
 *>          DA is DOUBLE PRECISION
 *> \endverbatim
 *>
-*> \param[in] DB
+*> \param[in,out] DB
 *> \verbatim
 *>          DB is DOUBLE PRECISION
 *> \endverbatim

--- a/BLAS/SRC/srotg.f
+++ b/BLAS/SRC/srotg.f
@@ -26,12 +26,12 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] SA
+*> \param[in,out] SA
 *> \verbatim
 *>          SA is REAL
 *> \endverbatim
 *>
-*> \param[in] SB
+*> \param[in,out] SB
 *> \verbatim
 *>          SB is REAL
 *> \endverbatim

--- a/BLAS/SRC/zrotg.f
+++ b/BLAS/SRC/zrotg.f
@@ -27,7 +27,7 @@
 *  Arguments:
 *  ==========
 *
-*> \param[in] CA
+*> \param[in,out] CA
 *> \verbatim
 *>          CA is COMPLEX*16
 *> \endverbatim


### PR DESCRIPTION
The `SA`, `SB` and `DA`, `DB` parameters of `SROTG` and `DROTG`, and `CA` parameters of `CROTG` and `ZROTG` are used to return the `r` and `z` value of the Givens rotation calculation. This PR updates the inline docs to represent this.