### PR TITLE
improve deflation criterion in xhgeqz

### DIFF
--- a/SRC/chgeqz.f
+++ b/SRC/chgeqz.f
@@ -518,13 +518,17 @@
          IF( ILAST.EQ.ILO ) THEN
             GO TO 60
          ELSE
-            IF( ABS1( H( ILAST, ILAST-1 ) ).LE.ATOL ) THEN
+            IF( ABS1( H( ILAST, ILAST-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS1( H( ILAST, ILAST ) ) + ABS1( H( ILAST-1, ILAST-1 ) 
+     $         ) ) ) ) THEN
                H( ILAST, ILAST-1 ) = CZERO
                GO TO 60
             END IF
          END IF
 *
-         IF( ABS( T( ILAST, ILAST ) ).LE.BTOL ) THEN
+         IF( ABS( T( ILAST, ILAST ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( T( ILAST - 1, ILAST ) ) + ABS( T( ILAST-1, ILAST-1 )
+     $          ) ) ) ) THEN
             T( ILAST, ILAST ) = CZERO
             GO TO 50
          END IF
@@ -538,7 +542,9 @@
             IF( J.EQ.ILO ) THEN
                ILAZRO = .TRUE.
             ELSE
-               IF( ABS1( H( J, J-1 ) ).LE.ATOL ) THEN
+               IF( ABS1( H( J, J-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $            ABS1( H( J, J ) ) + ABS1( H( J-1, J-1 ) ) 
+     $            ) ) ) THEN
                   H( J, J-1 ) = CZERO
                   ILAZRO = .TRUE.
                ELSE
@@ -548,7 +554,10 @@
 *
 *           Test 2: for T(j,j)=0
 *
-            IF( ABS( T( J, J ) ).LT.BTOL ) THEN
+            TEMP = ABS ( T( J, J + 1 ) )
+            IF ( J .GT. ILO )
+     $           TEMP = TEMP + ABS ( T( J - 1, J ) )
+            IF( ABS( T( J, J ) ).LT.MAX( SAFMIN,ULP*TEMP ) ) THEN
                T( J, J ) = CZERO
 *
 *              Test 1a: Check for 2 consecutive small subdiagonals in A

--- a/SRC/dhgeqz.f
+++ b/SRC/dhgeqz.f
@@ -531,13 +531,17 @@
 *
             GO TO 80
          ELSE
-            IF( ABS( H( ILAST, ILAST-1 ) ).LE.ATOL ) THEN
+            IF( ABS( H( ILAST, ILAST-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( H( ILAST, ILAST ) ) + ABS( H( ILAST-1, ILAST-1 ) ) 
+     $         ) ) ) THEN
                H( ILAST, ILAST-1 ) = ZERO
                GO TO 80
             END IF
          END IF
 *
-         IF( ABS( T( ILAST, ILAST ) ).LE.BTOL ) THEN
+         IF( ABS( T( ILAST, ILAST ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( T( ILAST - 1, ILAST ) ) + ABS( T( ILAST-1, ILAST-1 )
+     $          ) ) ) ) THEN
             T( ILAST, ILAST ) = ZERO
             GO TO 70
          END IF
@@ -551,7 +555,9 @@
             IF( J.EQ.ILO ) THEN
                ILAZRO = .TRUE.
             ELSE
-               IF( ABS( H( J, J-1 ) ).LE.ATOL ) THEN
+               IF( ABS( H( J, J-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( H( J, J ) ) + ABS( H( J-1, J-1 ) ) 
+     $         ) ) ) THEN
                   H( J, J-1 ) = ZERO
                   ILAZRO = .TRUE.
                ELSE
@@ -561,7 +567,10 @@
 *
 *           Test 2: for T(j,j)=0
 *
-            IF( ABS( T( J, J ) ).LT.BTOL ) THEN
+            TEMP = ABS ( T( J, J + 1 ) )
+            IF ( J .GT. ILO )
+     $           TEMP = TEMP + ABS ( T( J - 1, J ) )
+            IF( ABS( T( J, J ) ).LT.MAX( SAFMIN,ULP*TEMP ) ) THEN
                T( J, J ) = ZERO
 *
 *              Test 1a: Check for 2 consecutive small subdiagonals in A

--- a/SRC/shgeqz.f
+++ b/SRC/shgeqz.f
@@ -531,13 +531,17 @@
 *
             GO TO 80
          ELSE
