### PR TITLE
cmake build: more modularity, linker fix, pkg-config fixup

### DIFF
--- a/BLAS/SRC/CMakeLists.txt
+++ b/BLAS/SRC/CMakeLists.txt
@@ -105,3 +105,11 @@ set_target_properties(
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
 lapack_install_library(${BLASLIB})
+if(BUILD_SHARED_LIBS AND BUILD_STATIC_LIBS)
+  add_library(${BLASLIB}_static STATIC ${SOURCES})
+  set_target_properties(
+     ${BLASLIB}_static PROPERTIES
+     OUTPUT_NAME ${BLASLIB}
+    )
+  lapack_install_library(${BLASLIB}_static)
+endif()

--- a/CBLAS/cblas.pc.in
+++ b/CBLAS/cblas.pc.in
@@ -6,5 +6,5 @@ Description: C Standard Interface to BLAS Basic Linear Algebra Subprograms
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/blas/#_cblas
 Libs: -L${libdir} -l@CBLASLIB@
+Libs.private: @BLAS_PCLIBS@
 Cflags: -I${includedir}
-Requires.private: @BLASLIB@

--- a/CBLAS/src/CMakeLists.txt
+++ b/CBLAS/src/CMakeLists.txt
@@ -116,7 +116,6 @@ list(REMOVE_DUPLICATES SOURCES)
 add_library(${CBLASLIB} ${SOURCES})
 set_target_properties(
   ${CBLASLIB} PROPERTIES
-  LINKER_LANGUAGE C
   VERSION ${LAPACK_VERSION}
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
@@ -129,3 +128,17 @@ target_include_directories(${CBLASLIB} PUBLIC
 )
 target_link_libraries(${CBLASLIB} PRIVATE ${BLAS_LIBRARIES})
 lapack_install_library(${CBLASLIB})
+
+if(BUILD_SHARED_LIBS AND BUILD_STATIC_LIBS)
+  add_library(${CBLASLIB}_static STATIC ${SOURCES})
+  set_target_properties(
+    ${CBLASLIB}_static PROPERTIES
+    OUTPUT_NAME ${CBLASLIB}
+    )
+  target_include_directories(${CBLASLIB}_static PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:include>
+  )
+  target_link_libraries(${CBLASLIB}_static PRIVATE ${BLAS_LIBRARIES})
+  lapack_install_library(${CBLASLIB}_static)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,10 @@ if(USE_OPTIMIZED_BLAS)
   else()
     find_package(BLAS)
   endif()
+else()
+  if(BLAS_LIBRARIES)
+    message(FATAL_ERROR "USE_OPTIMIZED_BLAS unset but BLAS provided. Accident?")
+  endif()
 endif()
 
 # Neither user specified or optimized BLAS libraries can be used
@@ -343,6 +347,10 @@ if(USE_OPTIMIZED_LAPACK)
   else()
     # Let's hope for any working LAPACK.
     find_package(LAPACK)
+  endif()
+else()
+  if(LAPACK_LIBRARIES)
+    message(FATAL_ERROR "USE_OPTIMIZED_LAPACK unset but LAPACK provided. Accident?")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,11 @@ endif()
 
 
 # --------------------------------------------------
+
+option(LAPACK "Whether to build or use LAPACK (to enable a BLAS-only build when off)" ON)
+
+if(LAPACK)
+
 set(LAPACK_INSTALL_EXPORT_NAME ${LAPACKLIB}-targets)
 
 macro(lapack_install_library lib)
@@ -167,6 +172,18 @@ macro(lapack_install_library lib)
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT RuntimeLibraries
   )
 endmacro()
+
+else()
+
+macro(lapack_install_library lib)
+  install(TARGETS ${lib}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT RuntimeLibraries
+  )
+endmacro()
+
+endif()
 
 set(PKG_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
@@ -243,31 +260,37 @@ endif()
 option(USE_OPTIMIZED_BLAS "Whether or not to use an optimized BLAS library instead of included netlib BLAS" OFF)
 
 # Check the usage of the user provided BLAS libraries
-if(BLAS_LIBRARIES)
-  include(CheckFortranFunctionExists)
-  set(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
-  CHECK_FORTRAN_FUNCTION_EXISTS("dgemm" BLAS_FOUND)
-  unset(CMAKE_REQUIRED_LIBRARIES)
-  if(BLAS_FOUND)
-    message(STATUS "--> BLAS supplied by user is WORKING, will use ${BLAS_LIBRARIES}.")
+if(USE_OPTIMIZED_BLAS)
+  if(BLAS_LIBRARIES)
+    include(CheckFortranFunctionExists)
+    set(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
+    CHECK_FORTRAN_FUNCTION_EXISTS("dgemm" BLAS_FOUND)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    if(BLAS_FOUND)
+      message(STATUS "--> BLAS supplied by user is WORKING, will use ${BLAS_LIBRARIES}.")
+    else()
+      message(ERROR "--> BLAS supplied by user is not WORKING, CANNOT USE ${BLAS_LIBRARIES}.")
+      message(ERROR "-->     Fix BLAS_LIBRARIES or ensure that USE_OPTIMIZED_BLAS is off for REFERENCE BLAS.")
+    endif()
+  # User did not provide a BLAS Library but specified to search for one
   else()
-    message(ERROR "--> BLAS supplied by user is not WORKING, CANNOT USE ${BLAS_LIBRARIES}.")
-    message(ERROR "-->     Will use REFERENCE BLAS (by default)")
-    message(ERROR "-->     Or Correct your BLAS_LIBRARIES entry ")
-    message(ERROR "-->     Or Consider checking USE_OPTIMIZED_BLAS")
+    find_package(BLAS)
   endif()
-
-# User did not provide a BLAS Library but specified to search for one
-elseif(USE_OPTIMIZED_BLAS)
-  find_package(BLAS)
 endif()
 
 # Neither user specified or optimized BLAS libraries can be used
 if(NOT BLAS_FOUND)
+  if(USE_OPTIMIZED_BLAS)
+    message(FATAL_ERROR "USE_OPTIMIZED_BLAS set but no usable BLAS provided.")
+  endif()
   message(STATUS "Using supplied NETLIB BLAS implementation")
   add_subdirectory(BLAS)
   set(BLAS_LIBRARIES ${BLASLIB})
+  set(BLAS_PCLIBS -l${BLASLIB})
 else()
+  # This is the full path to a .so file from find_package, possibly.
+  # not ideal. Better ideas?
+  set(BLAS_PCLIBS ${BLAS_LIBRARIES})
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} ${BLAS_LINKER_FLAGS}"
     CACHE STRING "Linker flags for executables" FORCE)
@@ -298,36 +321,44 @@ endif()
 
 option(USE_OPTIMIZED_LAPACK "Whether or not to use an optimized LAPACK library instead of included netlib LAPACK" OFF)
 
+if(LAPACK)
+
 # --------------------------------------------------
 # LAPACK
-# User did not provide a LAPACK Library but specified to search for one
-if(USE_OPTIMIZED_LAPACK)
-  find_package(LAPACK)
-endif()
 
 # Check the usage of the user provided or automatically found LAPACK libraries
-if(LAPACK_LIBRARIES)
-  include(CheckFortranFunctionExists)
-  set(CMAKE_REQUIRED_LIBRARIES ${LAPACK_LIBRARIES})
-  # Check if new routine of 3.4.0 is in LAPACK_LIBRARIES
-  CHECK_FORTRAN_FUNCTION_EXISTS("dgeqrt" LATESTLAPACK_FOUND)
-  unset(CMAKE_REQUIRED_LIBRARIES)
-  if(LATESTLAPACK_FOUND)
-    message(STATUS "--> LAPACK supplied by user is WORKING, will use ${LAPACK_LIBRARIES}.")
+if(USE_OPTIMIZED_LAPACK)
+  if(LAPACK_LIBRARIES)
+    include(CheckFortranFunctionExists)
+    set(CMAKE_REQUIRED_LIBRARIES ${LAPACK_LIBRARIES})
+    # Check if new routine of 3.4.0 is in LAPACK_LIBRARIES
+    CHECK_FORTRAN_FUNCTION_EXISTS("dgeqrt" LAPACK_FOUND)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    if(LAPACK_FOUND)
+      message(STATUS "--> LAPACK supplied by user is WORKING, will use ${LAPACK_LIBRARIES}.")
+    else()
+      message(ERROR "--> LAPACK supplied by user is not WORKING or is older than LAPACK 3.4.0, CANNOT USE ${LAPACK_LIBRARIES}.")
+      message(ERROR "-->     Fix LAPACK_LIBRARIES or ensure that USE_OPTIMIZED_LAPACK is off for REFERENCE LAPACK.")
+    endif()
   else()
-    message(ERROR "--> LAPACK supplied by user is not WORKING or is older than LAPACK 3.4.0, CANNOT USE ${LAPACK_LIBRARIES}.")
-    message(ERROR "-->     Will use REFERENCE LAPACK (by default)")
-    message(ERROR "-->     Or Correct your LAPACK_LIBRARIES entry ")
-    message(ERROR "-->     Or Consider checking USE_OPTIMIZED_LAPACK")
+    # Let's hope for any working LAPACK.
+    find_package(LAPACK)
   endif()
 endif()
 
 # Neither user specified or optimized LAPACK libraries can be used
-if(NOT LATESTLAPACK_FOUND)
+if(NOT LAPACK_FOUND)
+  if(USE_OPTIMIZED_LAPACK)
+    message(FATAL_ERROR "USE_OPTIMIZED_LAPACK set but no usable LAPACK provided.")
+  endif()
   message(STATUS "Using supplied NETLIB LAPACK implementation")
   set(LAPACK_LIBRARIES ${LAPACKLIB})
+  set(LAPACK_PCLIBS -l${LAPACKLIB})
   add_subdirectory(SRC)
 else()
+  # This is the full path to a .so file from find_package, possibly.
+  # not ideal. Better ideas?
+  set(LAPACK_PCLIBS ${LAPACK_LIBRARIES})
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} ${LAPACK_LINKER_FLAGS}"
     CACHE STRING "Linker flags for executables" FORCE)
