### PR TITLE
Correct XERBLA argument in SLASQ2

### DIFF
--- a/SRC/slasq2.f
+++ b/SRC/slasq2.f
@@ -182,7 +182,7 @@
 *
          IF( Z( 1 ).LT.ZERO ) THEN
             INFO = -201
-            CALL XERBLA( 'DLASQ2', 2 )
+            CALL XERBLA( 'SLASQ2', 2 )
             RETURN
          ELSE IF( Z( 2 ).LT.ZERO ) THEN
             INFO = -202


### PR DESCRIPTION
**Description**

`SLASQ2` calls `XERBLA` with `'DLASQ2'`, instead of `'SLASQ2'`, as the first argument.
