### PR TITLE
enable building the cblas64 library

### DIFF
--- a/CBLAS/include/cblas.h
+++ b/CBLAS/include/cblas.h
@@ -13,7 +13,7 @@ extern "C" {            /* Assume C declarations for C++ */
 #ifdef WeirdNEC
    #define CBLAS_INDEX long
 #else
-    #define CBLAS_INDEX int
+   #define CBLAS_INDEX int
 #endif
 
 typedef enum {CblasRowMajor=101, CblasColMajor=102} CBLAS_LAYOUT;
@@ -35,52 +35,52 @@ typedef CBLAS_LAYOUT CBLAS_ORDER; /* this for backward compatibility with CBLAS_
 double cblas_dcabs1(const void  *z);
 float  cblas_scabs1(const void  *c);
 
-float  cblas_sdsdot(const int N, const float alpha, const float *X,
-                    const int incX, const float *Y, const int incY);
-double cblas_dsdot(const int N, const float *X, const int incX, const float *Y,
-                   const int incY);
-float  cblas_sdot(const int N, const float  *X, const int incX,
-                  const float  *Y, const int incY);
-double cblas_ddot(const int N, const double *X, const int incX,
-                  const double *Y, const int incY);
+float  cblas_sdsdot(const CBLAS_INDEX N, const float alpha, const float *X,
+                    const CBLAS_INDEX incX, const float *Y, const CBLAS_INDEX incY);
+double cblas_dsdot(const CBLAS_INDEX N, const float *X, const CBLAS_INDEX incX, const float *Y,
+                   const CBLAS_INDEX incY);
+float  cblas_sdot(const CBLAS_INDEX N, const float  *X, const CBLAS_INDEX incX,
+                  const float  *Y, const CBLAS_INDEX incY);
+double cblas_ddot(const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX,
+                  const double *Y, const CBLAS_INDEX incY);
 
 /*
  * Functions having prefixes Z and C only
  */
-void   cblas_cdotu_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotu);
-void   cblas_cdotc_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotc);
+void   cblas_cdotu_sub(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                       const void *Y, const CBLAS_INDEX incY, void *dotu);
+void   cblas_cdotc_sub(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                       const void *Y, const CBLAS_INDEX incY, void *dotc);
 
-void   cblas_zdotu_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotu);
-void   cblas_zdotc_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotc);
+void   cblas_zdotu_sub(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                       const void *Y, const CBLAS_INDEX incY, void *dotu);
+void   cblas_zdotc_sub(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                       const void *Y, const CBLAS_INDEX incY, void *dotc);
 
 
 /*
  * Functions having prefixes S D SC DZ
  */
-float  cblas_snrm2(const int N, const float *X, const int incX);
-float  cblas_sasum(const int N, const float *X, const int incX);
+float  cblas_snrm2(const CBLAS_INDEX N, const float *X, const CBLAS_INDEX incX);
+float  cblas_sasum(const CBLAS_INDEX N, const float *X, const CBLAS_INDEX incX);
 
-double cblas_dnrm2(const int N, const double *X, const int incX);
-double cblas_dasum(const int N, const double *X, const int incX);
+double cblas_dnrm2(const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX);
+double cblas_dasum(const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX);
 
-float  cblas_scnrm2(const int N, const void *X, const int incX);
-float  cblas_scasum(const int N, const void *X, const int incX);
+float  cblas_scnrm2(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX);
+float  cblas_scasum(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX);
 
-double cblas_dznrm2(const int N, const void *X, const int incX);
-double cblas_dzasum(const int N, const void *X, const int incX);
+double cblas_dznrm2(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX);
+double cblas_dzasum(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX);
 
 
 /*
  * Functions having standard 4 prefixes (S D C Z)
  */
-CBLAS_INDEX cblas_isamax(const int N, const float  *X, const int incX);
-CBLAS_INDEX cblas_idamax(const int N, const double *X, const int incX);
-CBLAS_INDEX cblas_icamax(const int N, const void   *X, const int incX);
-CBLAS_INDEX cblas_izamax(const int N, const void   *X, const int incX);
+CBLAS_INDEX cblas_isamax(const CBLAS_INDEX N, const float  *X, const CBLAS_INDEX incX);
+CBLAS_INDEX cblas_idamax(const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX);
+CBLAS_INDEX cblas_icamax(const CBLAS_INDEX N, const void   *X, const CBLAS_INDEX incX);
+CBLAS_INDEX cblas_izamax(const CBLAS_INDEX N, const void   *X, const CBLAS_INDEX incX);
 
 /*
  * ===========================================================================
@@ -91,33 +91,33 @@ CBLAS_INDEX cblas_izamax(const int N, const void   *X, const int incX);
 /*
  * Routines with standard 4 prefixes (s, d, c, z)
  */
-void cblas_sswap(const int N, float *X, const int incX,
-                 float *Y, const int incY);
-void cblas_scopy(const int N, const float *X, const int incX,
-                 float *Y, const int incY);
-void cblas_saxpy(const int N, const float alpha, const float *X,
-                 const int incX, float *Y, const int incY);
+void cblas_sswap(const CBLAS_INDEX N, float *X, const CBLAS_INDEX incX,
+                 float *Y, const CBLAS_INDEX incY);
+void cblas_scopy(const CBLAS_INDEX N, const float *X, const CBLAS_INDEX incX,
+                 float *Y, const CBLAS_INDEX incY);
+void cblas_saxpy(const CBLAS_INDEX N, const float alpha, const float *X,
+                 const CBLAS_INDEX incX, float *Y, const CBLAS_INDEX incY);
 
-void cblas_dswap(const int N, double *X, const int incX,
-                 double *Y, const int incY);
-void cblas_dcopy(const int N, const double *X, const int incX,
-                 double *Y, const int incY);
-void cblas_daxpy(const int N, const double alpha, const double *X,
-                 const int incX, double *Y, const int incY);
+void cblas_dswap(const CBLAS_INDEX N, double *X, const CBLAS_INDEX incX,
+                 double *Y, const CBLAS_INDEX incY);
+void cblas_dcopy(const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX,
+                 double *Y, const CBLAS_INDEX incY);
+void cblas_daxpy(const CBLAS_INDEX N, const double alpha, const double *X,
+                 const CBLAS_INDEX incX, double *Y, const CBLAS_INDEX incY);
 
