### PR TITLE
CMake: Bump minimum version to 3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.2)
 
 project(LAPACK Fortran C)
 

--- a/INSTALL/CMakeLists.txt
+++ b/INSTALL/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.2)
 project(TIMING Fortran)
 add_executable(secondtst_NONE second_NONE.f secondtst.f)
 add_executable(secondtst_EXT_ETIME second_EXT_ETIME.f secondtst.f)

--- a/LAPACKE/mangling/CMakeLists.txt
+++ b/LAPACKE/mangling/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.2)
 project(MANGLING C Fortran)
 
 add_executable(xintface Fintface.f Cintface.c)

--- a/lapack_build.cmake
+++ b/lapack_build.cmake
@@ -4,7 +4,7 @@
 ## HINTS: ctest -Ddashboard_model=Nightly      -S $(pwd)/lapack/lapack_build.cmake
 ##
 
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.2)
 ###################################################################
 # The values in this section must always be provided
 ###################################################################


### PR DESCRIPTION
Newer cmake issues a warning when required version is < 3.
Version 3.2 should be old enough (eg ubuntu 16.04 has version 3.5).