### PR TITLE
Fix Incorrect INFO value from SLASQ2 and DLASQ2

### DIFF
--- a/SRC/dlasq2.f
+++ b/SRC/dlasq2.f
@@ -184,10 +184,18 @@
 *
 *        2-by-2 case.
 *
-         IF( Z( 2 ).LT.ZERO .OR. Z( 3 ).LT.ZERO ) THEN
-            INFO = -2
+         IF( Z( 1 ).LT.ZERO ) THEN
+            INFO = -201
             CALL XERBLA( 'DLASQ2', 2 )
             RETURN
+         ELSE IF( Z( 2 ).LT.ZERO ) THEN
+            INFO = -202
+            CALL XERBLA( 'DLASQ2', 2 )
+            RETURN
+         ELSE IF( Z( 3 ).LT.ZERO ) THEN
+           INFO = -203
+           CALL XERBLA( 'DLASQ2', 2 )
+           RETURN
          ELSE IF( Z( 3 ).GT.Z( 1 ) ) THEN
             D = Z( 3 )
             Z( 3 ) = Z( 1 )

--- a/SRC/slasq2.f
+++ b/SRC/slasq2.f
@@ -183,10 +183,18 @@
 *
 *        2-by-2 case.
 *
-         IF( Z( 2 ).LT.ZERO .OR. Z( 3 ).LT.ZERO ) THEN
-            INFO = -2
+         IF( Z( 1 ).LT.ZERO ) THEN
+            INFO = -201
+            CALL XERBLA( 'DLASQ2', 2 )
+            RETURN
+         ELSE IF( Z( 2 ).LT.ZERO ) THEN
+            INFO = -202
             CALL XERBLA( 'SLASQ2', 2 )
             RETURN
+         ELSE IF( Z( 3 ).LT.ZERO ) THEN
+           INFO = -203
+           CALL XERBLA( 'SLASQ2', 2 )
+           RETURN
          ELSE IF( Z( 3 ).GT.Z( 1 ) ) THEN
             D = Z( 3 )
             Z( 3 ) = Z( 1 )


### PR DESCRIPTION
When the code checks elements of Z (the second parameter), INFO should be set according to the following
"if the i-th argument is an array and the j-entry had an illegal value, then INFO = -(i*100+j)"

Updated 2-by-2 case - adjusted value and added Z(1) check.

Will close #325