-void cblas_cswap(const int N, void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_ccopy(const int N, const void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_caxpy(const int N, const void *alpha, const void *X,
-                 const int incX, void *Y, const int incY);
+void cblas_cswap(const CBLAS_INDEX N, void *X, const CBLAS_INDEX incX,
+                 void *Y, const CBLAS_INDEX incY);
+void cblas_ccopy(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                 void *Y, const CBLAS_INDEX incY);
+void cblas_caxpy(const CBLAS_INDEX N, const void *alpha, const void *X,
+                 const CBLAS_INDEX incX, void *Y, const CBLAS_INDEX incY);
 
-void cblas_zswap(const int N, void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_zcopy(const int N, const void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_zaxpy(const int N, const void *alpha, const void *X,
-                 const int incX, void *Y, const int incY);
+void cblas_zswap(const CBLAS_INDEX N, void *X, const CBLAS_INDEX incX,
+                 void *Y, const CBLAS_INDEX incY);
+void cblas_zcopy(const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                 void *Y, const CBLAS_INDEX incY);
+void cblas_zaxpy(const CBLAS_INDEX N, const void *alpha, const void *X,
+                 const CBLAS_INDEX incX, void *Y, const CBLAS_INDEX incY);
 
 
 /*
@@ -125,28 +125,28 @@ void cblas_zaxpy(const int N, const void *alpha, const void *X,
  */
 void cblas_srotg(float *a, float *b, float *c, float *s);
 void cblas_srotmg(float *d1, float *d2, float *b1, const float b2, float *P);
-void cblas_srot(const int N, float *X, const int incX,
-                float *Y, const int incY, const float c, const float s);
-void cblas_srotm(const int N, float *X, const int incX,
-                float *Y, const int incY, const float *P);
+void cblas_srot(const CBLAS_INDEX N, float *X, const CBLAS_INDEX incX,
+                float *Y, const CBLAS_INDEX incY, const float c, const float s);
+void cblas_srotm(const CBLAS_INDEX N, float *X, const CBLAS_INDEX incX,
+                float *Y, const CBLAS_INDEX incY, const float *P);
 
 void cblas_drotg(double *a, double *b, double *c, double *s);
 void cblas_drotmg(double *d1, double *d2, double *b1, const double b2, double *P);
-void cblas_drot(const int N, double *X, const int incX,
-                double *Y, const int incY, const double c, const double  s);
-void cblas_drotm(const int N, double *X, const int incX,
-                double *Y, const int incY, const double *P);
+void cblas_drot(const CBLAS_INDEX N, double *X, const CBLAS_INDEX incX,
+                double *Y, const CBLAS_INDEX incY, const double c, const double  s);
+void cblas_drotm(const CBLAS_INDEX N, double *X, const CBLAS_INDEX incX,
+                double *Y, const CBLAS_INDEX incY, const double *P);
 
 
 /*
  * Routines with S D C Z CS and ZD prefixes
  */
-void cblas_sscal(const int N, const float alpha, float *X, const int incX);
-void cblas_dscal(const int N, const double alpha, double *X, const int incX);
-void cblas_cscal(const int N, const void *alpha, void *X, const int incX);
-void cblas_zscal(const int N, const void *alpha, void *X, const int incX);
-void cblas_csscal(const int N, const float alpha, void *X, const int incX);
-void cblas_zdscal(const int N, const double alpha, void *X, const int incX);
+void cblas_sscal(const CBLAS_INDEX N, const float alpha, float *X, const CBLAS_INDEX incX);
+void cblas_dscal(const CBLAS_INDEX N, const double alpha, double *X, const CBLAS_INDEX incX);
+void cblas_cscal(const CBLAS_INDEX N, const void *alpha, void *X, const CBLAS_INDEX incX);
+void cblas_zscal(const CBLAS_INDEX N, const void *alpha, void *X, const CBLAS_INDEX incX);
+void cblas_csscal(const CBLAS_INDEX N, const float alpha, void *X, const CBLAS_INDEX incX);
+void cblas_zdscal(const CBLAS_INDEX N, const double alpha, void *X, const CBLAS_INDEX incX);
 
 /*
  * ===========================================================================
@@ -158,264 +158,264 @@ void cblas_zdscal(const int N, const double alpha, void *X, const int incX);
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void cblas_sgemv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 const float *X, const int incX, const float beta,
-                 float *Y, const int incY);
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float *A, const CBLAS_INDEX lda,
+                 const float *X, const CBLAS_INDEX incX, const float beta,
+                 float *Y, const CBLAS_INDEX incY);
 void cblas_sgbmv(CBLAS_LAYOUT layout,
-                 CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const float alpha,
-                 const float *A, const int lda, const float *X,
-                 const int incX, const float beta, float *Y, const int incY);
+                 CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU, const float alpha,
+                 const float *A, const CBLAS_INDEX lda, const float *X,
+                 const CBLAS_INDEX incX, const float beta, float *Y, const CBLAS_INDEX incY);
 void cblas_strmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const float *A, const int lda,
-                 float *X, const int incX);
+                 const CBLAS_INDEX N, const float *A, const CBLAS_INDEX lda,
+                 float *X, const CBLAS_INDEX incX);
 void cblas_stbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const float *A, const int lda,
-                 float *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const float *A, const CBLAS_INDEX lda,
+                 float *X, const CBLAS_INDEX incX);
 void cblas_stpmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const float *Ap, float *X, const int incX);
+                 const CBLAS_INDEX N, const float *Ap, float *X, const CBLAS_INDEX incX);
 void cblas_strsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const float *A, const int lda, float *X,
-                 const int incX);
+                 const CBLAS_INDEX N, const float *A, const CBLAS_INDEX lda, float *X,
+                 const CBLAS_INDEX incX);
 void cblas_stbsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const float *A, const int lda,
-                 float *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const float *A, const CBLAS_INDEX lda,
+                 float *X, const CBLAS_INDEX incX);
 void cblas_stpsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const float *Ap, float *X, const int incX);
+                 const CBLAS_INDEX N, const float *Ap, float *X, const CBLAS_INDEX incX);
 
 void cblas_dgemv(CBLAS_LAYOUT layout,
-                 CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 const double *X, const int incX, const double beta,
-                 double *Y, const int incY);
+                 CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double *A, const CBLAS_INDEX lda,
+                 const double *X, const CBLAS_INDEX incX, const double beta,
+                 double *Y, const CBLAS_INDEX incY);
 void cblas_dgbmv(CBLAS_LAYOUT layout,
-                 CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const double alpha,
-                 const double *A, const int lda, const double *X,
-                 const int incX, const double beta, double *Y, const int incY);
+                 CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU, const double alpha,
+                 const double *A, const CBLAS_INDEX lda, const double *X,
+                 const CBLAS_INDEX incX, const double beta, double *Y, const CBLAS_INDEX incY);
 void cblas_dtrmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const double *A, const int lda,
-                 double *X, const int incX);
+                 const CBLAS_INDEX N, const double *A, const CBLAS_INDEX lda,
+                 double *X, const CBLAS_INDEX incX);
 void cblas_dtbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const double *A, const int lda,
-                 double *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const double *A, const CBLAS_INDEX lda,
+                 double *X, const CBLAS_INDEX incX);
 void cblas_dtpmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const double *Ap, double *X, const int incX);
+                 const CBLAS_INDEX N, const double *Ap, double *X, const CBLAS_INDEX incX);
 void cblas_dtrsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const double *A, const int lda, double *X,
-                 const int incX);
+                 const CBLAS_INDEX N, const double *A, const CBLAS_INDEX lda, double *X,
+                 const CBLAS_INDEX incX);
 void cblas_dtbsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const double *A, const int lda,
-                 double *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const double *A, const CBLAS_INDEX lda,
+                 double *X, const CBLAS_INDEX incX);
 void cblas_dtpsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const double *Ap, double *X, const int incX);
+                 const CBLAS_INDEX N, const double *Ap, double *X, const CBLAS_INDEX incX);
 
 void cblas_cgemv(CBLAS_LAYOUT layout,
-                 CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *X, const int incX, const void *beta,
-                 void *Y, const int incY);
+                 CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *X, const CBLAS_INDEX incX, const void *beta,
+                 void *Y, const CBLAS_INDEX incY);
 void cblas_cgbmv(CBLAS_LAYOUT layout,
-                 CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const void *alpha,
-                 const void *A, const int lda, const void *X,
-                 const int incX, const void *beta, void *Y, const int incY);
+                 CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU, const void *alpha,
+                 const void *A, const CBLAS_INDEX lda, const void *X,
+                 const CBLAS_INDEX incX, const void *beta, void *Y, const CBLAS_INDEX incY);
 void cblas_ctrmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda,
-                 void *X, const int incX);
+                 const CBLAS_INDEX N, const void *A, const CBLAS_INDEX lda,
+                 void *X, const CBLAS_INDEX incX);
 void cblas_ctbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void *A, const CBLAS_INDEX lda,
+                 void *X, const CBLAS_INDEX incX);
 void cblas_ctpmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
+                 const CBLAS_INDEX N, const void *Ap, void *X, const CBLAS_INDEX incX);
 void cblas_ctrsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda, void *X,
-                 const int incX);
+                 const CBLAS_INDEX N, const void *A, const CBLAS_INDEX lda, void *X,
+                 const CBLAS_INDEX incX);
 void cblas_ctbsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void *A, const CBLAS_INDEX lda,
+                 void *X, const CBLAS_INDEX incX);
 void cblas_ctpsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
+                 const CBLAS_INDEX N, const void *Ap, void *X, const CBLAS_INDEX incX);
 
 void cblas_zgemv(CBLAS_LAYOUT layout,
-                 CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *X, const int incX, const void *beta,
-                 void *Y, const int incY);
+                 CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *X, const CBLAS_INDEX incX, const void *beta,
+                 void *Y, const CBLAS_INDEX incY);
 void cblas_zgbmv(CBLAS_LAYOUT layout,
-                 CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const void *alpha,
-                 const void *A, const int lda, const void *X,
-                 const int incX, const void *beta, void *Y, const int incY);
+                 CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU, const void *alpha,
+                 const void *A, const CBLAS_INDEX lda, const void *X,
+                 const CBLAS_INDEX incX, const void *beta, void *Y, const CBLAS_INDEX incY);
 void cblas_ztrmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda,
-                 void *X, const int incX);
+                 const CBLAS_INDEX N, const void *A, const CBLAS_INDEX lda,
+                 void *X, const CBLAS_INDEX incX);
 void cblas_ztbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void *A, const CBLAS_INDEX lda,
+                 void *X, const CBLAS_INDEX incX);
 void cblas_ztpmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
+                 const CBLAS_INDEX N, const void *Ap, void *X, const CBLAS_INDEX incX);
 void cblas_ztrsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda, void *X,
-                 const int incX);
+                 const CBLAS_INDEX N, const void *A, const CBLAS_INDEX lda, void *X,
+                 const CBLAS_INDEX incX);
 void cblas_ztbsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void *A, const CBLAS_INDEX lda,
+                 void *X, const CBLAS_INDEX incX);
 void cblas_ztpsv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                  CBLAS_TRANSPOSE TransA, CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
+                 const CBLAS_INDEX N, const void *Ap, void *X, const CBLAS_INDEX incX);
 
 
 /*
  * Routines with S and D prefixes only
  */
 void cblas_ssymv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const float alpha, const float *A,
-                 const int lda, const float *X, const int incX,
-                 const float beta, float *Y, const int incY);
+                 const CBLAS_INDEX N, const float alpha, const float *A,
+                 const CBLAS_INDEX lda, const float *X, const CBLAS_INDEX incX,
+                 const float beta, float *Y, const CBLAS_INDEX incY);
 void cblas_ssbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const int K, const float alpha, const float *A,
-                 const int lda, const float *X, const int incX,
-                 const float beta, float *Y, const int incY);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const float alpha, const float *A,
+                 const CBLAS_INDEX lda, const float *X, const CBLAS_INDEX incX,
+                 const float beta, float *Y, const CBLAS_INDEX incY);
 void cblas_sspmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const float alpha, const float *Ap,
-                 const float *X, const int incX,
-                 const float beta, float *Y, const int incY);
-void cblas_sger(CBLAS_LAYOUT layout, const int M, const int N,
-                const float alpha, const float *X, const int incX,
-                const float *Y, const int incY, float *A, const int lda);
+                 const CBLAS_INDEX N, const float alpha, const float *Ap,
+                 const float *X, const CBLAS_INDEX incX,
+                 const float beta, float *Y, const CBLAS_INDEX incY);
+void cblas_sger(CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                const float alpha, const float *X, const CBLAS_INDEX incX,
+                const float *Y, const CBLAS_INDEX incY, float *A, const CBLAS_INDEX lda);
 void cblas_ssyr(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, float *A, const int lda);
+                const CBLAS_INDEX N, const float alpha, const float *X,
+                const CBLAS_INDEX incX, float *A, const CBLAS_INDEX lda);
 void cblas_sspr(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, float *Ap);
+                const CBLAS_INDEX N, const float alpha, const float *X,
+                const CBLAS_INDEX incX, float *Ap);
 void cblas_ssyr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, const float *Y, const int incY, float *A,
-                const int lda);
+                const CBLAS_INDEX N, const float alpha, const float *X,
+                const CBLAS_INDEX incX, const float *Y, const CBLAS_INDEX incY, float *A,
+                const CBLAS_INDEX lda);
 void cblas_sspr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, const float *Y, const int incY, float *A);
+                const CBLAS_INDEX N, const float alpha, const float *X,
+                const CBLAS_INDEX incX, const float *Y, const CBLAS_INDEX incY, float *A);
 
 void cblas_dsymv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const double alpha, const double *A,
-                 const int lda, const double *X, const int incX,
-                 const double beta, double *Y, const int incY);
+                 const CBLAS_INDEX N, const double alpha, const double *A,
+                 const CBLAS_INDEX lda, const double *X, const CBLAS_INDEX incX,
+                 const double beta, double *Y, const CBLAS_INDEX incY);
 void cblas_dsbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const int K, const double alpha, const double *A,
-                 const int lda, const double *X, const int incX,
-                 const double beta, double *Y, const int incY);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const double alpha, const double *A,
+                 const CBLAS_INDEX lda, const double *X, const CBLAS_INDEX incX,
+                 const double beta, double *Y, const CBLAS_INDEX incY);
 void cblas_dspmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const double alpha, const double *Ap,
-                 const double *X, const int incX,
-                 const double beta, double *Y, const int incY);
-void cblas_dger(CBLAS_LAYOUT layout, const int M, const int N,
-                const double alpha, const double *X, const int incX,
-                const double *Y, const int incY, double *A, const int lda);
+                 const CBLAS_INDEX N, const double alpha, const double *Ap,
+                 const double *X, const CBLAS_INDEX incX,
+                 const double beta, double *Y, const CBLAS_INDEX incY);
+void cblas_dger(CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                const double alpha, const double *X, const CBLAS_INDEX incX,
+                const double *Y, const CBLAS_INDEX incY, double *A, const CBLAS_INDEX lda);
 void cblas_dsyr(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, double *A, const int lda);
+                const CBLAS_INDEX N, const double alpha, const double *X,
+                const CBLAS_INDEX incX, double *A, const CBLAS_INDEX lda);
 void cblas_dspr(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, double *Ap);
+                const CBLAS_INDEX N, const double alpha, const double *X,
+                const CBLAS_INDEX incX, double *Ap);
 void cblas_dsyr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, const double *Y, const int incY, double *A,
