### PR TITLE
Try flag -fcheck=all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,32 +15,32 @@ matrix:
   include:
   - os: linux
     name: "CMake Release Test on Linux"
-    env: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
+    env: CMAKE_BUILD_TYPE=Release
   - os: linux
     name: "Makefile Test on Linux"
     script:
     - rm -f make.inc
     - cp make.inc.example make.inc
-    - make -s -j2 all
+    - make FFLAGS="-fimplicit-none -frecursive -fcheck=all" -s -j2 all
     - make -j2 lapack_install
   - os: linux
     name: "CMake Coverage Test on Linux"
-    env: CMAKE_BUILD_TYPE=Coverage CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
+    env: CMAKE_BUILD_TYPE=Coverage
   - os: osx
     name: "CMake Release Test on Mac OS X"
     osx_image: xcode10.3
-    env: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
+    env: CMAKE_BUILD_TYPE=Release
   - os: osx
     name: "CMake Release Test on OSX Catalina"
     osx_image: xcode12.2
-    env: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
+    env: CMAKE_BUILD_TYPE=Release
   - os: osx
     osx_image: xcode10.3
     name: "Makefile Test on Mac OS X"
     script:
     - rm -f make.inc
     - cp make.inc.example make.inc
-    - make -s -j2 all
+    - make FFLAGS="-fimplicit-none -frecursive -fcheck=all" -s -j2 all
     - make -j2 lapack_install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
   - os: osx
     name: "CMake Release Test on OSX Catalina"
     osx_image: xcode12.2
-    env: CMAKE_BUILD_TYPE=Release
+    env: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
   - os: osx
     osx_image: xcode10.3
     name: "Makefile Test on Mac OS X"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
   - os: linux
     name: "CMake Release Test on Linux"
-    env: CMAKE_BUILD_TYPE=Release
+    env: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
   - os: linux
     name: "Makefile Test on Linux"
     script:
@@ -25,11 +25,11 @@ matrix:
     - make -j2 lapack_install
   - os: linux
     name: "CMake Coverage Test on Linux"
-    env: CMAKE_BUILD_TYPE=Coverage
+    env: CMAKE_BUILD_TYPE=Coverage CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
   - os: osx
     name: "CMake Release Test on Mac OS X"
     osx_image: xcode10.3
-    env: CMAKE_BUILD_TYPE=Release
+    env: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-DLAPACK_FORTRAN_STRLEN_END
   - os: osx
     name: "CMake Release Test on OSX Catalina"
     osx_image: xcode12.2
@@ -63,7 +63,8 @@ script:
     -DLAPACKE:BOOL=ON
     -DBUILD_TESTING=ON
     -DLAPACKE_WITH_TMG:BOOL=ON
-    -DCMAKE_Fortran_FLAGS:STRING="-fimplicit-none -frecursive"
+    -DCMAKE_Fortran_FLAGS:STRING="-fimplicit-none -frecursive -fcheck=all"
+    -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
     ${SRC_DIR}
   - ctest -D ExperimentalStart
   - ctest -D ExperimentalConfigure

--- a/CBLAS/include/cblas_f77.h
+++ b/CBLAS/include/cblas_f77.h
@@ -11,6 +11,11 @@
 
 #include <stdarg.h>
 
+/* It seems all current Fortran compilers put strlen at end.
+*  Some historical compilers put strlen after the str argument
+*  or make the str argument into a struct. */
+#define BLAS_FORTRAN_STRLEN_END
+
 #ifdef CRAY
    #include <fortran.h>
    #define F77_CHAR _fcd
@@ -264,10 +269,10 @@
    #define F77_zgerc(...) F77_zgerc_base(__VA_ARGS__)
    #define F77_zgeru(...) F77_zgeru_base(__VA_ARGS__)
 
-#ifdef LAPACK_FORTRAN_STRLEN_END
+#ifdef BLAS_FORTRAN_STRLEN_END
 
    /*
-   * Level 2 Fortran variadic definitions with LAPACK_FORTRAN_STRLEN_END
+   * Level 2 Fortran variadic definitions with BLAS_FORTRAN_STRLEN_END
    */
 
    /* Single Precision */
@@ -343,7 +348,7 @@
    #define F77_zhpr2(...) F77_zhpr2_base(__VA_ARGS__, 1)
 
    /*
-   * Level 3 Fortran variadic definitions with LAPACK_FORTRAN_STRLEN_END
+   * Level 3 Fortran variadic definitions with BLAS_FORTRAN_STRLEN_END
    */
 
    /* Single Precision */
@@ -391,7 +396,7 @@
 #else
                               
    /*
-   * Level 2 Fortran variadic definitions without LAPACK_FORTRAN_STRLEN_END
+   * Level 2 Fortran variadic definitions without BLAS_FORTRAN_STRLEN_END
    */
 
    /* Single Precision */
@@ -467,7 +472,7 @@
    #define F77_zhpr2(...) F77_zhpr2_base(__VA_ARGS__)
 
    /*
-   * Level 3 Fortran variadic definitions without LAPACK_FORTRAN_STRLEN_END
+   * Level 3 Fortran variadic definitions without BLAS_FORTRAN_STRLEN_END
    */
 
    /* Single Precision */
