### PR TITLE
improve exceptional shift in xlahqr

### DIFF
--- a/SRC/clahqr.f
+++ b/SRC/clahqr.f
@@ -194,6 +194,7 @@
 *  =====================================================================
       SUBROUTINE CLAHQR( WANTT, WANTZ, N, ILO, IHI, H, LDH, W, ILOZ,
      $                   IHIZ, Z, LDZ, INFO )
+      IMPLICIT NONE
 *
 *  -- LAPACK auxiliary routine (version 3.7.0) --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -317,9 +318,9 @@
 *
       ITMAX = 30 * MAX( 10, NH )
 *
-*     KDFL counts the number of iterations since a deflation
+*     KDEFL counts the number of iterations since a deflation
 *
-      KDFL = -2
+      KDEFL = -2
 *
 *     The main loop begins here. I is the loop index and decreases from
 *     IHI to ILO in steps of 1. Each iteration of the loop works
@@ -564,7 +565,7 @@
 *
       W( I ) = H( I, I )
 *     reset deflation counter
-      KDFL = 0
+      KDEFL = 0
 *
 *     return to start of the main loop with new value of I.
 *

--- a/SRC/clahqr.f
+++ b/SRC/clahqr.f
@@ -218,6 +218,8 @@
       PARAMETER          ( RZERO = 0.0e0, RONE = 1.0e0, HALF = 0.5e0 )
       REAL               DAT1
       PARAMETER          ( DAT1 = 3.0e0 / 4.0e0 )
+      INTEGER            KEXSH
+      PARAMETER          ( KEXSH = 6 )
 *     ..
 *     .. Local Scalars ..
       COMPLEX            CDUM, H11, H11S, H22, SC, SUM, T, T1, TEMP, U,
@@ -225,7 +227,7 @@
       REAL               AA, AB, BA, BB, H10, H21, RTEMP, S, SAFMAX,
      $                   SAFMIN, SMLNUM, SX, T2, TST, ULP
       INTEGER            I, I1, I2, ITS, ITMAX, J, JHI, JLO, K, L, M,
-     $                   NH, NZ
+     $                   NH, NZ, KDEFL
 *     ..
 *     .. Local Arrays ..
       COMPLEX            V( 2 )
@@ -315,6 +317,10 @@
 *
       ITMAX = 30 * MAX( 10, NH )
 *
+*     KDFL counts the number of iterations since a deflation
+*
+      KDFL = -2
+*
 *     The main loop begins here. I is the loop index and decreases from
 *     IHI to ILO in steps of 1. Each iteration of the loop works
 *     with the active submatrix in rows and columns L to I.
@@ -374,6 +380,7 @@
 *
          IF( L.GE.I )
      $      GO TO 140
+         KDEFL = KDEFL + 1
 *
 *        Now the active submatrix is in rows and columns L to I. If
 *        eigenvalues only are being computed, only the active submatrix
@@ -384,18 +391,18 @@
             I2 = I
          END IF
 *
-         IF( ITS.EQ.10 ) THEN
-*
-*           Exceptional shift.
-*
-            S = DAT1*ABS( REAL( H( L+1, L ) ) )
-            T = S + H( L, L )
-         ELSE IF( ITS.EQ.20 ) THEN
+         IF( MOD(KDEFL,2*KEXSH).EQ.0 ) THEN
 *
 *           Exceptional shift.
 *
             S = DAT1*ABS( REAL( H( I, I-1 ) ) )
             T = S + H( I, I )
+         ELSE IF( MOD(KDEFL,KEXSH).EQ.0 ) THEN
+*
+*           Exceptional shift.
+*
+            S = DAT1*ABS( REAL( H( L+1, L ) ) )
+            T = S + H( L, L )
          ELSE
 *
 *           Wilkinson's shift.
@@ -556,6 +563,8 @@
 *     H(I,I-1) is negligible: one eigenvalue has converged.
 *
       W( I ) = H( I, I )
+*     reset deflation counter
+      KDFL = 0
 *
 *     return to start of the main loop with new value of I.
 *

--- a/SRC/dlahqr.f
+++ b/SRC/dlahqr.f
@@ -206,6 +206,7 @@
 *  =====================================================================
       SUBROUTINE DLAHQR( WANTT, WANTZ, N, ILO, IHI, H, LDH, WR, WI,
      $                   ILOZ, IHIZ, Z, LDZ, INFO )
+      IMPLICIT NONE
 *
 *  -- LAPACK auxiliary routine (version 3.7.0) --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -297,9 +298,9 @@
 *
       ITMAX = 30 * MAX( 10, NH )
 *
-*     KDFL counts the number of iterations since a deflation
+*     KDEFL counts the number of iterations since a deflation
 *
