### PR TITLE
Fix out-of-bounds in xORBDB2 and xORBDB3

### DIFF
--- a/SRC/cunbdb1.f
+++ b/SRC/cunbdb1.f
@@ -222,7 +222,7 @@
 *     .. Local Scalars ..
       REAL               C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -279,41 +279,48 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
-         I1 = MIN(I+1,P)
-         I2 = MIN(I+1,M-P)
-         I3 = MIN(I+1,Q)
-         I4 = MIN(I+2,Q)
 *
-         CALL CLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
-         CALL CLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           CLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1), LDX11, WORK(ILARF) )
+*        with I = Q, or
+*           CLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
+*        with I = Q-1. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
+         I1 = MIN(I+1,Q)
+         I2 = MIN(I+2,Q)
+*
+         CALL CLARFGP( P-I+1, X11(I,I), X11(MIN(I+1,P),I), 1, TAUP1(I) )
+         CALL CLARFGP( M-P-I+1, X21(I,I), X21(MIN(I+1,M-P),I), 1,
+     $                 TAUP2(I) )
          THETA(I) = ATAN2( REAL( X21(I,I) ), REAL( X11(I,I) ) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
          CALL CLARF( 'L', P-I+1, Q-I, X11(I,I), 1, CONJG(TAUP1(I)),
-     $               X11(I,I3), LDX11, WORK(ILARF) )
+     $               X11(I,I1), LDX11, WORK(ILARF) )
          CALL CLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, CONJG(TAUP2(I)),
-     $               X21(I,I3), LDX21, WORK(ILARF) )
+     $               X21(I,I1), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL CSROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C,
+            CALL CSROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C,
      $                  S )
-            CALL CLACGV( Q-I, X21(I,I3), LDX21 )
-            CALL CLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
-            S = REAL( X21(I,I3) )
-            X21(I,I3) = ONE
-            CALL CLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X11(I1,I3), LDX11, WORK(ILARF) )
-            CALL CLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X21(I2,I3), LDX21, WORK(ILARF) )
-            CALL CLACGV( Q-I, X21(I,I3), LDX21 )
-            C = SQRT( SCNRM2( P-I, X11(I1,I3), 1 )**2
-     $              + SCNRM2( M-P-I, X21(I2,I3), 1 )**2 )
+            CALL CLACGV( Q-I, X21(I,I+1), LDX21 )
+            CALL CLARFGP( Q-I, X21(I,I+1), X21(I,I2), LDX21, TAUQ1(I) )
+            S = REAL( X21(I,I+1) )
+            X21(I,I+1) = ONE
+            CALL CLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
+            CALL CLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
+            CALL CLACGV( Q-I, X21(I,I+1), LDX21 )
+            C = SQRT( SCNRM2( P-I, X11(I+1,I+1), 1 )**2
+     $              + SCNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL CUNBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
-     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
-     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL CUNBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
+     $                    X21(I+1,I+1), 1, X11(I+1,I2), LDX11,
+     $                    X21(I+1,I2), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/cunbdb1.f
+++ b/SRC/cunbdb1.f
@@ -222,7 +222,7 @@
 *     .. Local Scalars ..
       REAL               C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -279,37 +279,41 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
+         I1 = MIN(I+1,P)
+         I2 = MIN(I+1,M-P)
+         I3 = MIN(I+1,Q)
+         I4 = MIN(I+2,Q)
 *
-         CALL CLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
-         CALL CLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL CLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
+         CALL CLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
          THETA(I) = ATAN2( REAL( X21(I,I) ), REAL( X11(I,I) ) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
          CALL CLARF( 'L', P-I+1, Q-I, X11(I,I), 1, CONJG(TAUP1(I)),
-     $               X11(I,I+1), LDX11, WORK(ILARF) )
+     $               X11(I,I3), LDX11, WORK(ILARF) )
          CALL CLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, CONJG(TAUP2(I)),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I,I3), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL CSROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C,
+            CALL CSROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C,
      $                  S )
-            CALL CLACGV( Q-I, X21(I,I+1), LDX21 )
-            CALL CLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
-            S = REAL( X21(I,I+1) )
-            X21(I,I+1) = ONE
-            CALL CLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
-            CALL CLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
-            CALL CLACGV( Q-I, X21(I,I+1), LDX21 )
-            C = SQRT( SCNRM2( P-I, X11(I+1,I+1), 1 )**2
-     $              + SCNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
+            CALL CLACGV( Q-I, X21(I,I3), LDX21 )
+            CALL CLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
+            S = REAL( X21(I,I3) )
+            X21(I,I3) = ONE
+            CALL CLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X11(I1,I3), LDX11, WORK(ILARF) )
+            CALL CLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X21(I2,I3), LDX21, WORK(ILARF) )
+            CALL CLACGV( Q-I, X21(I,I3), LDX21 )
+            C = SQRT( SCNRM2( P-I, X11(I1,I3), 1 )**2
+     $              + SCNRM2( M-P-I, X21(I2,I3), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL CUNBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
-     $                    X21(I+1,I+1), 1, X11(I+1,I+2), LDX11,
-     $                    X21(I+1,I+2), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL CUNBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
+     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
+     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/cunbdb2.f
+++ b/SRC/cunbdb2.f
@@ -280,6 +280,14 @@
 *     Reduce rows 1, ..., P of X11 and X21
 *
       DO I = 1, P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           CLARF( 'R', P-I, Q-I+1, X11(I,I), LDX11, TAUQ1(I), X11(I+1,I), LDX11, WORK(ILARF) )
+*        with I = P, or
+*           CLARFGP( Q-I+1, X11(I,I), X11(I,I+1), LDX11, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,P)
          I2 = MIN(I+1,Q)
 *

--- a/SRC/cunbdb3.f
+++ b/SRC/cunbdb3.f
@@ -222,7 +222,7 @@
 *     .. Local Scalars ..
       REAL               C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -278,6 +278,8 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+         I1 = MIN(I+1,M-P)
+         I2 = MIN(I+1,Q)
 *
          IF( I .GT. 1 ) THEN
             CALL CSROT( Q-I+1, X11(I-1,I), LDX11, X21(I,I), LDX11, C,
@@ -285,44 +287,47 @@
          END IF
 *
          CALL CLACGV( Q-I+1, X21(I,I), LDX21 )
-         CALL CLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+         CALL CLARFGP( Q-I+1, X21(I,I), X21(I,I2), LDX21, TAUQ1(I) )
          S = REAL( X21(I,I) )
          X21(I,I) = ONE
          CALL CLARF( 'R', P-I+1, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
      $               X11(I,I), LDX11, WORK(ILARF) )
          CALL CLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
-     $               X21(I+1,I), LDX21, WORK(ILARF) )
+     $               X21(I1,I), LDX21, WORK(ILARF) )
          CALL CLACGV( Q-I+1, X21(I,I), LDX21 )
          C = SQRT( SCNRM2( P-I+1, X11(I,I), 1 )**2
-     $           + SCNRM2( M-P-I, X21(I+1,I), 1 )**2 )
+     $           + SCNRM2( M-P-I, X21(I1,I), 1 )**2 )
          THETA(I) = ATAN2( S, C )
 *
