### PR TITLE
[BLAS] Skip calculation of ROE when SCALE is zero

### DIFF
--- a/BLAS/SRC/drotg.f
+++ b/BLAS/SRC/drotg.f
@@ -86,8 +86,6 @@
 *     .. Intrinsic Functions ..
       INTRINSIC DABS,DSIGN,DSQRT
 *     ..
-      ROE = DB
-      IF (DABS(DA).GT.DABS(DB)) ROE = DA
       SCALE = DABS(DA) + DABS(DB)
       IF (SCALE.EQ.0.0d0) THEN
          C = 1.0d0
@@ -95,6 +93,8 @@
          R = 0.0d0
          Z = 0.0d0
       ELSE
+         ROE = DB
+         IF (DABS(DA).GT.DABS(DB)) ROE = DA
          R = SCALE*DSQRT((DA/SCALE)**2+ (DB/SCALE)**2)
          R = DSIGN(1.0d0,ROE)*R
          C = DA/R

--- a/BLAS/SRC/srotg.f
+++ b/BLAS/SRC/srotg.f
@@ -86,8 +86,6 @@
 *     .. Intrinsic Functions ..
       INTRINSIC ABS,SIGN,SQRT
 *     ..
-      ROE = SB
-      IF (ABS(SA).GT.ABS(SB)) ROE = SA
       SCALE = ABS(SA) + ABS(SB)
       IF (SCALE.EQ.0.0) THEN
          C = 1.0
@@ -95,6 +93,8 @@
          R = 0.0
          Z = 0.0
       ELSE
+         ROE = SB
+         IF (ABS(SA).GT.ABS(SB)) ROE = SA
          R = SCALE*SQRT((SA/SCALE)**2+ (SB/SCALE)**2)
          R = SIGN(1.0,ROE)*R
          C = SA/R


### PR DESCRIPTION
These changes in `SROTG` and `DROTG` will avoid an unnecessary comparison when `SCALE` is zero.