-      KDFL = -2
+      KDEFL = -2
 *
 *     The main loop begins here. I is the loop index and decreases from
 *     IHI to ILO in steps of 1 or 2. Each iteration of the loop works
@@ -608,7 +609,7 @@
          END IF
       END IF
 *     reset deflation counter
-      KDFL = 0
+      KDEFL = 0
 *
 *     return to start of the main loop with new value of I.
 *

--- a/SRC/slahqr.f
+++ b/SRC/slahqr.f
@@ -227,13 +227,16 @@
       PARAMETER          ( ZERO = 0.0e0, ONE = 1.0e0, TWO = 2.0e0 )
       REAL               DAT1, DAT2
       PARAMETER          ( DAT1 = 3.0e0 / 4.0e0, DAT2 = -0.4375e0 )
+      INTEGER            KEXSH
+      PARAMETER          ( KEXSH = 6 )
 *     ..
 *     .. Local Scalars ..
       REAL               AA, AB, BA, BB, CS, DET, H11, H12, H21, H21S,
      $                   H22, RT1I, RT1R, RT2I, RT2R, RTDISC, S, SAFMAX,
      $                   SAFMIN, SMLNUM, SN, SUM, T1, T2, T3, TR, TST,
      $                   ULP, V2, V3
-      INTEGER            I, I1, I2, ITS, ITMAX, J, K, L, M, NH, NR, NZ
+      INTEGER            I, I1, I2, ITS, ITMAX, J, K, L, M, NH, NR, NZ,
+     $                   KDEFL
 *     ..
 *     .. Local Arrays ..
       REAL               V( 3 )
@@ -294,6 +297,10 @@
 *
       ITMAX = 30 * MAX( 10, NH )
 *
+*     KDFL counts the number of iterations since a deflation
+*
+      KDFL = -2
+*
 *     The main loop begins here. I is the loop index and decreases from
 *     IHI to ILO in steps of 1 or 2. Each iteration of the loop works
 *     with the active submatrix in rows and columns L to I.
@@ -353,6 +360,7 @@
 *
          IF( L.GE.I-1 )
      $      GO TO 150
+         KDEFL = KDEFL + 1
 *
 *        Now the active submatrix is in rows and columns L to I. If
 *        eigenvalues only are being computed, only the active submatrix
@@ -363,16 +371,7 @@
             I2 = I
          END IF
 *
-         IF( ITS.EQ.10 ) THEN
-*
-*           Exceptional shift.
-*
-            S = ABS( H( L+1, L ) ) + ABS( H( L+2, L+1 ) )
-            H11 = DAT1*S + H( L, L )
-            H12 = DAT2*S
-            H21 = S
-            H22 = H11
-         ELSE IF( ITS.EQ.20 ) THEN
+         IF( MOD(KDEFL,2*KEXSH).EQ.0 ) THEN
 *
 *           Exceptional shift.
 *
@@ -381,7 +380,15 @@
             H12 = DAT2*S
             H21 = S
             H22 = H11
-         ELSE
+         ELSE IF( MOD(KDEFL,KEXSH).EQ.0 ) THEN
+*
+*           Exceptional shift.
+*
+            S = ABS( H( L+1, L ) ) + ABS( H( L+2, L+1 ) )
+            H11 = DAT1*S + H( L, L )
+            H12 = DAT2*S
+            H21 = S
+            H22 = H11
 *
 *           Prepare to use Francis' double shift
 *           (i.e. 2nd degree generalized Rayleigh quotient)
@@ -599,6 +606,8 @@
             CALL SROT( NZ, Z( ILOZ, I-1 ), 1, Z( ILOZ, I ), 1, CS, SN )
          END IF
       END IF
+*     reset deflation counter
+      KDFL = 0
 *
 *     return to start of the main loop with new value of I.
 *

--- a/SRC/slahqr.f
+++ b/SRC/slahqr.f
@@ -206,6 +206,7 @@
 *  =====================================================================
       SUBROUTINE SLAHQR( WANTT, WANTZ, N, ILO, IHI, H, LDH, WR, WI,
      $                   ILOZ, IHIZ, Z, LDZ, INFO )
+      IMPLICIT NONE
 *
 *  -- LAPACK auxiliary routine (version 3.7.0) --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -297,9 +298,9 @@
 *
       ITMAX = 30 * MAX( 10, NH )
 *
-*     KDFL counts the number of iterations since a deflation
+*     KDEFL counts the number of iterations since a deflation
 *
-      KDFL = -2
+      KDEFL = -2
 *
 *     The main loop begins here. I is the loop index and decreases from
 *     IHI to ILO in steps of 1 or 2. Each iteration of the loop works
@@ -607,7 +608,7 @@
          END IF
       END IF
 *     reset deflation counter