-                const int lda);
+                const CBLAS_INDEX N, const double alpha, const double *X,
+                const CBLAS_INDEX incX, const double *Y, const CBLAS_INDEX incY, double *A,
+                const CBLAS_INDEX lda);
 void cblas_dspr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, const double *Y, const int incY, double *A);
+                const CBLAS_INDEX N, const double alpha, const double *X,
+                const CBLAS_INDEX incX, const double *Y, const CBLAS_INDEX incY, double *A);
 
 
 /*
  * Routines with C and Z prefixes only
  */
 void cblas_chemv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
+                 const CBLAS_INDEX N, const void *alpha, const void *A,
+                 const CBLAS_INDEX lda, const void *X, const CBLAS_INDEX incX,
+                 const void *beta, void *Y, const CBLAS_INDEX incY);
 void cblas_chbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const int K, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void *alpha, const void *A,
+                 const CBLAS_INDEX lda, const void *X, const CBLAS_INDEX incX,
+                 const void *beta, void *Y, const CBLAS_INDEX incY);
 void cblas_chpmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *Ap,
-                 const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_cgeru(CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
-void cblas_cgerc(CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
+                 const CBLAS_INDEX N, const void *alpha, const void *Ap,
+                 const void *X, const CBLAS_INDEX incX,
+                 const void *beta, void *Y, const CBLAS_INDEX incY);
+void cblas_cgeru(CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda);
+void cblas_cgerc(CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda);
 void cblas_cher(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const float alpha, const void *X, const int incX,
-                void *A, const int lda);
+                const CBLAS_INDEX N, const float alpha, const void *X, const CBLAS_INDEX incX,
+                void *A, const CBLAS_INDEX lda);
 void cblas_chpr(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const float alpha, const void *X,
-                const int incX, void *A);
-void cblas_cher2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *A, const int lda);
-void cblas_chpr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *Ap);
+                const CBLAS_INDEX N, const float alpha, const void *X,
+                const CBLAS_INDEX incX, void *A);
+void cblas_cher2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                const void *alpha, const void *X, const CBLAS_INDEX incX,
+                const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda);
+void cblas_chpr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                const void *alpha, const void *X, const CBLAS_INDEX incX,
+                const void *Y, const CBLAS_INDEX incY, void *Ap);
 
 void cblas_zhemv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
+                 const CBLAS_INDEX N, const void *alpha, const void *A,
+                 const CBLAS_INDEX lda, const void *X, const CBLAS_INDEX incX,
+                 const void *beta, void *Y, const CBLAS_INDEX incY);
 void cblas_zhbmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const int K, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void *alpha, const void *A,
+                 const CBLAS_INDEX lda, const void *X, const CBLAS_INDEX incX,
+                 const void *beta, void *Y, const CBLAS_INDEX incY);
 void cblas_zhpmv(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *Ap,
-                 const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_zgeru(CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
-void cblas_zgerc(CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
+                 const CBLAS_INDEX N, const void *alpha, const void *Ap,
+                 const void *X, const CBLAS_INDEX incX,
+                 const void *beta, void *Y, const CBLAS_INDEX incY);
+void cblas_zgeru(CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda);
+void cblas_zgerc(CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda);
 void cblas_zher(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const double alpha, const void *X, const int incX,
-                void *A, const int lda);
+                const CBLAS_INDEX N, const double alpha, const void *X, const CBLAS_INDEX incX,
+                void *A, const CBLAS_INDEX lda);
 void cblas_zhpr(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                const int N, const double alpha, const void *X,
-                const int incX, void *A);
-void cblas_zher2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *A, const int lda);
-void cblas_zhpr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *Ap);
+                const CBLAS_INDEX N, const double alpha, const void *X,
+                const CBLAS_INDEX incX, void *A);
+void cblas_zher2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                const void *alpha, const void *X, const CBLAS_INDEX incX,
+                const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda);
+void cblas_zhpr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                const void *alpha, const void *X, const CBLAS_INDEX incX,
+                const void *Y, const CBLAS_INDEX incY, void *Ap);
 
 /*
  * ===========================================================================
@@ -427,160 +427,160 @@ void cblas_zhpr2(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo, const int N,
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void cblas_sgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE TransA,
-                 CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const float alpha, const float *A,
-                 const int lda, const float *B, const int ldb,
-                 const float beta, float *C, const int ldc);
+                 CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const float alpha, const float *A,
+                 const CBLAS_INDEX lda, const float *B, const CBLAS_INDEX ldb,
+                 const float beta, float *C, const CBLAS_INDEX ldc);
 void cblas_ssymm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
-                 CBLAS_UPLO Uplo, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 const float *B, const int ldb, const float beta,
-                 float *C, const int ldc);
+                 CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float *A, const CBLAS_INDEX lda,
+                 const float *B, const CBLAS_INDEX ldb, const float beta,
+                 float *C, const CBLAS_INDEX ldc);
 void cblas_ssyrk(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const float alpha, const float *A, const int lda,
-                 const float beta, float *C, const int ldc);
+                 CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const float alpha, const float *A, const CBLAS_INDEX lda,
+                 const float beta, float *C, const CBLAS_INDEX ldc);
 void cblas_ssyr2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                  CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const float alpha, const float *A, const int lda,
-                  const float *B, const int ldb, const float beta,
-                  float *C, const int ldc);
+                  CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const float alpha, const float *A, const CBLAS_INDEX lda,
+                  const float *B, const CBLAS_INDEX ldb, const float beta,
+                  float *C, const CBLAS_INDEX ldc);
 void cblas_strmm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 float *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float *A, const CBLAS_INDEX lda,
+                 float *B, const CBLAS_INDEX ldb);
 void cblas_strsm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 float *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float *A, const CBLAS_INDEX lda,
+                 float *B, const CBLAS_INDEX ldb);
 
 void cblas_dgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE TransA,
-                 CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const double alpha, const double *A,
-                 const int lda, const double *B, const int ldb,
-                 const double beta, double *C, const int ldc);
+                 CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const double alpha, const double *A,
+                 const CBLAS_INDEX lda, const double *B, const CBLAS_INDEX ldb,
+                 const double beta, double *C, const CBLAS_INDEX ldc);
 void cblas_dsymm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
-                 CBLAS_UPLO Uplo, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 const double *B, const int ldb, const double beta,
-                 double *C, const int ldc);
+                 CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double *A, const CBLAS_INDEX lda,
+                 const double *B, const CBLAS_INDEX ldb, const double beta,
+                 double *C, const CBLAS_INDEX ldc);
 void cblas_dsyrk(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const double alpha, const double *A, const int lda,
-                 const double beta, double *C, const int ldc);
+                 CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const double alpha, const double *A, const CBLAS_INDEX lda,
+                 const double beta, double *C, const CBLAS_INDEX ldc);
 void cblas_dsyr2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                  CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const double alpha, const double *A, const int lda,
-                  const double *B, const int ldb, const double beta,
-                  double *C, const int ldc);
+                  CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const double alpha, const double *A, const CBLAS_INDEX lda,
+                  const double *B, const CBLAS_INDEX ldb, const double beta,
+                  double *C, const CBLAS_INDEX ldc);
 void cblas_dtrmm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 double *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double *A, const CBLAS_INDEX lda,
+                 double *B, const CBLAS_INDEX ldb);
 void cblas_dtrsm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 double *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double *A, const CBLAS_INDEX lda,
+                 double *B, const CBLAS_INDEX ldb);
 
 void cblas_cgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE TransA,
-                 CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const void *alpha, const void *A,
-                 const int lda, const void *B, const int ldb,
-                 const void *beta, void *C, const int ldc);
+                 CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const void *alpha, const void *A,
+                 const CBLAS_INDEX lda, const void *B, const CBLAS_INDEX ldb,
+                 const void *beta, void *C, const CBLAS_INDEX ldc);
 void cblas_csymm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
-                 CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
+                 CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *B, const CBLAS_INDEX ldb, const void *beta,
+                 void *C, const CBLAS_INDEX ldc);
 void cblas_csyrk(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const void *alpha, const void *A, const int lda,
-                 const void *beta, void *C, const int ldc);
+                 CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *beta, void *C, const CBLAS_INDEX ldc);
 void cblas_csyr2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                  CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const void *beta,
-                  void *C, const int ldc);
+                  CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void *A, const CBLAS_INDEX lda,
+                  const void *B, const CBLAS_INDEX ldb, const void *beta,
+                  void *C, const CBLAS_INDEX ldc);
 void cblas_ctrmm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 void *B, const CBLAS_INDEX ldb);
 void cblas_ctrsm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 void *B, const CBLAS_INDEX ldb);
 
 void cblas_zgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE TransA,
-                 CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const void *alpha, const void *A,
-                 const int lda, const void *B, const int ldb,
-                 const void *beta, void *C, const int ldc);
+                 CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const void *alpha, const void *A,
+                 const CBLAS_INDEX lda, const void *B, const CBLAS_INDEX ldb,
+                 const void *beta, void *C, const CBLAS_INDEX ldc);
 void cblas_zsymm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
-                 CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
+                 CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *B, const CBLAS_INDEX ldb, const void *beta,
+                 void *C, const CBLAS_INDEX ldc);
 void cblas_zsyrk(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const void *alpha, const void *A, const int lda,
-                 const void *beta, void *C, const int ldc);
+                 CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *beta, void *C, const CBLAS_INDEX ldc);
 void cblas_zsyr2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                  CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const void *beta,
-                  void *C, const int ldc);
+                  CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void *A, const CBLAS_INDEX lda,
+                  const void *B, const CBLAS_INDEX ldb, const void *beta,
+                  void *C, const CBLAS_INDEX ldc);
 void cblas_ztrmm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 void *B, const CBLAS_INDEX ldb);
 void cblas_ztrsm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
                  CBLAS_UPLO Uplo, CBLAS_TRANSPOSE TransA,
-                 CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
+                 CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 void *B, const CBLAS_INDEX ldb);
 
 
 /*
  * Routines with prefixes C and Z only
  */
 void cblas_chemm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
-                 CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
+                 CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *B, const CBLAS_INDEX ldb, const void *beta,
+                 void *C, const CBLAS_INDEX ldc);
 void cblas_cherk(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const float alpha, const void *A, const int lda,
-                 const float beta, void *C, const int ldc);
+                 CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const float alpha, const void *A, const CBLAS_INDEX lda,
+                 const float beta, void *C, const CBLAS_INDEX ldc);
 void cblas_cher2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                  CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const float beta,
-                  void *C, const int ldc);
+                  CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void *A, const CBLAS_INDEX lda,
+                  const void *B, const CBLAS_INDEX ldb, const float beta,
+                  void *C, const CBLAS_INDEX ldc);
 
 void cblas_zhemm(CBLAS_LAYOUT layout, CBLAS_SIDE Side,
-                 CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
+                 CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *B, const CBLAS_INDEX ldb, const void *beta,
+                 void *C, const CBLAS_INDEX ldc);
 void cblas_zherk(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                 CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const double alpha, const void *A, const int lda,
-                 const double beta, void *C, const int ldc);
+                 CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const double alpha, const void *A, const CBLAS_INDEX lda,
+                 const double beta, void *C, const CBLAS_INDEX ldc);
 void cblas_zher2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