-         CALL CUNBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I+1,I), 1,
-     $                 X11(I,I+1), LDX11, X21(I+1,I+1), LDX21,
+         CALL CUNBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I1,I), 1,
+     $                 X11(I,I2), LDX11, X21(I1,I2), LDX21,
      $                 WORK(IORBDB5), LORBDB5, CHILDINFO )
-         CALL CLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL CLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $                 TAUP1(I) )
          IF( I .LT. M-P ) THEN
-            CALL CLARFGP( M-P-I, X21(I+1,I), X21(I+2,I), 1, TAUP2(I) )
-            PHI(I) = ATAN2( REAL( X21(I+1,I) ), REAL( X11(I,I) ) )
+            CALL CLARFGP( M-P-I, X21(I1,I), X21( MIN(I+2,M-P) ,I), 1,
+     $                    TAUP2(I) )
+            PHI(I) = ATAN2( REAL( X21(I1,I) ), REAL( X11(I,I) ) )
             C = COS( PHI(I) )
             S = SIN( PHI(I) )
-            X21(I+1,I) = ONE
-            CALL CLARF( 'L', M-P-I, Q-I, X21(I+1,I), 1, CONJG(TAUP2(I)),
-     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
+            X21(I1,I) = ONE
+            CALL CLARF( 'L', M-P-I, Q-I, X21(I1,I), 1, CONJG(TAUP2(I)),
+     $                  X21(I1,I2), LDX21, WORK(ILARF) )
          END IF
          X11(I,I) = ONE
          CALL CLARF( 'L', P-I+1, Q-I, X11(I,I), 1, CONJG(TAUP1(I)),
-     $               X11(I,I+1), LDX11, WORK(ILARF) )
+     $               X11(I,I2), LDX11, WORK(ILARF) )
 *
       END DO
 *
 *     Reduce the bottom-right portion of X11 to the identity matrix
 *
       DO I = M-P + 1, Q
-         CALL CLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL CLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $        TAUP1(I) )
          X11(I,I) = ONE
          CALL CLARF( 'L', P-I+1, Q-I, X11(I,I), 1, CONJG(TAUP1(I)),
-     $               X11(I,I+1), LDX11, WORK(ILARF) )
+     $               X11(I, MIN(I+1,Q) ), LDX11, WORK(ILARF) )
       END DO
 *
       RETURN

--- a/SRC/cunbdb3.f
+++ b/SRC/cunbdb3.f
@@ -278,6 +278,14 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           CLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I), X21(I+1,I), LDX21, WORK(ILARF) )
+*        with I = M-P, or
+*           CLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,M-P)
          I2 = MIN(I+1,Q)
 *

--- a/SRC/dorbdb1.f
+++ b/SRC/dorbdb1.f
@@ -223,7 +223,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -279,34 +279,38 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
+         I1 = MIN(I+1,P)
+         I2 = MIN(I+1,M-P)
+         I3 = MIN(I+1,Q)
+         I4 = MIN(I+2,Q)
 *
-         CALL DLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
-         CALL DLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL DLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
+         CALL DLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
          THETA(I) = ATAN2( X21(I,I), X11(I,I) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
-         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1),
+         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I3),
      $               LDX11, WORK(ILARF) )
          CALL DLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, TAUP2(I),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I,I3), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL DROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C, S )
-            CALL DLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
-            S = X21(I,I+1)
-            X21(I,I+1) = ONE
-            CALL DLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
-            CALL DLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
-            C = SQRT( DNRM2( P-I, X11(I+1,I+1), 1 )**2
-     $          + DNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
+            CALL DROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C, S )
+            CALL DLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
+            S = X21(I,I3)
+            X21(I,I3) = ONE
+            CALL DLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X11(I1,I3), LDX11, WORK(ILARF) )
+            CALL DLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X21(I2,I3), LDX21, WORK(ILARF) )
+            C = SQRT( DNRM2( P-I, X11(I1,I3), 1 )**2
+     $          + DNRM2( M-P-I, X21(I2,I3), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL DORBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
-     $                    X21(I+1,I+1), 1, X11(I+1,I+2), LDX11,
-     $                    X21(I+1,I+2), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL DORBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
+     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
+     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/dorbdb1.f
+++ b/SRC/dorbdb1.f
@@ -223,7 +223,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -279,38 +279,45 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
-         I1 = MIN(I+1,P)
-         I2 = MIN(I+1,M-P)
-         I3 = MIN(I+1,Q)
-         I4 = MIN(I+2,Q)
 *
-         CALL DLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
-         CALL DLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1), LDX11, WORK(ILARF) )
+*        with I = Q, or
+*           DLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
+*        with I = Q-1. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
+         I1 = MIN(I+1,Q)
+         I2 = MIN(I+2,Q)
+*
+         CALL DLARFGP( P-I+1, X11(I,I), X11(MIN(I+1,P),I), 1, TAUP1(I) )
+         CALL DLARFGP( M-P-I+1, X21(I,I), X21(MIN(I+1,M-P),I), 1,
+     $                 TAUP2(I) )
          THETA(I) = ATAN2( X21(I,I), X11(I,I) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
-         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I3),
+         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I1),
      $               LDX11, WORK(ILARF) )
          CALL DLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, TAUP2(I),