-            IF( ABS( H( ILAST, ILAST-1 ) ).LE.ATOL ) THEN
+            IF( ABS( H( ILAST, ILAST-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( H( ILAST, ILAST ) ) + ABS( H( ILAST-1, ILAST-1 ) ) 
+     $         ) ) ) THEN
                H( ILAST, ILAST-1 ) = ZERO
                GO TO 80
             END IF
          END IF
 *
-         IF( ABS( T( ILAST, ILAST ) ).LE.BTOL ) THEN
+         IF( ABS( T( ILAST, ILAST ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( T( ILAST - 1, ILAST ) ) + ABS( T( ILAST-1, ILAST-1 )
+     $          ) ) ) ) THEN
             T( ILAST, ILAST ) = ZERO
             GO TO 70
          END IF
@@ -551,7 +555,9 @@
             IF( J.EQ.ILO ) THEN
                ILAZRO = .TRUE.
             ELSE
-               IF( ABS( H( J, J-1 ) ).LE.ATOL ) THEN
+               IF( ABS( H( J, J-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( H( J, J ) ) + ABS( H( J-1, J-1 ) ) 
+     $         ) ) ) THEN
                   H( J, J-1 ) = ZERO
                   ILAZRO = .TRUE.
                ELSE
@@ -561,7 +567,10 @@
 *
 *           Test 2: for T(j,j)=0
 *
-            IF( ABS( T( J, J ) ).LT.BTOL ) THEN
+            TEMP = ABS ( T( J, J + 1 ) )
+            IF ( J .GT. ILO )
+     $           TEMP = TEMP + ABS ( T( J - 1, J ) )
+            IF( ABS( T( J, J ) ).LT.MAX( SAFMIN,ULP*TEMP ) ) THEN
                T( J, J ) = ZERO
 *
 *              Test 1a: Check for 2 consecutive small subdiagonals in A

--- a/SRC/zhgeqz.f
+++ b/SRC/zhgeqz.f
@@ -519,13 +519,17 @@
          IF( ILAST.EQ.ILO ) THEN
             GO TO 60
          ELSE
-            IF( ABS1( H( ILAST, ILAST-1 ) ).LE.ATOL ) THEN
+            IF( ABS1( H( ILAST, ILAST-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS1( H( ILAST, ILAST ) ) + ABS1( H( ILAST-1, ILAST-1 ) 
+     $         ) ) ) ) THEN
                H( ILAST, ILAST-1 ) = CZERO
                GO TO 60
             END IF
          END IF
 *
-         IF( ABS( T( ILAST, ILAST ) ).LE.BTOL ) THEN
+         IF( ABS( T( ILAST, ILAST ) ).LE.MAX( SAFMIN, ULP*( 
+     $         ABS( T( ILAST - 1, ILAST ) ) + ABS( T( ILAST-1, ILAST-1 )
+     $          ) ) ) ) THEN
             T( ILAST, ILAST ) = CZERO
             GO TO 50
          END IF
@@ -539,7 +543,9 @@
             IF( J.EQ.ILO ) THEN
                ILAZRO = .TRUE.
             ELSE
-               IF( ABS1( H( J, J-1 ) ).LE.ATOL ) THEN
+               IF( ABS1( H( J, J-1 ) ).LE.MAX( SAFMIN, ULP*( 
+     $            ABS1( H( J, J ) ) + ABS1( H( J-1, J-1 ) ) 
+     $            ) ) ) THEN
                   H( J, J-1 ) = CZERO
                   ILAZRO = .TRUE.
                ELSE
@@ -549,7 +555,10 @@
 *
 *           Test 2: for T(j,j)=0
 *
-            IF( ABS( T( J, J ) ).LT.BTOL ) THEN
+            TEMP = ABS ( T( J, J + 1 ) )
+            IF ( J .GT. ILO )
+     $           TEMP = TEMP + ABS ( T( J - 1, J ) )
+            IF( ABS( T( J, J ) ).LT.MAX( SAFMIN,ULP*TEMP ) ) THEN
                T( J, J ) = CZERO
 *
 *              Test 1a: Check for 2 consecutive small subdiagonals in A


### PR DESCRIPTION
This PR replaces the normwise deflation in xhgeqz with elementwise deflation. Split from my other PR at the request of @langou 
This is stricter than normwise deflation because the sum of the diagonals is always going to be smaller than the frobenius norm.
This also matches the criterion from my multishift QZ implementation.

Small note: This is less strict than the deflation in the QR algorithm, because there, both the smaller-than-diagonal criterion and the stricter criterion by Françoise Tisseur must be satisfied. This is a step in the right though.