### PR TITLE
Add versioning to matrix generator library

### DIFF
--- a/TESTING/MATGEN/CMakeLists.txt
+++ b/TESTING/MATGEN/CMakeLists.txt
@@ -48,5 +48,12 @@ endif()
 list(REMOVE_DUPLICATES SOURCES)
 
 add_library(${TMGLIB} ${SOURCES})
+
+set_target_properties(
+  ${TMGLIB} PROPERTIES
+  VERSION ${LAPACK_VERSION}
+  SOVERSION ${LAPACK_MAJOR_VERSION}
+)
+
 target_link_libraries(${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 lapack_install_library(${TMGLIB})


### PR DESCRIPTION
This pull request adds versioning to the matrix generator library. tmglib was the only CMake library without versioning information and there were previous requests to version this library, e.g., in commit 9e33d337c92728e96bfb7fb7b1b9c157f0acd735 / PR #218.