-     $               X21(I,I3), LDX21, WORK(ILARF) )
+     $               X21(I,I1), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL DROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C, S )
-            CALL DLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
-            S = X21(I,I3)
-            X21(I,I3) = ONE
-            CALL DLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X11(I1,I3), LDX11, WORK(ILARF) )
-            CALL DLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X21(I2,I3), LDX21, WORK(ILARF) )
-            C = SQRT( DNRM2( P-I, X11(I1,I3), 1 )**2
-     $          + DNRM2( M-P-I, X21(I2,I3), 1 )**2 )
+            CALL DROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C, S )
+            CALL DLARFGP( Q-I, X21(I,I+1), X21(I,I2), LDX21, TAUQ1(I) )
+            S = X21(I,I+1)
+            X21(I,I+1) = ONE
+            CALL DLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
+            CALL DLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
+            C = SQRT( DNRM2( P-I, X11(I+1,I+1), 1 )**2
+     $          + DNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL DORBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
-     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
-     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL DORBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
+     $                    X21(I+1,I+1), 1, X11(I+1,I2), LDX11,
+     $                    X21(I+1,I2), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/dorbdb2.f
+++ b/SRC/dorbdb2.f
@@ -278,6 +278,14 @@
 *     Reduce rows 1, ..., P of X11 and X21
 *
       DO I = 1, P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           DLARF( 'R', P-I, Q-I+1, X11(I,I), LDX11, TAUQ1(I), X11(I+1,I), LDX11, WORK(ILARF) )
+*        with I = P, or
+*           DLARFGP( Q-I+1, X11(I,I), X11(I,I+1), LDX11, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,P)
          I2 = MIN(I+1,Q)
 *

--- a/SRC/dorbdb2.f
+++ b/SRC/dorbdb2.f
@@ -278,48 +278,53 @@
 *     Reduce rows 1, ..., P of X11 and X21
 *
       DO I = 1, P
+         I1 = MIN(I+1,P)
+         I2 = MIN(I+1,Q)
 *
          IF( I .GT. 1 ) THEN
             CALL DROT( Q-I+1, X11(I,I), LDX11, X21(I-1,I), LDX21, C, S )
          END IF
-         CALL DLARFGP( Q-I+1, X11(I,I), X11(I,I+1), LDX11, TAUQ1(I) )
+         CALL DLARFGP( Q-I+1, X11(I,I), X11(I,I2), LDX11, TAUQ1(I) )
          C = X11(I,I)
          X11(I,I) = ONE
          CALL DLARF( 'R', P-I, Q-I+1, X11(I,I), LDX11, TAUQ1(I),
-     $               X11(I+1,I), LDX11, WORK(ILARF) )
+     $               X11(I1,I), LDX11, WORK(ILARF) )
          CALL DLARF( 'R', M-P-I+1, Q-I+1, X11(I,I), LDX11, TAUQ1(I),
      $               X21(I,I), LDX21, WORK(ILARF) )
-         S = SQRT( DNRM2( P-I, X11(I+1,I), 1 )**2
+         S = SQRT( DNRM2( P-I, X11(I1,I), 1 )**2
      $           + DNRM2( M-P-I+1, X21(I,I), 1 )**2 )
          THETA(I) = ATAN2( S, C )
 *
-         CALL DORBDB5( P-I, M-P-I+1, Q-I, X11(I+1,I), 1, X21(I,I), 1,
-     $                 X11(I+1,I+1), LDX11, X21(I,I+1), LDX21,
+         CALL DORBDB5( P-I, M-P-I+1, Q-I, X11(I1,I), 1, X21(I,I), 1,
+     $                 X11(I1,I2), LDX11, X21(I,I2), LDX21,
      $                 WORK(IORBDB5), LORBDB5, CHILDINFO )
-         CALL DSCAL( P-I, NEGONE, X11(I+1,I), 1 )
-         CALL DLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL DSCAL( P-I, NEGONE, X11(I1,I), 1 )
+         CALL DLARFGP( M-P-I+1, X21(I,I), X21( MIN(I+1,M-P) ,I), 1,
+     $                 TAUP2(I) )
          IF( I .LT. P ) THEN
-            CALL DLARFGP( P-I, X11(I+1,I), X11(I+2,I), 1, TAUP1(I) )
-            PHI(I) = ATAN2( X11(I+1,I), X21(I,I) )
+            CALL DLARFGP( P-I, X11(I1,I), X11( MIN(I+2,P) ,I), 1,
+     $                    TAUP1(I) )
+            PHI(I) = ATAN2( X11(I1,I), X21(I,I) )
             C = COS( PHI(I) )
             S = SIN( PHI(I) )
-            X11(I+1,I) = ONE
-            CALL DLARF( 'L', P-I, Q-I, X11(I+1,I), 1, TAUP1(I),
-     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
+            X11(I1,I) = ONE
+            CALL DLARF( 'L', P-I, Q-I, X11(I1,I), 1, TAUP1(I),
+     $                  X11(I1,I2), LDX11, WORK(ILARF) )
          END IF
          X21(I,I) = ONE
          CALL DLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, TAUP2(I),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I,I2), LDX21, WORK(ILARF) )
 *
       END DO
 *
 *     Reduce the bottom-right portion of X21 to the identity matrix
 *
       DO I = P + 1, Q
-         CALL DLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL DLARFGP( M-P-I+1, X21(I,I), X21( MIN(I+1,M-P) ,I), 1,
+     $                 TAUP2(I) )
          X21(I,I) = ONE
          CALL DLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, TAUP2(I),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I, MIN(I+1,Q) ), LDX21, WORK(ILARF) )
       END DO
 *
       RETURN

