### PR TITLE
add pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'Type: Bug'
+assignees: ''
+
+---
+
+# 1. Bug description
+
+A description of the bug: what is the expected behaviour? What is the actual behaviour?
+
+# 2. Reproduction
+
+Try to provide as much information to reproduce the bug as possible. If possible, also include a minimal example that we can use reproduce the bug.
+
+# 3. Fix
+
+(Optional) Do you have any suggestions of how to fix the issue? Are you willing to make a PR to fix this issue?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,15 +6,9 @@ labels: 'Type: Bug'
 assignees: ''
 
 ---
+**Description**
 
-# 1. Bug description
+**Checklist**
 
-A description of the bug: what is the expected behaviour? What is the actual behaviour?
-
-# 2. Reproduction
-
-Try to provide as much information to reproduce the bug as possible. If possible, also include a minimal example that we can use reproduce the bug.
-
-# 3. Fix
-
-(Optional) Do you have any suggestions of how to fix the issue? Are you willing to make a PR to fix this issue?
+- [ ] I've included a minimal example to reproduce the issue
+- [ ] I'd be willing to make a PR to solve this issue

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,15 +6,3 @@ labels: 'Type: Feature request'
 assignees: ''
 
 ---
-
-# 1. Description of the feature
-
-A description of the bug: what is the expected behaviour? What is the actual behaviour?
-
-# 2. Why would it be beneficial
-
-Try to provide as much information to reproduce the bug as possible. If possible, also include a minimal example that we can use reproduce the bug.
-
-# 3. Implementation
-
-(Optional) Are you willing to implement (part) of this feature yourself?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Request a feature
+title: ''
+labels: 'Type: Feature request'
+assignees: ''
+
+---
+
+# 1. Description of the feature
+
+A description of the bug: what is the expected behaviour? What is the actual behaviour?
+
+# 2. Why would it be beneficial
+
+Try to provide as much information to reproduce the bug as possible. If possible, also include a minimal example that we can use reproduce the bug.
+
+# 3. Implementation
+
+(Optional) Are you willing to implement (part) of this feature yourself?

--- a/.github/ISSUE_TEMPLATE/help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/help_wanted.md
@@ -1,0 +1,16 @@
+---
+name: Question
+about: Ask a question related to the use of the package
+title: ''
+labels: 'Type: Question'
+assignees: ''
+
+---
+
+# 1. The question
+
+A description of the bug: what is the expected behaviour? What is the actual behaviour?
+
+# 2. Your environment
+
+If you have a problem calling a LAPACK function we can usually help you faster if we know something about your environment. What programming language do you use? How do you compile and link your code?

--- a/.github/ISSUE_TEMPLATE/help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/help_wanted.md
@@ -6,11 +6,3 @@ labels: 'Type: Question'
 assignees: ''
 
 ---
-
-# 1. The question
-
-A description of the bug: what is the expected behaviour? What is the actual behaviour?
-
-# 2. Your environment
-
-If you have a problem calling a LAPACK function we can usually help you faster if we know something about your environment. What programming language do you use? How do you compile and link your code?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+**Short description**
+
+Short description of the problem or link to related issue on github.
+
+**Technical description**
+
+(Optional) Description of the changes and why they work. For larger PR's, this might include a link to a scientific paper/LAWN.
+
+**Checklist**
+
+- [ ] The documententation has been updated
+- [ ] The tests have been updated
+- [ ] The changes have been applied to all the relevant precisions
+- [ ] If the PR solves a specific issue, it is set to be closed on merge.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,6 @@
-**Short description**
-
-Short description of the problem or link to related issue on github.
-
-**Technical description**
-
-(Optional) Description of the changes and why they work. For larger PR's, this might include a link to a scientific paper/LAWN.
+**Description**
 
 **Checklist**
 
 - [ ] The documententation has been updated
-- [ ] The tests have been updated
-- [ ] The changes have been applied to all the relevant precisions
 - [ ] If the PR solves a specific issue, it is set to be closed on merge.


### PR DESCRIPTION
Inspired by issue #450 I thought it might be a good idea to start using a pretty nice feature: issue templates:

This PR adds a few templates that will be used when creating a new PR or issue on Github.
I think this might improve the quality of the reported issues and help us sort through them (by adding labels automatically).
When creating a new issue, users should now be offered a selection of templates.

Disclaimer, i'm not an expert with github, but have used this feature on other repositories. I think adding the templates to a .github folder does the trick, but some additional configuration might be required.