### PR TITLE
Fix for bug #481

### DIFF
--- a/SRC/cgetsqrhrt.f
+++ b/SRC/cgetsqrhrt.f
@@ -86,7 +86,7 @@
 *> \verbatim
 *>          NB2 is INTEGER
 *>          The block size to be used in the blocked QR that is
-*>          output. NB >= 1.
+*>          output. NB2 >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -119,7 +119,7 @@
 *> \param[in] LDT
 *> \verbatim
 *>          LDT is INTEGER
-*>          The leading dimension of the array T.  LDT >= NB.
+*>          The leading dimension of the array T.  LDT >= NB2.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/cungtsqr_row.f
+++ b/SRC/cungtsqr_row.f
@@ -214,6 +214,9 @@
      $                   LWORKOPT, NUM_ALL_ROW_BLOCKS, JB_T, IB, IMB,
      $                   KB, KB_LAST, KNB, MB1
 *     ..
+*     .. Local Arrays ..
+      COMPLEX            DUMMY( 1, 1 )
+*     ..
 *     .. External Subroutines ..
       EXTERNAL           CLARFB_GETT, CLASET, XERBLA
 *     ..
@@ -354,9 +357,21 @@
 *
          KNB = MIN( NBLOCAL, N - KB + 1 )
 *
-         CALL CLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
-     $               T( 1, KB ), LDT, A( KB, KB ), LDA,
-     $               A( KB+KNB, KB), LDA, WORK, KNB )
+         IF( MB1-KB-KNB+1.EQ.0 ) THEN
+*
+*           In SLARFB_GETT parameters, when M=0, then the matrix B
+*           does not exist, hence we need to pass a dummy array
+*           reference DUMMY(1,1) to B with LDDUMMY=1.
+*
+            CALL CLARFB_GETT( 'N', 0, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        DUMMY( 1, 1 ), 1, WORK, KNB )
+         ELSE
+            CALL CLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        A( KB+KNB, KB), LDA, WORK, KNB )
+
+         END IF
 *
       END DO
 *

--- a/SRC/dgetsqrhrt.f
+++ b/SRC/dgetsqrhrt.f
@@ -86,7 +86,7 @@
 *> \verbatim
 *>          NB2 is INTEGER
 *>          The block size to be used in the blocked QR that is
-*>          output. NB >= 1.
+*>          output. NB2 >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -119,7 +119,7 @@
 *> \param[in] LDT
 *> \verbatim
 *>          LDT is INTEGER
-*>          The leading dimension of the array T.  LDT >= NB.
+*>          The leading dimension of the array T.  LDT >= NB2.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/dorgtsqr_row.f
+++ b/SRC/dorgtsqr_row.f
@@ -213,6 +213,9 @@
      $                   LWORKOPT, NUM_ALL_ROW_BLOCKS, JB_T, IB, IMB,
      $                   KB, KB_LAST, KNB, MB1
 *     ..
+*     .. Local Arrays ..
+      DOUBLE PRECISION   DUMMY( 1, 1 )
+*     ..
 *     .. External Subroutines ..
       EXTERNAL           DLARFB_GETT, DLASET, XERBLA
 *     ..
@@ -353,9 +356,21 @@
 *
          KNB = MIN( NBLOCAL, N - KB + 1 )
 *
-         CALL DLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
-     $               T( 1, KB ), LDT, A( KB, KB ), LDA,
-     $               A( KB+KNB, KB), LDA, WORK, KNB )
+         IF( MB1-KB-KNB+1.EQ.0 ) THEN
+*
+*           In SLARFB_GETT parameters, when M=0, then the matrix B
+*           does not exist, hence we need to pass a dummy array
+*           reference DUMMY(1,1) to B with LDDUMMY=1.
+*
+            CALL DLARFB_GETT( 'N', 0, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        DUMMY( 1, 1 ), 1, WORK, KNB )
+         ELSE
+            CALL DLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        A( KB+KNB, KB), LDA, WORK, KNB )
+
+         END IF
 *
       END DO
 *

--- a/SRC/sgetsqrhrt.f
+++ b/SRC/sgetsqrhrt.f
@@ -86,7 +86,7 @@
 *> \verbatim
 *>          NB2 is INTEGER
 *>          The block size to be used in the blocked QR that is