--- a/SRC/dorbdb2.f
+++ b/SRC/dorbdb2.f
@@ -222,7 +222,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..

--- a/SRC/dorbdb3.f
+++ b/SRC/dorbdb3.f
@@ -277,37 +277,41 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+         I1 = MIN(I+1,M-P)
+         I2 = MIN(I+1,Q)
 *
          IF( I .GT. 1 ) THEN
             CALL DROT( Q-I+1, X11(I-1,I), LDX11, X21(I,I), LDX11, C, S )
          END IF
 *
-         CALL DLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+         CALL DLARFGP( Q-I+1, X21(I,I), X21(I,I2), LDX21, TAUQ1(I) )
          S = X21(I,I)
          X21(I,I) = ONE
          CALL DLARF( 'R', P-I+1, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
      $               X11(I,I), LDX11, WORK(ILARF) )
          CALL DLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
-     $               X21(I+1,I), LDX21, WORK(ILARF) )
+     $               X21(I1,I), LDX21, WORK(ILARF) )
          C = SQRT( DNRM2( P-I+1, X11(I,I), 1 )**2
-     $           + DNRM2( M-P-I, X21(I+1,I), 1 )**2 )
+     $           + DNRM2( M-P-I, X21(I1,I), 1 )**2 )
          THETA(I) = ATAN2( S, C )
 *
-         CALL DORBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I+1,I), 1,
-     $                 X11(I,I+1), LDX11, X21(I+1,I+1), LDX21,
+         CALL DORBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I1,I), 1,
+     $                 X11(I,I2), LDX11, X21(I1,I2), LDX21,
      $                 WORK(IORBDB5), LORBDB5, CHILDINFO )
-         CALL DLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL DLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $                 TAUP1(I) )
          IF( I .LT. M-P ) THEN
-            CALL DLARFGP( M-P-I, X21(I+1,I), X21(I+2,I), 1, TAUP2(I) )
-            PHI(I) = ATAN2( X21(I+1,I), X11(I,I) )
+            CALL DLARFGP( M-P-I, X21(I1,I), X21( MIN(I+2,M-P) ,I), 1,
+     $                    TAUP2(I) )
+            PHI(I) = ATAN2( X21(I1,I), X11(I,I) )
             C = COS( PHI(I) )
             S = SIN( PHI(I) )
-            X21(I+1,I) = ONE
-            CALL DLARF( 'L', M-P-I, Q-I, X21(I+1,I), 1, TAUP2(I),
-     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
+            X21(I1,I) = ONE
+            CALL DLARF( 'L', M-P-I, Q-I, X21(I1,I), 1, TAUP2(I),
+     $                  X21(I1,I2), LDX21, WORK(ILARF) )
          END IF
          X11(I,I) = ONE
-         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1),
+         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I2),
      $               LDX11, WORK(ILARF) )
 *
       END DO
@@ -315,10 +319,11 @@
 *     Reduce the bottom-right portion of X11 to the identity matrix
 *
       DO I = M-P + 1, Q
-         CALL DLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL DLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $                 TAUP1(I) )
          X11(I,I) = ONE
-         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1),
-     $               LDX11, WORK(ILARF) )
+         CALL DLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I),
+     $               X11(I, MIN(I+1,Q) ), LDX11, WORK(ILARF) )
       END DO
 *
       RETURN

--- a/SRC/dorbdb3.f
+++ b/SRC/dorbdb3.f
@@ -277,6 +277,14 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           DLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I), X21(I+1,I), LDX21, WORK(ILARF) )
+*        with I = M-P, or
+*           DLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,M-P)
          I2 = MIN(I+1,Q)
 *

--- a/SRC/dorbdb3.f
+++ b/SRC/dorbdb3.f
@@ -221,7 +221,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..

--- a/SRC/sorbdb1.f
+++ b/SRC/sorbdb1.f
@@ -223,7 +223,7 @@
 *     .. Local Scalars ..
       REAL               C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -279,38 +279,45 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
-         I1 = MIN(I+1,P)
-         I2 = MIN(I+1,M-P)
-         I3 = MIN(I+1,Q)
-         I4 = MIN(I+2,Q)
 *
-         CALL SLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
-         CALL SLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1), LDX11, WORK(ILARF) )
+*        with I = Q, or
+*           SLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
+*        with I = Q-1. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
+         I1 = MIN(I+1,Q)
+         I2 = MIN(I+2,Q)
+*
+         CALL SLARFGP( P-I+1, X11(I,I), X11(MIN(I+1,P),I), 1, TAUP1(I) )
+         CALL SLARFGP( M-P-I+1, X21(I,I), X21(MIN(I+1,M-P),I), 1,
+     $                 TAUP2(I) )
          THETA(I) = ATAN2( X21(I,I), X11(I,I) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
-         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I3),
+         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I1),
      $               LDX11, WORK(ILARF) )
          CALL SLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, TAUP2(I),
-     $               X21(I,I3), LDX21, WORK(ILARF) )
+     $               X21(I,I1), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL SROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C, S )
-            CALL SLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
-            S = X21(I,I3)
-            X21(I,I3) = ONE
-            CALL SLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X11(I1,I3), LDX11, WORK(ILARF) )
-            CALL SLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X21(I2,I3), LDX21, WORK(ILARF) )
-            C = SQRT( SNRM2( P-I, X11(I1,I3), 1 )**2
-     $              + SNRM2( M-P-I, X21(I2,I3), 1 )**2 )
+            CALL SROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C, S )
+            CALL SLARFGP( Q-I, X21(I,I+1), X21(I,I2), LDX21, TAUQ1(I) )
+            S = X21(I,I+1)
+            X21(I,I+1) = ONE
+            CALL SLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
+            CALL SLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
+            C = SQRT( SNRM2( P-I, X11(I+1,I+1), 1 )**2
+     $              + SNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL SORBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
-     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
-     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL SORBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
+     $                    X21(I+1,I+1), 1, X11(I+1,I2), LDX11,
+     $                    X21(I+1,I2), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/sorbdb1.f
+++ b/SRC/sorbdb1.f
@@ -223,7 +223,7 @@
 *     .. Local Scalars ..
       REAL               C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -279,34 +279,38 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
+         I1 = MIN(I+1,P)
+         I2 = MIN(I+1,M-P)
+         I3 = MIN(I+1,Q)
+         I4 = MIN(I+2,Q)
 *
-         CALL SLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
-         CALL SLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL SLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
+         CALL SLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
          THETA(I) = ATAN2( X21(I,I), X11(I,I) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
-         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1),
+         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I3),
      $               LDX11, WORK(ILARF) )
          CALL SLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, TAUP2(I),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I,I3), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL SROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C, S )