-                  CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const double beta,
-                  void *C, const int ldc);
+                  CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void *A, const CBLAS_INDEX lda,
+                  const void *B, const CBLAS_INDEX ldb, const double beta,
+                  void *C, const CBLAS_INDEX ldc);
 
-void cblas_xerbla(int p, const char *rout, const char *form, ...);
+void cblas_xerbla(CBLAS_INDEX p, const char *rout, const char *form, ...);
 
 #ifdef __cplusplus
 }

--- a/CBLAS/include/cblas_f77.h
+++ b/CBLAS/include/cblas_f77.h
@@ -19,6 +19,8 @@
 
 #ifdef WeirdNEC
    #define F77_INT long
+#else
+   #define F77_INT int
 #endif
 
 #ifdef  F77_CHAR
@@ -27,13 +29,8 @@
    #define FCHAR char *
 #endif
 
-#ifdef F77_INT
-   #define FINT const F77_INT *
-   #define FINT2 F77_INT *
-#else
-   #define FINT const int *
-   #define FINT2 int *
-#endif
+#define FINT const F77_INT *
+#define FINT2 F77_INT *
 
 /*
  * Level 1 BLAS

--- a/CBLAS/src/cblas_caxpy.c
+++ b/CBLAS/src/cblas_caxpy.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_caxpy( const int N, const void *alpha, const void *X,
-                       const int incX, void *Y, const int incY)
+void cblas_caxpy( const CBLAS_INDEX N, const void *alpha, const void *X,
+                       const CBLAS_INDEX incX, void *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_ccopy.c
+++ b/CBLAS/src/cblas_ccopy.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_ccopy( const int N, const void *X,
-                      const int incX, void *Y, const int incY)
+void cblas_ccopy( const CBLAS_INDEX N, const void *X,
+                      const CBLAS_INDEX incX, void *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_cdotc_sub.c
+++ b/CBLAS/src/cblas_cdotc_sub.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_cdotc_sub( const int N, const void *X, const int incX,
-                      const void *Y, const int incY, void *dotc)
+void cblas_cdotc_sub( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                      const void *Y, const CBLAS_INDEX incY, void *dotc)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_cdotu_sub.c
+++ b/CBLAS/src/cblas_cdotu_sub.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_cdotu_sub( const int N, const void *X, const int incX,
-	                  const void *Y, const int incY, void *dotu)
+void cblas_cdotu_sub( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+		      const void *Y, const CBLAS_INDEX incY, void *dotu)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_cgbmv.c
+++ b/CBLAS/src/cblas_cgbmv.c
@@ -10,11 +10,11 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_cgbmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR
@@ -34,10 +34,10 @@ void cblas_cgbmv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n=0, i=0, incx=incX;
+   CBLAS_INDEX n=0, i=0, incx=incX;
    const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
    float ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    float *x=(float *)X, *y=(float *)Y, *st=0, *tx=0;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_cgemm.c
+++ b/CBLAS/src/cblas_cgemm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_cgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const void *alpha, const void  *A,
-                 const int lda, const void  *B, const int ldb,
-                 const void *beta, void  *C, const int ldc)
+                 const CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const void *alpha, const void  *A,
+                 const CBLAS_INDEX lda, const void  *B, const CBLAS_INDEX ldb,
+                 const void *beta, void  *C, const CBLAS_INDEX ldc)
 {
    char TA, TB;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_cgemv.c
+++ b/CBLAS/src/cblas_cgemv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_cgemv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR
@@ -31,10 +31,10 @@ void cblas_cgemv(const CBLAS_LAYOUT layout,
    #define F77_incY incY
 #endif
 
-   int n=0, i=0, incx=incX;
+   CBLAS_INDEX n=0, i=0, incx=incX;
    const float *xx= (const float *)X;
    float ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    float *x=(float *)X, *y=(float *)Y, *st=0, *tx=0;
    const float *stx = x;
    extern int CBLAS_CallFromC;

--- a/CBLAS/src/cblas_cgerc.c
+++ b/CBLAS/src/cblas_cgerc.c
@@ -9,9 +9,9 @@
 #include <stdlib.h>
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_cgerc(const CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda)
+void cblas_cgerc(const CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda)
 {
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
@@ -23,7 +23,7 @@ void cblas_cgerc(const CBLAS_LAYOUT layout, const int M, const int N,
    #define F77_lda lda
 #endif
 
-   int n, i, tincy, incy=incY;
+   CBLAS_INDEX n, i, tincy, incy=incY;
    float *y=(float *)Y, *yy=(float *)Y, *ty, *st;
 
    extern int CBLAS_CallFromC;

--- a/CBLAS/src/cblas_cgeru.c
+++ b/CBLAS/src/cblas_cgeru.c
@@ -7,9 +7,9 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_cgeru(const CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda)
+void cblas_cgeru(const CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda)
 {
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_chbmv.c
+++ b/CBLAS/src/cblas_chbmv.c
@@ -10,10 +10,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 void cblas_chbmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo,const int N,const int K,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_UPLO Uplo,const CBLAS_INDEX N,const CBLAS_INDEX K,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR
@@ -30,10 +30,10 @@ void cblas_chbmv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n, i=0, incx=incX;
+   CBLAS_INDEX n, i=0, incx=incX;
    const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
    float ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    float *x=(float *)X, *y=(float *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_chemm.c
+++ b/CBLAS/src/cblas_chemm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_chemm(const CBLAS_LAYOUT layout, const  CBLAS_SIDE Side,
-                 const CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *B, const CBLAS_INDEX ldb, const void *beta,
+                 void *C, const CBLAS_INDEX ldc)
 {
    char SD, UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_chemv.c
+++ b/CBLAS/src/cblas_chemv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_chemv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR
@@ -29,10 +29,10 @@ void cblas_chemv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n=0, i=0, incx=incX;
+   CBLAS_INDEX n=0, i=0, incx=incX;
    const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
    float ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    float *x=(float *)X, *y=(float *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_cher.c
+++ b/CBLAS/src/cblas_cher.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_cher(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const float alpha, const void *X, const int incX
-                ,void *A, const int lda)
+                const CBLAS_INDEX N, const float alpha, const void *X, const CBLAS_INDEX incX
+                ,void *A, const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR
@@ -27,7 +27,7 @@ void cblas_cher(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incx
 #endif
-   int n, i, tincx, incx=incX;
+   CBLAS_INDEX n, i, tincx, incx=incX;
    float *x=(float *)X, *xx=(float *)X, *tx, *st;
 
    extern int CBLAS_CallFromC;

--- a/CBLAS/src/cblas_cher2.c
+++ b/CBLAS/src/cblas_cher2.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_cher2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda)
+                 const CBLAS_INDEX N, const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR
@@ -28,7 +28,7 @@ void cblas_cher2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   int n, i, j, tincx, tincy, incx=incX, incy=incY;
+   CBLAS_INDEX n, i, j, tincx, tincy, incx=incX, incy=incY;
    float *x=(float *)X, *xx=(float *)X, *y=(float *)Y,
          *yy=(float *)Y, *tx, *ty, *stx, *sty;
 

--- a/CBLAS/src/cblas_cher2k.c
+++ b/CBLAS/src/cblas_cher2k.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_cher2k(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const float beta,
-                  void *C, const int ldc)
+                  const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void *A, const CBLAS_INDEX lda,
+                  const void *B, const CBLAS_INDEX ldb, const float beta,
+                  void *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_cherk.c
+++ b/CBLAS/src/cblas_cherk.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_cherk(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const float alpha, const void *A, const int lda,
-                 const float beta, void *C, const int ldc)
+                 const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const float alpha, const void *A, const CBLAS_INDEX lda,
+                 const float beta, void *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_chpmv.c
+++ b/CBLAS/src/cblas_chpmv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_chpmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo,const int N,
+                 const CBLAS_UPLO Uplo,const CBLAS_INDEX N,
                  const void *alpha, const void  *AP,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR
@@ -28,10 +28,10 @@ void cblas_chpmv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n, i=0, incx=incX;
+   CBLAS_INDEX n, i=0, incx=incX;
    const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
    float ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    float *x=(float *)X, *y=(float *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_chpr.c
+++ b/CBLAS/src/cblas_chpr.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_chpr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const float alpha, const void *X,
-                const int incX, void *A)
+                const CBLAS_INDEX N, const float alpha, const void *X,
+                const CBLAS_INDEX incX, void *A)
 {
    char UL;
 #ifdef F77_CHAR
@@ -26,7 +26,7 @@ void cblas_chpr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_N N
    #define F77_incX incx
 #endif
-   int n, i, tincx, incx=incX;
+   CBLAS_INDEX n, i, tincx, incx=incX;
    float *x=(float *)X, *xx=(float *)X, *tx, *st;
 
    extern int CBLAS_CallFromC;

--- a/CBLAS/src/cblas_chpr2.c
+++ b/CBLAS/src/cblas_chpr2.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_chpr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                      const int N,const void *alpha, const void *X,
-                      const int incX,const void *Y, const int incY, void *Ap)
+                      const CBLAS_INDEX N,const void *alpha, const void *X,
+                      const CBLAS_INDEX incX,const void *Y, const CBLAS_INDEX incY, void *Ap)
 
 {
    char UL;
@@ -28,7 +28,7 @@ void cblas_chpr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   int n, i, j, tincx, tincy, incx=incX, incy=incY;
+   CBLAS_INDEX n, i, j, tincx, tincy, incx=incX, incy=incY;
    float *x=(float *)X, *xx=(float *)X, *y=(float *)Y,
          *yy=(float *)Y, *tx, *ty, *stx, *sty;
 

--- a/CBLAS/src/cblas_cscal.c
+++ b/CBLAS/src/cblas_cscal.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_cscal( const int N, const void *alpha, void *X,
-                       const int incX)
+void cblas_cscal( const CBLAS_INDEX N, const void *alpha, void *X,
+                       const CBLAS_INDEX incX)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;

--- a/CBLAS/src/cblas_csscal.c
+++ b/CBLAS/src/cblas_csscal.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_csscal( const int N, const float alpha, void *X,
-                       const int incX)
+void cblas_csscal( const CBLAS_INDEX N, const float alpha, void *X,
+                       const CBLAS_INDEX incX)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;

--- a/CBLAS/src/cblas_cswap.c
+++ b/CBLAS/src/cblas_cswap.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_cswap( const int N, void *X, const int incX, void *Y,
-                       const int incY)
+void cblas_cswap( const CBLAS_INDEX N, void *X, const CBLAS_INDEX incX, void *Y,
+                       const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_csymm.c
+++ b/CBLAS/src/cblas_csymm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_csymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
-                 const CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *B, const int ldb, const void *beta,
-                 void  *C, const int ldc)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *B, const CBLAS_INDEX ldb, const void *beta,
+                 void  *C, const CBLAS_INDEX ldc)
 {
    char SD, UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_csyr2k.c
+++ b/CBLAS/src/cblas_csyr2k.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_csyr2k(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void  *A, const int lda,
-                  const void  *B, const int ldb, const void *beta,
-                  void  *C, const int ldc)
+                  const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                  const void  *B, const CBLAS_INDEX ldb, const void *beta,
+                  void  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_csyrk.c
+++ b/CBLAS/src/cblas_csyrk.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_csyrk(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const void *alpha, const void  *A, const int lda,
-                 const void *beta, void  *C, const int ldc)
+                 const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void *beta, void  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ctbmv.c
+++ b/CBLAS/src/cblas_ctbmv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ctbmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const void  *A, const int lda,
-                 void  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void  *A, const CBLAS_INDEX lda,
+                 void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -30,7 +30,7 @@ void cblas_ctbmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    float *st=0, *x=(float *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ctbsv.c
+++ b/CBLAS/src/cblas_ctbsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ctbsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const void  *A, const int lda,
-                 void  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void  *A, const CBLAS_INDEX lda,
+                 void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -30,7 +30,7 @@ void cblas_ctbsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    float *st=0,*x=(float *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ctpmv.c
+++ b/CBLAS/src/cblas_ctpmv.c
@@ -9,7 +9,7 @@
 #include "cblas_f77.h"
 void cblas_ctpmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *Ap, void  *X, const int incX)
+                 const CBLAS_INDEX N, const void  *Ap, void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -27,7 +27,7 @@ void cblas_ctpmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_N N
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    float *st=0,*x=(float *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ctpsv.c
+++ b/CBLAS/src/cblas_ctpsv.c
@@ -9,7 +9,7 @@
 #include "cblas_f77.h"
 void cblas_ctpsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *Ap, void  *X, const int incX)
+                 const CBLAS_INDEX N, const void  *Ap, void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -27,7 +27,7 @@ void cblas_ctpsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_N N
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    float *st=0, *x=(float*)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ctrmm.c
+++ b/CBLAS/src/cblas_ctrmm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_ctrmm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const  CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 void  *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 void  *B, const CBLAS_INDEX ldb)
 {
    char UL, TA, SD, DI;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ctrmv.c
+++ b/CBLAS/src/cblas_ctrmv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ctrmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *A, const int lda,
-                 void  *X, const int incX)
+                 const CBLAS_INDEX N, const void  *A, const CBLAS_INDEX lda,
+                 void  *X, const CBLAS_INDEX incX)
 
 {
    char TA;
@@ -30,7 +30,7 @@ void cblas_ctrmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    float *st=0,*x=(float *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ctrsm.c
+++ b/CBLAS/src/cblas_ctrsm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_ctrsm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 void  *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 void  *B, const CBLAS_INDEX ldb)
 {
    char UL, TA, SD, DI;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ctrsv.c
+++ b/CBLAS/src/cblas_ctrsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ctrsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *A, const int lda, void  *X,
-                 const int incX)
+                 const CBLAS_INDEX N, const void  *A, const CBLAS_INDEX lda, void  *X,
+                 const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -29,7 +29,7 @@ void cblas_ctrsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    float *st=0,*x=(float *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_dasum.c
+++ b/CBLAS/src/cblas_dasum.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-double cblas_dasum( const int N, const double *X, const int incX)
+double cblas_dasum( const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX)
 {
    double asum;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_daxpy.c
+++ b/CBLAS/src/cblas_daxpy.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_daxpy( const int N, const double alpha, const double *X,
-                       const int incX, double *Y, const int incY)
+void cblas_daxpy( const CBLAS_INDEX N, const double alpha, const double *X,
+                       const CBLAS_INDEX incX, double *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_dcopy.c
+++ b/CBLAS/src/cblas_dcopy.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_dcopy( const int N, const double *X,
-                      const int incX, double *Y, const int incY)
+void cblas_dcopy( const CBLAS_INDEX N, const double *X,
+                      const CBLAS_INDEX incX, double *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_ddot.c
+++ b/CBLAS/src/cblas_ddot.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-double cblas_ddot( const int N, const double *X,
-                      const int incX, const double *Y, const int incY)
+double cblas_ddot( const CBLAS_INDEX N, const double *X,
+                      const CBLAS_INDEX incX, const double *Y, const CBLAS_INDEX incY)
 {
    double dot;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_dgbmv.c
+++ b/CBLAS/src/cblas_dgbmv.c
@@ -9,11 +9,11 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dgbmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU,
-                 const double alpha, const double  *A, const int lda,
-                 const double  *X, const int incX, const double beta,
-                 double  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 const double  *X, const CBLAS_INDEX incX, const double beta,
+                 double  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dgemm.c
+++ b/CBLAS/src/cblas_dgemm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const double alpha, const double  *A,
-                 const int lda, const double  *B, const int ldb,
-                 const double beta, double  *C, const int ldc)
+                 const CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const double alpha, const double  *A,
+                 const CBLAS_INDEX lda, const double  *B, const CBLAS_INDEX ldb,
+                 const double beta, double  *C, const CBLAS_INDEX ldc)
 {
    char TA, TB;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dgemv.c
+++ b/CBLAS/src/cblas_dgemv.c
@@ -9,10 +9,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dgemv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const double alpha, const double  *A, const int lda,
-                 const double  *X, const int incX, const double beta,
-                 double  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 const double  *X, const CBLAS_INDEX incX, const double beta,
+                 double  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dger.c
+++ b/CBLAS/src/cblas_dger.c
@@ -9,9 +9,9 @@
 
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_dger(const CBLAS_LAYOUT layout, const int M, const int N,
-                const double alpha, const double  *X, const int incX,
-                const double  *Y, const int incY, double  *A, const int lda)
+void cblas_dger(const CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                const double alpha, const double  *X, const CBLAS_INDEX incX,
+                const double  *Y, const CBLAS_INDEX incY, double  *A, const CBLAS_INDEX lda)
 {
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_dnrm2.c
+++ b/CBLAS/src/cblas_dnrm2.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-double cblas_dnrm2( const int N, const double *X, const int incX)
+double cblas_dnrm2( const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX)
 {
    double nrm2;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_drot.c
+++ b/CBLAS/src/cblas_drot.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_drot(const int N, double *X, const int incX,
-   double *Y, const int incY, const double c, const double s)
+void cblas_drot(const CBLAS_INDEX N, double *X, const CBLAS_INDEX incX,
+   double *Y, const CBLAS_INDEX incY, const double c, const double s)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_drotm.c
+++ b/CBLAS/src/cblas_drotm.c
@@ -1,7 +1,7 @@
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_drotm( const int N, double *X, const int incX, double *Y,
-                       const int incY, const double *P)
+void cblas_drotm( const CBLAS_INDEX N, double *X, const CBLAS_INDEX incX, double *Y,
+                       const CBLAS_INDEX incY, const double *P)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_dsbmv.c
+++ b/CBLAS/src/cblas_dsbmv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dsbmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo, const int N, const int K,
-                 const double alpha, const double  *A, const int lda,
-                 const double  *X, const int incX, const double beta,
-                 double  *Y, const int incY)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 const double  *X, const CBLAS_INDEX incX, const double beta,
+                 double  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dscal.c
+++ b/CBLAS/src/cblas_dscal.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_dscal( const int N, const double alpha, double *X,
-                       const int incX)
+void cblas_dscal( const CBLAS_INDEX N, const double alpha, double *X,
+                       const CBLAS_INDEX incX)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;

--- a/CBLAS/src/cblas_dsdot.c
+++ b/CBLAS/src/cblas_dsdot.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-double  cblas_dsdot( const int N, const float *X,
-                      const int incX, const float *Y, const int incY)
+double  cblas_dsdot( const CBLAS_INDEX N, const float *X,
+                      const CBLAS_INDEX incX, const float *Y, const CBLAS_INDEX incY)
 {
    double dot;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_dspmv.c
+++ b/CBLAS/src/cblas_dspmv.c
@@ -11,10 +11,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dspmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo, const int N,
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX N,
                  const double alpha, const double  *AP,
-                 const double  *X, const int incX, const double beta,
-                 double  *Y, const int incY)
+                 const double  *X, const CBLAS_INDEX incX, const double beta,
+                 double  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dspr.c
+++ b/CBLAS/src/cblas_dspr.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dspr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, double *Ap)
+                const CBLAS_INDEX N, const double alpha, const double *X,
+                const CBLAS_INDEX incX, double *Ap)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dspr2.c
+++ b/CBLAS/src/cblas_dspr2.c
@@ -8,8 +8,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dspr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const double  alpha, const double  *X,
-                const int incX, const double  *Y, const int incY, double  *A)
+                const CBLAS_INDEX N, const double  alpha, const double  *X,
+                const CBLAS_INDEX incX, const double  *Y, const CBLAS_INDEX incY, double  *A)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dswap.c
+++ b/CBLAS/src/cblas_dswap.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_dswap( const int N, double *X, const int incX, double *Y,
-                       const int incY)
+void cblas_dswap( const CBLAS_INDEX N, double *X, const CBLAS_INDEX incX, double *Y,
+                       const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_dsymm.c
+++ b/CBLAS/src/cblas_dsymm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dsymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
-                 const CBLAS_UPLO Uplo, const int M, const int N,
-                 const double alpha, const double  *A, const int lda,
-                 const double  *B, const int ldb, const double beta,
-                 double  *C, const int ldc)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 const double  *B, const CBLAS_INDEX ldb, const double beta,
+                 double  *C, const CBLAS_INDEX ldc)
 {
    char SD, UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dsymv.c
+++ b/CBLAS/src/cblas_dsymv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dsymv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo, const int N,
-                 const double alpha, const double  *A, const int lda,
-                 const double  *X, const int incX, const double beta,
-                 double  *Y, const int incY)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 const double  *X, const CBLAS_INDEX incX, const double beta,
+                 double  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dsyr.c
+++ b/CBLAS/src/cblas_dsyr.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dsyr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const double  alpha, const double  *X,
-                const int incX, double  *A, const int lda)
+                const CBLAS_INDEX N, const double  alpha, const double  *X,
+                const CBLAS_INDEX incX, double  *A, const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dsyr2.c
+++ b/CBLAS/src/cblas_dsyr2.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dsyr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const double  alpha, const double  *X,
-                const int incX, const double  *Y, const int incY, double  *A,
-                const int lda)
+                const CBLAS_INDEX N, const double  alpha, const double  *X,
+                const CBLAS_INDEX incX, const double  *Y, const CBLAS_INDEX incY, double  *A,
+                const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dsyr2k.c
+++ b/CBLAS/src/cblas_dsyr2k.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dsyr2k(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const double alpha, const double  *A, const int lda,
-                  const double  *B, const int ldb, const double beta,
-                  double  *C, const int ldc)
+                  const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const double alpha, const double  *A, const CBLAS_INDEX lda,
+                  const double  *B, const CBLAS_INDEX ldb, const double beta,
+                  double  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dsyrk.c
+++ b/CBLAS/src/cblas_dsyrk.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_dsyrk(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const double alpha, const double  *A, const int lda,
-                 const double beta, double  *C, const int ldc)
+                 const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 const double beta, double  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dtbmv.c
+++ b/CBLAS/src/cblas_dtbmv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_dtbmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const double  *A, const int lda,
-                 double  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const double  *A, const CBLAS_INDEX lda,
+                 double  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_dtbsv.c
+++ b/CBLAS/src/cblas_dtbsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_dtbsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const double  *A, const int lda,
-                 double  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const double  *A, const CBLAS_INDEX lda,
+                 double  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_dtpmv.c
+++ b/CBLAS/src/cblas_dtpmv.c
@@ -9,7 +9,7 @@
 #include "cblas_f77.h"
 void cblas_dtpmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const double  *Ap, double  *X, const int incX)
+                 const CBLAS_INDEX N, const double  *Ap, double  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_dtpsv.c
+++ b/CBLAS/src/cblas_dtpsv.c
@@ -9,7 +9,7 @@
 #include "cblas_f77.h"
 void cblas_dtpsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const double  *Ap, double  *X, const int incX)
+                 const CBLAS_INDEX N, const double  *Ap, double  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_dtrmm.c
+++ b/CBLAS/src/cblas_dtrmm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_dtrmm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const  CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const double alpha, const double  *A, const int lda,
-                 double  *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 double  *B, const CBLAS_INDEX ldb)
 {
    char UL, TA, SD, DI;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_dtrmv.c
+++ b/CBLAS/src/cblas_dtrmv.c
@@ -11,8 +11,8 @@
 #include "cblas_f77.h"
 void cblas_dtrmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const double  *A, const int lda,
-                 double  *X, const int incX)
+                 const CBLAS_INDEX N, const double  *A, const CBLAS_INDEX lda,
+                 double  *X, const CBLAS_INDEX incX)
 
 {
    char TA;

--- a/CBLAS/src/cblas_dtrsm.c
+++ b/CBLAS/src/cblas_dtrsm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_dtrsm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const double alpha, const double  *A, const int lda,
-                 double  *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const double alpha, const double  *A, const CBLAS_INDEX lda,
+                 double  *B, const CBLAS_INDEX ldb)
 
 {
    char UL, TA, SD, DI;

--- a/CBLAS/src/cblas_dtrsv.c
+++ b/CBLAS/src/cblas_dtrsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_dtrsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const double  *A, const int lda, double  *X,
-                 const int incX)
+                 const CBLAS_INDEX N, const double  *A, const CBLAS_INDEX lda, double  *X,
+                 const CBLAS_INDEX incX)
 
 {
    char TA;

--- a/CBLAS/src/cblas_dzasum.c
+++ b/CBLAS/src/cblas_dzasum.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-double cblas_dzasum( const int N, const void *X, const int incX)
+double cblas_dzasum( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX)
 {
    double asum;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_dznrm2.c
+++ b/CBLAS/src/cblas_dznrm2.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-double cblas_dznrm2( const int N, const void *X, const int incX)
+double cblas_dznrm2( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX)
 {
    double nrm2;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_globals.c
+++ b/CBLAS/src/cblas_globals.c
@@ -1,2 +1,2 @@
-int CBLAS_CallFromC=0;
-int RowMajorStrg=0;
+   int CBLAS_CallFromC=0;
+   int RowMajorStrg=0;

--- a/CBLAS/src/cblas_icamax.c
+++ b/CBLAS/src/cblas_icamax.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-CBLAS_INDEX cblas_icamax( const int N, const void *X, const int incX)
+CBLAS_INDEX cblas_icamax( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX)
 {
    CBLAS_INDEX iamax;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_idamax.c
+++ b/CBLAS/src/cblas_idamax.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-CBLAS_INDEX cblas_idamax( const int N, const double *X, const int incX)
+CBLAS_INDEX cblas_idamax( const CBLAS_INDEX N, const double *X, const CBLAS_INDEX incX)
 {
    CBLAS_INDEX iamax;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_isamax.c
+++ b/CBLAS/src/cblas_isamax.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-CBLAS_INDEX cblas_isamax( const int N, const float *X, const int incX)
+CBLAS_INDEX cblas_isamax( const CBLAS_INDEX N, const float *X, const CBLAS_INDEX incX)
 {
    CBLAS_INDEX iamax;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_izamax.c
+++ b/CBLAS/src/cblas_izamax.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-CBLAS_INDEX cblas_izamax( const int N, const void *X, const int incX)
+CBLAS_INDEX cblas_izamax( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX)
 {
    CBLAS_INDEX iamax;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_sasum.c
+++ b/CBLAS/src/cblas_sasum.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-float cblas_sasum( const int N, const float *X, const int incX)
+float cblas_sasum( const CBLAS_INDEX N, const float *X, const CBLAS_INDEX incX)
 {
    float asum;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_saxpy.c
+++ b/CBLAS/src/cblas_saxpy.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_saxpy( const int N, const float alpha, const float *X,
-                       const int incX, float *Y, const int incY)
+void cblas_saxpy( const CBLAS_INDEX N, const float alpha, const float *X,
+                       const CBLAS_INDEX incX, float *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_scasum.c
+++ b/CBLAS/src/cblas_scasum.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-float cblas_scasum( const int N, const void *X, const int incX)
+float cblas_scasum( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX)
 {
    float asum;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_scnrm2.c
+++ b/CBLAS/src/cblas_scnrm2.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-float cblas_scnrm2( const int N, const void *X, const int incX)
+float cblas_scnrm2( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX)
 {
    float nrm2;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_scopy.c
+++ b/CBLAS/src/cblas_scopy.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_scopy( const int N, const float *X,
-                      const int incX, float *Y, const int incY)
+void cblas_scopy( const CBLAS_INDEX N, const float *X,
+                      const CBLAS_INDEX incX, float *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_sdot.c
+++ b/CBLAS/src/cblas_sdot.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-float cblas_sdot( const int N, const float *X,
-                      const int incX, const float *Y, const int incY)
+float cblas_sdot( const CBLAS_INDEX N, const float *X,
+                      const CBLAS_INDEX incX, const float *Y, const CBLAS_INDEX incY)
 {
    float dot;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_sdsdot.c
+++ b/CBLAS/src/cblas_sdsdot.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-float cblas_sdsdot( const int N, const float alpha, const float *X,
-                      const int incX, const float *Y, const int incY)
+float cblas_sdsdot( const CBLAS_INDEX N, const float alpha, const float *X,
+                      const CBLAS_INDEX incX, const float *Y, const CBLAS_INDEX incY)
 {
    float dot;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_sgbmv.c
+++ b/CBLAS/src/cblas_sgbmv.c
@@ -10,11 +10,11 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_sgbmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU,
-                 const float alpha, const float *A, const int lda,
-                 const float  *X, const int incX, const float beta,
-                 float  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU,
+                 const float alpha, const float *A, const CBLAS_INDEX lda,
+                 const float  *X, const CBLAS_INDEX incX, const float beta,
+                 float  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_sgemm.c
+++ b/CBLAS/src/cblas_sgemm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_sgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const float alpha, const float  *A,
-                 const int lda, const float  *B, const int ldb,
-                 const float beta, float  *C, const int ldc)
+                 const CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const float alpha, const float  *A,
+                 const CBLAS_INDEX lda, const float  *B, const CBLAS_INDEX ldb,
+                 const float beta, float  *C, const CBLAS_INDEX ldc)
 {
    char TA, TB;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_sgemv.c
+++ b/CBLAS/src/cblas_sgemv.c
@@ -9,10 +9,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_sgemv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const float alpha, const float  *A, const int lda,
-                 const float  *X, const int incX, const float beta,
-                 float  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float  *A, const CBLAS_INDEX lda,
+                 const float  *X, const CBLAS_INDEX incX, const float beta,
+                 float  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_sger.c
+++ b/CBLAS/src/cblas_sger.c
@@ -9,9 +9,9 @@
 
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_sger(const CBLAS_LAYOUT layout, const int M, const int N,
-                const float  alpha, const float  *X, const int incX,
-                const float  *Y, const int incY, float  *A, const int lda)
+void cblas_sger(const CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                const float  alpha, const float  *X, const CBLAS_INDEX incX,
+                const float  *Y, const CBLAS_INDEX incY, float  *A, const CBLAS_INDEX lda)
 {
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_snrm2.c
+++ b/CBLAS/src/cblas_snrm2.c
@@ -9,7 +9,7 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-float cblas_snrm2( const int N, const float *X, const int incX)
+float cblas_snrm2( const CBLAS_INDEX N, const float *X, const CBLAS_INDEX incX)
 {
    float nrm2;
 #ifdef F77_INT

--- a/CBLAS/src/cblas_srot.c
+++ b/CBLAS/src/cblas_srot.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_srot( const int N, float *X, const int incX, float *Y,
-                      const int incY, const float  c, const float  s)
+void cblas_srot( const CBLAS_INDEX N, float *X, const CBLAS_INDEX incX, float *Y,
+                      const CBLAS_INDEX incY, const float  c, const float  s)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_srotm.c
+++ b/CBLAS/src/cblas_srotm.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_srotm( const int N, float *X, const int incX, float *Y,
-                       const int incY, const float *P)
+void cblas_srotm( const CBLAS_INDEX N, float *X, const CBLAS_INDEX incX, float *Y,
+                       const CBLAS_INDEX incY, const float *P)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_ssbmv.c
+++ b/CBLAS/src/cblas_ssbmv.c
@@ -9,9 +9,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_ssbmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-           const int N, const int K, const float alpha, const float *A,
-           const int lda, const float *X, const int incX,
-           const float beta, float *Y, const int incY)
+           const CBLAS_INDEX N, const CBLAS_INDEX K, const float alpha, const float *A,
+           const CBLAS_INDEX lda, const float *X, const CBLAS_INDEX incX,
+           const float beta, float *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_sscal.c
+++ b/CBLAS/src/cblas_sscal.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_sscal( const int N, const float alpha, float *X,
-                       const int incX)
+void cblas_sscal( const CBLAS_INDEX N, const float alpha, float *X,
+                       const CBLAS_INDEX incX)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;

--- a/CBLAS/src/cblas_sspmv.c
+++ b/CBLAS/src/cblas_sspmv.c
@@ -9,10 +9,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_sspmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo, const int N,
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX N,
                  const float alpha, const float  *AP,
-                 const float  *X, const int incX, const float beta,
-                 float  *Y, const int incY)
+                 const float  *X, const CBLAS_INDEX incX, const float beta,
+                 float  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_sspr.c
+++ b/CBLAS/src/cblas_sspr.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_sspr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const  float alpha, const float *X,
-                const int incX, float *Ap)
+                const CBLAS_INDEX N, const  float alpha, const float *X,
+                const CBLAS_INDEX incX, float *Ap)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_sspr2.c
+++ b/CBLAS/src/cblas_sspr2.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_sspr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const float  alpha, const float  *X,
-                const int incX, const float  *Y, const int incY, float  *A)
+                const CBLAS_INDEX N, const float  alpha, const float  *X,
+                const CBLAS_INDEX incX, const float  *Y, const CBLAS_INDEX incY, float  *A)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_sswap.c
+++ b/CBLAS/src/cblas_sswap.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_sswap( const int N, float *X, const int incX, float *Y,
-                       const int incY)
+void cblas_sswap( const CBLAS_INDEX N, float *X, const CBLAS_INDEX incX, float *Y,
+                       const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_ssymm.c
+++ b/CBLAS/src/cblas_ssymm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_ssymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
-                 const CBLAS_UPLO Uplo, const int M, const int N,
-                 const float alpha, const float  *A, const int lda,
-                 const float  *B, const int ldb, const float beta,
-                 float  *C, const int ldc)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float  *A, const CBLAS_INDEX lda,
+                 const float  *B, const CBLAS_INDEX ldb, const float beta,
+                 float  *C, const CBLAS_INDEX ldc)
 {
    char SD, UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ssymv.c
+++ b/CBLAS/src/cblas_ssymv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_ssymv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo, const int N,
-                 const float alpha, const float  *A, const int lda,
-                 const float  *X, const int incX, const float beta,
-                 float  *Y, const int incY)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                 const float alpha, const float  *A, const CBLAS_INDEX lda,
+                 const float  *X, const CBLAS_INDEX incX, const float beta,
+                 float  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ssyr.c
+++ b/CBLAS/src/cblas_ssyr.c
@@ -9,8 +9,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_ssyr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const float  alpha, const float  *X,
-                const int incX, float  *A, const int lda)
+                const CBLAS_INDEX N, const float  alpha, const float  *X,
+                const CBLAS_INDEX incX, float  *A, const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ssyr2.c
+++ b/CBLAS/src/cblas_ssyr2.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_ssyr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const float  alpha, const float  *X,
-                const int incX, const float  *Y, const int incY, float  *A,
-                const int lda)
+                const CBLAS_INDEX N, const float  alpha, const float  *X,
+                const CBLAS_INDEX incX, const float  *Y, const CBLAS_INDEX incY, float  *A,
+                const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ssyr2k.c
+++ b/CBLAS/src/cblas_ssyr2k.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_ssyr2k(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const float alpha, const float  *A, const int lda,
-                  const float  *B, const int ldb, const float beta,
-                  float  *C, const int ldc)
+                  const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const float alpha, const float  *A, const CBLAS_INDEX lda,
+                  const float  *B, const CBLAS_INDEX ldb, const float beta,
+                  float  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ssyrk.c
+++ b/CBLAS/src/cblas_ssyrk.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_ssyrk(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const float alpha, const float  *A, const int lda,
-                 const float beta, float  *C, const int ldc)
+                 const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const float alpha, const float  *A, const CBLAS_INDEX lda,
+                 const float beta, float  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_stbmv.c
+++ b/CBLAS/src/cblas_stbmv.c
@@ -9,8 +9,8 @@
 
 void cblas_stbmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const float  *A, const int lda,
-                 float  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const float  *A, const CBLAS_INDEX lda,
+                 float  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_stbsv.c
+++ b/CBLAS/src/cblas_stbsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_stbsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const float  *A, const int lda,
-                 float  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const float  *A, const CBLAS_INDEX lda,
+                 float  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_stpmv.c
+++ b/CBLAS/src/cblas_stpmv.c
@@ -10,7 +10,7 @@
 #include "cblas_f77.h"
 void cblas_stpmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const float  *Ap, float  *X, const int incX)
+                 const CBLAS_INDEX N, const float  *Ap, float  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_stpsv.c
+++ b/CBLAS/src/cblas_stpsv.c
@@ -9,7 +9,7 @@
 #include "cblas_f77.h"
 void cblas_stpsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const float  *Ap, float  *X, const int incX)
+                 const CBLAS_INDEX N, const float  *Ap, float  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;

--- a/CBLAS/src/cblas_strmm.c
+++ b/CBLAS/src/cblas_strmm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_strmm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const  CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 float *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float *A, const CBLAS_INDEX lda,
+                 float *B, const CBLAS_INDEX ldb)
 {
    char UL, TA, SD, DI;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_strmv.c
+++ b/CBLAS/src/cblas_strmv.c
@@ -10,8 +10,8 @@
 #include "cblas_f77.h"
 void cblas_strmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const float  *A, const int lda,
-                 float  *X, const int incX)
+                 const CBLAS_INDEX N, const float  *A, const CBLAS_INDEX lda,
+                 float  *X, const CBLAS_INDEX incX)
 
 {
    char TA;

--- a/CBLAS/src/cblas_strsm.c
+++ b/CBLAS/src/cblas_strsm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_strsm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const float alpha, const float  *A, const int lda,
-                 float  *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const float alpha, const float  *A, const CBLAS_INDEX lda,
+                 float  *B, const CBLAS_INDEX ldb)
 
 {
    char UL, TA, SD, DI;

--- a/CBLAS/src/cblas_strsv.c
+++ b/CBLAS/src/cblas_strsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_strsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const float  *A, const int lda, float  *X,
-                 const int incX)
+                 const CBLAS_INDEX N, const float  *A, const CBLAS_INDEX lda, float  *X,
+                 const CBLAS_INDEX incX)
 
 {
    char TA;

--- a/CBLAS/src/cblas_xerbla.c
+++ b/CBLAS/src/cblas_xerbla.c
@@ -5,7 +5,7 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 
-void cblas_xerbla(int info, const char *rout, const char *form, ...)
+void cblas_xerbla(CBLAS_INDEX info, const char *rout, const char *form, ...)
 {
    extern int RowMajorStrg;
    char empty[1] = "";

--- a/CBLAS/src/cblas_zaxpy.c
+++ b/CBLAS/src/cblas_zaxpy.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zaxpy( const int N, const void *alpha, const void *X,
-                       const int incX, void *Y, const int incY)
+void cblas_zaxpy( const CBLAS_INDEX N, const void *alpha, const void *X,
+                       const CBLAS_INDEX incX, void *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_zcopy.c
+++ b/CBLAS/src/cblas_zcopy.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zcopy( const int N, const void *X,
-                      const int incX, void *Y, const int incY)
+void cblas_zcopy( const CBLAS_INDEX N, const void *X,
+                      const CBLAS_INDEX incX, void *Y, const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_zdotc_sub.c
+++ b/CBLAS/src/cblas_zdotc_sub.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zdotc_sub( const int N, const void *X, const int incX,
-                      const void *Y, const int incY, void *dotc)
+void cblas_zdotc_sub( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                      const void *Y, const CBLAS_INDEX incY, void *dotc)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_zdotu_sub.c
+++ b/CBLAS/src/cblas_zdotu_sub.c
@@ -9,8 +9,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zdotu_sub( const int N, const void *X, const int incX,
-                      const void *Y, const int incY, void *dotu)
+void cblas_zdotu_sub( const CBLAS_INDEX N, const void *X, const CBLAS_INDEX incX,
+                      const void *Y, const CBLAS_INDEX incY, void *dotu)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_zdscal.c
+++ b/CBLAS/src/cblas_zdscal.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zdscal( const int N, const double alpha, void  *X,
-                       const int incX)
+void cblas_zdscal( const CBLAS_INDEX N, const double alpha, void  *X,
+                       const CBLAS_INDEX incX)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;

--- a/CBLAS/src/cblas_zgbmv.c
+++ b/CBLAS/src/cblas_zgbmv.c
@@ -10,11 +10,11 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zgbmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX KL, const CBLAS_INDEX KU,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR
@@ -34,10 +34,10 @@ void cblas_zgbmv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n, i=0, incx=incX;
+   CBLAS_INDEX n, i=0, incx=incX;
    const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
    double ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_zgemm.c
+++ b/CBLAS/src/cblas_zgemm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const void *alpha, const void  *A,
-                 const int lda, const void  *B, const int ldb,
-                 const void *beta, void  *C, const int ldc)
+                 const CBLAS_TRANSPOSE TransB, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const CBLAS_INDEX K, const void *alpha, const void  *A,
+                 const CBLAS_INDEX lda, const void  *B, const CBLAS_INDEX ldb,
+                 const void *beta, void  *C, const CBLAS_INDEX ldc)
 {
    char TA, TB;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_zgemv.c
+++ b/CBLAS/src/cblas_zgemv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zgemv(const CBLAS_LAYOUT layout,
-                 const CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_TRANSPOSE TransA, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char TA;
 #ifdef F77_CHAR
@@ -31,10 +31,10 @@ void cblas_zgemv(const CBLAS_LAYOUT layout,
    #define F77_incY incY
 #endif
 
-   int n, i=0, incx=incX;
+   CBLAS_INDEX n, i=0, incx=incX;
    const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
    double ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_zgerc.c
+++ b/CBLAS/src/cblas_zgerc.c
@@ -9,9 +9,9 @@
 #include <stdlib.h>
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zgerc(const CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda)
+void cblas_zgerc(const CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda)
 {
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
@@ -23,7 +23,7 @@ void cblas_zgerc(const CBLAS_LAYOUT layout, const int M, const int N,
    #define F77_lda lda
 #endif
 
-   int n, i, tincy, incy=incY;
+   CBLAS_INDEX n, i, tincy, incy=incY;
    double *y=(double *)Y, *yy=(double *)Y, *ty, *st;
 
    extern int CBLAS_CallFromC;

--- a/CBLAS/src/cblas_zgeru.c
+++ b/CBLAS/src/cblas_zgeru.c
@@ -7,9 +7,9 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zgeru(const CBLAS_LAYOUT layout, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda)
+void cblas_zgeru(const CBLAS_LAYOUT layout, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda)
 {
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_zhbmv.c
+++ b/CBLAS/src/cblas_zhbmv.c
@@ -10,10 +10,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 void cblas_zhbmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo,const int N,const int K,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_UPLO Uplo,const CBLAS_INDEX N,const CBLAS_INDEX K,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR
@@ -30,10 +30,10 @@ void cblas_zhbmv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n, i=0, incx=incX;
+   CBLAS_INDEX n, i=0, incx=incX;
    const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
    double ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_zhemm.c
+++ b/CBLAS/src/cblas_zhemm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zhemm(const CBLAS_LAYOUT layout, const  CBLAS_SIDE Side,
-                 const CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *B, const CBLAS_INDEX ldb, const void *beta,
+                 void *C, const CBLAS_INDEX ldc)
 {
    char SD, UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_zhemv.c
+++ b/CBLAS/src/cblas_zhemv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zhemv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX N,
+                 const void *alpha, const void *A, const CBLAS_INDEX lda,
+                 const void *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR
@@ -29,10 +29,10 @@ void cblas_zhemv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n, i=0, incx=incX;
+   CBLAS_INDEX n, i=0, incx=incX;
    const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
    double ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_zher.c
+++ b/CBLAS/src/cblas_zher.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zher(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const double alpha, const void *X, const int incX
-                ,void *A, const int lda)
+                const CBLAS_INDEX N, const double alpha, const void *X, const CBLAS_INDEX incX
+                ,void *A, const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR
@@ -27,7 +27,7 @@ void cblas_zher(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incx
 #endif
-   int n, i, tincx, incx=incX;
+   CBLAS_INDEX n, i, tincx, incx=incX;
    double *x=(double *)X, *xx=(double *)X, *tx, *st;
 
    extern int CBLAS_CallFromC;

--- a/CBLAS/src/cblas_zher2.c
+++ b/CBLAS/src/cblas_zher2.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zher2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda)
+                 const CBLAS_INDEX N, const void *alpha, const void *X, const CBLAS_INDEX incX,
+                 const void *Y, const CBLAS_INDEX incY, void *A, const CBLAS_INDEX lda)
 {
    char UL;
 #ifdef F77_CHAR
@@ -28,7 +28,7 @@ void cblas_zher2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   int n, i, j, tincx, tincy, incx=incX, incy=incY;
+   CBLAS_INDEX n, i, j, tincx, tincy, incx=incX, incy=incY;
    double *x=(double *)X, *xx=(double *)X, *y=(double *)Y,
          *yy=(double *)Y, *tx, *ty, *stx, *sty;
 

--- a/CBLAS/src/cblas_zher2k.c
+++ b/CBLAS/src/cblas_zher2k.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zher2k(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const double beta,
-                  void *C, const int ldc)
+                  const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void *A, const CBLAS_INDEX lda,
+                  const void *B, const CBLAS_INDEX ldb, const double beta,
+                  void *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_zherk.c
+++ b/CBLAS/src/cblas_zherk.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zherk(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const double alpha, const void *A, const int lda,
-                 const double beta, void *C, const int ldc)
+                 const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const double alpha, const void *A, const CBLAS_INDEX lda,
+                 const double beta, void *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_zhpmv.c
+++ b/CBLAS/src/cblas_zhpmv.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zhpmv(const CBLAS_LAYOUT layout,
-                 const CBLAS_UPLO Uplo,const int N,
+                 const CBLAS_UPLO Uplo,const CBLAS_INDEX N,
                  const void *alpha, const void  *AP,
-                 const void  *X, const int incX, const void *beta,
-                 void  *Y, const int incY)
+                 const void  *X, const CBLAS_INDEX incX, const void *beta,
+                 void  *Y, const CBLAS_INDEX incY)
 {
    char UL;
 #ifdef F77_CHAR
@@ -28,10 +28,10 @@ void cblas_zhpmv(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   int n, i=0, incx=incX;
+   CBLAS_INDEX n, i=0, incx=incX;
    const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
    double ALPHA[2],BETA[2];
-   int tincY, tincx;
+   CBLAS_INDEX tincY, tincx;
    double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_zhpr.c
+++ b/CBLAS/src/cblas_zhpr.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zhpr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                const int N, const double alpha, const void *X,
-                const int incX, void *A)
+                const CBLAS_INDEX N, const double alpha, const void *X,
+                const CBLAS_INDEX incX, void *A)
 {
    char UL;
 #ifdef F77_CHAR
@@ -26,7 +26,7 @@ void cblas_zhpr(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_N N
    #define F77_incX incx
 #endif
-   int n, i, tincx, incx=incX;
+   CBLAS_INDEX n, i, tincx, incx=incX;
    double *x=(double *)X, *xx=(double *)X, *tx, *st;
 
    extern int CBLAS_CallFromC;

--- a/CBLAS/src/cblas_zhpr2.c
+++ b/CBLAS/src/cblas_zhpr2.c
@@ -10,8 +10,8 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zhpr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                      const int N,const void *alpha, const void *X,
-                      const int incX,const void *Y, const int incY, void *Ap)
+                      const CBLAS_INDEX N,const void *alpha, const void *X,
+                      const CBLAS_INDEX incX,const void *Y, const CBLAS_INDEX incY, void *Ap)
 
 {
    char UL;
@@ -28,7 +28,7 @@ void cblas_zhpr2(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   int n, i, j, incx=incX, incy=incY;
+   CBLAS_INDEX n, i, j, incx=incX, incy=incY;
    double *x=(double *)X, *xx=(double *)X, *y=(double *)Y,
          *yy=(double *)Y, *stx, *sty;
 

--- a/CBLAS/src/cblas_zscal.c
+++ b/CBLAS/src/cblas_zscal.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zscal( const int N, const void *alpha, void *X,
-                       const int incX)
+void cblas_zscal( const CBLAS_INDEX N, const void *alpha, void *X,
+                       const CBLAS_INDEX incX)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;

--- a/CBLAS/src/cblas_zswap.c
+++ b/CBLAS/src/cblas_zswap.c
@@ -8,8 +8,8 @@
  */
 #include "cblas.h"
 #include "cblas_f77.h"
