### PR TITLE
cblas: mark cblas_xerbla and F77_xerbla symbols as weak

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -18,6 +18,10 @@ if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
                  ${LAPACK_BINARY_DIR}/include/cblas_mangling.h)
 endif()
 
+include(CheckCSourceCompiles)
+check_c_source_compiles("void __attribute__((weak)) main() {};"
+                        HAS_ATTRIBUTE_WEAK_SUPPORT)
+
 include_directories(include ${LAPACK_BINARY_DIR}/include)
 add_subdirectory(include)
 add_subdirectory(src)

--- a/CBLAS/src/CMakeLists.txt
+++ b/CBLAS/src/CMakeLists.txt
@@ -120,6 +120,9 @@ set_target_properties(
   VERSION ${LAPACK_VERSION}
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
+if(HAS_ATTRIBUTE_WEAK_SUPPORT)
+  target_compile_definitions(${CBLASLIB} PRIVATE HAS_ATTRIBUTE_WEAK_SUPPORT)
+endif()
 target_include_directories(${CBLASLIB} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<INSTALL_INTERFACE:include>

--- a/CBLAS/src/cblas_xerbla.c
+++ b/CBLAS/src/cblas_xerbla.c
@@ -5,7 +5,11 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 
-void cblas_xerbla(CBLAS_INDEX info, const char *rout, const char *form, ...)
+void
+#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
+__attribute__((weak))
+#endif
+cblas_xerbla(CBLAS_INDEX info, const char *rout, const char *form, ...)
 {
    extern int RowMajorStrg;
    char empty[1] = "";

--- a/CBLAS/src/xerbla.c
+++ b/CBLAS/src/xerbla.c
@@ -6,10 +6,15 @@
 #define XerblaStrLen 6
 #define XerblaStrLen1 7
 
+void
+#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
+__attribute__((weak))
+#endif
+F77_xerbla
 #ifdef F77_CHAR
-void F77_xerbla(F77_CHAR F77_srname, void *vinfo)
+(F77_CHAR F77_srname, void *vinfo)
 #else
-void F77_xerbla(char *srname, void *vinfo)
+(char *srname, void *vinfo)
 #endif
 
 {

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -36,11 +36,13 @@ void F77_c2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -39,11 +39,13 @@ void  F77_c3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    if (strncmp( sf,"cblas_cgemm"   ,11)==0) {
       cblas_rout = "cblas_cgemm"   ;

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -34,11 +34,13 @@ void F77_d2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -34,11 +34,13 @@ void F77_d3chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -34,11 +34,13 @@ void F77_s2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -34,11 +34,13 @@ void F77_s3chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -12,7 +12,7 @@ void cblas_xerbla(CBLAS_INDEX info, const char *rout, const char *form, ...)
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
-   /* Initially, c__3chke will call this routine with
+   /* Initially, c__3chke may call this routine with
     * global variable link_xerbla=1, and F77_xerbla will set link_xerbla=0.
     * This is done to fool the linker into loading these subroutines first
     * instead of ones in the CBLAS or the legacy BLAS library.

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -36,11 +36,13 @@ void F77_z2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -39,11 +39,13 @@ void  F77_z3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
+#ifndef HAS_ATTRIBUTE_WEAK_SUPPORT
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
+#endif
 
    if (strncmp( sf,"cblas_zgemm"   ,11)==0) {
       cblas_rout = "cblas_zgemm"   ;


### PR DESCRIPTION
This should fix an issue reported by @bobrik in https://github.com/Reference-LAPACK/lapack/issues/440#issuecomment-792117758, although I discovered it was also appearing on x86_64-darwin. Thanks to @langou for the useful summary https://github.com/Reference-LAPACK/lapack/issues/440#issuecomment-795909116 .