### PR TITLE
Typo .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
     -DLAPACKE:BOOL=ON
     -DBUILD_TESTING=ON
     -DLAPACKE_WITH_TMG:BOOL=ON
-    -DBUILD_SHARED_LIBS=BOOL:ON
+    -DBUILD_SHARED_LIBS:BOOL=ON
     -DCMAKE_Fortran_FLAGS:STRING="-fimplicit-none -frecursive -fcheck=all"
     -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
     ${SRC_DIR}


### PR DESCRIPTION
**Description**
A typo was causing Travis not to run. This PR fixes it.