-void cblas_zswap( const int N, void  *X, const int incX, void  *Y,
-                       const int incY)
+void cblas_zswap( const CBLAS_INDEX N, void  *X, const CBLAS_INDEX incX, void  *Y,
+                       const CBLAS_INDEX incY)
 {
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;

--- a/CBLAS/src/cblas_zsymm.c
+++ b/CBLAS/src/cblas_zsymm.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zsymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
-                 const CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 const void  *B, const int ldb, const void *beta,
-                 void  *C, const int ldc)
+                 const CBLAS_UPLO Uplo, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void  *B, const CBLAS_INDEX ldb, const void *beta,
+                 void  *C, const CBLAS_INDEX ldc)
 {
    char SD, UL;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_zsyr2k.c
+++ b/CBLAS/src/cblas_zsyr2k.c
@@ -10,10 +10,10 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zsyr2k(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                  const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void  *A, const int lda,
-                  const void  *B, const int ldb, const void *beta,
-                  void  *C, const int ldc)
+                  const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                  const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                  const void  *B, const CBLAS_INDEX ldb, const void *beta,
+                  void  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_zsyrk.c
+++ b/CBLAS/src/cblas_zsyrk.c
@@ -10,9 +10,9 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 void cblas_zsyrk(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
-                 const CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const void *alpha, const void  *A, const int lda,
-                 const void *beta, void  *C, const int ldc)
+                 const CBLAS_TRANSPOSE Trans, const CBLAS_INDEX N, const CBLAS_INDEX K,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 const void *beta, void  *C, const CBLAS_INDEX ldc)
 {
    char UL, TR;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ztbmv.c
+++ b/CBLAS/src/cblas_ztbmv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ztbmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const void  *A, const int lda,
-                 void  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void  *A, const CBLAS_INDEX lda,
+                 void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -30,7 +30,7 @@ void cblas_ztbmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    double *st=0, *x=(double *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ztbsv.c
+++ b/CBLAS/src/cblas_ztbsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ztbsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const int K, const void  *A, const int lda,
-                 void  *X, const int incX)
+                 const CBLAS_INDEX N, const CBLAS_INDEX K, const void  *A, const CBLAS_INDEX lda,
+                 void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -30,7 +30,7 @@ void cblas_ztbsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    double *st=0,*x=(double *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ztpmv.c
+++ b/CBLAS/src/cblas_ztpmv.c
@@ -9,7 +9,7 @@
 #include "cblas_f77.h"
 void cblas_ztpmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *Ap, void  *X, const int incX)
+                 const CBLAS_INDEX N, const void  *Ap, void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -27,7 +27,7 @@ void cblas_ztpmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_N N
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    double *st=0,*x=(double *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ztpsv.c
+++ b/CBLAS/src/cblas_ztpsv.c
@@ -9,7 +9,7 @@
 #include "cblas_f77.h"
 void cblas_ztpsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *Ap, void  *X, const int incX)
+                 const CBLAS_INDEX N, const void  *Ap, void  *X, const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -27,7 +27,7 @@ void cblas_ztpsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_N N
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    double *st=0, *x=(double*)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ztrmm.c
+++ b/CBLAS/src/cblas_ztrmm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_ztrmm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const  CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 void  *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 void  *B, const CBLAS_INDEX ldb)
 {
    char UL, TA, SD, DI;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ztrmv.c
+++ b/CBLAS/src/cblas_ztrmv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ztrmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *A, const int lda,
-                 void  *X, const int incX)
+                 const CBLAS_INDEX N, const void  *A, const CBLAS_INDEX lda,
+                 void  *X, const CBLAS_INDEX incX)
 
 {
    char TA;
@@ -30,7 +30,7 @@ void cblas_ztrmv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    double *st=0,*x=(double *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/src/cblas_ztrsm.c
+++ b/CBLAS/src/cblas_ztrsm.c
@@ -11,9 +11,9 @@
 #include "cblas_f77.h"
 void cblas_ztrsm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side,
                  const CBLAS_UPLO Uplo, const CBLAS_TRANSPOSE TransA,
-                 const CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void  *A, const int lda,
-                 void  *B, const int ldb)
+                 const CBLAS_DIAG Diag, const CBLAS_INDEX M, const CBLAS_INDEX N,
+                 const void *alpha, const void  *A, const CBLAS_INDEX lda,
+                 void  *B, const CBLAS_INDEX ldb)
 {
    char UL, TA, SD, DI;
 #ifdef F77_CHAR

--- a/CBLAS/src/cblas_ztrsv.c
+++ b/CBLAS/src/cblas_ztrsv.c
@@ -9,8 +9,8 @@
 #include "cblas_f77.h"
 void cblas_ztrsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
                  const CBLAS_TRANSPOSE TransA, const CBLAS_DIAG Diag,
-                 const int N, const void  *A, const int lda, void  *X,
-                 const int incX)
+                 const CBLAS_INDEX N, const void  *A, const CBLAS_INDEX lda, void  *X,
+                 const CBLAS_INDEX incX)
 {
    char TA;
    char UL;
@@ -29,7 +29,7 @@ void cblas_ztrsv(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    #define F77_lda lda
    #define F77_incX incX
 #endif
-   int n, i=0, tincX;
+   CBLAS_INDEX n, i=0, tincX;
    double *st=0,*x=(double *)X;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -5,7 +5,7 @@
 #include "cblas.h"
 #include "cblas_test.h"
 
-void cblas_xerbla(int info, const char *rout, const char *form, ...)
+void cblas_xerbla(CBLAS_INDEX info, const char *rout, const char *form, ...)
 {
    extern int cblas_lerr, cblas_info, cblas_ok;
    extern int link_xerbla;


### PR DESCRIPTION
changes all function signatures to use CBLAS_INDEX
also fixes internal variables to be CBLAS_INDEX
all tests are passing

---

A lot of the optimized implementations are providing an implementation for CBLAS64
It is good to have the reference implementation also providing this, as we already have the 64 bit libraries for others.

I've followed your standard syntax rules from other files.
The variable name used is the standard CBLAS_INDEX which should keep it compatible with all other files.

Would be **really** awesome to finally have this reference implementation :heart: 

Thanks a lot,
Aisha