-            CALL SLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
-            S = X21(I,I+1)
-            X21(I,I+1) = ONE
-            CALL SLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
-            CALL SLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
-            C = SQRT( SNRM2( P-I, X11(I+1,I+1), 1 )**2
-     $              + SNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
+            CALL SROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C, S )
+            CALL SLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
+            S = X21(I,I3)
+            X21(I,I3) = ONE
+            CALL SLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X11(I1,I3), LDX11, WORK(ILARF) )
+            CALL SLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X21(I2,I3), LDX21, WORK(ILARF) )
+            C = SQRT( SNRM2( P-I, X11(I1,I3), 1 )**2
+     $              + SNRM2( M-P-I, X21(I2,I3), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL SORBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
-     $                    X21(I+1,I+1), 1, X11(I+1,I+2), LDX11,
-     $                    X21(I+1,I+2), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL SORBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
+     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
+     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/sorbdb2.f
+++ b/SRC/sorbdb2.f
@@ -277,6 +277,14 @@
 *     Reduce rows 1, ..., P of X11 and X21
 *
       DO I = 1, P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           SLARF( 'R', P-I, Q-I+1, X11(I,I), LDX11, TAUQ1(I), X11(I+1,I), LDX11, WORK(ILARF) )
+*        with I = P, or
+*           SLARFGP( Q-I+1, X11(I,I), X11(I,I+1), LDX11, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,P)
          I2 = MIN(I+1,Q)
 *

--- a/SRC/sorbdb3.f
+++ b/SRC/sorbdb3.f
@@ -222,7 +222,7 @@
 *     .. Local Scalars ..
       REAL               C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -278,37 +278,41 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+         I1 = MIN(I+1,M-P)
+         I2 = MIN(I+1,Q)
 *
          IF( I .GT. 1 ) THEN
             CALL SROT( Q-I+1, X11(I-1,I), LDX11, X21(I,I), LDX11, C, S )
          END IF
 *
-         CALL SLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+         CALL SLARFGP( Q-I+1, X21(I,I), X21(I,I2), LDX21, TAUQ1(I) )
          S = X21(I,I)
          X21(I,I) = ONE
          CALL SLARF( 'R', P-I+1, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
      $               X11(I,I), LDX11, WORK(ILARF) )
          CALL SLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
-     $               X21(I+1,I), LDX21, WORK(ILARF) )
+     $               X21(I1,I), LDX21, WORK(ILARF) )
          C = SQRT( SNRM2( P-I+1, X11(I,I), 1 )**2
-     $           + SNRM2( M-P-I, X21(I+1,I), 1 )**2 )
+     $           + SNRM2( M-P-I, X21(I1,I), 1 )**2 )
          THETA(I) = ATAN2( S, C )
 *
-         CALL SORBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I+1,I), 1,
-     $                 X11(I,I+1), LDX11, X21(I+1,I+1), LDX21,
+         CALL SORBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I1,I), 1,
+     $                 X11(I,I2), LDX11, X21(I1,I2), LDX21,
      $                 WORK(IORBDB5), LORBDB5, CHILDINFO )
-         CALL SLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL SLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $                 TAUP1(I) )
          IF( I .LT. M-P ) THEN
-            CALL SLARFGP( M-P-I, X21(I+1,I), X21(I+2,I), 1, TAUP2(I) )
-            PHI(I) = ATAN2( X21(I+1,I), X11(I,I) )
+            CALL SLARFGP( M-P-I, X21(I1,I), X21( MIN(I+2,M-P) ,I), 1,
+     $                    TAUP2(I) )
+            PHI(I) = ATAN2( X21(I1,I), X11(I,I) )
             C = COS( PHI(I) )
             S = SIN( PHI(I) )
-            X21(I+1,I) = ONE
-            CALL SLARF( 'L', M-P-I, Q-I, X21(I+1,I), 1, TAUP2(I),
-     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
+            X21(I1,I) = ONE
+            CALL SLARF( 'L', M-P-I, Q-I, X21(I1,I), 1, TAUP2(I),
+     $                  X21(I1,I2), LDX21, WORK(ILARF) )
          END IF
          X11(I,I) = ONE
-         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1),
+         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I2),
      $               LDX11, WORK(ILARF) )
 *
       END DO
@@ -316,10 +320,11 @@
 *     Reduce the bottom-right portion of X11 to the identity matrix
 *
       DO I = M-P + 1, Q
-         CALL SLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL SLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $                 TAUP1(I) )
          X11(I,I) = ONE
-         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1),
-     $               LDX11, WORK(ILARF) )
+         CALL SLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I),
+     $               X11(I, MIN(I+1,Q) ), LDX11, WORK(ILARF) )
       END DO
 *
       RETURN

--- a/SRC/sorbdb3.f
+++ b/SRC/sorbdb3.f
@@ -278,6 +278,14 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           SLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I), X21(I+1,I), LDX21, WORK(ILARF) )
+*        with I = M-P, or
+*           SLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,M-P)
          I2 = MIN(I+1,Q)
 *

--- a/SRC/zunbdb1.f
+++ b/SRC/zunbdb1.f
@@ -223,7 +223,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -280,41 +280,48 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
-         I1 = MIN(I+1,P)
-         I2 = MIN(I+1,M-P)
-         I3 = MIN(I+1,Q)
-         I4 = MIN(I+2,Q)
 *