-      KDFL = 0
+      KDEFL = 0
 *
 *     return to start of the main loop with new value of I.
 *

--- a/SRC/zlahqr.f
+++ b/SRC/zlahqr.f
@@ -218,6 +218,8 @@
       PARAMETER          ( RZERO = 0.0d0, RONE = 1.0d0, HALF = 0.5d0 )
       DOUBLE PRECISION   DAT1
       PARAMETER          ( DAT1 = 3.0d0 / 4.0d0 )
+      INTEGER            KEXSH
+      PARAMETER          ( KEXSH = 6 )
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16         CDUM, H11, H11S, H22, SC, SUM, T, T1, TEMP, U,
@@ -225,7 +227,7 @@
       DOUBLE PRECISION   AA, AB, BA, BB, H10, H21, RTEMP, S, SAFMAX,
      $                   SAFMIN, SMLNUM, SX, T2, TST, ULP
       INTEGER            I, I1, I2, ITS, ITMAX, J, JHI, JLO, K, L, M,
-     $                   NH, NZ
+     $                   NH, NZ, KDEFL
 *     ..
 *     .. Local Arrays ..
       COMPLEX*16         V( 2 )
@@ -315,6 +317,10 @@
 *
       ITMAX = 30 * MAX( 10, NH )
 *
+*     KDFL counts the number of iterations since a deflation
+*
+      KDFL = -2
+*
 *     The main loop begins here. I is the loop index and decreases from
 *     IHI to ILO in steps of 1. Each iteration of the loop works
 *     with the active submatrix in rows and columns L to I.
@@ -374,6 +380,7 @@
 *
          IF( L.GE.I )
      $      GO TO 140
+         KDEFL = KDEFL + 1
 *
 *        Now the active submatrix is in rows and columns L to I. If
 *        eigenvalues only are being computed, only the active submatrix
@@ -384,18 +391,18 @@
             I2 = I
          END IF
 *
-         IF( ITS.EQ.10 ) THEN
-*
-*           Exceptional shift.
-*
-            S = DAT1*ABS( DBLE( H( L+1, L ) ) )
-            T = S + H( L, L )
-         ELSE IF( ITS.EQ.20 ) THEN
+         IF( MOD(KDEFL,2*KEXSH).EQ.0 ) THEN
 *
 *           Exceptional shift.
 *
             S = DAT1*ABS( DBLE( H( I, I-1 ) ) )
             T = S + H( I, I )
+         ELSE IF( MOD(KDEFL,KEXSH).EQ.0 ) THEN
+*
+*           Exceptional shift.
+*
+            S = DAT1*ABS( DBLE( H( L+1, L ) ) )
+            T = S + H( L, L )
          ELSE
 *
 *           Wilkinson's shift.
@@ -557,6 +564,8 @@
 *     H(I,I-1) is negligible: one eigenvalue has converged.
 *
       W( I ) = H( I, I )
+*     reset deflation counter
+      KDFL = 0
 *
 *     return to start of the main loop with new value of I.
 *

--- a/SRC/zlahqr.f
+++ b/SRC/zlahqr.f
@@ -194,6 +194,7 @@
 *  =====================================================================
       SUBROUTINE ZLAHQR( WANTT, WANTZ, N, ILO, IHI, H, LDH, W, ILOZ,
      $                   IHIZ, Z, LDZ, INFO )
+      IMPLICIT NONE
 *
 *  -- LAPACK auxiliary routine (version 3.7.0) --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -317,9 +318,9 @@
 *
       ITMAX = 30 * MAX( 10, NH )
 *
-*     KDFL counts the number of iterations since a deflation
+*     KDEFL counts the number of iterations since a deflation
 *
-      KDFL = -2
+      KDEFL = -2
 *
 *     The main loop begins here. I is the loop index and decreases from
 *     IHI to ILO in steps of 1. Each iteration of the loop works
@@ -565,7 +566,7 @@
 *
       W( I ) = H( I, I )
 *     reset deflation counter
-      KDFL = 0
+      KDEFL = 0
 *
 *     return to start of the main loop with new value of I.
 *


### PR DESCRIPTION
While working on the exceptional shift strategy in QZ, i noticed something weird about the exceptional shifts in `xlahqr`.

In that routine, an exceptional shift is used when `ITS` is either 10 or 20. But `ITS` is the iteration counter! So we will be using an exceptional shift whether we get convergence or not. And even worse, if we get stagnation after those first 20 iterations, no further exceptional shifts will be used.

This PR fixes that by counting the number of iterations since the last deflation and basing the exceptional shifts based on that. I also went ahead and lowered the number of required iterations to 6, with an initial requirement of 8 to account for the typical slow startup of the QR algorithm.