@@ -337,6 +368,8 @@ else()
   set(CMAKE_SHARED_LINKER_FLAGS
     "${CMAKE_SHARED_LINKER_FLAGS} ${LAPACK_LINKER_FLAGS}"
     CACHE STRING "Linker flags for shared libs" FORCE)
+endif()
+
 endif()
 
 if(BUILD_TESTING)
@@ -464,10 +497,14 @@ if(NOT BLAS_FOUND)
   set(ALL_TARGETS ${ALL_TARGETS} ${BLASLIB})
 endif()
 
-if(NOT LATESTLAPACK_FOUND)
+if(LAPACK)
+if(NOT LAPACK_FOUND)
   set(ALL_TARGETS ${ALL_TARGETS} ${LAPACKLIB})
+  set(BUILD_LAPACK ON)
+endif()
 endif()
 
+if(LAPACK)
 # Export lapack targets, not including lapacke, from the
 # install tree, if any.
 set(_lapack_config_install_guard_target "")
@@ -480,6 +517,7 @@ if(ALL_TARGETS)
   # Choose one of the lapack targets to use as a guard for
   # lapack-config.cmake to load targets from the install tree.
   list(GET ALL_TARGETS 0 _lapack_config_install_guard_target)
+endif()
 endif()
 
 # Include cblas in targets exported from the build tree.