-         CALL ZLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
-         CALL ZLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           ZLARF( 'L', P-I+1, Q-I, X11(I,I), 1, TAUP1(I), X11(I,I+1), LDX11, WORK(ILARF) )
+*        with I = Q, or
+*           ZLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
+*        with I = Q-1. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
+         I1 = MIN(I+1,Q)
+         I2 = MIN(I+2,Q)
+*
+         CALL ZLARFGP( P-I+1, X11(I,I), X11(MIN(I+1,P),I), 1, TAUP1(I) )
+         CALL ZLARFGP( M-P-I+1, X21(I,I), X21(MIN(I+1,M-P),I), 1,
+     $                 TAUP2(I) )
          THETA(I) = ATAN2( DBLE( X21(I,I) ), DBLE( X11(I,I) ) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
          CALL ZLARF( 'L', P-I+1, Q-I, X11(I,I), 1, DCONJG(TAUP1(I)),
-     $               X11(I,I3), LDX11, WORK(ILARF) )
+     $               X11(I,I1), LDX11, WORK(ILARF) )
          CALL ZLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, DCONJG(TAUP2(I)),
-     $               X21(I,I3), LDX21, WORK(ILARF) )
+     $               X21(I,I1), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL ZDROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C,
+            CALL ZDROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C,
      $                  S )
-            CALL ZLACGV( Q-I, X21(I,I3), LDX21 )
-            CALL ZLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
-            S = DBLE( X21(I,I3) )
-            X21(I,I3) = ONE
-            CALL ZLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X11(I1,I3), LDX11, WORK(ILARF) )
-            CALL ZLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
-     $                  X21(I2,I3), LDX21, WORK(ILARF) )
-            CALL ZLACGV( Q-I, X21(I,I3), LDX21 )
-            C = SQRT( DZNRM2( P-I, X11(I1,I3), 1 )**2
-     $          + DZNRM2( M-P-I, X21(I2,I3), 1 )**2 )
+            CALL ZLACGV( Q-I, X21(I,I+1), LDX21 )
+            CALL ZLARFGP( Q-I, X21(I,I+1), X21(I,I2), LDX21, TAUQ1(I) )
+            S = DBLE( X21(I,I+1) )
+            X21(I,I+1) = ONE
+            CALL ZLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
+            CALL ZLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
+     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
+            CALL ZLACGV( Q-I, X21(I,I+1), LDX21 )
+            C = SQRT( DZNRM2( P-I, X11(I+1,I+1), 1 )**2
+     $          + DZNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL ZUNBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
-     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
-     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL ZUNBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
+     $                    X21(I+1,I+1), 1, X11(I+1,I2), LDX11,
+     $                    X21(I+1,I2), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/zunbdb1.f
+++ b/SRC/zunbdb1.f
@@ -223,7 +223,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2, I3, I4
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -280,37 +280,41 @@
 *     Reduce columns 1, ..., Q of X11 and X21
 *
       DO I = 1, Q
+         I1 = MIN(I+1,P)
+         I2 = MIN(I+1,M-P)
+         I3 = MIN(I+1,Q)
+         I4 = MIN(I+2,Q)
 *
-         CALL ZLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
-         CALL ZLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL ZLARFGP( P-I+1, X11(I,I), X11(I1,I), 1, TAUP1(I) )
+         CALL ZLARFGP( M-P-I+1, X21(I,I), X21(I2,I), 1, TAUP2(I) )
          THETA(I) = ATAN2( DBLE( X21(I,I) ), DBLE( X11(I,I) ) )
          C = COS( THETA(I) )
          S = SIN( THETA(I) )
          X11(I,I) = ONE
          X21(I,I) = ONE
          CALL ZLARF( 'L', P-I+1, Q-I, X11(I,I), 1, DCONJG(TAUP1(I)),
-     $               X11(I,I+1), LDX11, WORK(ILARF) )
+     $               X11(I,I3), LDX11, WORK(ILARF) )
          CALL ZLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, DCONJG(TAUP2(I)),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I,I3), LDX21, WORK(ILARF) )
 *
          IF( I .LT. Q ) THEN
