### PR TITLE
fix osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,11 @@ matrix:
   - os: linux
     env: CMAKE_BUILD_TYPE=Coverage
   - os: osx
+    osx_image: xcode10.3
     env: CMAKE_BUILD_TYPE=Release
-    before_install:
-    - brew update > /dev/null
-    - brew upgrade gcc > /dev/null
   - os: osx
+    osx_image: xcode10.3
     env: CMAKE_BUILD_TYPE=Coverage
-    before_install:
-    - brew update > /dev/null
-    - brew upgrade gcc > /dev/null
 
 script:
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ matrix:
   - os: osx
     osx_image: xcode10.3
     env: CMAKE_BUILD_TYPE=Release
-  - os: osx
-    osx_image: xcode10.3
-    env: CMAKE_BUILD_TYPE=Coverage
 
 script:
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST


### PR DESCRIPTION
Currently, the osx travis builds fail because of the way gcc10 is installed (brew update, upgrade) (see https://github.com/Homebrew/discussions/discussions/226). Instead of using homebrew, we could edit the osx image to `osx_image: xcode10.3`, which should include gcc10, avoiding the issue.

Disclaimer: I'm not an export on CI's, hope this works.