### PR TITLE
Add xcode12.3 test on macOS Big Sur

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ script:
     -DLAPACKE:BOOL=ON
     -DBUILD_TESTING=ON
     -DLAPACKE_WITH_TMG:BOOL=ON
+    -DBUILD_SHARED_LIBS=BOOL:ON
     -DCMAKE_Fortran_FLAGS:STRING="-fimplicit-none -frecursive -fcheck=all"
     -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
     ${SRC_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,12 @@ matrix:
     osx_image: xcode10.3
     env: CMAKE_BUILD_TYPE=Release
   - os: osx
-    name: "CMake Release Test on OSX Catalina"
+    name: "CMake Release Test on macOS Catalina"
     osx_image: xcode12.2
+    env: CMAKE_BUILD_TYPE=Release
+  - os: osx
+    name: "CMake Release Test on macOS Big Sur"
+    osx_image: xcode12.3
     env: CMAKE_BUILD_TYPE=Release
   - os: osx
     osx_image: xcode10.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,20 +27,12 @@ matrix:
     name: "CMake Coverage Test on Linux"
     env: CMAKE_BUILD_TYPE=Coverage
   - os: osx
-    name: "CMake Release Test on Mac OS X"
-    osx_image: xcode10.3
-    env: CMAKE_BUILD_TYPE=Release
-  - os: osx
-    name: "CMake Release Test on macOS Catalina"
-    osx_image: xcode12.2
-    env: CMAKE_BUILD_TYPE=Release
-  - os: osx
     name: "CMake Release Test on macOS Big Sur"
     osx_image: xcode12.3
     env: CMAKE_BUILD_TYPE=Release
   - os: osx
-    osx_image: xcode10.3
-    name: "Makefile Test on Mac OS X"
+    osx_image: xcode12.3
+    name: "Makefile Test on on macOS Big Sur"
     script:
     - rm -f make.inc
     - cp make.inc.example make.inc


### PR DESCRIPTION
While not mentioned in the docs:

* https://docs.travis-ci.com/user/reference/osx/

It appears available in the changelog:

* https://changelog.travis-ci.com/xcode-12-3-and-big-sur-11-1-available-179909

cc @martin-frbg 