-            CALL ZDROT( Q-I, X11(I,I+1), LDX11, X21(I,I+1), LDX21, C,
+            CALL ZDROT( Q-I, X11(I,I3), LDX11, X21(I,I3), LDX21, C,
      $                  S )
-            CALL ZLACGV( Q-I, X21(I,I+1), LDX21 )
-            CALL ZLARFGP( Q-I, X21(I,I+1), X21(I,I+2), LDX21, TAUQ1(I) )
-            S = DBLE( X21(I,I+1) )
-            X21(I,I+1) = ONE
-            CALL ZLARF( 'R', P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
-            CALL ZLARF( 'R', M-P-I, Q-I, X21(I,I+1), LDX21, TAUQ1(I),
-     $                  X21(I+1,I+1), LDX21, WORK(ILARF) )
-            CALL ZLACGV( Q-I, X21(I,I+1), LDX21 )
-            C = SQRT( DZNRM2( P-I, X11(I+1,I+1), 1 )**2
-     $          + DZNRM2( M-P-I, X21(I+1,I+1), 1 )**2 )
+            CALL ZLACGV( Q-I, X21(I,I3), LDX21 )
+            CALL ZLARFGP( Q-I, X21(I,I3), X21(I,I4), LDX21, TAUQ1(I) )
+            S = DBLE( X21(I,I3) )
+            X21(I,I3) = ONE
+            CALL ZLARF( 'R', P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X11(I1,I3), LDX11, WORK(ILARF) )
+            CALL ZLARF( 'R', M-P-I, Q-I, X21(I,I3), LDX21, TAUQ1(I),
+     $                  X21(I2,I3), LDX21, WORK(ILARF) )
+            CALL ZLACGV( Q-I, X21(I,I3), LDX21 )
+            C = SQRT( DZNRM2( P-I, X11(I1,I3), 1 )**2
+     $          + DZNRM2( M-P-I, X21(I2,I3), 1 )**2 )
             PHI(I) = ATAN2( S, C )
-            CALL ZUNBDB5( P-I, M-P-I, Q-I-1, X11(I+1,I+1), 1,
-     $                    X21(I+1,I+1), 1, X11(I+1,I+2), LDX11,
-     $                    X21(I+1,I+2), LDX21, WORK(IORBDB5), LORBDB5,
+            CALL ZUNBDB5( P-I, M-P-I, Q-I-1, X11(I1,I3), 1,
+     $                    X21(I2,I3), 1, X11(I1,I4), LDX11,
+     $                    X21(I2,I4), LDX21, WORK(IORBDB5), LORBDB5,
      $                    CHILDINFO )
          END IF
 *

--- a/SRC/zunbdb2.f
+++ b/SRC/zunbdb2.f
@@ -279,6 +279,14 @@
 *     Reduce rows 1, ..., P of X11 and X21
 *
       DO I = 1, P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           ZLARF( 'R', P-I, Q-I+1, X11(I,I), LDX11, TAUQ1(I), X11(I+1,I), LDX11, WORK(ILARF) )
+*        with I = P, or
+*           ZLARFGP( Q-I+1, X11(I,I), X11(I,I+1), LDX11, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,P)
          I2 = MIN(I+1,Q)
 *

--- a/SRC/zunbdb2.f
+++ b/SRC/zunbdb2.f
@@ -222,7 +222,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -279,51 +279,56 @@
 *     Reduce rows 1, ..., P of X11 and X21
 *
       DO I = 1, P
+         I1 = MIN(I+1,P)
+         I2 = MIN(I+1,Q)
 *
          IF( I .GT. 1 ) THEN
             CALL ZDROT( Q-I+1, X11(I,I), LDX11, X21(I-1,I), LDX21, C,
      $                  S )
          END IF
          CALL ZLACGV( Q-I+1, X11(I,I), LDX11 )
-         CALL ZLARFGP( Q-I+1, X11(I,I), X11(I,I+1), LDX11, TAUQ1(I) )
+         CALL ZLARFGP( Q-I+1, X11(I,I), X11(I,I2), LDX11, TAUQ1(I) )
          C = DBLE( X11(I,I) )
          X11(I,I) = ONE
          CALL ZLARF( 'R', P-I, Q-I+1, X11(I,I), LDX11, TAUQ1(I),
-     $               X11(I+1,I), LDX11, WORK(ILARF) )
+     $               X11(I1,I), LDX11, WORK(ILARF) )
          CALL ZLARF( 'R', M-P-I+1, Q-I+1, X11(I,I), LDX11, TAUQ1(I),
      $               X21(I,I), LDX21, WORK(ILARF) )
          CALL ZLACGV( Q-I+1, X11(I,I), LDX11 )
-         S = SQRT( DZNRM2( P-I, X11(I+1,I), 1 )**2
+         S = SQRT( DZNRM2( P-I, X11(I1,I), 1 )**2
      $           + DZNRM2( M-P-I+1, X21(I,I), 1 )**2 )
          THETA(I) = ATAN2( S, C )
 *
-         CALL ZUNBDB5( P-I, M-P-I+1, Q-I, X11(I+1,I), 1, X21(I,I), 1,
-     $                 X11(I+1,I+1), LDX11, X21(I,I+1), LDX21,
+         CALL ZUNBDB5( P-I, M-P-I+1, Q-I, X11(I1,I), 1, X21(I,I), 1,
+     $                 X11(I1,I2), LDX11, X21(I,I2), LDX21,
      $                 WORK(IORBDB5), LORBDB5, CHILDINFO )
-         CALL ZSCAL( P-I, NEGONE, X11(I+1,I), 1 )
-         CALL ZLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL ZSCAL( P-I, NEGONE, X11(I1,I), 1 )
+         CALL ZLARFGP( M-P-I+1, X21(I,I), X21( MIN(I+1,M-P) ,I), 1,
+     $                 TAUP2(I) )
          IF( I .LT. P ) THEN
-            CALL ZLARFGP( P-I, X11(I+1,I), X11(I+2,I), 1, TAUP1(I) )
-            PHI(I) = ATAN2( DBLE( X11(I+1,I) ), DBLE( X21(I,I) ) )
+            CALL ZLARFGP( P-I, X11(I1,I), X11( MIN(I+2,P) ,I), 1,
+     $                    TAUP1(I) )
+            PHI(I) = ATAN2( DBLE( X11(I1,I) ), DBLE( X21(I,I) ) )
             C = COS( PHI(I) )
             S = SIN( PHI(I) )
-            X11(I+1,I) = ONE
-            CALL ZLARF( 'L', P-I, Q-I, X11(I+1,I), 1, DCONJG(TAUP1(I)),
-     $                  X11(I+1,I+1), LDX11, WORK(ILARF) )
+            X11(I1,I) = ONE
+            CALL ZLARF( 'L', P-I, Q-I, X11(I1,I), 1, DCONJG(TAUP1(I)),
+     $                  X11(I1,I2), LDX11, WORK(ILARF) )
          END IF
          X21(I,I) = ONE
          CALL ZLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, DCONJG(TAUP2(I)),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I,I2), LDX21, WORK(ILARF) )
 *
       END DO
 *
 *     Reduce the bottom-right portion of X21 to the identity matrix
 *
       DO I = P + 1, Q
-         CALL ZLARFGP( M-P-I+1, X21(I,I), X21(I+1,I), 1, TAUP2(I) )
+         CALL ZLARFGP( M-P-I+1, X21(I,I), X21( MIN(I+1,M-P) ,I), 1,
+     $                 TAUP2(I) )
          X21(I,I) = ONE
          CALL ZLARF( 'L', M-P-I+1, Q-I, X21(I,I), 1, DCONJG(TAUP2(I)),
-     $               X21(I,I+1), LDX21, WORK(ILARF) )
+     $               X21(I, MIN(I+1,Q) ), LDX21, WORK(ILARF) )
       END DO
 *
       RETURN

--- a/SRC/zunbdb3.f
+++ b/SRC/zunbdb3.f
@@ -221,7 +221,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   C, S
       INTEGER            CHILDINFO, I, ILARF, IORBDB5, LLARF, LORBDB5,
-     $                   LWORKMIN, LWORKOPT
+     $                   LWORKMIN, LWORKOPT, I1, I2
       LOGICAL            LQUERY
 *     ..
 *     .. External Subroutines ..
@@ -277,6 +277,8 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+         I1 = MIN(I+1,M-P)
+         I2 = MIN(I+1,Q)
 *
          IF( I .GT. 1 ) THEN
             CALL ZDROT( Q-I+1, X11(I-1,I), LDX11, X21(I,I), LDX11, C,
@@ -284,45 +286,48 @@
          END IF
 *
          CALL ZLACGV( Q-I+1, X21(I,I), LDX21 )
-         CALL ZLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+         CALL ZLARFGP( Q-I+1, X21(I,I), X21(I,I2), LDX21, TAUQ1(I) )
          S = DBLE( X21(I,I) )
          X21(I,I) = ONE
          CALL ZLARF( 'R', P-I+1, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
      $               X11(I,I), LDX11, WORK(ILARF) )
          CALL ZLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I),
-     $               X21(I+1,I), LDX21, WORK(ILARF) )
+     $               X21(I1,I), LDX21, WORK(ILARF) )
          CALL ZLACGV( Q-I+1, X21(I,I), LDX21 )
          C = SQRT( DZNRM2( P-I+1, X11(I,I), 1 )**2
-     $           + DZNRM2( M-P-I, X21(I+1,I), 1 )**2 )
+     $           + DZNRM2( M-P-I, X21(I1,I), 1 )**2 )
          THETA(I) = ATAN2( S, C )
 *
