### PR TITLE
Change the way of adding additional CMake_Fortran_FLAGS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,10 +76,10 @@ include(PreventInBuildInstalls)
 
 if(UNIX)
   if(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
-    string(APPEND CMAKE_Fortran_FLAGS "-fp-model strict")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model strict")
   endif()
   if(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
-    string(APPEND CMAKE_Fortran_FLAGS "-qnosave -qstrict=none")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict=none")
   endif()
 # Delete libmtsk in linking sequence for Sun/Oracle Fortran Compiler.
 # This library is not present in the Sun package SolarisStudio12.3-linux-x86-bin


### PR DESCRIPTION
When LAPACK is added as part of another cmake project.
The current setting ends up in an error.
```
/usr/bin/xlf90_r   -qthreaded -qhalt=e;-qnosave;-qstrict=none -qfixed    -c /home/yeluo/opt/q-e/external/fox/cmake/flush_xlf.f90 -o CMakeFiles/cmTC_eb2f1.dir/flush_xlf.f90.o
/opt/ibm/xlf/16.1.1/bin/.orig/xlf90_r: 1501-294 (S) No input file specified. Please use -qhelp for more information.
/bin/sh: -qnosave: command not found
/bin/sh: -qstrict=none: command not found
```
Due to the treating CMAKE_Fortran_COMPILER as a list. This patch addresses this issue.