-*>          output. NB >= 1.
+*>          output. NB2 >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -119,7 +119,7 @@
 *> \param[in] LDT
 *> \verbatim
 *>          LDT is INTEGER
-*>          The leading dimension of the array T.  LDT >= NB.
+*>          The leading dimension of the array T.  LDT >= NB2.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/sorgtsqr_row.f
+++ b/SRC/sorgtsqr_row.f
@@ -213,6 +213,9 @@
      $                   LWORKOPT, NUM_ALL_ROW_BLOCKS, JB_T, IB, IMB,
      $                   KB, KB_LAST, KNB, MB1
 *     ..
+*     .. Local Arrays ..
+      REAL               DUMMY( 1, 1 )
+*     ..
 *     .. External Subroutines ..
       EXTERNAL           SLARFB_GETT, SLASET, XERBLA
 *     ..
@@ -353,9 +356,21 @@
 *
          KNB = MIN( NBLOCAL, N - KB + 1 )
 *
-         CALL SLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
-     $               T( 1, KB ), LDT, A( KB, KB ), LDA,
-     $               A( KB+KNB, KB), LDA, WORK, KNB )
+         IF( MB1-KB-KNB+1.EQ.0 ) THEN
+*
+*           In SLARFB_GETT parameters, when M=0, then the matrix B
+*           does not exist, hence we need to pass a dummy array
+*           reference DUMMY(1,1) to B with LDDUMMY=1.
+*
+            CALL SLARFB_GETT( 'N', 0, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        DUMMY( 1, 1 ), 1, WORK, KNB )
+         ELSE
+            CALL SLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        A( KB+KNB, KB), LDA, WORK, KNB )
+
+         END IF
 *
       END DO
 *

--- a/SRC/zgetsqrhrt.f
+++ b/SRC/zgetsqrhrt.f
@@ -86,7 +86,7 @@
 *> \verbatim
 *>          NB2 is INTEGER
 *>          The block size to be used in the blocked QR that is
-*>          output. NB >= 1.
+*>          output. NB2 >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -119,7 +119,7 @@
 *> \param[in] LDT
 *> \verbatim
 *>          LDT is INTEGER
-*>          The leading dimension of the array T.  LDT >= NB.
+*>          The leading dimension of the array T.  LDT >= NB2.
 *> \endverbatim
 *>
 *> \param[out] WORK

--- a/SRC/zungtsqr_row.f
+++ b/SRC/zungtsqr_row.f
@@ -214,6 +214,9 @@
      $                   LWORKOPT, NUM_ALL_ROW_BLOCKS, JB_T, IB, IMB,
      $                   KB, KB_LAST, KNB, MB1
 *     ..
+*     .. Local Arrays ..
+      COMPLEX*16         DUMMY( 1, 1 )
+*     ..
 *     .. External Subroutines ..
       EXTERNAL           ZLARFB_GETT, ZLASET, XERBLA
 *     ..
@@ -354,9 +357,21 @@
 *
          KNB = MIN( NBLOCAL, N - KB + 1 )
 *
-         CALL ZLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
-     $               T( 1, KB ), LDT, A( KB, KB ), LDA,
-     $               A( KB+KNB, KB), LDA, WORK, KNB )
+         IF( MB1-KB-KNB+1.EQ.0 ) THEN
+*
+*           In SLARFB_GETT parameters, when M=0, then the matrix B
+*           does not exist, hence we need to pass a dummy array
+*           reference DUMMY(1,1) to B with LDDUMMY=1.
+*
+            CALL ZLARFB_GETT( 'N', 0, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        DUMMY( 1, 1 ), 1, WORK, KNB )
+         ELSE
+            CALL ZLARFB_GETT( 'N', MB1-KB-KNB+1, N-KB+1, KNB,
+     $                        T( 1, KB ), LDT, A( KB, KB ), LDA,
+     $                        A( KB+KNB, KB), LDA, WORK, KNB )
+
+         END IF
 *
       END DO
 *


### PR DESCRIPTION
1) Fix for bug #481 (If compiled with FFLAGS = -O0 -frecursive -ggdb3 -fcheck=bounds,the TSQR tests fail - array index out of bounds).
2) Comment fixes.