-         CALL ZUNBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I+1,I), 1,
-     $                 X11(I,I+1), LDX11, X21(I+1,I+1), LDX21,
+         CALL ZUNBDB5( P-I+1, M-P-I, Q-I, X11(I,I), 1, X21(I1,I), 1,
+     $                 X11(I,I2), LDX11, X21(I1,I2), LDX21,
      $                 WORK(IORBDB5), LORBDB5, CHILDINFO )
-         CALL ZLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL ZLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $                 TAUP1(I) )
          IF( I .LT. M-P ) THEN
-            CALL ZLARFGP( M-P-I, X21(I+1,I), X21(I+2,I), 1, TAUP2(I) )
-            PHI(I) = ATAN2( DBLE( X21(I+1,I) ), DBLE( X11(I,I) ) )
+            CALL ZLARFGP( M-P-I, X21(I1,I), X21( MIN(I+2,M-P) ,I), 1,
+     $                    TAUP2(I) )
+            PHI(I) = ATAN2( DBLE( X21(I1,I) ), DBLE( X11(I,I) ) )
             C = COS( PHI(I) )
             S = SIN( PHI(I) )
-            X21(I+1,I) = ONE
-            CALL ZLARF( 'L', M-P-I, Q-I, X21(I+1,I), 1,
-     $                  DCONJG(TAUP2(I)), X21(I+1,I+1), LDX21,
+            X21(I1,I) = ONE
+            CALL ZLARF( 'L', M-P-I, Q-I, X21(I1,I), 1,
+     $                  DCONJG(TAUP2(I)), X21(I1,I2), LDX21,
      $                  WORK(ILARF) )
          END IF
          X11(I,I) = ONE
          CALL ZLARF( 'L', P-I+1, Q-I, X11(I,I), 1, DCONJG(TAUP1(I)),
-     $               X11(I,I+1), LDX11, WORK(ILARF) )
+     $               X11(I,I2), LDX11, WORK(ILARF) )
 *
       END DO
 *
 *     Reduce the bottom-right portion of X11 to the identity matrix
 *
       DO I = M-P + 1, Q
-         CALL ZLARFGP( P-I+1, X11(I,I), X11(I+1,I), 1, TAUP1(I) )
+         CALL ZLARFGP( P-I+1, X11(I,I), X11( MIN(I+1,P) ,I), 1,
+     $        TAUP1(I) )
          X11(I,I) = ONE
          CALL ZLARF( 'L', P-I+1, Q-I, X11(I,I), 1, DCONJG(TAUP1(I)),
-     $               X11(I,I+1), LDX11, WORK(ILARF) )
+     $               X11(I, MIN(I+1,Q) ), LDX11, WORK(ILARF) )
       END DO
 *
       RETURN

--- a/SRC/zunbdb3.f
+++ b/SRC/zunbdb3.f
@@ -277,6 +277,14 @@
 *     Reduce rows 1, ..., M-P of X11 and X21
 *
       DO I = 1, M-P
+*
+*        The two lines of code below are meant to avoid an out-of-bound run-time error
+*        when we call subroutines like
+*           ZLARF( 'R', M-P-I, Q-I+1, X21(I,I), LDX21, TAUQ1(I), X21(I+1,I), LDX21, WORK(ILARF) )
+*        with I = M-P, or
+*           ZLARFGP( Q-I+1, X21(I,I), X21(I,I+1), LDX21, TAUQ1(I) )
+*        with I = Q. The invalid arrays have size 0, so they are never referenced in the subroutines.
+*
          I1 = MIN(I+1,M-P)
          I2 = MIN(I+1,Q)
 *


### PR DESCRIPTION
Fix #549.

**Description**
In #549, we verified xORBDB2 and xORBDB3 use subarrays of size 0 starting at `X(N+1)`, where N is the size of X. These arrays are passed as arguments to other subroutines that never reference the arrays. Therefore, this is a false positive case of out-of-bounds. The code provokes no errors in practice, but some compilers (like gfortran) identify and return an `out-of-bounds error`. This PR tries to rewrite the code while keeping the check of bounds. __[edited]__

**Checklist**

- [x] Fix sORBDB2
- [x] Fix sORBDB3
- [x] Fix dORBDB2 and dORBDB3