### PR TITLE
Change OMP_GET_NUM_THREADS to OMP_GET_MAX_THREADS in xCHKEE

### DIFF
--- a/TESTING/EIG/cchkee.F
+++ b/TESTING/EIG/cchkee.F
@@ -1868,7 +1868,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL CERRST( 'CST', NOUT )
@@ -2335,7 +2335,7 @@
          CALL ALAREQ( C3, NTYPES, DOTYPE, MAXTYP, NIN, NOUT )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL CERRST( 'CHB', NOUT )

--- a/TESTING/EIG/dchkee.F
+++ b/TESTING/EIG/dchkee.F
@@ -1873,7 +1873,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL DERRST( 'DST', NOUT )

--- a/TESTING/EIG/schkee.F
+++ b/TESTING/EIG/schkee.F
@@ -1874,7 +1874,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL SERRST( 'SST', NOUT )

--- a/TESTING/EIG/zchkee.F
+++ b/TESTING/EIG/zchkee.F
@@ -1868,7 +1868,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL ZERRST( 'ZST', NOUT )
@@ -2333,7 +2333,7 @@
          CALL ALAREQ( C3, NTYPES, DOTYPE, MAXTYP, NIN, NOUT )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL ZERRST( 'ZHB', NOUT )


### PR DESCRIPTION
**Description**

The xCHKEE programs were modified at LAPACK 3.9.1 to force OpenMP to use 1 thread when testing the routine error exits, and then switch back to the original desired thread count for subsequent tests. Use of OMP_GET_NUM_THREADS() is not correct in this context (it will return 1 as this code is not inside a parallel region), we should use OMP_GET_MAX_THREADS() instead.