@@ -495,6 +533,8 @@ endif()
 if(NOT LAPACK_WITH_TMGLIB_FOUND AND LAPACKE_WITH_TMG)
   set(ALL_TARGETS ${ALL_TARGETS} ${TMGLIB})
 endif()
+
+if(BUILD_LAPACK)
 
 # Export lapack and lapacke targets from the build tree, if any.
 set(_lapack_config_build_guard_target "")
@@ -533,6 +573,9 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKLIB}-${LAPACK_VERSION}
   COMPONENT Development
   )
+
+endif() # BUILD_LAPACK
+
 if (LAPACK++)
   install(
   DIRECTORY "${LAPACK_BINARY_DIR}/lib/"

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -99,6 +99,25 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   COMPONENT Development
   )
+if(BUILD_SHARED_LIBS AND BUILD_STATIC_LIBS)
+  add_library(${LAPACKELIB}_static STATIC ${SOURCES})
+  set_target_properties(
+    ${LAPACKELIB}_static PROPERTIES
+    LINKER_LANGUAGE C
+    OUTPUT_NAME ${LAPACKELIB}
+    )
+   target_include_directories(${LAPACKELIB}_static PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  if(LAPACKE_WITH_TMG)
+    target_link_libraries(${LAPACKELIB}_static PRIVATE ${TMGLIB})
+  endif()
+  target_link_libraries(${LAPACKELIB}_static PRIVATE ${LAPACK_LIBRARIES})
+
+  lapack_install_library(${LAPACKELIB}_static)
+endif()
 
 if(BUILD_TESTING)
   add_subdirectory(example)

--- a/LAPACKE/lapacke.pc.in
+++ b/LAPACKE/lapacke.pc.in
@@ -6,5 +6,5 @@ Description: C Standard Interface to LAPACK Linear Algebra PACKage
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/lapack/#_standard_c_language_apis_for_lapack
 Libs: -L${libdir} -l@LAPACKELIB@
+Libs.private: @LAPACK_PCLIBS@ @BLAS_PCLIBS@
 Cflags: -I${includedir}
-Requires.private: @LAPACKLIB@

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -524,3 +524,22 @@ if(_is_coverage_build)
 endif()
 
 lapack_install_library(${LAPACKLIB})
+if(BUILD_SHARED_LIBS AND BUILD_STATIC_LIBS)
+  add_library(${LAPACKLIB}_static STATIC ${SOURCES})
+  set_target_properties(
+    ${LAPACKLIB}_static PROPERTIES
+    OUTPUT_NAME ${LAPACKLIB}
+    )
+
+  if(USE_XBLAS)
+    target_link_libraries(${LAPACKLIB}_static PRIVATE ${XBLAS_LIBRARY})
+  endif()
+  target_link_libraries(${LAPACKLIB}_static PRIVATE ${BLAS_LIBRARIES})
+
+  if (_is_coverage_build)
+    target_link_libraries(${LAPACKLIB}_static PRIVATE gcov)
+    add_coverage(${LAPACKLIB}_static)
+  endif()
+
+  lapack_install_library(${LAPACKLIB}_static)
+endif()

--- a/TESTING/MATGEN/CMakeLists.txt
+++ b/TESTING/MATGEN/CMakeLists.txt
@@ -57,3 +57,12 @@ set_target_properties(
 
 target_link_libraries(${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 lapack_install_library(${TMGLIB})
+if(BUILD_SHARED_LIBS AND BUILD_STATIC_LIBS)
+  add_library(${TMGLIB}_static STATIC ${SOURCES})
+  set_target_properties(
+    ${TMGLIB}_static PROPERTIES
+    OUTPUT_NAME ${TMGLIB}
+  )
+  target_link_libraries(${TMGLIB}_static ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+  lapack_install_library(${TMGLIB}_static)
+endif()

--- a/lapack.pc.in
+++ b/lapack.pc.in
@@ -5,5 +5,5 @@ Name: LAPACK
 Description: FORTRAN reference implementation of LAPACK Linear Algebra PACKage
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/lapack/
-Libs: -L${libdir} -llapack
-Requires.private: blas
+Libs: -L${libdir} -l@LAPACKLIB@
+Libs.private: @BLAS_PCLIBS@


### PR DESCRIPTION
This set of changes stems from the packaging of netlib code in pkgsrc,
where we decided to provide blas, lapack, cblas, and lapacke as separate
packages and hence need clean support in the build system for this and
also for combining the wrappers lapacke and cblas with any prescribed
optimized blas or lapack library.

- LAPACK option to be able to just build BLAS
- consistent logic for USE_OPTIMIZED_BLAS and USE_OPTIMIZED_LAPACK
  (including clear failure instead of silent fallback if BLAS_LIBARIES
  or LAPACK_LIBRARIES do not work)
- Fix linking of CBLAS on NetBSD with pkgsrc, use Fortran and not C
  for linking (same as LAPACKE already).
- Allow building of shared and static libs at the same time.
- Trying to fix up pkg-config files for all cases of internal or
  external libs

The last one is not in really proper shape yet. The idea is that the
.pc files contain

  Libs.private= -L/fooprefix -lfoo

if foo is your optimized BLAS/LAPACK, not assuming presence of a .pc file
for that itself. This works for user-supplied BLAS_LIBRARIES so far, but
inserts the full path to the .so file from its search … which does not fit
the case of static linking. And well, yes, you do not know if both static
and shared libs are present. So maybe it's a complex problem. My use case
so far is fine as I explicitly provide BLAS_LIBRARIES and actually this is
what I try to get into other upstream packages that need BLAS or LAPACK:
Just use BLAS_LIBS or LAPACK_LIBS as provided by the user (the packager).

Would be nice if (most of) this can be included in the official LAPACK CMake
build so that we do not have to carry and update the patches all the time.

**Description**

**Checklist**

- [ ] The documententation has been updated
- [ ] If the PR solves a specific issue, it is set to be closed on merge.