### PR TITLE
maint: removed unused calls and variables in testing routines

### DIFF
--- a/TESTING/LIN/cqrt14.f
+++ b/TESTING/LIN/cqrt14.f
@@ -197,7 +197,6 @@
          IF( XNRM.NE.ZERO )
      $      CALL CLASCL( 'G', 0, 0, XNRM, ONE, M, NRHS,
      $                   WORK( N*LDWORK+1 ), LDWORK, INFO )
-         ANRM = CLANGE( 'One-norm', M, N+NRHS, WORK, LDWORK, RWORK )
 *
 *        Compute QR factorization of X
 *

--- a/TESTING/LIN/cqrt17.f
+++ b/TESTING/LIN/cqrt17.f
@@ -169,7 +169,7 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            INFO, ISCL, NCOLS, NROWS
-      REAL               BIGNUM, ERR, NORMA, NORMB, NORMRS, SMLNUM
+      REAL               ERR, NORMA, NORMB, NORMRS, SMLNUM
 *     ..
 *     .. Local Arrays ..
       REAL               RWORK( 1 )
@@ -210,7 +210,6 @@
 *
       NORMA = CLANGE( 'One-norm', M, N, A, LDA, RWORK )
       SMLNUM = SLAMCH( 'Safe minimum' ) / SLAMCH( 'Precision' )
-      BIGNUM = ONE / SMLNUM
       ISCL = 0
 *
 *     compute residual and scale it

--- a/TESTING/LIN/dqrt14.f
+++ b/TESTING/LIN/dqrt14.f
@@ -197,7 +197,6 @@
          IF( XNRM.NE.ZERO )
      $      CALL DLASCL( 'G', 0, 0, XNRM, ONE, M, NRHS,
      $                   WORK( N*LDWORK+1 ), LDWORK, INFO )
-         ANRM = DLANGE( 'One-norm', M, N+NRHS, WORK, LDWORK, RWORK )
 *
 *        Compute QR factorization of X
 *

--- a/TESTING/LIN/dqrt17.f
+++ b/TESTING/LIN/dqrt17.f
@@ -169,7 +169,7 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            INFO, ISCL, NCOLS, NROWS
-      DOUBLE PRECISION   BIGNUM, ERR, NORMA, NORMB, NORMRS, SMLNUM
+      DOUBLE PRECISION   ERR, NORMA, NORMB, NORMRS, SMLNUM
 *     ..
 *     .. Local Arrays ..
       DOUBLE PRECISION   RWORK( 1 )
@@ -211,7 +211,6 @@
 *
       NORMA = DLANGE( 'One-norm', M, N, A, LDA, RWORK )
       SMLNUM = DLAMCH( 'Safe minimum' ) / DLAMCH( 'Precision' )
-      BIGNUM = ONE / SMLNUM
       ISCL = 0
 *
 *     compute residual and scale it

--- a/TESTING/LIN/sqrt14.f
+++ b/TESTING/LIN/sqrt14.f
@@ -197,7 +197,6 @@
          IF( XNRM.NE.ZERO )
      $      CALL SLASCL( 'G', 0, 0, XNRM, ONE, M, NRHS,
      $                   WORK( N*LDWORK+1 ), LDWORK, INFO )
-         ANRM = SLANGE( 'One-norm', M, N+NRHS, WORK, LDWORK, RWORK )
 *
 *        Compute QR factorization of X
 *

--- a/TESTING/LIN/sqrt17.f
+++ b/TESTING/LIN/sqrt17.f
@@ -169,7 +169,7 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            INFO, ISCL, NCOLS, NROWS
-      REAL               BIGNUM, ERR, NORMA, NORMB, NORMRS, SMLNUM
+      REAL               ERR, NORMA, NORMB, NORMRS, SMLNUM
 *     ..
 *     .. Local Arrays ..
       REAL               RWORK( 1 )
@@ -211,7 +211,6 @@
 *
       NORMA = SLANGE( 'One-norm', M, N, A, LDA, RWORK )
       SMLNUM = SLAMCH( 'Safe minimum' ) / SLAMCH( 'Precision' )
-      BIGNUM = ONE / SMLNUM
       ISCL = 0
 *
 *     compute residual and scale it

--- a/TESTING/LIN/zqrt14.f
+++ b/TESTING/LIN/zqrt14.f
@@ -197,7 +197,6 @@
          IF( XNRM.NE.ZERO )
      $      CALL ZLASCL( 'G', 0, 0, XNRM, ONE, M, NRHS,
      $                   WORK( N*LDWORK+1 ), LDWORK, INFO )
-         ANRM = ZLANGE( 'One-norm', M, N+NRHS, WORK, LDWORK, RWORK )
 *
 *        Compute QR factorization of X
 *

--- a/TESTING/LIN/zqrt17.f
+++ b/TESTING/LIN/zqrt17.f
@@ -169,7 +169,7 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            INFO, ISCL, NCOLS, NROWS
-      DOUBLE PRECISION   BIGNUM, ERR, NORMA, NORMB, NORMRS, SMLNUM
+      DOUBLE PRECISION   ERR, NORMA, NORMB, NORMRS, SMLNUM
 *     ..
 *     .. Local Arrays ..
       DOUBLE PRECISION   RWORK( 1 )
@@ -210,7 +210,6 @@
 *
       NORMA = ZLANGE( 'One-norm', M, N, A, LDA, RWORK )
       SMLNUM = DLAMCH( 'Safe minimum' ) / DLAMCH( 'Precision' )
-      BIGNUM = ONE / SMLNUM
       ISCL = 0
 *
 *     compute residual and scale it


### PR DESCRIPTION
**Description**

1. Result of call to xLANGE is stored in ANRM variable but then not used in xQRT14 routines.
2. BIGNUM unused variable removed in xQRT17 routines.

**Checklist**

- [ ] The documententation has been updated
- [ ] If the PR solves a specific issue, it is set to be closed on merge.