@@ -522,8 +527,9 @@
 extern "C" {
 #endif
 
+void F77_xerbla(FCHAR, void *);
 void F77_xerbla_base(FCHAR, void *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
@@ -599,78 +605,78 @@ void F77_xerbla_base(FCHAR, void *
 /* Single Precision */
 
    void F77_sgemv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_sgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const float *,  const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_ssymv_base(FCHAR, FINT, const float *, const float *, FINT, const float *,  FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_ssbmv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_sspmv_base(FCHAR, FINT, const float *, const float *, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_strmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_stbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_strsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_stbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_stpmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_stpsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_sger_base( FINT, FINT, const float *, const float *, FINT, const float *, FINT, float *, FINT);
    void F77_ssyr_base(FCHAR, FINT, const float *, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_sspr_base(FCHAR, FINT, const float *, const float *, FINT, float *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_sspr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_ssyr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
@@ -678,78 +684,78 @@ void F77_xerbla_base(FCHAR, void *
 /* Double Precision */
 
    void F77_dgemv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const double *,  const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dsymv_base(FCHAR, FINT, const double *, const double *, FINT, const double *,  FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dsbmv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dspmv_base(FCHAR, FINT, const double *, const double *, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dtrmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_dtbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_dtrsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_dtbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_dtpmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_dtpsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_dger_base( FINT, FINT, const double *, const double *, FINT, const double *, FINT, double *, FINT);
    void F77_dsyr_base(FCHAR, FINT, const double *, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dspr_base(FCHAR, FINT, const double *, const double *, FINT, double *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dspr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_dsyr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
@@ -757,79 +763,79 @@ void F77_xerbla_base(FCHAR, void *
 /* Single Complex Precision */
 
    void F77_cgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_cgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_chemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_chbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_chpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_ctrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ctbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ctpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ctrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ctbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ctpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_cgerc_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
    void F77_cgeru_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
    void F77_cher_base(FCHAR, FINT, const float *, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_cher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_chpr_base(FCHAR, FINT, const float *, const void *, FINT, void *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_chpr2_base(FCHAR, FINT, const float *, const void *, FINT, const void *, FINT, void *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
@@ -837,79 +843,79 @@ void F77_xerbla_base(FCHAR, void *
 /* Double Complex Precision */
 
    void F77_zgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_zgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_zhemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_zhbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_zhpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_ztrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ztbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ztpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ztrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ztbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_ztpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t
    #endif
    );
    void F77_zgerc_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
    void F77_zgeru_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
    void F77_zher_base(FCHAR, FINT, const double *, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_zher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_zhpr_base(FCHAR, FINT, const double *, const void *, FINT, void *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
    void F77_zhpr2_base(FCHAR, FINT, const double *, const void *, FINT, const void *, FINT, void *
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t
    #endif
    );
@@ -921,32 +927,32 @@ void F77_xerbla_base(FCHAR, void *
 /* Single Precision */
 
    void F77_sgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_ssymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_ssyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_ssyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_strmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_strsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );
@@ -954,32 +960,32 @@ void F77_xerbla_base(FCHAR, void *
 /* Double Precision */
 
    void F77_dgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_dsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_dsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_dsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_dtrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_dtrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );
@@ -987,47 +993,47 @@ void F77_xerbla_base(FCHAR, void *
 /* Single Complex Precision */
 
    void F77_cgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_csymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_chemm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_csyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_cherk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_csyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_cher2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_ctrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );
@@ -1035,47 +1041,47 @@ void F77_xerbla_base(FCHAR, void *
 /* Double Complex Precision */
 
    void F77_zgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_zsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_zhemm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_zsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_zherk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_zsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_zher2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t
    #endif
    );
    void F77_ztrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_ztrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
-   #ifdef LAPACK_FORTRAN_STRLEN_END
+   #ifdef BLAS_FORTRAN_STRLEN_END
       , size_t, size_t, size_t, size_t
    #endif
    );

--- a/CBLAS/include/cblas_f77.h
+++ b/CBLAS/include/cblas_f77.h
@@ -524,7 +524,7 @@ extern "C" {
 
 void F77_xerbla_base(FCHAR, void *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
 /*
@@ -600,78 +600,78 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_sgemv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_sgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const float *,  const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_ssymv_base(FCHAR, FINT, const float *, const float *, FINT, const float *,  FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_ssbmv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_sspmv_base(FCHAR, FINT, const float *, const float *, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_strmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_stbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_strsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_stbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_stpmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_stpsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_sger_base( FINT, FINT, const float *, const float *, FINT, const float *, FINT, float *, FINT);
    void F77_ssyr_base(FCHAR, FINT, const float *, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_sspr_base(FCHAR, FINT, const float *, const float *, FINT, float *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_sspr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_ssyr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
 
@@ -679,78 +679,78 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_dgemv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const double *,  const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dsymv_base(FCHAR, FINT, const double *, const double *, FINT, const double *,  FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dsbmv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dspmv_base(FCHAR, FINT, const double *, const double *, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dtrmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_dtbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_dtrsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_dtbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_dtpmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_dtpsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_dger_base( FINT, FINT, const double *, const double *, FINT, const double *, FINT, double *, FINT);
    void F77_dsyr_base(FCHAR, FINT, const double *, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dspr_base(FCHAR, FINT, const double *, const double *, FINT, double *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dspr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_dsyr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
 
@@ -758,79 +758,79 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_cgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_cgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_chemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_chbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_chpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_ctrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ctbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ctpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ctrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ctbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ctpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_cgerc_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
    void F77_cgeru_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
    void F77_cher_base(FCHAR, FINT, const float *, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_cher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_chpr_base(FCHAR, FINT, const float *, const void *, FINT, void *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_chpr2_base(FCHAR, FINT, const float *, const void *, FINT, const void *, FINT, void *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
 
@@ -838,79 +838,79 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_zgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_zgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_zhemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_zhbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_zhpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_ztrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ztbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ztpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ztrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ztbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_ztpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned
+      , size_t, size_t, size_t
    #endif
    );
    void F77_zgerc_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
    void F77_zgeru_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
    void F77_zher_base(FCHAR, FINT, const double *, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_zher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_zhpr_base(FCHAR, FINT, const double *, const void *, FINT, void *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
    void F77_zhpr2_base(FCHAR, FINT, const double *, const void *, FINT, const void *, FINT, void *
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned
+      , size_t
    #endif
    );
 
@@ -922,32 +922,32 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_sgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_ssymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_ssyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_ssyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_strmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_strsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
 
@@ -955,32 +955,32 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_dgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_dsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_dsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_dsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_dtrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_dtrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
 
@@ -988,47 +988,47 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_cgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_csymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_chemm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_csyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_cherk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_csyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_cher2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_ctrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
 
@@ -1036,47 +1036,47 @@ void F77_xerbla_base(FCHAR, void *
 
    void F77_zgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_zsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_zhemm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_zsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_zherk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_zsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_zher2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned
+      , size_t, size_t
    #endif
    );
    void F77_ztrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
    void F77_ztrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
    #ifdef LAPACK_FORTRAN_STRLEN_END
-      , unsigned, unsigned, unsigned, unsigned
+      , size_t, size_t, size_t, size_t
    #endif
    );
 

--- a/CBLAS/include/cblas_f77.h
+++ b/CBLAS/include/cblas_f77.h
@@ -9,6 +9,8 @@
 #ifndef CBLAS_F77_H
 #define CBLAS_F77_H
 
+#include <stdarg.h>
+
 #ifdef CRAY
    #include <fortran.h>
    #define F77_CHAR _fcd
@@ -36,225 +38,559 @@
  * Level 1 BLAS
  */
 
-#define F77_xerbla 		F77_GLOBAL(xerbla,XERBLA)
-#define F77_srotg 		F77_GLOBAL(srotg,SROTG)
-#define F77_srotmg 		F77_GLOBAL(srotmg,SROTMG)
-#define F77_srot 		F77_GLOBAL(srot,SROT)
-#define F77_srotm 		F77_GLOBAL(srotm,SROTM)
-#define F77_drotg 		F77_GLOBAL(drotg,DROTG)
-#define F77_drotmg 		F77_GLOBAL(drotmg,DROTMG)
-#define F77_drot 		F77_GLOBAL(drot,DROT)
-#define F77_drotm 		F77_GLOBAL(drotm,DROTM)
-#define F77_sswap 		F77_GLOBAL(sswap,SSWAP)
-#define F77_scopy 		F77_GLOBAL(scopy,SCOPY)
-#define F77_saxpy 		F77_GLOBAL(saxpy,SAXPY)
-#define F77_isamax_sub 	F77_GLOBAL(isamaxsub,ISAMAXSUB)
-#define F77_dswap 		F77_GLOBAL(dswap,DSWAP)
-#define F77_dcopy 		F77_GLOBAL(dcopy,DCOPY)
-#define F77_daxpy 		F77_GLOBAL(daxpy,DAXPY)
-#define F77_idamax_sub 	F77_GLOBAL(idamaxsub,IDAMAXSUB)
-#define F77_cswap 		F77_GLOBAL(cswap,CSWAP)
-#define F77_ccopy 		F77_GLOBAL(ccopy,CCOPY)
-#define F77_caxpy 		F77_GLOBAL(caxpy,CAXPY)
-#define F77_icamax_sub 	F77_GLOBAL(icamaxsub,ICAMAXSUB)
-#define F77_zswap 		F77_GLOBAL(zswap,ZSWAP)
-#define F77_zcopy 		F77_GLOBAL(zcopy,ZCOPY)
-#define F77_zaxpy 		F77_GLOBAL(zaxpy,ZAXPY)
-#define F77_izamax_sub 	F77_GLOBAL(izamaxsub,IZAMAXSUB)
-#define F77_sdot_sub 	F77_GLOBAL(sdotsub,SDOTSUB)
-#define F77_ddot_sub 	F77_GLOBAL(ddotsub,DDOTSUB)
-#define F77_dsdot_sub 	F77_GLOBAL(dsdotsub,DSDOTSUB)
-#define F77_sscal 		F77_GLOBAL(sscal,SSCAL)
-#define F77_dscal 		F77_GLOBAL(dscal,DSCAL)
-#define F77_cscal 		F77_GLOBAL(cscal,CSCAL)
-#define F77_zscal 		F77_GLOBAL(zscal,ZSCAL)
-#define F77_csscal 		F77_GLOBAL(csscal,CSSCAL)
-#define F77_zdscal 		F77_GLOBAL(zdscal,ZDSCAL)
-#define F77_cdotu_sub 	F77_GLOBAL(cdotusub,CDOTUSUB)
-#define F77_cdotc_sub 	F77_GLOBAL(cdotcsub,CDOTCSUB)
-#define F77_zdotu_sub 	F77_GLOBAL(zdotusub,ZDOTUSUB)
-#define F77_zdotc_sub 	F77_GLOBAL(zdotcsub,ZDOTCSUB)
-#define F77_snrm2_sub 	F77_GLOBAL(snrm2sub,SNRM2SUB)
-#define F77_sasum_sub 	F77_GLOBAL(sasumsub,SASUMSUB)
-#define F77_dnrm2_sub 	F77_GLOBAL(dnrm2sub,DNRM2SUB)
-#define F77_dasum_sub 	F77_GLOBAL(dasumsub,DASUMSUB)
-#define F77_scnrm2_sub 	F77_GLOBAL(scnrm2sub,SCNRM2SUB)
-#define F77_scasum_sub 	F77_GLOBAL(scasumsub,SCASUMSUB)
-#define F77_dznrm2_sub 	F77_GLOBAL(dznrm2sub,DZNRM2SUB)
-#define F77_dzasum_sub 	F77_GLOBAL(dzasumsub,DZASUMSUB)
-#define F77_sdsdot_sub 	F77_GLOBAL(sdsdotsub,SDSDOTSUB)
+#define F77_xerbla_base 		F77_GLOBAL(xerbla,XERBLA)
+#define F77_srotg_base 		F77_GLOBAL(srotg,SROTG)
+#define F77_srotmg_base 		F77_GLOBAL(srotmg,SROTMG)
+#define F77_srot_base 		F77_GLOBAL(srot,SROT)
+#define F77_srotm_base 		F77_GLOBAL(srotm,SROTM)
+#define F77_drotg_base 		F77_GLOBAL(drotg,DROTG)
+#define F77_drotmg_base 		F77_GLOBAL(drotmg,DROTMG)
+#define F77_drot_base 		F77_GLOBAL(drot,DROT)
+#define F77_drotm_base 		F77_GLOBAL(drotm,DROTM)
+#define F77_sswap_base 		F77_GLOBAL(sswap,SSWAP)
+#define F77_scopy_base 		F77_GLOBAL(scopy,SCOPY)
+#define F77_saxpy_base 		F77_GLOBAL(saxpy,SAXPY)
+#define F77_isamax_sub_base 	F77_GLOBAL(isamaxsub,ISAMAXSUB)
+#define F77_dswap_base 		F77_GLOBAL(dswap,DSWAP)
+#define F77_dcopy_base 		F77_GLOBAL(dcopy,DCOPY)
+#define F77_daxpy_base 		F77_GLOBAL(daxpy,DAXPY)
+#define F77_idamax_sub_base 	F77_GLOBAL(idamaxsub,IDAMAXSUB)
+#define F77_cswap_base 		F77_GLOBAL(cswap,CSWAP)
+#define F77_ccopy_base 		F77_GLOBAL(ccopy,CCOPY)
+#define F77_caxpy_base 		F77_GLOBAL(caxpy,CAXPY)
+#define F77_icamax_sub_base 	F77_GLOBAL(icamaxsub,ICAMAXSUB)
+#define F77_zswap_base 		F77_GLOBAL(zswap,ZSWAP)
+#define F77_zcopy_base 		F77_GLOBAL(zcopy,ZCOPY)
+#define F77_zaxpy_base 		F77_GLOBAL(zaxpy,ZAXPY)
+#define F77_izamax_sub_base 	F77_GLOBAL(izamaxsub,IZAMAXSUB)
+#define F77_sdot_sub_base 	F77_GLOBAL(sdotsub,SDOTSUB)
+#define F77_ddot_sub_base 	F77_GLOBAL(ddotsub,DDOTSUB)
+#define F77_dsdot_sub_base 	F77_GLOBAL(dsdotsub,DSDOTSUB)
+#define F77_sscal_base 		F77_GLOBAL(sscal,SSCAL)
+#define F77_dscal_base 		F77_GLOBAL(dscal,DSCAL)
+#define F77_cscal_base 		F77_GLOBAL(cscal,CSCAL)
+#define F77_zscal_base 		F77_GLOBAL(zscal,ZSCAL)
+#define F77_csscal_base 		F77_GLOBAL(csscal,CSSCAL)
+#define F77_zdscal_base 		F77_GLOBAL(zdscal,ZDSCAL)
+#define F77_cdotu_sub_base 	F77_GLOBAL(cdotusub,CDOTUSUB)
+#define F77_cdotc_sub_base 	F77_GLOBAL(cdotcsub,CDOTCSUB)
+#define F77_zdotu_sub_base 	F77_GLOBAL(zdotusub,ZDOTUSUB)
+#define F77_zdotc_sub_base 	F77_GLOBAL(zdotcsub,ZDOTCSUB)
+#define F77_snrm2_sub_base 	F77_GLOBAL(snrm2sub,SNRM2SUB)
+#define F77_sasum_sub_base 	F77_GLOBAL(sasumsub,SASUMSUB)
+#define F77_dnrm2_sub_base 	F77_GLOBAL(dnrm2sub,DNRM2SUB)
+#define F77_dasum_sub_base 	F77_GLOBAL(dasumsub,DASUMSUB)
+#define F77_scnrm2_sub_base 	F77_GLOBAL(scnrm2sub,SCNRM2SUB)
+#define F77_scasum_sub_base 	F77_GLOBAL(scasumsub,SCASUMSUB)
+#define F77_dznrm2_sub_base 	F77_GLOBAL(dznrm2sub,DZNRM2SUB)
+#define F77_dzasum_sub_base 	F77_GLOBAL(dzasumsub,DZASUMSUB)
+#define F77_sdsdot_sub_base 	F77_GLOBAL(sdsdotsub,SDSDOTSUB)
 /*
  * Level 2 BLAS
  */
-#define F77_ssymv 		F77_GLOBAL(ssymv,SSYMV)
-#define F77_ssbmv 		F77_GLOBAL(ssbmv,SSBMV)
-#define F77_sspmv 		F77_GLOBAL(sspmv,SSPMV)
-#define F77_sger 		F77_GLOBAL(sger,SGER)
-#define F77_ssyr 		F77_GLOBAL(ssyr,SSYR)
-#define F77_sspr 		F77_GLOBAL(sspr,SSPR)
-#define F77_ssyr2 		F77_GLOBAL(ssyr2,SSYR2)
-#define F77_sspr2 		F77_GLOBAL(sspr2,SSPR2)
-#define F77_dsymv 		F77_GLOBAL(dsymv,DSYMV)
-#define F77_dsbmv 		F77_GLOBAL(dsbmv,DSBMV)
-#define F77_dspmv 		F77_GLOBAL(dspmv,DSPMV)
-#define F77_dger 		F77_GLOBAL(dger,DGER)
-#define F77_dsyr 		F77_GLOBAL(dsyr,DSYR)
-#define F77_dspr 		F77_GLOBAL(dspr,DSPR)
-#define F77_dsyr2 		F77_GLOBAL(dsyr2,DSYR2)
-#define F77_dspr2 		F77_GLOBAL(dspr2,DSPR2)
-#define F77_chemv 		F77_GLOBAL(chemv,CHEMV)
-#define F77_chbmv 		F77_GLOBAL(chbmv,CHBMV)
-#define F77_chpmv 		F77_GLOBAL(chpmv,CHPMV)
-#define F77_cgeru 		F77_GLOBAL(cgeru,CGERU)
-#define F77_cgerc 		F77_GLOBAL(cgerc,CGERC)
-#define F77_cher 		F77_GLOBAL(cher,CHER)
-#define F77_chpr 		F77_GLOBAL(chpr,CHPR)
-#define F77_cher2 		F77_GLOBAL(cher2,CHER2)
-#define F77_chpr2 		F77_GLOBAL(chpr2,CHPR2)
-#define F77_zhemv 		F77_GLOBAL(zhemv,ZHEMV)
-#define F77_zhbmv 		F77_GLOBAL(zhbmv,ZHBMV)
-#define F77_zhpmv 		F77_GLOBAL(zhpmv,ZHPMV)
-#define F77_zgeru 		F77_GLOBAL(zgeru,ZGERU)
-#define F77_zgerc 		F77_GLOBAL(zgerc,ZGERC)
-#define F77_zher 		F77_GLOBAL(zher,ZHER)
-#define F77_zhpr 		F77_GLOBAL(zhpr,ZHPR)
-#define F77_zher2 		F77_GLOBAL(zher2,ZHER2)
-#define F77_zhpr2 		F77_GLOBAL(zhpr2,ZHPR2)
-#define F77_sgemv 		F77_GLOBAL(sgemv,SGEMV)
-#define F77_sgbmv 		F77_GLOBAL(sgbmv,SGBMV)
-#define F77_strmv 		F77_GLOBAL(strmv,STRMV)
-#define F77_stbmv 		F77_GLOBAL(stbmv,STBMV)
-#define F77_stpmv 		F77_GLOBAL(stpmv,STPMV)
-#define F77_strsv 		F77_GLOBAL(strsv,STRSV)
-#define F77_stbsv 		F77_GLOBAL(stbsv,STBSV)
-#define F77_stpsv 		F77_GLOBAL(stpsv,STPSV)
-#define F77_dgemv 		F77_GLOBAL(dgemv,DGEMV)
-#define F77_dgbmv 		F77_GLOBAL(dgbmv,DGBMV)
-#define F77_dtrmv 		F77_GLOBAL(dtrmv,DTRMV)
-#define F77_dtbmv 		F77_GLOBAL(dtbmv,DTBMV)
-#define F77_dtpmv 		F77_GLOBAL(dtpmv,DTPMV)
-#define F77_dtrsv 		F77_GLOBAL(dtrsv,DTRSV)
-#define F77_dtbsv 		F77_GLOBAL(dtbsv,DTBSV)
-#define F77_dtpsv 		F77_GLOBAL(dtpsv,DTPSV)
-#define F77_cgemv 		F77_GLOBAL(cgemv,CGEMV)
-#define F77_cgbmv 		F77_GLOBAL(cgbmv,CGBMV)
-#define F77_ctrmv 		F77_GLOBAL(ctrmv,CTRMV)
-#define F77_ctbmv 		F77_GLOBAL(ctbmv,CTBMV)
-#define F77_ctpmv 		F77_GLOBAL(ctpmv,CTPMV)
-#define F77_ctrsv 		F77_GLOBAL(ctrsv,CTRSV)
-#define F77_ctbsv 		F77_GLOBAL(ctbsv,CTBSV)
-#define F77_ctpsv 		F77_GLOBAL(ctpsv,CTPSV)
-#define F77_zgemv 		F77_GLOBAL(zgemv,ZGEMV)
-#define F77_zgbmv 		F77_GLOBAL(zgbmv,ZGBMV)
-#define F77_ztrmv 		F77_GLOBAL(ztrmv,ZTRMV)
-#define F77_ztbmv 		F77_GLOBAL(ztbmv,ZTBMV)
-#define F77_ztpmv 		F77_GLOBAL(ztpmv,ZTPMV)
-#define F77_ztrsv 		F77_GLOBAL(ztrsv,ZTRSV)
-#define F77_ztbsv 		F77_GLOBAL(ztbsv,ZTBSV)
-#define F77_ztpsv 		F77_GLOBAL(ztpsv,ZTPSV)
+#define F77_ssymv_base 		F77_GLOBAL(ssymv,SSYMV)
+#define F77_ssbmv_base 		F77_GLOBAL(ssbmv,SSBMV)
+#define F77_sspmv_base 		F77_GLOBAL(sspmv,SSPMV)
+#define F77_sger_base 		F77_GLOBAL(sger,SGER)
+#define F77_ssyr_base 		F77_GLOBAL(ssyr,SSYR)
+#define F77_sspr_base 		F77_GLOBAL(sspr,SSPR)
+#define F77_ssyr2_base 		F77_GLOBAL(ssyr2,SSYR2)
+#define F77_sspr2_base 		F77_GLOBAL(sspr2,SSPR2)
+#define F77_dsymv_base 		F77_GLOBAL(dsymv,DSYMV)
+#define F77_dsbmv_base 		F77_GLOBAL(dsbmv,DSBMV)
+#define F77_dspmv_base 		F77_GLOBAL(dspmv,DSPMV)
+#define F77_dger_base 		F77_GLOBAL(dger,DGER)
+#define F77_dsyr_base 		F77_GLOBAL(dsyr,DSYR)
+#define F77_dspr_base 		F77_GLOBAL(dspr,DSPR)
+#define F77_dsyr2_base 		F77_GLOBAL(dsyr2,DSYR2)
+#define F77_dspr2_base 		F77_GLOBAL(dspr2,DSPR2)
+#define F77_chemv_base 		F77_GLOBAL(chemv,CHEMV)
+#define F77_chbmv_base 		F77_GLOBAL(chbmv,CHBMV)
+#define F77_chpmv_base 		F77_GLOBAL(chpmv,CHPMV)
+#define F77_cgeru_base 		F77_GLOBAL(cgeru,CGERU)
+#define F77_cgerc_base 		F77_GLOBAL(cgerc,CGERC)
+#define F77_cher_base 		F77_GLOBAL(cher,CHER)
+#define F77_chpr_base 		F77_GLOBAL(chpr,CHPR)
+#define F77_cher2_base 		F77_GLOBAL(cher2,CHER2)
+#define F77_chpr2_base 		F77_GLOBAL(chpr2,CHPR2)
+#define F77_zhemv_base 		F77_GLOBAL(zhemv,ZHEMV)
+#define F77_zhbmv_base 		F77_GLOBAL(zhbmv,ZHBMV)
+#define F77_zhpmv_base 		F77_GLOBAL(zhpmv,ZHPMV)
+#define F77_zgeru_base 		F77_GLOBAL(zgeru,ZGERU)
+#define F77_zgerc_base 		F77_GLOBAL(zgerc,ZGERC)
+#define F77_zher_base 		F77_GLOBAL(zher,ZHER)
+#define F77_zhpr_base 		F77_GLOBAL(zhpr,ZHPR)
+#define F77_zher2_base 		F77_GLOBAL(zher2,ZHER2)
+#define F77_zhpr2_base 		F77_GLOBAL(zhpr2,ZHPR2)
+#define F77_sgemv_base 		F77_GLOBAL(sgemv,SGEMV)
+#define F77_sgbmv_base 		F77_GLOBAL(sgbmv,SGBMV)
+#define F77_strmv_base 		F77_GLOBAL(strmv,STRMV)
+#define F77_stbmv_base 		F77_GLOBAL(stbmv,STBMV)
+#define F77_stpmv_base 		F77_GLOBAL(stpmv,STPMV)
+#define F77_strsv_base 		F77_GLOBAL(strsv,STRSV)
+#define F77_stbsv_base 		F77_GLOBAL(stbsv,STBSV)
+#define F77_stpsv_base 		F77_GLOBAL(stpsv,STPSV)
+#define F77_dgemv_base 		F77_GLOBAL(dgemv,DGEMV)
+#define F77_dgbmv_base 		F77_GLOBAL(dgbmv,DGBMV)
+#define F77_dtrmv_base 		F77_GLOBAL(dtrmv,DTRMV)
+#define F77_dtbmv_base 		F77_GLOBAL(dtbmv,DTBMV)
+#define F77_dtpmv_base 		F77_GLOBAL(dtpmv,DTPMV)
+#define F77_dtrsv_base 		F77_GLOBAL(dtrsv,DTRSV)
+#define F77_dtbsv_base 		F77_GLOBAL(dtbsv,DTBSV)
+#define F77_dtpsv_base 		F77_GLOBAL(dtpsv,DTPSV)
+#define F77_cgemv_base 		F77_GLOBAL(cgemv,CGEMV)
+#define F77_cgbmv_base 		F77_GLOBAL(cgbmv,CGBMV)
+#define F77_ctrmv_base 		F77_GLOBAL(ctrmv,CTRMV)
+#define F77_ctbmv_base 		F77_GLOBAL(ctbmv,CTBMV)
+#define F77_ctpmv_base 		F77_GLOBAL(ctpmv,CTPMV)
+#define F77_ctrsv_base 		F77_GLOBAL(ctrsv,CTRSV)
+#define F77_ctbsv_base 		F77_GLOBAL(ctbsv,CTBSV)
+#define F77_ctpsv_base 		F77_GLOBAL(ctpsv,CTPSV)
+#define F77_zgemv_base 		F77_GLOBAL(zgemv,ZGEMV)
+#define F77_zgbmv_base 		F77_GLOBAL(zgbmv,ZGBMV)
+#define F77_ztrmv_base 		F77_GLOBAL(ztrmv,ZTRMV)
+#define F77_ztbmv_base 		F77_GLOBAL(ztbmv,ZTBMV)
+#define F77_ztpmv_base 		F77_GLOBAL(ztpmv,ZTPMV)
+#define F77_ztrsv_base 		F77_GLOBAL(ztrsv,ZTRSV)
+#define F77_ztbsv_base 		F77_GLOBAL(ztbsv,ZTBSV)
+#define F77_ztpsv_base 		F77_GLOBAL(ztpsv,ZTPSV)
 /*
  * Level 3 BLAS
  */
-#define F77_chemm 		F77_GLOBAL(chemm,CHEMM)
-#define F77_cherk 		F77_GLOBAL(cherk,CHERK)
-#define F77_cher2k 		F77_GLOBAL(cher2k,CHER2K)
-#define F77_zhemm 		F77_GLOBAL(zhemm,ZHEMM)
-#define F77_zherk 		F77_GLOBAL(zherk,ZHERK)
-#define F77_zher2k 		F77_GLOBAL(zher2k,ZHER2K)
-#define F77_sgemm 		F77_GLOBAL(sgemm,SGEMM)
-#define F77_ssymm 		F77_GLOBAL(ssymm,SSYMM)
-#define F77_ssyrk 		F77_GLOBAL(ssyrk,SSYRK)
-#define F77_ssyr2k 		F77_GLOBAL(ssyr2k,SSYR2K)
-#define F77_strmm 		F77_GLOBAL(strmm,STRMM)
-#define F77_strsm 		F77_GLOBAL(strsm,STRSM)
-#define F77_dgemm 		F77_GLOBAL(dgemm,DGEMM)
-#define F77_dsymm 		F77_GLOBAL(dsymm,DSYMM)
-#define F77_dsyrk 		F77_GLOBAL(dsyrk,DSYRK)
-#define F77_dsyr2k 		F77_GLOBAL(dsyr2k,DSYR2K)
-#define F77_dtrmm 		F77_GLOBAL(dtrmm,DTRMM)
-#define F77_dtrsm 		F77_GLOBAL(dtrsm,DTRSM)
-#define F77_cgemm 		F77_GLOBAL(cgemm,CGEMM)
-#define F77_csymm 		F77_GLOBAL(csymm,CSYMM)
-#define F77_csyrk 		F77_GLOBAL(csyrk,CSYRK)
-#define F77_csyr2k 		F77_GLOBAL(csyr2k,CSYR2K)
-#define F77_ctrmm 		F77_GLOBAL(ctrmm,CTRMM)
-#define F77_ctrsm 		F77_GLOBAL(ctrsm,CTRSM)
-#define F77_zgemm 		F77_GLOBAL(zgemm,ZGEMM)
-#define F77_zsymm 		F77_GLOBAL(zsymm,ZSYMM)
-#define F77_zsyrk 		F77_GLOBAL(zsyrk,ZSYRK)
-#define F77_zsyr2k 		F77_GLOBAL(zsyr2k,ZSYR2K)
-#define F77_ztrmm 		F77_GLOBAL(ztrmm,ZTRMM)
-#define F77_ztrsm 		F77_GLOBAL(ztrsm,ZTRSM)
+#define F77_chemm_base 		F77_GLOBAL(chemm,CHEMM)
+#define F77_cherk_base 		F77_GLOBAL(cherk,CHERK)
+#define F77_cher2k_base 		F77_GLOBAL(cher2k,CHER2K)
+#define F77_zhemm_base 		F77_GLOBAL(zhemm,ZHEMM)
+#define F77_zherk_base 		F77_GLOBAL(zherk,ZHERK)
+#define F77_zher2k_base 		F77_GLOBAL(zher2k,ZHER2K)
+#define F77_sgemm_base 		F77_GLOBAL(sgemm,SGEMM)
+#define F77_ssymm_base 		F77_GLOBAL(ssymm,SSYMM)
+#define F77_ssyrk_base 		F77_GLOBAL(ssyrk,SSYRK)
+#define F77_ssyr2k_base 		F77_GLOBAL(ssyr2k,SSYR2K)
+#define F77_strmm_base 		F77_GLOBAL(strmm,STRMM)
+#define F77_strsm_base 		F77_GLOBAL(strsm,STRSM)
+#define F77_dgemm_base 		F77_GLOBAL(dgemm,DGEMM)
+#define F77_dsymm_base 		F77_GLOBAL(dsymm,DSYMM)
+#define F77_dsyrk_base 		F77_GLOBAL(dsyrk,DSYRK)
+#define F77_dsyr2k_base 		F77_GLOBAL(dsyr2k,DSYR2K)
+#define F77_dtrmm_base 		F77_GLOBAL(dtrmm,DTRMM)
+#define F77_dtrsm_base 		F77_GLOBAL(dtrsm,DTRSM)
+#define F77_cgemm_base 		F77_GLOBAL(cgemm,CGEMM)
+#define F77_csymm_base 		F77_GLOBAL(csymm,CSYMM)
+#define F77_csyrk_base 		F77_GLOBAL(csyrk,CSYRK)
+#define F77_csyr2k_base 		F77_GLOBAL(csyr2k,CSYR2K)
+#define F77_ctrmm_base 		F77_GLOBAL(ctrmm,CTRMM)
+#define F77_ctrsm_base 		F77_GLOBAL(ctrsm,CTRSM)
+#define F77_zgemm_base 		F77_GLOBAL(zgemm,ZGEMM)
+#define F77_zsymm_base 		F77_GLOBAL(zsymm,ZSYMM)
+#define F77_zsyrk_base 		F77_GLOBAL(zsyrk,ZSYRK)
+#define F77_zsyr2k_base 		F77_GLOBAL(zsyr2k,ZSYR2K)
+#define F77_ztrmm_base 		F77_GLOBAL(ztrmm,ZTRMM)
+#define F77_ztrsm_base 		F77_GLOBAL(ztrsm,ZTRSM)
+
+/*
+ * Level 1 Fortran variadic definitions
+ */
+
+/* Single Precision */
+
+   #define F77_srot(...) F77_srot_base(__VA_ARGS__)
+   #define F77_srotg(...) F77_srotg_base(__VA_ARGS__)
+   #define F77_srotm(...) F77_srotm_base(__VA_ARGS__)
+   #define F77_srotmg(...) F77_srotmg_base(__VA_ARGS__)
+   #define F77_sswap(...) F77_sswap_base(__VA_ARGS__)
+   #define F77_scopy(...) F77_scopy_base(__VA_ARGS__)
+   #define F77_saxpy(...) F77_saxpy_base(__VA_ARGS__)
+   #define F77_sdot_sub(...) F77_sdot_sub_base(__VA_ARGS__)
+   #define F77_sdsdot_sub(...) F77_sdsdot_sub_base(__VA_ARGS__)
+   #define F77_sscal(...) F77_sscal_base(__VA_ARGS__)
+   #define F77_snrm2_sub(...) F77_snrm2_sub_base(__VA_ARGS__)
+   #define F77_sasum_sub(...) F77_sasum_sub_base(__VA_ARGS__)
+   #define F77_isamax_sub(...) F77_isamax_sub_base(__VA_ARGS__)
+
+/* Double Precision */
+
+   #define F77_drot(...) F77_drot_base(__VA_ARGS__)
+   #define F77_drotg(...) F77_drotg_base(__VA_ARGS__)
+   #define F77_drotm(...) F77_drotm_base(__VA_ARGS__)
+   #define F77_drotmg(...) F77_drotmg_base(__VA_ARGS__)
+   #define F77_dswap(...) F77_dswap_base(__VA_ARGS__)
+   #define F77_dcopy(...) F77_dcopy_base(__VA_ARGS__)
+   #define F77_daxpy(...) F77_daxpy_base(__VA_ARGS__)
+   #define F77_dswap(...) F77_dswap_base(__VA_ARGS__)
+   #define F77_dsdot_sub(...) F77_dsdot_sub_base(__VA_ARGS__)
+   #define F77_ddot_sub(...) F77_ddot_sub_base(__VA_ARGS__)
+   #define F77_dscal(...) F77_dscal_base(__VA_ARGS__)
+   #define F77_dnrm2_sub(...) F77_dnrm2_sub_base(__VA_ARGS__)
+   #define F77_dasum_sub(...) F77_dasum_sub_base(__VA_ARGS__)
+   #define F77_idamax_sub(...) F77_idamax_sub_base(__VA_ARGS__)
+
+/* Single Complex Precision */
+
+   #define F77_cswap(...) F77_cswap_base(__VA_ARGS__)
+   #define F77_ccopy(...) F77_ccopy_base(__VA_ARGS__)
+   #define F77_caxpy(...) F77_caxpy_base(__VA_ARGS__)
+   #define F77_cswap(...) F77_cswap_base(__VA_ARGS__)
+   #define F77_cdotc_sub(...) F77_cdotc_sub_base(__VA_ARGS__)
+   #define F77_cdotu_sub(...) F77_cdotu_sub_base(__VA_ARGS__)
+   #define F77_cscal(...) F77_cscal_base(__VA_ARGS__)
+   #define F77_icamax_sub(...) F77_icamax_sub_base(__VA_ARGS__)
+   #define F77_csscal(...) F77_csscal_base(__VA_ARGS__)
+   #define F77_scnrm2_sub(...) F77_scnrm2_sub_base(__VA_ARGS__)
+   #define F77_scasum_sub(...) F77_scasum_sub_base(__VA_ARGS__)
+
+/* Double Complex Precision */
+
+   #define F77_zswap(...) F77_zswap_base(__VA_ARGS__)
+   #define F77_zcopy(...) F77_zcopy_base(__VA_ARGS__)
+   #define F77_zaxpy(...) F77_zaxpy_base(__VA_ARGS__)
+   #define F77_zswap(...) F77_zswap_base(__VA_ARGS__)
+   #define F77_zdotc_sub(...) F77_zdotc_sub_base(__VA_ARGS__)
+   #define F77_zdotu_sub(...) F77_zdotu_sub_base(__VA_ARGS__)
+   #define F77_zdscal(...) F77_zdscal_base(__VA_ARGS__)
+   #define F77_zscal(...) F77_zscal_base(__VA_ARGS__)
+   #define F77_dznrm2_sub(...) F77_dznrm2_sub_base(__VA_ARGS__)
+   #define F77_dzasum_sub(...) F77_dzasum_sub_base(__VA_ARGS__)
+   #define F77_izamax_sub(...) F77_izamax_sub_base(__VA_ARGS__)
+
+/*
+ * Level 2 Fortran variadic definitions without FCHAR
+ */
+
+   #define F77_sger(...) F77_sger_base(__VA_ARGS__)
+   #define F77_dger(...) F77_dger_base(__VA_ARGS__)
+   #define F77_cgerc(...) F77_cgerc_base(__VA_ARGS__)
+   #define F77_cgeru(...) F77_cgeru_base(__VA_ARGS__)
+   #define F77_zgerc(...) F77_zgerc_base(__VA_ARGS__)
+   #define F77_zgeru(...) F77_zgeru_base(__VA_ARGS__)
+
+#ifdef LAPACK_FORTRAN_STRLEN_END
+
+   /*
+   * Level 2 Fortran variadic definitions with LAPACK_FORTRAN_STRLEN_END
+   */
+
+   /* Single Precision */
+
+   #define F77_sgemv(...) F77_sgemv_base(__VA_ARGS__, 1)
+   #define F77_sgbmv(...) F77_sgbmv_base(__VA_ARGS__, 1)
+   #define F77_ssymv(...) F77_ssymv_base(__VA_ARGS__, 1)
+   #define F77_ssbmv(...) F77_ssbmv_base(__VA_ARGS__, 1)
+   #define F77_sspmv(...) F77_sspmv_base(__VA_ARGS__, 1)
+   #define F77_strmv(...) F77_strmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_stbmv(...) F77_stbmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_strsv(...) F77_strsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_stbsv(...) F77_stbsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_stpmv(...) F77_stpmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_stpsv(...) F77_stpsv_base(__VA_ARGS__, 1, 1, 1)
+      #define F77_ssyr(...) F77_ssyr_base(__VA_ARGS__, 1)
+   #define F77_sspr(...) F77_sspr_base(__VA_ARGS__, 1)
+   #define F77_sspr2(...) F77_sspr2_base(__VA_ARGS__, 1)
+   #define F77_ssyr2(...) F77_ssyr2_base(__VA_ARGS__, 1)
+
+   /* Double Precision */
+
+   #define F77_dgemv(...) F77_dgemv_base(__VA_ARGS__, 1)
+   #define F77_dgbmv(...) F77_dgbmv_base(__VA_ARGS__, 1)
+   #define F77_dsymv(...) F77_dsymv_base(__VA_ARGS__, 1)
+   #define F77_dsbmv(...) F77_dsbmv_base(__VA_ARGS__, 1)
+   #define F77_dspmv(...) F77_dspmv_base(__VA_ARGS__, 1)
+   #define F77_dtrmv(...) F77_dtrmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_dtbmv(...) F77_dtbmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_dtrsv(...) F77_dtrsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_dtbsv(...) F77_dtbsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_dtpmv(...) F77_dtpmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_dtpsv(...) F77_dtpsv_base(__VA_ARGS__, 1, 1, 1)
+      #define F77_dsyr(...) F77_dsyr_base(__VA_ARGS__, 1)
+   #define F77_dspr(...) F77_dspr_base(__VA_ARGS__, 1)
+   #define F77_dspr2(...) F77_dspr2_base(__VA_ARGS__, 1)
+   #define F77_dsyr2(...) F77_dsyr2_base(__VA_ARGS__, 1)
+
+      /* Single Complex Precision */
+
+   #define F77_cgemv(...) F77_cgemv_base(__VA_ARGS__, 1)
+   #define F77_cgbmv(...) F77_cgbmv_base(__VA_ARGS__, 1)
+   #define F77_chemv(...) F77_chemv_base(__VA_ARGS__, 1)
+   #define F77_chbmv(...) F77_chbmv_base(__VA_ARGS__, 1)
+   #define F77_chpmv(...) F77_chpmv_base(__VA_ARGS__, 1)
+   #define F77_ctrmv(...) F77_ctrmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ctbmv(...) F77_ctbmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ctpmv(...) F77_ctpmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ctrsv(...) F77_ctrsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ctbsv(...) F77_ctbsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ctpsv(...) F77_ctpsv_base(__VA_ARGS__, 1, 1, 1)
+         #define F77_cher(...) F77_cher_base(__VA_ARGS__, 1)
+   #define F77_cher2(...) F77_cher2_base(__VA_ARGS__, 1)
+   #define F77_chpr(...) F77_chpr_base(__VA_ARGS__, 1)
+   #define F77_chpr2(...) F77_chpr2_base(__VA_ARGS__, 1)
+
+   /* Double Complex Precision */
+
+   #define F77_zgemv(...) F77_zgemv_base(__VA_ARGS__, 1)
+   #define F77_zgbmv(...) F77_zgbmv_base(__VA_ARGS__, 1)
+   #define F77_zhemv(...) F77_zhemv_base(__VA_ARGS__, 1)
+   #define F77_zhbmv(...) F77_zhbmv_base(__VA_ARGS__, 1)
+   #define F77_zhpmv(...) F77_zhpmv_base(__VA_ARGS__, 1)
+   #define F77_ztrmv(...) F77_ztrmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ztbmv(...) F77_ztbmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ztpmv(...) F77_ztpmv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ztrsv(...) F77_ztrsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ztbsv(...) F77_ztbsv_base(__VA_ARGS__, 1, 1, 1)
+   #define F77_ztpsv(...) F77_ztpsv_base(__VA_ARGS__, 1, 1, 1)
+         #define F77_zher(...) F77_zher_base(__VA_ARGS__, 1)
+   #define F77_zher2(...) F77_zher2_base(__VA_ARGS__, 1)
+   #define F77_zhpr(...) F77_zhpr_base(__VA_ARGS__, 1)
+   #define F77_zhpr2(...) F77_zhpr2_base(__VA_ARGS__, 1)
+
+   /*
+   * Level 3 Fortran variadic definitions with LAPACK_FORTRAN_STRLEN_END
+   */
+
+   /* Single Precision */
+
+   #define F77_sgemm(...) F77_sgemm_base(__VA_ARGS__, 1, 1)
+   #define F77_ssymm(...) F77_ssymm_base(__VA_ARGS__, 1, 1)
+   #define F77_ssyrk(...) F77_ssyrk_base(__VA_ARGS__, 1, 1)
+   #define F77_ssyr2k(...) F77_ssyr2k_base(__VA_ARGS__, 1, 1)
+   #define F77_strmm(...) F77_strmm_base(__VA_ARGS__, 1, 1, 1, 1)
+   #define F77_strsm(...) F77_strsm_base(__VA_ARGS__, 1, 1, 1, 1)
+
+   /* Double Precision */
+
+   #define F77_dgemm(...) F77_dgemm_base(__VA_ARGS__, 1, 1)
+   #define F77_dsymm(...) F77_dsymm_base(__VA_ARGS__, 1, 1)
+   #define F77_dsyrk(...) F77_dsyrk_base(__VA_ARGS__, 1, 1)
+   #define F77_dsyr2k(...) F77_dsyr2k_base(__VA_ARGS__, 1, 1)
+   #define F77_dtrmm(...) F77_dtrmm_base(__VA_ARGS__, 1, 1, 1, 1)
+   #define F77_dtrsm(...) F77_dtrsm_base(__VA_ARGS__, 1, 1, 1, 1)
+
+   /* Single Complex Precision */
+
+   #define F77_cgemm(...) F77_cgemm_base(__VA_ARGS__, 1, 1)
+   #define F77_csymm(...) F77_csymm_base(__VA_ARGS__, 1, 1)
+   #define F77_chemm(...) F77_chemm_base(__VA_ARGS__, 1, 1)
+   #define F77_csyrk(...) F77_csyrk_base(__VA_ARGS__, 1, 1)
+   #define F77_cherk(...) F77_cherk_base(__VA_ARGS__, 1, 1)
+   #define F77_csyr2k(...) F77_csyr2k_base(__VA_ARGS__, 1, 1)
+   #define F77_cher2k(...) F77_cher2k_base(__VA_ARGS__, 1, 1)
+   #define F77_ctrmm(...) F77_ctrmm_base(__VA_ARGS__, 1, 1, 1, 1)
+   #define F77_ctrsm(...) F77_ctrsm_base(__VA_ARGS__, 1, 1, 1, 1)
+
+   /* Double Complex Precision */
+
+   #define F77_zgemm(...) F77_zgemm_base(__VA_ARGS__, 1, 1)
+   #define F77_zsymm(...) F77_zsymm_base(__VA_ARGS__, 1, 1)
+   #define F77_zhemm(...) F77_zhemm_base(__VA_ARGS__, 1, 1)
+   #define F77_zsyrk(...) F77_zsyrk_base(__VA_ARGS__, 1, 1)
+   #define F77_zherk(...) F77_zherk_base(__VA_ARGS__, 1, 1)
+   #define F77_zsyr2k(...) F77_zsyr2k_base(__VA_ARGS__, 1, 1)
+   #define F77_zher2k(...) F77_zher2k_base(__VA_ARGS__, 1, 1)
+   #define F77_ztrmm(...) F77_ztrmm_base(__VA_ARGS__, 1, 1, 1, 1)
+   #define F77_ztrsm(...) F77_ztrsm_base(__VA_ARGS__, 1, 1, 1, 1)
+
+#else
+                              
+   /*
+   * Level 2 Fortran variadic definitions without LAPACK_FORTRAN_STRLEN_END
+   */
+
+   /* Single Precision */
+
+   #define F77_sgemv(...) F77_sgemv_base(__VA_ARGS__)
+   #define F77_sgbmv(...) F77_sgbmv_base(__VA_ARGS__)
+   #define F77_ssymv(...) F77_ssymv_base(__VA_ARGS__)
+   #define F77_ssbmv(...) F77_ssbmv_base(__VA_ARGS__)
+   #define F77_sspmv(...) F77_sspmv_base(__VA_ARGS__)
+   #define F77_strmv(...) F77_strmv_base(__VA_ARGS__)
+   #define F77_stbmv(...) F77_stbmv_base(__VA_ARGS__)
+   #define F77_strsv(...) F77_strsv_base(__VA_ARGS__)
+   #define F77_stbsv(...) F77_stbsv_base(__VA_ARGS__)
+   #define F77_stpmv(...) F77_stpmv_base(__VA_ARGS__)
+   #define F77_stpsv(...) F77_stpsv_base(__VA_ARGS__)
+      #define F77_ssyr(...) F77_ssyr_base(__VA_ARGS__)
+   #define F77_sspr(...) F77_sspr_base(__VA_ARGS__)
+   #define F77_sspr2(...) F77_sspr2_base(__VA_ARGS__)
+   #define F77_ssyr2(...) F77_ssyr2_base(__VA_ARGS__)
+
+   /* Double Precision */
+
+   #define F77_dgemv(...) F77_dgemv_base(__VA_ARGS__)
+   #define F77_dgbmv(...) F77_dgbmv_base(__VA_ARGS__)
+   #define F77_dsymv(...) F77_dsymv_base(__VA_ARGS__)
+   #define F77_dsbmv(...) F77_dsbmv_base(__VA_ARGS__)
+   #define F77_dspmv(...) F77_dspmv_base(__VA_ARGS__)
+   #define F77_dtrmv(...) F77_dtrmv_base(__VA_ARGS__)
+   #define F77_dtbmv(...) F77_dtbmv_base(__VA_ARGS__)
+   #define F77_dtrsv(...) F77_dtrsv_base(__VA_ARGS__)
+   #define F77_dtbsv(...) F77_dtbsv_base(__VA_ARGS__)
+   #define F77_dtpmv(...) F77_dtpmv_base(__VA_ARGS__)
+   #define F77_dtpsv(...) F77_dtpsv_base(__VA_ARGS__)
+      #define F77_dsyr(...) F77_dsyr_base(__VA_ARGS__)
+   #define F77_dspr(...) F77_dspr_base(__VA_ARGS__)
+   #define F77_dspr2(...) F77_dspr2_base(__VA_ARGS__)
+   #define F77_dsyr2(...) F77_dsyr2_base(__VA_ARGS__)
+
+   /* Single Complex Precision */
+
+   #define F77_cgemv(...) F77_cgemv_base(__VA_ARGS__)
+   #define F77_cgbmv(...) F77_cgbmv_base(__VA_ARGS__)
+   #define F77_chemv(...) F77_chemv_base(__VA_ARGS__)
+   #define F77_chbmv(...) F77_chbmv_base(__VA_ARGS__)
+   #define F77_chpmv(...) F77_chpmv_base(__VA_ARGS__)
+   #define F77_ctrmv(...) F77_ctrmv_base(__VA_ARGS__)
+   #define F77_ctbmv(...) F77_ctbmv_base(__VA_ARGS__)
+   #define F77_ctpmv(...) F77_ctpmv_base(__VA_ARGS__)
+   #define F77_ctrsv(...) F77_ctrsv_base(__VA_ARGS__)
+   #define F77_ctbsv(...) F77_ctbsv_base(__VA_ARGS__)
+   #define F77_ctpsv(...) F77_ctpsv_base(__VA_ARGS__)
+         #define F77_cher(...) F77_cher_base(__VA_ARGS__)
+   #define F77_cher2(...) F77_cher2_base(__VA_ARGS__)
+   #define F77_chpr(...) F77_chpr_base(__VA_ARGS__)
+   #define F77_chpr2(...) F77_chpr2_base(__VA_ARGS__)
+
+   /* Double Complex Precision */
+
+   #define F77_zgemv(...) F77_zgemv_base(__VA_ARGS__)
+   #define F77_zgbmv(...) F77_zgbmv_base(__VA_ARGS__)
+   #define F77_zhemv(...) F77_zhemv_base(__VA_ARGS__)
+   #define F77_zhbmv(...) F77_zhbmv_base(__VA_ARGS__)
+   #define F77_zhpmv(...) F77_zhpmv_base(__VA_ARGS__)
+   #define F77_ztrmv(...) F77_ztrmv_base(__VA_ARGS__)
+   #define F77_ztbmv(...) F77_ztbmv_base(__VA_ARGS__)
+   #define F77_ztpmv(...) F77_ztpmv_base(__VA_ARGS__)
+   #define F77_ztrsv(...) F77_ztrsv_base(__VA_ARGS__)
+   #define F77_ztbsv(...) F77_ztbsv_base(__VA_ARGS__)
+   #define F77_ztpsv(...) F77_ztpsv_base(__VA_ARGS__)
+         #define F77_zher(...) F77_zher_base(__VA_ARGS__)
+   #define F77_zher2(...) F77_zher2_base(__VA_ARGS__)
+   #define F77_zhpr(...) F77_zhpr_base(__VA_ARGS__)
+   #define F77_zhpr2(...) F77_zhpr2_base(__VA_ARGS__)
+
+   /*
+   * Level 3 Fortran variadic definitions without LAPACK_FORTRAN_STRLEN_END
+   */
+
+   /* Single Precision */
+
+   #define F77_sgemm(...) F77_sgemm_base(__VA_ARGS__)
+   #define F77_ssymm(...) F77_ssymm_base(__VA_ARGS__)
+   #define F77_ssyrk(...) F77_ssyrk_base(__VA_ARGS__)
+   #define F77_ssyr2k(...) F77_ssyr2k_base(__VA_ARGS__)
+   #define F77_strmm(...) F77_strmm_base(__VA_ARGS__)
+   #define F77_strsm(...) F77_strsm_base(__VA_ARGS__)
+
+   /* Double Precision */
+
+   #define F77_dgemm(...) F77_dgemm_base(__VA_ARGS__)
+   #define F77_dsymm(...) F77_dsymm_base(__VA_ARGS__)
+   #define F77_dsyrk(...) F77_dsyrk_base(__VA_ARGS__)
+   #define F77_dsyr2k(...) F77_dsyr2k_base(__VA_ARGS__)
+   #define F77_dtrmm(...) F77_dtrmm_base(__VA_ARGS__)
+   #define F77_dtrsm(...) F77_dtrsm_base(__VA_ARGS__)
+
+   /* Single Complex Precision */
+
+   #define F77_cgemm(...) F77_cgemm_base(__VA_ARGS__)
+   #define F77_csymm(...) F77_csymm_base(__VA_ARGS__)
+   #define F77_chemm(...) F77_chemm_base(__VA_ARGS__)
+   #define F77_csyrk(...) F77_csyrk_base(__VA_ARGS__)
+   #define F77_cherk(...) F77_cherk_base(__VA_ARGS__)
+   #define F77_csyr2k(...) F77_csyr2k_base(__VA_ARGS__)
+   #define F77_cher2k(...) F77_cher2k_base(__VA_ARGS__)
+   #define F77_ctrmm(...) F77_ctrmm_base(__VA_ARGS__)
+   #define F77_ctrsm(...) F77_ctrsm_base(__VA_ARGS__)
+
+   /* Double Complex Precision */
+
+   #define F77_zgemm(...) F77_zgemm_base(__VA_ARGS__)
+   #define F77_zsymm(...) F77_zsymm_base(__VA_ARGS__)
+   #define F77_zhemm(...) F77_zhemm_base(__VA_ARGS__)
+   #define F77_zsyrk(...) F77_zsyrk_base(__VA_ARGS__)
+   #define F77_zherk(...) F77_zherk_base(__VA_ARGS__)
+   #define F77_zsyr2k(...) F77_zsyr2k_base(__VA_ARGS__)
+   #define F77_zher2k(...) F77_zher2k_base(__VA_ARGS__)
+   #define F77_ztrmm(...) F77_ztrmm_base(__VA_ARGS__)
+   #define F77_ztrsm(...) F77_ztrsm_base(__VA_ARGS__)
+
+#endif
+
+/*
+ * Base function prototypes
+ */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void F77_xerbla(FCHAR, void *);
+void F77_xerbla_base(FCHAR, void *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
 /*
  * Level 1 Fortran Prototypes
  */
 
 /* Single Precision */
 
-   void F77_srot(FINT, float *, FINT, float *, FINT, const float *, const float *);
-   void F77_srotg(float *,float *,float *,float *);
-   void F77_srotm( FINT, float *, FINT, float *, FINT, const float *);
-   void F77_srotmg(float *,float *,float *,const float *, float *);
-   void F77_sswap( FINT, float *, FINT, float *, FINT);
-   void F77_scopy( FINT, const float *, FINT, float *, FINT);
-   void F77_saxpy( FINT, const float *, const float *, FINT, float *, FINT);
-   void F77_sdot_sub(FINT, const float *, FINT, const float *, FINT, float *);
-   void F77_sdsdot_sub( FINT, const float *, const float *, FINT, const float *, FINT, float *);
-   void F77_sscal( FINT, const float *, float *, FINT);
-   void F77_snrm2_sub( FINT, const float *, FINT, float *);
-   void F77_sasum_sub( FINT, const float *, FINT, float *);
-   void F77_isamax_sub( FINT, const float * , FINT, FINT2);
+   void F77_srot_base(FINT, float *, FINT, float *, FINT, const float *, const float *);
+   void F77_srotg_base(float *,float *,float *,float *);
+   void F77_srotm_base( FINT, float *, FINT, float *, FINT, const float *);
+   void F77_srotmg_base(float *,float *,float *,const float *, float *);
+   void F77_sswap_base( FINT, float *, FINT, float *, FINT);
+   void F77_scopy_base( FINT, const float *, FINT, float *, FINT);
+   void F77_saxpy_base( FINT, const float *, const float *, FINT, float *, FINT);
+   void F77_sdot_sub_base(FINT, const float *, FINT, const float *, FINT, float *);
+   void F77_sdsdot_sub_base( FINT, const float *, const float *, FINT, const float *, FINT, float *);
+   void F77_sscal_base( FINT, const float *, float *, FINT);
+   void F77_snrm2_sub_base( FINT, const float *, FINT, float *);
+   void F77_sasum_sub_base( FINT, const float *, FINT, float *);
+   void F77_isamax_sub_base( FINT, const float * , FINT, FINT2);
 
 /* Double Precision */
 
-   void F77_drot(FINT, double *, FINT, double *, FINT, const double *, const double *);
-   void F77_drotg(double *,double *,double *,double *);
-   void F77_drotm( FINT, double *, FINT, double *, FINT, const double *);
-   void F77_drotmg(double *,double *,double *,const double *, double *);
-   void F77_dswap( FINT, double *, FINT, double *, FINT);
-   void F77_dcopy( FINT, const double *, FINT, double *, FINT);
-   void F77_daxpy( FINT, const double *, const double *, FINT, double *, FINT);
-   void F77_dswap( FINT, double *, FINT, double *, FINT);
-   void F77_dsdot_sub(FINT, const float *, FINT, const float *, FINT, double *);
-   void F77_ddot_sub( FINT, const double *, FINT, const double *, FINT, double *);
-   void F77_dscal( FINT, const double *, double *, FINT);
-   void F77_dnrm2_sub( FINT, const double *, FINT, double *);
-   void F77_dasum_sub( FINT, const double *, FINT, double *);
-   void F77_idamax_sub( FINT, const double * , FINT, FINT2);
+   void F77_drot_base(FINT, double *, FINT, double *, FINT, const double *, const double *);
+   void F77_drotg_base(double *,double *,double *,double *);
+   void F77_drotm_base( FINT, double *, FINT, double *, FINT, const double *);
+   void F77_drotmg_base(double *,double *,double *,const double *, double *);
+   void F77_dswap_base( FINT, double *, FINT, double *, FINT);
+   void F77_dcopy_base( FINT, const double *, FINT, double *, FINT);
+   void F77_daxpy_base( FINT, const double *, const double *, FINT, double *, FINT);
+   void F77_dswap_base( FINT, double *, FINT, double *, FINT);
+   void F77_dsdot_sub_base(FINT, const float *, FINT, const float *, FINT, double *);
+   void F77_ddot_sub_base( FINT, const double *, FINT, const double *, FINT, double *);
+   void F77_dscal_base( FINT, const double *, double *, FINT);
+   void F77_dnrm2_sub_base( FINT, const double *, FINT, double *);
+   void F77_dasum_sub_base( FINT, const double *, FINT, double *);
+   void F77_idamax_sub_base( FINT, const double * , FINT, FINT2);
 
 /* Single Complex Precision */
 
-   void F77_cswap( FINT, void *, FINT, void *, FINT);
-   void F77_ccopy( FINT, const void *, FINT, void *, FINT);
-   void F77_caxpy( FINT, const void *, const void *, FINT, void *, FINT);
-   void F77_cswap( FINT, void *, FINT, void *, FINT);
-   void F77_cdotc_sub( FINT, const void *, FINT, const void *, FINT, void *);
-   void F77_cdotu_sub( FINT, const void *, FINT, const void *, FINT, void *);
-   void F77_cscal( FINT, const void *, void *, FINT);
-   void F77_icamax_sub( FINT, const void *, FINT, FINT2);
-   void F77_csscal( FINT, const float *, void *, FINT);
-   void F77_scnrm2_sub( FINT, const void *, FINT, float *);
-   void F77_scasum_sub( FINT, const void *, FINT, float *);
+   void F77_cswap_base( FINT, void *, FINT, void *, FINT);
+   void F77_ccopy_base( FINT, const void *, FINT, void *, FINT);
+   void F77_caxpy_base( FINT, const void *, const void *, FINT, void *, FINT);
+   void F77_cswap_base( FINT, void *, FINT, void *, FINT);
+   void F77_cdotc_sub_base( FINT, const void *, FINT, const void *, FINT, void *);
+   void F77_cdotu_sub_base( FINT, const void *, FINT, const void *, FINT, void *);
+   void F77_cscal_base( FINT, const void *, void *, FINT);
+   void F77_icamax_sub_base( FINT, const void *, FINT, FINT2);
+   void F77_csscal_base( FINT, const float *, void *, FINT);
+   void F77_scnrm2_sub_base( FINT, const void *, FINT, float *);
+   void F77_scasum_sub_base( FINT, const void *, FINT, float *);
 
 /* Double Complex Precision */
 
-   void F77_zswap( FINT, void *, FINT, void *, FINT);
-   void F77_zcopy( FINT, const void *, FINT, void *, FINT);
-   void F77_zaxpy( FINT, const void *, const void *, FINT, void *, FINT);
-   void F77_zswap( FINT, void *, FINT, void *, FINT);
-   void F77_zdotc_sub( FINT, const void *, FINT, const void *, FINT, void *);
-   void F77_zdotu_sub( FINT, const void *, FINT, const void *, FINT, void *);
-   void F77_zdscal( FINT, const double *, void *, FINT);
-   void F77_zscal( FINT, const void *, void *, FINT);
-   void F77_dznrm2_sub( FINT, const void *, FINT, double *);
-   void F77_dzasum_sub( FINT, const void *, FINT, double *);
-   void F77_izamax_sub( FINT, const void *, FINT, FINT2);
+   void F77_zswap_base( FINT, void *, FINT, void *, FINT);
+   void F77_zcopy_base( FINT, const void *, FINT, void *, FINT);
+   void F77_zaxpy_base( FINT, const void *, const void *, FINT, void *, FINT);
+   void F77_zswap_base( FINT, void *, FINT, void *, FINT);
+   void F77_zdotc_sub_base( FINT, const void *, FINT, const void *, FINT, void *);
+   void F77_zdotu_sub_base( FINT, const void *, FINT, const void *, FINT, void *);
+   void F77_zdscal_base( FINT, const double *, void *, FINT);
+   void F77_zscal_base( FINT, const void *, void *, FINT);
+   void F77_dznrm2_sub_base( FINT, const void *, FINT, double *);
+   void F77_dzasum_sub_base( FINT, const void *, FINT, double *);
+   void F77_izamax_sub_base( FINT, const void *, FINT, FINT2);
 
 /*
  * Level 2 Fortran Prototypes
@@ -262,81 +598,321 @@ void F77_xerbla(FCHAR, void *);
 
 /* Single Precision */
 
-   void F77_sgemv(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_sgbmv(FCHAR, FINT, FINT, FINT, FINT, const float *,  const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_ssymv(FCHAR, FINT, const float *, const float *, FINT, const float *,  FINT, const float *, float *, FINT);
-   void F77_ssbmv(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_sspmv(FCHAR, FINT, const float *, const float *, const float *, FINT, const float *, float *, FINT);
-   void F77_strmv( FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT);
-   void F77_stbmv( FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT);
-   void F77_strsv( FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT);
-   void F77_stbsv( FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT);
-   void F77_stpmv( FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT);
-   void F77_stpsv( FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT);
-   void F77_sger( FINT, FINT, const float *, const float *, FINT, const float *, FINT, float *, FINT);
-   void F77_ssyr(FCHAR, FINT, const float *, const float *, FINT, float *, FINT);
-   void F77_sspr(FCHAR, FINT, const float *, const float *, FINT, float *);
-   void F77_sspr2(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *);
-   void F77_ssyr2(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *, FINT);
+   void F77_sgemv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_sgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const float *,  const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_ssymv_base(FCHAR, FINT, const float *, const float *, FINT, const float *,  FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_ssbmv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_sspmv_base(FCHAR, FINT, const float *, const float *, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_strmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_stbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_strsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_stbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_stpmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_stpsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_sger_base( FINT, FINT, const float *, const float *, FINT, const float *, FINT, float *, FINT);
+   void F77_ssyr_base(FCHAR, FINT, const float *, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_sspr_base(FCHAR, FINT, const float *, const float *, FINT, float *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_sspr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_ssyr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
 
 /* Double Precision */
 
-   void F77_dgemv(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_dgbmv(FCHAR, FINT, FINT, FINT, FINT, const double *,  const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_dsymv(FCHAR, FINT, const double *, const double *, FINT, const double *,  FINT, const double *, double *, FINT);
-   void F77_dsbmv(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_dspmv(FCHAR, FINT, const double *, const double *, const double *, FINT, const double *, double *, FINT);
-   void F77_dtrmv( FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT);
-   void F77_dtbmv( FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT);
-   void F77_dtrsv( FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT);
-   void F77_dtbsv( FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT);
-   void F77_dtpmv( FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT);
-   void F77_dtpsv( FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT);
-   void F77_dger( FINT, FINT, const double *, const double *, FINT, const double *, FINT, double *, FINT);
-   void F77_dsyr(FCHAR, FINT, const double *, const double *, FINT, double *, FINT);
-   void F77_dspr(FCHAR, FINT, const double *, const double *, FINT, double *);
-   void F77_dspr2(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *);
-   void F77_dsyr2(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *, FINT);
+   void F77_dgemv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const double *,  const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dsymv_base(FCHAR, FINT, const double *, const double *, FINT, const double *,  FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dsbmv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dspmv_base(FCHAR, FINT, const double *, const double *, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dtrmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_dtbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_dtrsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_dtbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_dtpmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_dtpsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_dger_base( FINT, FINT, const double *, const double *, FINT, const double *, FINT, double *, FINT);
+   void F77_dsyr_base(FCHAR, FINT, const double *, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dspr_base(FCHAR, FINT, const double *, const double *, FINT, double *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dspr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_dsyr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
 
 /* Single Complex Precision */
 
-   void F77_cgemv(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_cgbmv(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_chemv(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_chbmv(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_chpmv(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT);
-   void F77_ctrmv( FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT);
-   void F77_ctbmv( FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT);
-   void F77_ctpmv( FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT);
-   void F77_ctrsv( FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT);
-   void F77_ctbsv( FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT);
-   void F77_ctpsv( FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT);
-   void F77_cgerc( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
-   void F77_cgeru( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
-   void F77_cher(FCHAR, FINT, const float *, const void *, FINT, void *, FINT);
-   void F77_cher2(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
-   void F77_chpr(FCHAR, FINT, const float *, const void *, FINT, void *);
-   void F77_chpr2(FCHAR, FINT, const float *, const void *, FINT, const void *, FINT, void *);
+   void F77_cgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_cgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_chemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_chbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_chpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_ctrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ctbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ctpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ctrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ctbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ctpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_cgerc_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
+   void F77_cgeru_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
+   void F77_cher_base(FCHAR, FINT, const float *, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_cher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_chpr_base(FCHAR, FINT, const float *, const void *, FINT, void *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_chpr2_base(FCHAR, FINT, const float *, const void *, FINT, const void *, FINT, void *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
 
 /* Double Complex Precision */
 
-   void F77_zgemv(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_zgbmv(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_zhemv(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_zhbmv(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT);
-   void F77_zhpmv(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT);
-   void F77_ztrmv( FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT);
-   void F77_ztbmv( FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT);
-   void F77_ztpmv( FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT);
-   void F77_ztrsv( FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT);
-   void F77_ztbsv( FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT);
-   void F77_ztpsv( FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT);
-   void F77_zgerc( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
-   void F77_zgeru( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
-   void F77_zher(FCHAR, FINT, const double *, const void *, FINT, void *, FINT);
-   void F77_zher2(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
-   void F77_zhpr(FCHAR, FINT, const double *, const void *, FINT, void *);
-   void F77_zhpr2(FCHAR, FINT, const double *, const void *, FINT, const void *, FINT, void *);
+   void F77_zgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_zgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_zhemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_zhbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_zhpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_ztrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ztbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ztpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ztrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ztbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ztpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_zgerc_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
+   void F77_zgeru_base( FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
+   void F77_zher_base(FCHAR, FINT, const double *, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_zher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_zhpr_base(FCHAR, FINT, const double *, const void *, FINT, void *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
+   void F77_zhpr2_base(FCHAR, FINT, const double *, const void *, FINT, const void *, FINT, void *
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned
+   #endif
+   );
 
 /*
  * Level 3 Fortran Prototypes
@@ -344,45 +920,165 @@ void F77_xerbla(FCHAR, void *);
 
 /* Single Precision */
 
-   void F77_sgemm(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_ssymm(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_ssyrk(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT);
-   void F77_ssyr2k(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_strmm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT);
-   void F77_strsm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT);
+   void F77_sgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_ssymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_ssyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_ssyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_strmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_strsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
 
 /* Double Precision */
 
-   void F77_dgemm(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_dsymm(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_dsyrk(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT);
-   void F77_dsyr2k(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_dtrmm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT);
-   void F77_dtrsm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT);
+   void F77_dgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_dsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_dsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_dsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_dtrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_dtrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
 
 /* Single Complex Precision */
 
-   void F77_cgemm(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_csymm(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_chemm(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_csyrk(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT);
-   void F77_cherk(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT);
-   void F77_csyr2k(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_cher2k(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT);
-   void F77_ctrmm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT);
-   void F77_ctrsm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT);
+   void F77_cgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_csymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_chemm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_csyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_cherk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_csyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_cher2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_ctrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
 
 /* Double Complex Precision */
 
-   void F77_zgemm(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_zsymm(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_zhemm(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_zsyrk(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT);
-   void F77_zherk(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT);
-   void F77_zsyr2k(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_zher2k(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT);
-   void F77_ztrmm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT);
-   void F77_ztrsm(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT);
+   void F77_zgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_zsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_zhemm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_zsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_zherk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_zsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_zher2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned
+   #endif
+   );
+   void F77_ztrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
+   void F77_ztrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+      , unsigned, unsigned, unsigned, unsigned
+   #endif
+   );
 
 #ifdef __cplusplus
 }

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -1525,7 +1525,7 @@ void LAPACK_dgels_base(
     double* work, lapack_int const* lwork,
     lapack_int* info 
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , unsigned
+    , size_t
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -11,6 +11,7 @@
 #include "lapacke_mangling.h"
 
 #include <stdlib.h>
+#include <stdarg.h>
 
 /* Complex types are structures equivalent to the
 * Fortran complex types COMPLEX(4) and COMPLEX(8).
@@ -1515,14 +1516,23 @@ void LAPACK_cgels(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_dgels LAPACK_GLOBAL(dgels,DGELS)
-void LAPACK_dgels(
+#define LAPACK_dgels_base LAPACK_GLOBAL(dgels,DGELS)
+void LAPACK_dgels_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info 
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , unsigned
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgels(...) LAPACK_dgels_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgels(...) LAPACK_dgels_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_sgels LAPACK_GLOBAL(sgels,SGELS)
 void LAPACK_sgels(

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -13,6 +13,11 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+/* It seems all current Fortran compilers put strlen at end.
+*  Some historical compilers put strlen after the str argument
+*  or make the str argument into a struct. */
+#define LAPACK_FORTRAN_STRLEN_END
+
 /* Complex types are structures equivalent to the
 * Fortran complex types COMPLEX(4) and COMPLEX(8).
 *

--- a/make.inc.example
+++ b/make.inc.example
@@ -20,9 +20,9 @@ CFLAGS = -O3
 #  should not compile LAPACK with flags such as -ffpe-trap=overflow.
 #
 FC = gfortran
-FFLAGS = -O2 -frecursive
+FFLAGS = -O2 -frecursive -fcheck=all
 FFLAGS_DRV = $(FFLAGS)
-FFLAGS_NOOPT = -O0 -frecursive
+FFLAGS_NOOPT = -O0 -frecursive -fcheck=all
 
 #  Define LDFLAGS to the desired linker options for your machine.
 #

--- a/make.inc.example
+++ b/make.inc.example
@@ -20,9 +20,9 @@ CFLAGS = -O3
 #  should not compile LAPACK with flags such as -ffpe-trap=overflow.
 #
 FC = gfortran
-FFLAGS = -O2 -frecursive -fcheck=all
+FFLAGS = -O2 -frecursive
 FFLAGS_DRV = $(FFLAGS)
-FFLAGS_NOOPT = -O0 -frecursive -fcheck=all
+FFLAGS_NOOPT = -O0 -frecursive
 
 #  Define LDFLAGS to the desired linker options for your machine.
 #


### PR DESCRIPTION
Fix #512 using @jabl (#339) and @mgates (https://github.com/Reference-LAPACK/lapack/issues/512#issuecomment-799665934) suggestions.

Uses a flag `LAPACK_FORTRAN_STRLEN_END` in CBLAS and LAPACKE.

Maybe I shall also: 
- [x] update make.inc.* with the new flag (I just used `LAPACK_FORTRAN_STRLEN_END` as set by default)
?? - [ ] change all methods in `LAPACKE/include/lapack.h` 