### PR TITLE
[BLAS] Fix missing logic path in xrotmg.f

### DIFF
--- a/BLAS/SRC/drotmg.f
+++ b/BLAS/SRC/drotmg.f
@@ -153,6 +153,9 @@
              DD2 = DD2/DU
              DX1 = DX1*DU
            ELSE
+*            This code path if here for safety. We do not expect this
+*            condition to ever hold except in edge cases with rounding
+*            errors. See DOI: 10.1145/355841.355847
              DFLAG = -ONE
              DH11 = ZERO
              DH12 = ZERO

--- a/BLAS/SRC/drotmg.f
+++ b/BLAS/SRC/drotmg.f
@@ -152,6 +152,16 @@
              DD1 = DD1/DU
              DD2 = DD2/DU
              DX1 = DX1*DU
+           ELSE
+             DFLAG = -ONE
+             DH11 = ZERO
+             DH12 = ZERO
+             DH21 = ZERO
+             DH22 = ZERO
+*
+             DD1 = ZERO
+             DD2 = ZERO
+             DX1 = ZERO
            END IF
          ELSE
 

--- a/BLAS/SRC/srotmg.f
+++ b/BLAS/SRC/srotmg.f
@@ -153,6 +153,9 @@
              SD2 = SD2/SU
              SX1 = SX1*SU
            ELSE
+*            This code path if here for safety. We do not expect this
+*            condition to ever hold except in edge cases with rounding
+*            errors. See DOI: 10.1145/355841.355847
              SFLAG = -ONE
              SH11 = ZERO
              SH12 = ZERO

--- a/BLAS/SRC/srotmg.f
+++ b/BLAS/SRC/srotmg.f
@@ -152,6 +152,16 @@
              SD1 = SD1/SU
              SD2 = SD2/SU
              SX1 = SX1*SU
+           ELSE
+             SFLAG = -ONE
+             SH11 = ZERO
+             SH12 = ZERO
+             SH21 = ZERO
+             SH22 = ZERO
+*
+             SD1 = ZERO
+             SD2 = ZERO
+             SX1 = ZERO
            END IF
          ELSE
 


### PR DESCRIPTION
This fixes a bug in `SROTMG` and `DROTMG` where there is a missing code path.

I traced the bug back to the following commit: https://github.com/Reference-LAPACK/lapack/commit/1767365dbf4c05eb481a920a5c59beb20cbe9ba5#diff-17bc8cba27cfa755d1503dee5651235a35de951b677ecaa5f3adb596137005a2

In particular, the original code had:

```fortran
  IF (.NOT.DU.LE.ZERO) GO TO 30
*         GO ZERO-H-D-AND-DX1..
  GO TO 60
```

The code at `60` provided the `ZERO-H-D-AND-DX1` operations, which is what was lost in the referenced commit. This PR puts this code path back in.

It's worth noting that according to file:///Users/timl/Downloads/Restructuring_the_BLAS_Level_1_Routine_for_Computi.pdf (bottom of page 7) this code path may not actually be reachable, so this change is possibly just for completeness, it may not fix any real world cases.