### PR TITLE
xUNHR_COL01: pass required complex-valued argument

### DIFF
--- a/TESTING/LIN/cunhr_col01.f
+++ b/TESTING/LIN/cunhr_col01.f
@@ -313,7 +313,7 @@
 *     TEST 2
 *     Compute |I - (Q**H)*Q| / ( eps * m ) and store in RESULT(2)
 *
-      CALL CLASET( 'Full', M, M, ZERO, CONE, R, M )
+      CALL CLASET( 'Full', M, M, CZERO, CONE, R, M )
       CALL CHERK( 'U', 'C', M, M, -CONE, Q, M, CONE, R, M )
       RESID = CLANSY( '1', 'Upper', M, R, M, RWORK )
       RESULT( 2 ) = RESID / ( EPS * MAX( 1, M ) )

--- a/TESTING/LIN/zunhr_col01.f
+++ b/TESTING/LIN/zunhr_col01.f
@@ -313,7 +313,7 @@
 *     TEST 2
 *     Compute |I - (Q**H)*Q| / ( eps * m ) and store in RESULT(2)
 *
-      CALL ZLASET( 'Full', M, M, ZERO, CONE, R, M )
+      CALL ZLASET( 'Full', M, M, CZERO, CONE, R, M )
       CALL ZHERK( 'U', 'C', M, M, -CONE, Q, M, CONE, R, M )
       RESID = ZLANSY( '1', 'Upper', M, R, M, RWORK )
       RESULT( 2 ) = RESID / ( EPS * MAX( 1, M ) )


### PR DESCRIPTION
This issue was detected by gfortran 10.2 on Fedora 33 (amd64).