### PR TITLE
Add LAPACK_FORTRAN_STRLEN_END info to function prototypes in LAPACKE/include/lapack.h

### DIFF
--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -5973,7 +5973,7 @@ void LAPACK_sgtsvx_base(
 #endif
 
 #define LAPACK_zgtsvx_base LAPACK_GLOBAL(zgtsvx,ZGTSVX)
-void LAPACK_zgtsv_basex(
+void LAPACK_zgtsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* DL,
@@ -6834,7 +6834,7 @@ void LAPACK_zheevd_base(
 #endif
 
 #define LAPACK_cheevd_2stage_base LAPACK_GLOBAL(cheevd_2stage,CHEEVD_2STAGE)
-void LAPACK_cheevd_2stag_basee(
+void LAPACK_cheevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -114,16 +114,25 @@ typedef lapack_logical (*LAPACK_Z_SELECT1) ( const lapack_complex_double* );
 typedef lapack_logical (*LAPACK_Z_SELECT2)
     ( const lapack_complex_double*, const lapack_complex_double* );
 
-#define LAPACK_lsame LAPACK_GLOBAL(lsame,LSAME)
-lapack_logical LAPACK_lsame( char* ca,  char* cb,
-                              lapack_int lca, lapack_int lcb );
+#define LAPACK_lsame_base LAPACK_GLOBAL(lsame,LSAME)
+lapack_logical LAPACK_lsame_base( char* ca,  char* cb,
+                              lapack_int lca, lapack_int lcb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_lsame(...) LAPACK_lsame_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_lsame(...) LAPACK_lsame_base(__VA_ARGS__)
+#endif
 
 
 /*----------------------------------------------------------------------------*/
 /* This is in alphabetical order (ignoring leading precision). */
 
-#define LAPACK_cbbcsd LAPACK_GLOBAL(cbbcsd,CBBCSD)
-void LAPACK_cbbcsd(
+#define LAPACK_cbbcsd_base LAPACK_GLOBAL(cbbcsd,CBBCSD)
+void LAPACK_cbbcsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     float* theta,
@@ -141,10 +150,19 @@ void LAPACK_cbbcsd(
     float* B22D,
     float* B22E,
     float* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cbbcsd(...) LAPACK_cbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_cbbcsd(...) LAPACK_cbbcsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dbbcsd LAPACK_GLOBAL(dbbcsd,DBBCSD)
-void LAPACK_dbbcsd(
+#define LAPACK_dbbcsd_base LAPACK_GLOBAL(dbbcsd,DBBCSD)
+void LAPACK_dbbcsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     double* theta,
@@ -162,10 +180,19 @@ void LAPACK_dbbcsd(
     double* b22d,
     double* b22e,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_dbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sbbcsd LAPACK_GLOBAL(sbbcsd,SBBCSD)
-void LAPACK_sbbcsd(
+#define LAPACK_sbbcsd_base LAPACK_GLOBAL(sbbcsd,SBBCSD)
+void LAPACK_sbbcsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     float* theta,
@@ -183,10 +210,19 @@ void LAPACK_sbbcsd(
     float* B22D,
     float* B22E,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_sbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zbbcsd LAPACK_GLOBAL(zbbcsd,ZBBCSD)
-void LAPACK_zbbcsd(
+#define LAPACK_zbbcsd_base LAPACK_GLOBAL(zbbcsd,ZBBCSD)
+void LAPACK_zbbcsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     double* theta,
@@ -204,10 +240,19 @@ void LAPACK_zbbcsd(
     double* B22D,
     double* B22E,
     double* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zbbcsd(...) LAPACK_zbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_zbbcsd(...) LAPACK_zbbcsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dbdsdc LAPACK_GLOBAL(dbdsdc,DBDSDC)
-void LAPACK_dbdsdc(
+#define LAPACK_dbdsdc_base LAPACK_GLOBAL(dbdsdc,DBDSDC)
+void LAPACK_dbdsdc_base(
     char const* uplo, char const* compq,
     lapack_int const* n,
     double* D,
@@ -217,10 +262,19 @@ void LAPACK_dbdsdc(
     double* Q, lapack_int* IQ,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dbdsdc(...) LAPACK_dbdsdc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dbdsdc(...) LAPACK_dbdsdc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sbdsdc LAPACK_GLOBAL(sbdsdc,SBDSDC)
-void LAPACK_sbdsdc(
+#define LAPACK_sbdsdc_base LAPACK_GLOBAL(sbdsdc,SBDSDC)
+void LAPACK_sbdsdc_base(
     char const* uplo, char const* compq,
     lapack_int const* n,
     float* D,
@@ -230,10 +284,19 @@ void LAPACK_sbdsdc(
     float* Q, lapack_int* IQ,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sbdsdc(...) LAPACK_sbdsdc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sbdsdc(...) LAPACK_sbdsdc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cbdsqr LAPACK_GLOBAL(cbdsqr,CBDSQR)
-void LAPACK_cbdsqr(
+#define LAPACK_cbdsqr_base LAPACK_GLOBAL(cbdsqr,CBDSQR)
+void LAPACK_cbdsqr_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* ncvt, lapack_int const* nru, lapack_int const* ncc,
     float* D,
@@ -242,10 +305,19 @@ void LAPACK_cbdsqr(
     lapack_complex_float* U, lapack_int const* ldu,
     lapack_complex_float* C, lapack_int const* ldc,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cbdsqr(...) LAPACK_cbdsqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cbdsqr(...) LAPACK_cbdsqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dbdsqr LAPACK_GLOBAL(dbdsqr,DBDSQR)
-void LAPACK_dbdsqr(
+#define LAPACK_dbdsqr_base LAPACK_GLOBAL(dbdsqr,DBDSQR)
+void LAPACK_dbdsqr_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* ncvt, lapack_int const* nru, lapack_int const* ncc,
     double* D,
@@ -254,10 +326,19 @@ void LAPACK_dbdsqr(
     double* U, lapack_int const* ldu,
     double* C, lapack_int const* ldc,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dbdsqr(...) LAPACK_dbdsqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dbdsqr(...) LAPACK_dbdsqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sbdsqr LAPACK_GLOBAL(sbdsqr,SBDSQR)
-void LAPACK_sbdsqr(
+#define LAPACK_sbdsqr_base LAPACK_GLOBAL(sbdsqr,SBDSQR)
+void LAPACK_sbdsqr_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* ncvt, lapack_int const* nru, lapack_int const* ncc,
     float* D,
@@ -266,10 +347,19 @@ void LAPACK_sbdsqr(
     float* U, lapack_int const* ldu,
     float* C, lapack_int const* ldc,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sbdsqr(...) LAPACK_sbdsqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sbdsqr(...) LAPACK_sbdsqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zbdsqr LAPACK_GLOBAL(zbdsqr,ZBDSQR)
-void LAPACK_zbdsqr(
+#define LAPACK_zbdsqr_base LAPACK_GLOBAL(zbdsqr,ZBDSQR)
+void LAPACK_zbdsqr_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* ncvt, lapack_int const* nru, lapack_int const* ncc,
     double* D,
@@ -278,10 +368,19 @@ void LAPACK_zbdsqr(
     lapack_complex_double* U, lapack_int const* ldu,
     lapack_complex_double* C, lapack_int const* ldc,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zbdsqr(...) LAPACK_zbdsqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zbdsqr(...) LAPACK_zbdsqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dbdsvdx LAPACK_GLOBAL(dbdsvdx,DBDSVDX)
-void LAPACK_dbdsvdx(
+#define LAPACK_dbdsvdx_base LAPACK_GLOBAL(dbdsvdx,DBDSVDX)
+void LAPACK_dbdsvdx_base(
     char const* uplo, char const* jobz, char const* range,
     lapack_int const* n,
     double const* D,
@@ -292,10 +391,19 @@ void LAPACK_dbdsvdx(
     double* Z, lapack_int const* ldz,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dbdsvdx(...) LAPACK_dbdsvdx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dbdsvdx(...) LAPACK_dbdsvdx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sbdsvdx LAPACK_GLOBAL(sbdsvdx,SBDSVDX)
-void LAPACK_sbdsvdx(
+#define LAPACK_sbdsvdx_base LAPACK_GLOBAL(sbdsvdx,SBDSVDX)
+void LAPACK_sbdsvdx_base(
     char const* uplo, char const* jobz, char const* range,
     lapack_int const* n,
     float const* D,
@@ -306,26 +414,53 @@ void LAPACK_sbdsvdx(
     float* Z, lapack_int const* ldz,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sbdsvdx(...) LAPACK_sbdsvdx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sbdsvdx(...) LAPACK_sbdsvdx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ddisna LAPACK_GLOBAL(ddisna,DDISNA)
-void LAPACK_ddisna(
+#define LAPACK_ddisna_base LAPACK_GLOBAL(ddisna,DDISNA)
+void LAPACK_ddisna_base(
     char const* job,
     lapack_int const* m, lapack_int const* n,
     double const* D,
     double* SEP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ddisna(...) LAPACK_ddisna_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ddisna(...) LAPACK_ddisna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sdisna LAPACK_GLOBAL(sdisna,SDISNA)
-void LAPACK_sdisna(
+#define LAPACK_sdisna_base LAPACK_GLOBAL(sdisna,SDISNA)
+void LAPACK_sdisna_base(
     char const* job,
     lapack_int const* m, lapack_int const* n,
     float const* D,
     float* SEP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sdisna(...) LAPACK_sdisna_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sdisna(...) LAPACK_sdisna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgbbrd LAPACK_GLOBAL(cgbbrd,CGBBRD)
-void LAPACK_cgbbrd(
+#define LAPACK_cgbbrd_base LAPACK_GLOBAL(cgbbrd,CGBBRD)
+void LAPACK_cgbbrd_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* ncc, lapack_int const* kl, lapack_int const* ku,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -336,10 +471,19 @@ void LAPACK_cgbbrd(
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgbbrd(...) LAPACK_cgbbrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgbbrd(...) LAPACK_cgbbrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgbbrd LAPACK_GLOBAL(dgbbrd,DGBBRD)
-void LAPACK_dgbbrd(
+#define LAPACK_dgbbrd_base LAPACK_GLOBAL(dgbbrd,DGBBRD)
+void LAPACK_dgbbrd_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* ncc, lapack_int const* kl, lapack_int const* ku,
     double* AB, lapack_int const* ldab,
@@ -349,10 +493,19 @@ void LAPACK_dgbbrd(
     double* PT, lapack_int const* ldpt,
     double* C, lapack_int const* ldc,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgbbrd(...) LAPACK_dgbbrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgbbrd(...) LAPACK_dgbbrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgbbrd LAPACK_GLOBAL(sgbbrd,SGBBRD)
-void LAPACK_sgbbrd(
+#define LAPACK_sgbbrd_base LAPACK_GLOBAL(sgbbrd,SGBBRD)
+void LAPACK_sgbbrd_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* ncc, lapack_int const* kl, lapack_int const* ku,
     float* AB, lapack_int const* ldab,
@@ -362,10 +515,19 @@ void LAPACK_sgbbrd(
     float* PT, lapack_int const* ldpt,
     float* C, lapack_int const* ldc,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgbbrd(...) LAPACK_sgbbrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgbbrd(...) LAPACK_sgbbrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgbbrd LAPACK_GLOBAL(zgbbrd,ZGBBRD)
-void LAPACK_zgbbrd(
+#define LAPACK_zgbbrd_base LAPACK_GLOBAL(zgbbrd,ZGBBRD)
+void LAPACK_zgbbrd_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* ncc, lapack_int const* kl, lapack_int const* ku,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -376,10 +538,19 @@ void LAPACK_zgbbrd(
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgbbrd(...) LAPACK_zgbbrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgbbrd(...) LAPACK_zgbbrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgbcon LAPACK_GLOBAL(cgbcon,CGBCON)
-void LAPACK_cgbcon(
+#define LAPACK_cgbcon_base LAPACK_GLOBAL(cgbcon,CGBCON)
+void LAPACK_cgbcon_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     lapack_complex_float const* AB, lapack_int const* ldab, lapack_int const* ipiv,
@@ -387,10 +558,19 @@ void LAPACK_cgbcon(
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgbcon(...) LAPACK_cgbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgbcon(...) LAPACK_cgbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgbcon LAPACK_GLOBAL(dgbcon,DGBCON)
-void LAPACK_dgbcon(
+#define LAPACK_dgbcon_base LAPACK_GLOBAL(dgbcon,DGBCON)
+void LAPACK_dgbcon_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     double const* AB, lapack_int const* ldab, lapack_int const* ipiv,
@@ -398,10 +578,19 @@ void LAPACK_dgbcon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgbcon(...) LAPACK_dgbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgbcon(...) LAPACK_dgbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgbcon LAPACK_GLOBAL(sgbcon,SGBCON)
-void LAPACK_sgbcon(
+#define LAPACK_sgbcon_base LAPACK_GLOBAL(sgbcon,SGBCON)
+void LAPACK_sgbcon_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     float const* AB, lapack_int const* ldab, lapack_int const* ipiv,
@@ -409,10 +598,19 @@ void LAPACK_sgbcon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgbcon(...) LAPACK_sgbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgbcon(...) LAPACK_sgbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgbcon LAPACK_GLOBAL(zgbcon,ZGBCON)
-void LAPACK_zgbcon(
+#define LAPACK_zgbcon_base LAPACK_GLOBAL(zgbcon,ZGBCON)
+void LAPACK_zgbcon_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     lapack_complex_double const* AB, lapack_int const* ldab, lapack_int const* ipiv,
@@ -420,7 +618,16 @@ void LAPACK_zgbcon(
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgbcon(...) LAPACK_zgbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgbcon(...) LAPACK_zgbcon_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgbequ LAPACK_GLOBAL(cgbequ,CGBEQU)
 void LAPACK_cgbequ(
@@ -510,8 +717,8 @@ void LAPACK_zgbequb(
     double* amax,
     lapack_int* info );
 
-#define LAPACK_cgbrfs LAPACK_GLOBAL(cgbrfs,CGBRFS)
-void LAPACK_cgbrfs(
+#define LAPACK_cgbrfs_base LAPACK_GLOBAL(cgbrfs,CGBRFS)
+void LAPACK_cgbrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_float const* AB, lapack_int const* ldab,
@@ -522,10 +729,19 @@ void LAPACK_cgbrfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgbrfs(...) LAPACK_cgbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgbrfs(...) LAPACK_cgbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgbrfs LAPACK_GLOBAL(dgbrfs,DGBRFS)
-void LAPACK_dgbrfs(
+#define LAPACK_dgbrfs_base LAPACK_GLOBAL(dgbrfs,DGBRFS)
+void LAPACK_dgbrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     double const* AB, lapack_int const* ldab,
@@ -536,10 +752,19 @@ void LAPACK_dgbrfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgbrfs(...) LAPACK_dgbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgbrfs(...) LAPACK_dgbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgbrfs LAPACK_GLOBAL(sgbrfs,SGBRFS)
-void LAPACK_sgbrfs(
+#define LAPACK_sgbrfs_base LAPACK_GLOBAL(sgbrfs,SGBRFS)
+void LAPACK_sgbrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     float const* AB, lapack_int const* ldab,
@@ -550,10 +775,19 @@ void LAPACK_sgbrfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgbrfs(...) LAPACK_sgbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgbrfs(...) LAPACK_sgbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgbrfs LAPACK_GLOBAL(zgbrfs,ZGBRFS)
-void LAPACK_zgbrfs(
+#define LAPACK_zgbrfs_base LAPACK_GLOBAL(zgbrfs,ZGBRFS)
+void LAPACK_zgbrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_double const* AB, lapack_int const* ldab,
@@ -564,10 +798,19 @@ void LAPACK_zgbrfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgbrfs(...) LAPACK_zgbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgbrfs(...) LAPACK_zgbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgbrfsx LAPACK_GLOBAL(cgbrfsx,CGBRFSX)
-void LAPACK_cgbrfsx(
+#define LAPACK_cgbrfsx_base LAPACK_GLOBAL(cgbrfsx,CGBRFSX)
+void LAPACK_cgbrfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_float const* AB, lapack_int const* ldab,
@@ -583,10 +826,19 @@ void LAPACK_cgbrfsx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgbrfsx(...) LAPACK_cgbrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgbrfsx(...) LAPACK_cgbrfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgbrfsx LAPACK_GLOBAL(dgbrfsx,DGBRFSX)
-void LAPACK_dgbrfsx(
+#define LAPACK_dgbrfsx_base LAPACK_GLOBAL(dgbrfsx,DGBRFSX)
+void LAPACK_dgbrfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     double const* AB, lapack_int const* ldab,
@@ -602,10 +854,19 @@ void LAPACK_dgbrfsx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgbrfsx(...) LAPACK_dgbrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgbrfsx(...) LAPACK_dgbrfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgbrfsx LAPACK_GLOBAL(sgbrfsx,SGBRFSX)
-void LAPACK_sgbrfsx(
+#define LAPACK_sgbrfsx_base LAPACK_GLOBAL(sgbrfsx,SGBRFSX)
+void LAPACK_sgbrfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     float const* AB, lapack_int const* ldab,
@@ -621,10 +882,19 @@ void LAPACK_sgbrfsx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgbrfsx(...) LAPACK_sgbrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgbrfsx(...) LAPACK_sgbrfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgbrfsx LAPACK_GLOBAL(zgbrfsx,ZGBRFSX)
-void LAPACK_zgbrfsx(
+#define LAPACK_zgbrfsx_base LAPACK_GLOBAL(zgbrfsx,ZGBRFSX)
+void LAPACK_zgbrfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_double const* AB, lapack_int const* ldab,
@@ -640,7 +910,16 @@ void LAPACK_zgbrfsx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgbrfsx(...) LAPACK_zgbrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgbrfsx(...) LAPACK_zgbrfsx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgbsv LAPACK_GLOBAL(cgbsv,CGBSV)
 void LAPACK_cgbsv(
@@ -670,8 +949,8 @@ void LAPACK_zgbsv(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info );
 
-#define LAPACK_cgbsvx LAPACK_GLOBAL(cgbsvx,CGBSVX)
-void LAPACK_cgbsvx(
+#define LAPACK_cgbsvx_base LAPACK_GLOBAL(cgbsvx,CGBSVX)
+void LAPACK_cgbsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -686,10 +965,19 @@ void LAPACK_cgbsvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgbsvx(...) LAPACK_cgbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgbsvx(...) LAPACK_cgbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgbsvx LAPACK_GLOBAL(dgbsvx,DGBSVX)
-void LAPACK_dgbsvx(
+#define LAPACK_dgbsvx_base LAPACK_GLOBAL(dgbsvx,DGBSVX)
+void LAPACK_dgbsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     double* AB, lapack_int const* ldab,
@@ -704,10 +992,19 @@ void LAPACK_dgbsvx(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgbsvx(...) LAPACK_dgbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgbsvx(...) LAPACK_dgbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgbsvx LAPACK_GLOBAL(sgbsvx,SGBSVX)
-void LAPACK_sgbsvx(
+#define LAPACK_sgbsvx_base LAPACK_GLOBAL(sgbsvx,SGBSVX)
+void LAPACK_sgbsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     float* AB, lapack_int const* ldab,
@@ -722,10 +1019,19 @@ void LAPACK_sgbsvx(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgbsvx(...) LAPACK_sgbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgbsvx(...) LAPACK_sgbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgbsvx LAPACK_GLOBAL(zgbsvx,ZGBSVX)
-void LAPACK_zgbsvx(
+#define LAPACK_zgbsvx_base LAPACK_GLOBAL(zgbsvx,ZGBSVX)
+void LAPACK_zgbsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -740,10 +1046,19 @@ void LAPACK_zgbsvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgbsvx(...) LAPACK_zgbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgbsvx(...) LAPACK_zgbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgbsvxx LAPACK_GLOBAL(cgbsvxx,CGBSVXX)
-void LAPACK_cgbsvxx(
+#define LAPACK_cgbsvxx_base LAPACK_GLOBAL(cgbsvxx,CGBSVXX)
+void LAPACK_cgbsvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -761,10 +1076,19 @@ void LAPACK_cgbsvxx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgbsvxx(...) LAPACK_cgbsvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgbsvxx(...) LAPACK_cgbsvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgbsvxx LAPACK_GLOBAL(dgbsvxx,DGBSVXX)
-void LAPACK_dgbsvxx(
+#define LAPACK_dgbsvxx_base LAPACK_GLOBAL(dgbsvxx,DGBSVXX)
+void LAPACK_dgbsvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     double* AB, lapack_int const* ldab,
@@ -782,10 +1106,19 @@ void LAPACK_dgbsvxx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgbsvxx(...) LAPACK_dgbsvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgbsvxx(...) LAPACK_dgbsvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgbsvxx LAPACK_GLOBAL(sgbsvxx,SGBSVXX)
-void LAPACK_sgbsvxx(
+#define LAPACK_sgbsvxx_base LAPACK_GLOBAL(sgbsvxx,SGBSVXX)
+void LAPACK_sgbsvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     float* AB, lapack_int const* ldab,
@@ -803,10 +1136,19 @@ void LAPACK_sgbsvxx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgbsvxx(...) LAPACK_sgbsvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgbsvxx(...) LAPACK_sgbsvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgbsvxx LAPACK_GLOBAL(zgbsvxx,ZGBSVXX)
-void LAPACK_zgbsvxx(
+#define LAPACK_zgbsvxx_base LAPACK_GLOBAL(zgbsvxx,ZGBSVXX)
+void LAPACK_zgbsvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -824,7 +1166,16 @@ void LAPACK_zgbsvxx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgbsvxx(...) LAPACK_zgbsvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgbsvxx(...) LAPACK_zgbsvxx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgbtrf LAPACK_GLOBAL(cgbtrf,CGBTRF)
 void LAPACK_cgbtrf(
@@ -850,101 +1201,209 @@ void LAPACK_zgbtrf(
     lapack_complex_double* AB, lapack_int const* ldab, lapack_int* ipiv,
     lapack_int* info );
 
-#define LAPACK_cgbtrs LAPACK_GLOBAL(cgbtrs,CGBTRS)
-void LAPACK_cgbtrs(
+#define LAPACK_cgbtrs_base LAPACK_GLOBAL(cgbtrs,CGBTRS)
+void LAPACK_cgbtrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_float const* AB, lapack_int const* ldab, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgbtrs(...) LAPACK_cgbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgbtrs(...) LAPACK_cgbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgbtrs LAPACK_GLOBAL(dgbtrs,DGBTRS)
-void LAPACK_dgbtrs(
+#define LAPACK_dgbtrs_base LAPACK_GLOBAL(dgbtrs,DGBTRS)
+void LAPACK_dgbtrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     double const* AB, lapack_int const* ldab, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgbtrs(...) LAPACK_dgbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgbtrs(...) LAPACK_dgbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgbtrs LAPACK_GLOBAL(sgbtrs,SGBTRS)
-void LAPACK_sgbtrs(
+#define LAPACK_sgbtrs_base LAPACK_GLOBAL(sgbtrs,SGBTRS)
+void LAPACK_sgbtrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     float const* AB, lapack_int const* ldab, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgbtrs(...) LAPACK_sgbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgbtrs(...) LAPACK_sgbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgbtrs LAPACK_GLOBAL(zgbtrs,ZGBTRS)
-void LAPACK_zgbtrs(
+#define LAPACK_zgbtrs_base LAPACK_GLOBAL(zgbtrs,ZGBTRS)
+void LAPACK_zgbtrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku, lapack_int const* nrhs,
     lapack_complex_double const* AB, lapack_int const* ldab, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgbtrs(...) LAPACK_zgbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgbtrs(...) LAPACK_zgbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgebak LAPACK_GLOBAL(cgebak,CGEBAK)
-void LAPACK_cgebak(
+#define LAPACK_cgebak_base LAPACK_GLOBAL(cgebak,CGEBAK)
+void LAPACK_cgebak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float const* scale, lapack_int const* m,
     lapack_complex_float* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgebak(...) LAPACK_cgebak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgebak(...) LAPACK_cgebak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgebak LAPACK_GLOBAL(dgebak,DGEBAK)
-void LAPACK_dgebak(
+#define LAPACK_dgebak_base LAPACK_GLOBAL(dgebak,DGEBAK)
+void LAPACK_dgebak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double const* scale, lapack_int const* m,
     double* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgebak(...) LAPACK_dgebak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgebak(...) LAPACK_dgebak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgebak LAPACK_GLOBAL(sgebak,SGEBAK)
-void LAPACK_sgebak(
+#define LAPACK_sgebak_base LAPACK_GLOBAL(sgebak,SGEBAK)
+void LAPACK_sgebak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float const* scale, lapack_int const* m,
     float* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgebak(...) LAPACK_sgebak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgebak(...) LAPACK_sgebak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgebak LAPACK_GLOBAL(zgebak,ZGEBAK)
-void LAPACK_zgebak(
+#define LAPACK_zgebak_base LAPACK_GLOBAL(zgebak,ZGEBAK)
+void LAPACK_zgebak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double const* scale, lapack_int const* m,
     lapack_complex_double* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgebak(...) LAPACK_zgebak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgebak(...) LAPACK_zgebak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgebal LAPACK_GLOBAL(cgebal,CGEBAL)
-void LAPACK_cgebal(
+#define LAPACK_cgebal_base LAPACK_GLOBAL(cgebal,CGEBAL)
+void LAPACK_cgebal_base(
     char const* job,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ilo, lapack_int* ihi,
     float* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgebal(...) LAPACK_cgebal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgebal(...) LAPACK_cgebal_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgebal LAPACK_GLOBAL(dgebal,DGEBAL)
-void LAPACK_dgebal(
+#define LAPACK_dgebal_base LAPACK_GLOBAL(dgebal,DGEBAL)
+void LAPACK_dgebal_base(
     char const* job,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* ilo, lapack_int* ihi,
     double* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgebal(...) LAPACK_dgebal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgebal(...) LAPACK_dgebal_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgebal LAPACK_GLOBAL(sgebal,SGEBAL)
-void LAPACK_sgebal(
+#define LAPACK_sgebal_base LAPACK_GLOBAL(sgebal,SGEBAL)
+void LAPACK_sgebal_base(
     char const* job,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* ilo, lapack_int* ihi,
     float* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgebal(...) LAPACK_sgebal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgebal(...) LAPACK_sgebal_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgebal LAPACK_GLOBAL(zgebal,ZGEBAL)
-void LAPACK_zgebal(
+#define LAPACK_zgebal_base LAPACK_GLOBAL(zgebal,ZGEBAL)
+void LAPACK_zgebal_base(
     char const* job,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ilo, lapack_int* ihi,
     double* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgebal(...) LAPACK_zgebal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgebal(...) LAPACK_zgebal_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgebrd LAPACK_GLOBAL(cgebrd,CGEBRD)
 void LAPACK_cgebrd(
@@ -990,8 +1449,8 @@ void LAPACK_zgebrd(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cgecon LAPACK_GLOBAL(cgecon,CGECON)
-void LAPACK_cgecon(
+#define LAPACK_cgecon_base LAPACK_GLOBAL(cgecon,CGECON)
+void LAPACK_cgecon_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -999,10 +1458,19 @@ void LAPACK_cgecon(
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgecon(...) LAPACK_cgecon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgecon(...) LAPACK_cgecon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgecon LAPACK_GLOBAL(dgecon,DGECON)
-void LAPACK_dgecon(
+#define LAPACK_dgecon_base LAPACK_GLOBAL(dgecon,DGECON)
+void LAPACK_dgecon_base(
     char const* norm,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
@@ -1010,10 +1478,19 @@ void LAPACK_dgecon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgecon(...) LAPACK_dgecon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgecon(...) LAPACK_dgecon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgecon LAPACK_GLOBAL(sgecon,SGECON)
-void LAPACK_sgecon(
+#define LAPACK_sgecon_base LAPACK_GLOBAL(sgecon,SGECON)
+void LAPACK_sgecon_base(
     char const* norm,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
@@ -1021,10 +1498,19 @@ void LAPACK_sgecon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgecon(...) LAPACK_sgecon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgecon(...) LAPACK_sgecon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgecon LAPACK_GLOBAL(zgecon,ZGECON)
-void LAPACK_zgecon(
+#define LAPACK_zgecon_base LAPACK_GLOBAL(zgecon,ZGECON)
+void LAPACK_zgecon_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -1032,7 +1518,16 @@ void LAPACK_zgecon(
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgecon(...) LAPACK_zgecon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgecon(...) LAPACK_zgecon_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgeequ LAPACK_GLOBAL(cgeequ,CGEEQU)
 void LAPACK_cgeequ(
@@ -1122,8 +1617,8 @@ void LAPACK_zgeequb(
     double* amax,
     lapack_int* info );
 
-#define LAPACK_cgees LAPACK_GLOBAL(cgees,CGEES)
-void LAPACK_cgees(
+#define LAPACK_cgees_base LAPACK_GLOBAL(cgees,CGEES)
+void LAPACK_cgees_base(
     char const* jobvs, char const* sort, LAPACK_C_SELECT1 select,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* sdim,
@@ -1131,10 +1626,19 @@ void LAPACK_cgees(
     lapack_complex_float* VS, lapack_int const* ldvs,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgees(...) LAPACK_cgees_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgees(...) LAPACK_cgees_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgees LAPACK_GLOBAL(dgees,DGEES)
-void LAPACK_dgees(
+#define LAPACK_dgees_base LAPACK_GLOBAL(dgees,DGEES)
+void LAPACK_dgees_base(
     char const* jobvs, char const* sort, LAPACK_D_SELECT2 select,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* sdim,
@@ -1142,10 +1646,19 @@ void LAPACK_dgees(
     double* WI,
     double* VS, lapack_int const* ldvs,
     double* work, lapack_int const* lwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgees(...) LAPACK_dgees_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgees(...) LAPACK_dgees_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgees LAPACK_GLOBAL(sgees,SGEES)
-void LAPACK_sgees(
+#define LAPACK_sgees_base LAPACK_GLOBAL(sgees,SGEES)
+void LAPACK_sgees_base(
     char const* jobvs, char const* sort, LAPACK_S_SELECT2 select,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* sdim,
@@ -1153,10 +1666,19 @@ void LAPACK_sgees(
     float* WI,
     float* VS, lapack_int const* ldvs,
     float* work, lapack_int const* lwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgees(...) LAPACK_sgees_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgees(...) LAPACK_sgees_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgees LAPACK_GLOBAL(zgees,ZGEES)
-void LAPACK_zgees(
+#define LAPACK_zgees_base LAPACK_GLOBAL(zgees,ZGEES)
+void LAPACK_zgees_base(
     char const* jobvs, char const* sort, LAPACK_Z_SELECT1 select,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* sdim,
@@ -1164,10 +1686,19 @@ void LAPACK_zgees(
     lapack_complex_double* VS, lapack_int const* ldvs,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgees(...) LAPACK_zgees_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgees(...) LAPACK_zgees_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgeesx LAPACK_GLOBAL(cgeesx,CGEESX)
-void LAPACK_cgeesx(
+#define LAPACK_cgeesx_base LAPACK_GLOBAL(cgeesx,CGEESX)
+void LAPACK_cgeesx_base(
     char const* jobvs, char const* sort, LAPACK_C_SELECT1 select, char const* sense,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* sdim,
@@ -1177,10 +1708,19 @@ void LAPACK_cgeesx(
     float* rcondv,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgeesx(...) LAPACK_cgeesx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgeesx(...) LAPACK_cgeesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgeesx LAPACK_GLOBAL(dgeesx,DGEESX)
-void LAPACK_dgeesx(
+#define LAPACK_dgeesx_base LAPACK_GLOBAL(dgeesx,DGEESX)
+void LAPACK_dgeesx_base(
     char const* jobvs, char const* sort, LAPACK_D_SELECT2 select, char const* sense,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* sdim,
@@ -1191,10 +1731,19 @@ void LAPACK_dgeesx(
     double* rcondv,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgeesx(...) LAPACK_dgeesx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgeesx(...) LAPACK_dgeesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgeesx LAPACK_GLOBAL(sgeesx,SGEESX)
-void LAPACK_sgeesx(
+#define LAPACK_sgeesx_base LAPACK_GLOBAL(sgeesx,SGEESX)
+void LAPACK_sgeesx_base(
     char const* jobvs, char const* sort, LAPACK_S_SELECT2 select, char const* sense,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* sdim,
@@ -1205,10 +1754,19 @@ void LAPACK_sgeesx(
     float* rcondv,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgeesx(...) LAPACK_sgeesx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgeesx(...) LAPACK_sgeesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgeesx LAPACK_GLOBAL(zgeesx,ZGEESX)
-void LAPACK_zgeesx(
+#define LAPACK_zgeesx_base LAPACK_GLOBAL(zgeesx,ZGEESX)
+void LAPACK_zgeesx_base(
     char const* jobvs, char const* sort, LAPACK_Z_SELECT1 select, char const* sense,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* sdim,
@@ -1218,10 +1776,19 @@ void LAPACK_zgeesx(
     double* rcondv,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgeesx(...) LAPACK_zgeesx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgeesx(...) LAPACK_zgeesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgeev LAPACK_GLOBAL(cgeev,CGEEV)
-void LAPACK_cgeev(
+#define LAPACK_cgeev_base LAPACK_GLOBAL(cgeev,CGEEV)
+void LAPACK_cgeev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -1230,10 +1797,19 @@ void LAPACK_cgeev(
     lapack_complex_float* VR, lapack_int const* ldvr,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgeev(...) LAPACK_cgeev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgeev(...) LAPACK_cgeev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgeev LAPACK_GLOBAL(dgeev,DGEEV)
-void LAPACK_dgeev(
+#define LAPACK_dgeev_base LAPACK_GLOBAL(dgeev,DGEEV)
+void LAPACK_dgeev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -1242,10 +1818,19 @@ void LAPACK_dgeev(
     double* VL, lapack_int const* ldvl,
     double* VR, lapack_int const* ldvr,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgeev(...) LAPACK_dgeev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgeev(...) LAPACK_dgeev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgeev LAPACK_GLOBAL(sgeev,SGEEV)
-void LAPACK_sgeev(
+#define LAPACK_sgeev_base LAPACK_GLOBAL(sgeev,SGEEV)
+void LAPACK_sgeev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -1254,10 +1839,19 @@ void LAPACK_sgeev(
     float* VL, lapack_int const* ldvl,
     float* VR, lapack_int const* ldvr,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgeev(...) LAPACK_sgeev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgeev(...) LAPACK_sgeev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgeev LAPACK_GLOBAL(zgeev,ZGEEV)
-void LAPACK_zgeev(
+#define LAPACK_zgeev_base LAPACK_GLOBAL(zgeev,ZGEEV)
+void LAPACK_zgeev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -1266,10 +1860,19 @@ void LAPACK_zgeev(
     lapack_complex_double* VR, lapack_int const* ldvr,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgeev(...) LAPACK_zgeev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgeev(...) LAPACK_zgeev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgeevx LAPACK_GLOBAL(cgeevx,CGEEVX)
-void LAPACK_cgeevx(
+#define LAPACK_cgeevx_base LAPACK_GLOBAL(cgeevx,CGEEVX)
+void LAPACK_cgeevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -1282,10 +1885,19 @@ void LAPACK_cgeevx(
     float* rcondv,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgeevx(...) LAPACK_cgeevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_cgeevx(...) LAPACK_cgeevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgeevx LAPACK_GLOBAL(dgeevx,DGEEVX)
-void LAPACK_dgeevx(
+#define LAPACK_dgeevx_base LAPACK_GLOBAL(dgeevx,DGEEVX)
+void LAPACK_dgeevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -1299,10 +1911,19 @@ void LAPACK_dgeevx(
     double* rcondv,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgeevx(...) LAPACK_dgeevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_dgeevx(...) LAPACK_dgeevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgeevx LAPACK_GLOBAL(sgeevx,SGEEVX)
-void LAPACK_sgeevx(
+#define LAPACK_sgeevx_base LAPACK_GLOBAL(sgeevx,SGEEVX)
+void LAPACK_sgeevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -1316,10 +1937,19 @@ void LAPACK_sgeevx(
     float* rcondv,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgeevx(...) LAPACK_sgeevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_sgeevx(...) LAPACK_sgeevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgeevx LAPACK_GLOBAL(zgeevx,ZGEEVX)
-void LAPACK_zgeevx(
+#define LAPACK_zgeevx_base LAPACK_GLOBAL(zgeevx,ZGEEVX)
+void LAPACK_zgeevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -1332,7 +1962,16 @@ void LAPACK_zgeevx(
     double* rcondv,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgeevx(...) LAPACK_zgeevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_zgeevx(...) LAPACK_zgeevx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgehrd LAPACK_GLOBAL(cgehrd,CGEHRD)
 void LAPACK_cgehrd(
@@ -1366,8 +2005,8 @@ void LAPACK_zgehrd(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cgejsv LAPACK_GLOBAL(cgejsv,CGEJSV)
-void LAPACK_cgejsv(
+#define LAPACK_cgejsv_base LAPACK_GLOBAL(cgejsv,CGEJSV)
+void LAPACK_cgejsv_base(
     char const* joba, char const* jobu, char const* jobv, char const* jobr, char const* jobt, char const* jobp,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -1377,10 +2016,19 @@ void LAPACK_cgejsv(
     lapack_complex_float* cwork, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgejsv(...) LAPACK_cgejsv_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_cgejsv(...) LAPACK_cgejsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgejsv LAPACK_GLOBAL(dgejsv,DGEJSV)
-void LAPACK_dgejsv(
+#define LAPACK_dgejsv_base LAPACK_GLOBAL(dgejsv,DGEJSV)
+void LAPACK_dgejsv_base(
     char const* joba, char const* jobu, char const* jobv, char const* jobr, char const* jobt, char const* jobp,
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -1389,10 +2037,19 @@ void LAPACK_dgejsv(
     double* V, lapack_int const* ldv,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgejsv(...) LAPACK_dgejsv_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_dgejsv(...) LAPACK_dgejsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgejsv LAPACK_GLOBAL(sgejsv,SGEJSV)
-void LAPACK_sgejsv(
+#define LAPACK_sgejsv_base LAPACK_GLOBAL(sgejsv,SGEJSV)
+void LAPACK_sgejsv_base(
     char const* joba, char const* jobu, char const* jobv, char const* jobr, char const* jobt, char const* jobp,
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -1401,10 +2058,19 @@ void LAPACK_sgejsv(
     float* V, lapack_int const* ldv,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgejsv(...) LAPACK_sgejsv_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_sgejsv(...) LAPACK_sgejsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgejsv LAPACK_GLOBAL(zgejsv,ZGEJSV)
-void LAPACK_zgejsv(
+#define LAPACK_zgejsv_base LAPACK_GLOBAL(zgejsv,ZGEJSV)
+void LAPACK_zgejsv_base(
     char const* joba, char const* jobu, char const* jobv, char const* jobr, char const* jobt, char const* jobp,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -1414,7 +2080,16 @@ void LAPACK_zgejsv(
     lapack_complex_double* cwork, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgejsv(...) LAPACK_zgejsv_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_zgejsv(...) LAPACK_zgejsv_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgelq LAPACK_GLOBAL(cgelq,CGELQ)
 void LAPACK_cgelq(
@@ -1512,14 +2187,23 @@ void LAPACK_zgelqf(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cgels LAPACK_GLOBAL(cgels,CGELS)
-void LAPACK_cgels(
+#define LAPACK_cgels_base LAPACK_GLOBAL(cgels,CGELS)
+void LAPACK_cgels_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgels(...) LAPACK_cgels_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgels(...) LAPACK_cgels_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_dgels_base LAPACK_GLOBAL(dgels,DGELS)
 void LAPACK_dgels_base(
@@ -1528,7 +2212,7 @@ void LAPACK_dgels_base(
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info 
+    lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
     , size_t
 #endif
@@ -1539,23 +2223,41 @@ void LAPACK_dgels_base(
     #define LAPACK_dgels(...) LAPACK_dgels_base(__VA_ARGS__)
 #endif
 
-#define LAPACK_sgels LAPACK_GLOBAL(sgels,SGELS)
-void LAPACK_sgels(
+#define LAPACK_sgels_base LAPACK_GLOBAL(sgels,SGELS)
+void LAPACK_sgels_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgels(...) LAPACK_sgels_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgels(...) LAPACK_sgels_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgels LAPACK_GLOBAL(zgels,ZGELS)
-void LAPACK_zgels(
+#define LAPACK_zgels_base LAPACK_GLOBAL(zgels,ZGELS)
+void LAPACK_zgels_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgels(...) LAPACK_zgels_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgels(...) LAPACK_zgels_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgelsd LAPACK_GLOBAL(cgelsd,CGELSD)
 void LAPACK_cgelsd(
@@ -1683,125 +2385,233 @@ void LAPACK_zgelsy(
     double* rwork,
     lapack_int* info );
 
-#define LAPACK_cgemlq LAPACK_GLOBAL(cgemlq,CGEMLQ)
-void LAPACK_cgemlq(
+#define LAPACK_cgemlq_base LAPACK_GLOBAL(cgemlq,CGEMLQ)
+void LAPACK_cgemlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* T, lapack_int const* tsize,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgemlq(...) LAPACK_cgemlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgemlq(...) LAPACK_cgemlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgemlq LAPACK_GLOBAL(dgemlq,DGEMLQ)
-void LAPACK_dgemlq(
+#define LAPACK_dgemlq_base LAPACK_GLOBAL(dgemlq,DGEMLQ)
+void LAPACK_dgemlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* A, lapack_int const* lda,
     double const* T, lapack_int const* tsize,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgemlq(...) LAPACK_dgemlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgemlq(...) LAPACK_dgemlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgemlq LAPACK_GLOBAL(sgemlq,SGEMLQ)
-void LAPACK_sgemlq(
+#define LAPACK_sgemlq_base LAPACK_GLOBAL(sgemlq,SGEMLQ)
+void LAPACK_sgemlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* A, lapack_int const* lda,
     float const* T, lapack_int const* tsize,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgemlq(...) LAPACK_sgemlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgemlq(...) LAPACK_sgemlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgemlq LAPACK_GLOBAL(zgemlq,ZGEMLQ)
-void LAPACK_zgemlq(
+#define LAPACK_zgemlq_base LAPACK_GLOBAL(zgemlq,ZGEMLQ)
+void LAPACK_zgemlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* T, lapack_int const* tsize,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgemlq(...) LAPACK_zgemlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgemlq(...) LAPACK_zgemlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgemqr LAPACK_GLOBAL(cgemqr,CGEMQR)
-void LAPACK_cgemqr(
+#define LAPACK_cgemqr_base LAPACK_GLOBAL(cgemqr,CGEMQR)
+void LAPACK_cgemqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* T, lapack_int const* tsize,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgemqr(...) LAPACK_cgemqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgemqr(...) LAPACK_cgemqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgemqr LAPACK_GLOBAL(dgemqr,DGEMQR)
-void LAPACK_dgemqr(
+#define LAPACK_dgemqr_base LAPACK_GLOBAL(dgemqr,DGEMQR)
+void LAPACK_dgemqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* A, lapack_int const* lda,
     double const* T, lapack_int const* tsize,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgemqr(...) LAPACK_dgemqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgemqr(...) LAPACK_dgemqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgemqr LAPACK_GLOBAL(sgemqr,SGEMQR)
-void LAPACK_sgemqr(
+#define LAPACK_sgemqr_base LAPACK_GLOBAL(sgemqr,SGEMQR)
+void LAPACK_sgemqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* A, lapack_int const* lda,
     float const* T, lapack_int const* tsize,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgemqr(...) LAPACK_sgemqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgemqr(...) LAPACK_sgemqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgemqr LAPACK_GLOBAL(zgemqr,ZGEMQR)
-void LAPACK_zgemqr(
+#define LAPACK_zgemqr_base LAPACK_GLOBAL(zgemqr,ZGEMQR)
+void LAPACK_zgemqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* T, lapack_int const* tsize,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgemqr(...) LAPACK_zgemqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgemqr(...) LAPACK_zgemqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgemqrt LAPACK_GLOBAL(cgemqrt,CGEMQRT)
-void LAPACK_cgemqrt(
+#define LAPACK_cgemqrt_base LAPACK_GLOBAL(cgemqrt,CGEMQRT)
+void LAPACK_cgemqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* nb,
     lapack_complex_float const* V, lapack_int const* ldv,
     lapack_complex_float const* T, lapack_int const* ldt,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgemqrt(...) LAPACK_cgemqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgemqrt(...) LAPACK_cgemqrt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgemqrt LAPACK_GLOBAL(dgemqrt,DGEMQRT)
-void LAPACK_dgemqrt(
+#define LAPACK_dgemqrt_base LAPACK_GLOBAL(dgemqrt,DGEMQRT)
+void LAPACK_dgemqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* nb,
     double const* V, lapack_int const* ldv,
     double const* T, lapack_int const* ldt,
     double* C, lapack_int const* ldc,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgemqrt(...) LAPACK_dgemqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgemqrt(...) LAPACK_dgemqrt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgemqrt LAPACK_GLOBAL(sgemqrt,SGEMQRT)
-void LAPACK_sgemqrt(
+#define LAPACK_sgemqrt_base LAPACK_GLOBAL(sgemqrt,SGEMQRT)
+void LAPACK_sgemqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* nb,
     float const* V, lapack_int const* ldv,
     float const* T, lapack_int const* ldt,
     float* C, lapack_int const* ldc,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgemqrt(...) LAPACK_sgemqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgemqrt(...) LAPACK_sgemqrt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgemqrt LAPACK_GLOBAL(zgemqrt,ZGEMQRT)
-void LAPACK_zgemqrt(
+#define LAPACK_zgemqrt_base LAPACK_GLOBAL(zgemqrt,ZGEMQRT)
+void LAPACK_zgemqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* nb,
     lapack_complex_double const* V, lapack_int const* ldv,
     lapack_complex_double const* T, lapack_int const* ldt,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgemqrt(...) LAPACK_zgemqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgemqrt(...) LAPACK_zgemqrt_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgeql2 LAPACK_GLOBAL(cgeql2,CGEQL2)
 void LAPACK_cgeql2(
@@ -2139,8 +2949,8 @@ void LAPACK_zgeqrt3(
     lapack_complex_double* T, lapack_int const* ldt,
     lapack_int* info );
 
-#define LAPACK_cgerfs LAPACK_GLOBAL(cgerfs,CGERFS)
-void LAPACK_cgerfs(
+#define LAPACK_cgerfs_base LAPACK_GLOBAL(cgerfs,CGERFS)
+void LAPACK_cgerfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -2151,10 +2961,19 @@ void LAPACK_cgerfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgerfs(...) LAPACK_cgerfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgerfs(...) LAPACK_cgerfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgerfs LAPACK_GLOBAL(dgerfs,DGERFS)
-void LAPACK_dgerfs(
+#define LAPACK_dgerfs_base LAPACK_GLOBAL(dgerfs,DGERFS)
+void LAPACK_dgerfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -2165,10 +2984,19 @@ void LAPACK_dgerfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgerfs(...) LAPACK_dgerfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgerfs(...) LAPACK_dgerfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgerfs LAPACK_GLOBAL(sgerfs,SGERFS)
-void LAPACK_sgerfs(
+#define LAPACK_sgerfs_base LAPACK_GLOBAL(sgerfs,SGERFS)
+void LAPACK_sgerfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -2179,10 +3007,19 @@ void LAPACK_sgerfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgerfs(...) LAPACK_sgerfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgerfs(...) LAPACK_sgerfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgerfs LAPACK_GLOBAL(zgerfs,ZGERFS)
-void LAPACK_zgerfs(
+#define LAPACK_zgerfs_base LAPACK_GLOBAL(zgerfs,ZGERFS)
+void LAPACK_zgerfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -2193,10 +3030,19 @@ void LAPACK_zgerfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgerfs(...) LAPACK_zgerfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgerfs(...) LAPACK_zgerfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgerfsx LAPACK_GLOBAL(cgerfsx,CGERFSX)
-void LAPACK_cgerfsx(
+#define LAPACK_cgerfsx_base LAPACK_GLOBAL(cgerfsx,CGERFSX)
+void LAPACK_cgerfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -2212,10 +3058,19 @@ void LAPACK_cgerfsx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgerfsx(...) LAPACK_cgerfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgerfsx(...) LAPACK_cgerfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgerfsx LAPACK_GLOBAL(dgerfsx,DGERFSX)
-void LAPACK_dgerfsx(
+#define LAPACK_dgerfsx_base LAPACK_GLOBAL(dgerfsx,DGERFSX)
+void LAPACK_dgerfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -2231,10 +3086,19 @@ void LAPACK_dgerfsx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgerfsx(...) LAPACK_dgerfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgerfsx(...) LAPACK_dgerfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgerfsx LAPACK_GLOBAL(sgerfsx,SGERFSX)
-void LAPACK_sgerfsx(
+#define LAPACK_sgerfsx_base LAPACK_GLOBAL(sgerfsx,SGERFSX)
+void LAPACK_sgerfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -2250,10 +3114,19 @@ void LAPACK_sgerfsx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgerfsx(...) LAPACK_sgerfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgerfsx(...) LAPACK_sgerfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgerfsx LAPACK_GLOBAL(zgerfsx,ZGERFSX)
-void LAPACK_zgerfsx(
+#define LAPACK_zgerfsx_base LAPACK_GLOBAL(zgerfsx,ZGERFSX)
+void LAPACK_zgerfsx_base(
     char const* trans, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -2269,7 +3142,16 @@ void LAPACK_zgerfsx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgerfsx(...) LAPACK_zgerfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgerfsx(...) LAPACK_zgerfsx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgerq2 LAPACK_GLOBAL(cgerq2,CGERQ2)
 void LAPACK_cgerq2(
@@ -2335,8 +3217,8 @@ void LAPACK_zgerqf(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cgesdd LAPACK_GLOBAL(cgesdd,CGESDD)
-void LAPACK_cgesdd(
+#define LAPACK_cgesdd_base LAPACK_GLOBAL(cgesdd,CGESDD)
+void LAPACK_cgesdd_base(
     char const* jobz,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -2346,10 +3228,19 @@ void LAPACK_cgesdd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgesdd(...) LAPACK_cgesdd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgesdd(...) LAPACK_cgesdd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgesdd LAPACK_GLOBAL(dgesdd,DGESDD)
-void LAPACK_dgesdd(
+#define LAPACK_dgesdd_base LAPACK_GLOBAL(dgesdd,DGESDD)
+void LAPACK_dgesdd_base(
     char const* jobz,
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -2358,10 +3249,19 @@ void LAPACK_dgesdd(
     double* VT, lapack_int const* ldvt,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgesdd(...) LAPACK_dgesdd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgesdd(...) LAPACK_dgesdd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgesdd LAPACK_GLOBAL(sgesdd,SGESDD)
-void LAPACK_sgesdd(
+#define LAPACK_sgesdd_base LAPACK_GLOBAL(sgesdd,SGESDD)
+void LAPACK_sgesdd_base(
     char const* jobz,
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -2370,10 +3270,19 @@ void LAPACK_sgesdd(
     float* VT, lapack_int const* ldvt,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgesdd(...) LAPACK_sgesdd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgesdd(...) LAPACK_sgesdd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgesdd LAPACK_GLOBAL(zgesdd,ZGESDD)
-void LAPACK_zgesdd(
+#define LAPACK_zgesdd_base LAPACK_GLOBAL(zgesdd,ZGESDD)
+void LAPACK_zgesdd_base(
     char const* jobz,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -2383,7 +3292,16 @@ void LAPACK_zgesdd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgesdd(...) LAPACK_zgesdd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgesdd(...) LAPACK_zgesdd_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgesv LAPACK_GLOBAL(cgesv,CGESV)
 void LAPACK_cgesv(
@@ -2434,8 +3352,8 @@ void LAPACK_zcgesv(
     double* rwork, lapack_int* iter,
     lapack_int* info );
 
-#define LAPACK_cgesvd LAPACK_GLOBAL(cgesvd,CGESVD)
-void LAPACK_cgesvd(
+#define LAPACK_cgesvd_base LAPACK_GLOBAL(cgesvd,CGESVD)
+void LAPACK_cgesvd_base(
     char const* jobu, char const* jobvt,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -2444,10 +3362,19 @@ void LAPACK_cgesvd(
     lapack_complex_float* VT, lapack_int const* ldvt,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgesvd(...) LAPACK_cgesvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgesvd(...) LAPACK_cgesvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgesvd LAPACK_GLOBAL(dgesvd,DGESVD)
-void LAPACK_dgesvd(
+#define LAPACK_dgesvd_base LAPACK_GLOBAL(dgesvd,DGESVD)
+void LAPACK_dgesvd_base(
     char const* jobu, char const* jobvt,
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -2455,10 +3382,19 @@ void LAPACK_dgesvd(
     double* U, lapack_int const* ldu,
     double* VT, lapack_int const* ldvt,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgesvd(...) LAPACK_dgesvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgesvd(...) LAPACK_dgesvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgesvd LAPACK_GLOBAL(sgesvd,SGESVD)
-void LAPACK_sgesvd(
+#define LAPACK_sgesvd_base LAPACK_GLOBAL(sgesvd,SGESVD)
+void LAPACK_sgesvd_base(
     char const* jobu, char const* jobvt,
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -2466,10 +3402,19 @@ void LAPACK_sgesvd(
     float* U, lapack_int const* ldu,
     float* VT, lapack_int const* ldvt,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgesvd(...) LAPACK_sgesvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgesvd(...) LAPACK_sgesvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgesvd LAPACK_GLOBAL(zgesvd,ZGESVD)
-void LAPACK_zgesvd(
+#define LAPACK_zgesvd_base LAPACK_GLOBAL(zgesvd,ZGESVD)
+void LAPACK_zgesvd_base(
     char const* jobu, char const* jobvt,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -2478,10 +3423,19 @@ void LAPACK_zgesvd(
     lapack_complex_double* VT, lapack_int const* ldvt,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgesvd(...) LAPACK_zgesvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgesvd(...) LAPACK_zgesvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgesvdq LAPACK_GLOBAL(cgesvdq,CGESVDQ)
-void LAPACK_cgesvdq(
+#define LAPACK_cgesvdq_base LAPACK_GLOBAL(cgesvdq,CGESVDQ)
+void LAPACK_cgesvdq_base(
     char const* joba, char const* jobp, char const* jobr, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -2491,10 +3445,19 @@ void LAPACK_cgesvdq(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_complex_float* cwork, lapack_int* lcwork,
     float* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgesvdq(...) LAPACK_cgesvdq_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_cgesvdq(...) LAPACK_cgesvdq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgesvdq LAPACK_GLOBAL(dgesvdq,DGESVDQ)
-void LAPACK_dgesvdq(
+#define LAPACK_dgesvdq_base LAPACK_GLOBAL(dgesvdq,DGESVDQ)
+void LAPACK_dgesvdq_base(
     char const* joba, char const* jobp, char const* jobr, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -2504,10 +3467,19 @@ void LAPACK_dgesvdq(
     lapack_int* iwork, lapack_int const* liwork,
     double* work, lapack_int* lwork,
     double* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgesvdq(...) LAPACK_dgesvdq_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_dgesvdq(...) LAPACK_dgesvdq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgesvdq LAPACK_GLOBAL(sgesvdq,SGESVDQ)
-void LAPACK_sgesvdq(
+#define LAPACK_sgesvdq_base LAPACK_GLOBAL(sgesvdq,SGESVDQ)
+void LAPACK_sgesvdq_base(
     char const* joba, char const* jobp, char const* jobr, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -2517,10 +3489,19 @@ void LAPACK_sgesvdq(
     lapack_int* iwork, lapack_int const* liwork,
     float* work, lapack_int* lwork,
     float* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgesvdq(...) LAPACK_sgesvdq_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_sgesvdq(...) LAPACK_sgesvdq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgesvdq LAPACK_GLOBAL(zgesvdq,ZGESVDQ)
-void LAPACK_zgesvdq(
+#define LAPACK_zgesvdq_base LAPACK_GLOBAL(zgesvdq,ZGESVDQ)
+void LAPACK_zgesvdq_base(
     char const* joba, char const* jobp, char const* jobr, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -2530,10 +3511,19 @@ void LAPACK_zgesvdq(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_complex_double* cwork, lapack_int* lcwork,
     double* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgesvdq(...) LAPACK_zgesvdq_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_zgesvdq(...) LAPACK_zgesvdq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgesvdx LAPACK_GLOBAL(cgesvdx,CGESVDX)
-void LAPACK_cgesvdx(
+#define LAPACK_cgesvdx_base LAPACK_GLOBAL(cgesvdx,CGESVDX)
+void LAPACK_cgesvdx_base(
     char const* jobu, char const* jobvt, char const* range,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -2545,10 +3535,20 @@ void LAPACK_cgesvdx(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgesvdx(...) LAPACK_cgesvdx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgesvdx(...) LAPACK_cgesvdx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgesvdx LAPACK_GLOBAL(dgesvdx,DGESVDX)
-void LAPACK_dgesvdx(
+
+#define LAPACK_dgesvdx_base LAPACK_GLOBAL(dgesvdx,DGESVDX)
+void LAPACK_dgesvdx_base(
     char const* jobu, char const* jobvt, char const* range,
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -2559,10 +3559,19 @@ void LAPACK_dgesvdx(
     double* VT, lapack_int const* ldvt,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgesvdx(...) LAPACK_dgesvdx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgesvdx(...) LAPACK_dgesvdx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgesvdx LAPACK_GLOBAL(sgesvdx,SGESVDX)
-void LAPACK_sgesvdx(
+#define LAPACK_sgesvdx_base LAPACK_GLOBAL(sgesvdx,SGESVDX)
+void LAPACK_sgesvdx_base(
     char const* jobu, char const* jobvt, char const* range,
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -2573,10 +3582,19 @@ void LAPACK_sgesvdx(
     float* VT, lapack_int const* ldvt,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgesvdx(...) LAPACK_sgesvdx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgesvdx(...) LAPACK_sgesvdx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgesvdx LAPACK_GLOBAL(zgesvdx,ZGESVDX)
-void LAPACK_zgesvdx(
+#define LAPACK_zgesvdx_base LAPACK_GLOBAL(zgesvdx,ZGESVDX)
+void LAPACK_zgesvdx_base(
     char const* jobu, char const* jobvt, char const* range,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -2588,10 +3606,19 @@ void LAPACK_zgesvdx(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgesvdx(...) LAPACK_zgesvdx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgesvdx(...) LAPACK_zgesvdx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgesvj LAPACK_GLOBAL(cgesvj,CGESVJ)
-void LAPACK_cgesvj(
+#define LAPACK_cgesvj_base LAPACK_GLOBAL(cgesvj,CGESVJ)
+void LAPACK_cgesvj_base(
     char const* joba, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -2599,30 +3626,57 @@ void LAPACK_cgesvj(
     lapack_complex_float* V, lapack_int const* ldv,
     lapack_complex_float* cwork, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgesvj(...) LAPACK_cgesvj_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgesvj(...) LAPACK_cgesvj_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgesvj LAPACK_GLOBAL(dgesvj,DGESVJ)
-void LAPACK_dgesvj(
+#define LAPACK_dgesvj_base LAPACK_GLOBAL(dgesvj,DGESVJ)
+void LAPACK_dgesvj_base(
     char const* joba, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda,
     double* SVA, lapack_int const* mv,
     double* V, lapack_int const* ldv,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgesvj(...) LAPACK_dgesvj_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgesvj(...) LAPACK_dgesvj_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgesvj LAPACK_GLOBAL(sgesvj,SGESVJ)
-void LAPACK_sgesvj(
+#define LAPACK_sgesvj_base LAPACK_GLOBAL(sgesvj,SGESVJ)
+void LAPACK_sgesvj_base(
     char const* joba, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda,
     float* SVA, lapack_int const* mv,
     float* V, lapack_int const* ldv,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgesvj(...) LAPACK_sgesvj_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgesvj(...) LAPACK_sgesvj_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgesvj LAPACK_GLOBAL(zgesvj,ZGESVJ)
-void LAPACK_zgesvj(
+#define LAPACK_zgesvj_base LAPACK_GLOBAL(zgesvj,ZGESVJ)
+void LAPACK_zgesvj_base(
     char const* joba, char const* jobu, char const* jobv,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -2630,10 +3684,19 @@ void LAPACK_zgesvj(
     lapack_complex_double* V, lapack_int const* ldv,
     lapack_complex_double* cwork, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgesvj(...) LAPACK_zgesvj_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgesvj(...) LAPACK_zgesvj_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgesvx LAPACK_GLOBAL(cgesvx,CGESVX)
-void LAPACK_cgesvx(
+#define LAPACK_cgesvx_base LAPACK_GLOBAL(cgesvx,CGESVX)
+void LAPACK_cgesvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
@@ -2648,10 +3711,19 @@ void LAPACK_cgesvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgesvx(...) LAPACK_cgesvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgesvx(...) LAPACK_cgesvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgesvx LAPACK_GLOBAL(dgesvx,DGESVX)
-void LAPACK_dgesvx(
+#define LAPACK_dgesvx_base LAPACK_GLOBAL(dgesvx,DGESVX)
+void LAPACK_dgesvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
@@ -2666,10 +3738,19 @@ void LAPACK_dgesvx(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgesvx(...) LAPACK_dgesvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgesvx(...) LAPACK_dgesvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgesvx LAPACK_GLOBAL(sgesvx,SGESVX)
-void LAPACK_sgesvx(
+#define LAPACK_sgesvx_base LAPACK_GLOBAL(sgesvx,SGESVX)
+void LAPACK_sgesvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
@@ -2684,10 +3765,19 @@ void LAPACK_sgesvx(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgesvx(...) LAPACK_sgesvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgesvx(...) LAPACK_sgesvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgesvx LAPACK_GLOBAL(zgesvx,ZGESVX)
-void LAPACK_zgesvx(
+#define LAPACK_zgesvx_base LAPACK_GLOBAL(zgesvx,ZGESVX)
+void LAPACK_zgesvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
@@ -2702,10 +3792,19 @@ void LAPACK_zgesvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgesvx(...) LAPACK_zgesvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgesvx(...) LAPACK_zgesvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgesvxx LAPACK_GLOBAL(cgesvxx,CGESVXX)
-void LAPACK_cgesvxx(
+#define LAPACK_cgesvxx_base LAPACK_GLOBAL(cgesvxx,CGESVXX)
+void LAPACK_cgesvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
@@ -2723,10 +3822,19 @@ void LAPACK_cgesvxx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgesvxx(...) LAPACK_cgesvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgesvxx(...) LAPACK_cgesvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgesvxx LAPACK_GLOBAL(dgesvxx,DGESVXX)
-void LAPACK_dgesvxx(
+#define LAPACK_dgesvxx_base LAPACK_GLOBAL(dgesvxx,DGESVXX)
+void LAPACK_dgesvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
@@ -2744,10 +3852,19 @@ void LAPACK_dgesvxx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgesvxx(...) LAPACK_dgesvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgesvxx(...) LAPACK_dgesvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgesvxx LAPACK_GLOBAL(sgesvxx,SGESVXX)
-void LAPACK_sgesvxx(
+#define LAPACK_sgesvxx_base LAPACK_GLOBAL(sgesvxx,SGESVXX)
+void LAPACK_sgesvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
@@ -2765,10 +3882,19 @@ void LAPACK_sgesvxx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgesvxx(...) LAPACK_sgesvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgesvxx(...) LAPACK_sgesvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgesvxx LAPACK_GLOBAL(zgesvxx,ZGESVXX)
-void LAPACK_zgesvxx(
+#define LAPACK_zgesvxx_base LAPACK_GLOBAL(zgesvxx,ZGESVXX)
+void LAPACK_zgesvxx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
@@ -2786,7 +3912,16 @@ void LAPACK_zgesvxx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgesvxx(...) LAPACK_zgesvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgesvxx(...) LAPACK_zgesvxx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgetf2 LAPACK_GLOBAL(cgetf2,CGETF2)
 void LAPACK_cgetf2(
@@ -2888,73 +4023,145 @@ void LAPACK_zgetri(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cgetrs LAPACK_GLOBAL(cgetrs,CGETRS)
-void LAPACK_cgetrs(
+#define LAPACK_cgetrs_base LAPACK_GLOBAL(cgetrs,CGETRS)
+void LAPACK_cgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgetrs(...) LAPACK_cgetrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgetrs(...) LAPACK_cgetrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgetrs LAPACK_GLOBAL(dgetrs,DGETRS)
-void LAPACK_dgetrs(
+#define LAPACK_dgetrs_base LAPACK_GLOBAL(dgetrs,DGETRS)
+void LAPACK_dgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgetrs(...) LAPACK_dgetrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgetrs(...) LAPACK_dgetrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgetrs LAPACK_GLOBAL(sgetrs,SGETRS)
-void LAPACK_sgetrs(
+#define LAPACK_sgetrs_base LAPACK_GLOBAL(sgetrs,SGETRS)
+void LAPACK_sgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgetrs(...) LAPACK_sgetrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgetrs(...) LAPACK_sgetrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgetrs LAPACK_GLOBAL(zgetrs,ZGETRS)
-void LAPACK_zgetrs(
+#define LAPACK_zgetrs_base LAPACK_GLOBAL(zgetrs,ZGETRS)
+void LAPACK_zgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgetrs(...) LAPACK_zgetrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgetrs(...) LAPACK_zgetrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgetsls LAPACK_GLOBAL(cgetsls,CGETSLS)
-void LAPACK_cgetsls(
+#define LAPACK_cgetsls_base LAPACK_GLOBAL(cgetsls,CGETSLS)
+void LAPACK_cgetsls_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgetsls(...) LAPACK_cgetsls_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgetsls(...) LAPACK_cgetsls_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgetsls LAPACK_GLOBAL(dgetsls,DGETSLS)
-void LAPACK_dgetsls(
+#define LAPACK_dgetsls_base LAPACK_GLOBAL(dgetsls,DGETSLS)
+void LAPACK_dgetsls_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgetsls(...) LAPACK_dgetsls_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgetsls(...) LAPACK_dgetsls_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgetsls LAPACK_GLOBAL(sgetsls,SGETSLS)
-void LAPACK_sgetsls(
+#define LAPACK_sgetsls_base LAPACK_GLOBAL(sgetsls,SGETSLS)
+void LAPACK_sgetsls_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgetsls(...) LAPACK_sgetsls_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgetsls(...) LAPACK_sgetsls_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgetsls LAPACK_GLOBAL(zgetsls,ZGETSLS)
-void LAPACK_zgetsls(
+#define LAPACK_zgetsls_base LAPACK_GLOBAL(zgetsls,ZGETSLS)
+void LAPACK_zgetsls_base(
     char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgetsls(...) LAPACK_zgetsls_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgetsls(...) LAPACK_zgetsls_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgetsqrhrt LAPACK_GLOBAL(cgetsqrhrt,CGETSQRHRT)
 void LAPACK_cgetsqrhrt(
@@ -2992,44 +4199,80 @@ void LAPACK_zgetsqrhrt(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cggbak LAPACK_GLOBAL(cggbak,CGGBAK)
-void LAPACK_cggbak(
+#define LAPACK_cggbak_base LAPACK_GLOBAL(cggbak,CGGBAK)
+void LAPACK_cggbak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float const* lscale,
     float const* rscale, lapack_int const* m,
     lapack_complex_float* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggbak(...) LAPACK_cggbak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cggbak(...) LAPACK_cggbak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggbak LAPACK_GLOBAL(dggbak,DGGBAK)
-void LAPACK_dggbak(
+#define LAPACK_dggbak_base LAPACK_GLOBAL(dggbak,DGGBAK)
+void LAPACK_dggbak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double const* lscale,
     double const* rscale, lapack_int const* m,
     double* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggbak(...) LAPACK_dggbak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dggbak(...) LAPACK_dggbak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggbak LAPACK_GLOBAL(sggbak,SGGBAK)
-void LAPACK_sggbak(
+#define LAPACK_sggbak_base LAPACK_GLOBAL(sggbak,SGGBAK)
+void LAPACK_sggbak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float const* lscale,
     float const* rscale, lapack_int const* m,
     float* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggbak(...) LAPACK_sggbak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sggbak(...) LAPACK_sggbak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggbak LAPACK_GLOBAL(zggbak,ZGGBAK)
-void LAPACK_zggbak(
+#define LAPACK_zggbak_base LAPACK_GLOBAL(zggbak,ZGGBAK)
+void LAPACK_zggbak_base(
     char const* job, char const* side,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double const* lscale,
     double const* rscale, lapack_int const* m,
     lapack_complex_double* V, lapack_int const* ldv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggbak(...) LAPACK_zggbak_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zggbak(...) LAPACK_zggbak_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggbal LAPACK_GLOBAL(cggbal,CGGBAL)
-void LAPACK_cggbal(
+#define LAPACK_cggbal_base LAPACK_GLOBAL(cggbal,CGGBAL)
+void LAPACK_cggbal_base(
     char const* job,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3037,10 +4280,19 @@ void LAPACK_cggbal(
     float* lscale,
     float* rscale,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggbal(...) LAPACK_cggbal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cggbal(...) LAPACK_cggbal_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggbal LAPACK_GLOBAL(dggbal,DGGBAL)
-void LAPACK_dggbal(
+#define LAPACK_dggbal_base LAPACK_GLOBAL(dggbal,DGGBAL)
+void LAPACK_dggbal_base(
     char const* job,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3048,10 +4300,19 @@ void LAPACK_dggbal(
     double* lscale,
     double* rscale,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggbal(...) LAPACK_dggbal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dggbal(...) LAPACK_dggbal_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggbal LAPACK_GLOBAL(sggbal,SGGBAL)
-void LAPACK_sggbal(
+#define LAPACK_sggbal_base LAPACK_GLOBAL(sggbal,SGGBAL)
+void LAPACK_sggbal_base(
     char const* job,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3059,10 +4320,19 @@ void LAPACK_sggbal(
     float* lscale,
     float* rscale,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggbal(...) LAPACK_sggbal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sggbal(...) LAPACK_sggbal_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggbal LAPACK_GLOBAL(zggbal,ZGGBAL)
-void LAPACK_zggbal(
+#define LAPACK_zggbal_base LAPACK_GLOBAL(zggbal,ZGGBAL)
+void LAPACK_zggbal_base(
     char const* job,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3070,10 +4340,19 @@ void LAPACK_zggbal(
     double* lscale,
     double* rscale,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggbal(...) LAPACK_zggbal_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zggbal(...) LAPACK_zggbal_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgges LAPACK_GLOBAL(cgges,CGGES)
-void LAPACK_cgges(
+#define LAPACK_cgges_base LAPACK_GLOBAL(cgges,CGGES)
+void LAPACK_cgges_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_C_SELECT2 selctg,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3084,10 +4363,19 @@ void LAPACK_cgges(
     lapack_complex_float* VSR, lapack_int const* ldvsr,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgges(...) LAPACK_cgges_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgges(...) LAPACK_cgges_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgges LAPACK_GLOBAL(dgges,DGGES)
-void LAPACK_dgges(
+#define LAPACK_dgges_base LAPACK_GLOBAL(dgges,DGGES)
+void LAPACK_dgges_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_D_SELECT3 selctg,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3098,10 +4386,19 @@ void LAPACK_dgges(
     double* VSL, lapack_int const* ldvsl,
     double* VSR, lapack_int const* ldvsr,
     double* work, lapack_int const* lwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgges(...) LAPACK_dgges_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgges(...) LAPACK_dgges_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgges LAPACK_GLOBAL(sgges,SGGES)
-void LAPACK_sgges(
+#define LAPACK_sgges_base LAPACK_GLOBAL(sgges,SGGES)
+void LAPACK_sgges_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_S_SELECT3 selctg,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3112,10 +4409,19 @@ void LAPACK_sgges(
     float* VSL, lapack_int const* ldvsl,
     float* VSR, lapack_int const* ldvsr,
     float* work, lapack_int const* lwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgges(...) LAPACK_sgges_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgges(...) LAPACK_sgges_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgges LAPACK_GLOBAL(zgges,ZGGES)
-void LAPACK_zgges(
+#define LAPACK_zgges_base LAPACK_GLOBAL(zgges,ZGGES)
+void LAPACK_zgges_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_Z_SELECT2 selctg,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3126,10 +4432,19 @@ void LAPACK_zgges(
     lapack_complex_double* VSR, lapack_int const* ldvsr,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgges(...) LAPACK_zgges_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgges(...) LAPACK_zgges_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgges3 LAPACK_GLOBAL(cgges3,CGGES3)
-void LAPACK_cgges3(
+#define LAPACK_cgges3_base LAPACK_GLOBAL(cgges3,CGGES3)
+void LAPACK_cgges3_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_C_SELECT2 selctg,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3140,10 +4455,19 @@ void LAPACK_cgges3(
     lapack_complex_float* VSR, lapack_int const* ldvsr,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgges3(...) LAPACK_cgges3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cgges3(...) LAPACK_cgges3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgges3 LAPACK_GLOBAL(dgges3,DGGES3)
-void LAPACK_dgges3(
+#define LAPACK_dgges3_base LAPACK_GLOBAL(dgges3,DGGES3)
+void LAPACK_dgges3_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_D_SELECT3 selctg,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3154,10 +4478,19 @@ void LAPACK_dgges3(
     double* VSL, lapack_int const* ldvsl,
     double* VSR, lapack_int const* ldvsr,
     double* work, lapack_int const* lwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgges3(...) LAPACK_dgges3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dgges3(...) LAPACK_dgges3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgges3 LAPACK_GLOBAL(sgges3,SGGES3)
-void LAPACK_sgges3(
+#define LAPACK_sgges3_base LAPACK_GLOBAL(sgges3,SGGES3)
+void LAPACK_sgges3_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_S_SELECT3 selctg,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3168,10 +4501,19 @@ void LAPACK_sgges3(
     float* VSL, lapack_int const* ldvsl,
     float* VSR, lapack_int const* ldvsr,
     float* work, lapack_int const* lwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgges3(...) LAPACK_sgges3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sgges3(...) LAPACK_sgges3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgges3 LAPACK_GLOBAL(zgges3,ZGGES3)
-void LAPACK_zgges3(
+#define LAPACK_zgges3_base LAPACK_GLOBAL(zgges3,ZGGES3)
+void LAPACK_zgges3_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_Z_SELECT2 selctg,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3182,10 +4524,19 @@ void LAPACK_zgges3(
     lapack_complex_double* VSR, lapack_int const* ldvsr,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgges3(...) LAPACK_zgges3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zgges3(...) LAPACK_zgges3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggesx LAPACK_GLOBAL(cggesx,CGGESX)
-void LAPACK_cggesx(
+#define LAPACK_cggesx_base LAPACK_GLOBAL(cggesx,CGGESX)
+void LAPACK_cggesx_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_C_SELECT2 selctg, char const* sense,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3199,10 +4550,19 @@ void LAPACK_cggesx(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggesx(...) LAPACK_cggesx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_cggesx(...) LAPACK_cggesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggesx LAPACK_GLOBAL(dggesx,DGGESX)
-void LAPACK_dggesx(
+#define LAPACK_dggesx_base LAPACK_GLOBAL(dggesx,DGGESX)
+void LAPACK_dggesx_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_D_SELECT3 selctg, char const* sense,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3216,10 +4576,19 @@ void LAPACK_dggesx(
     double* rcondv,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggesx(...) LAPACK_dggesx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_dggesx(...) LAPACK_dggesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggesx LAPACK_GLOBAL(sggesx,SGGESX)
-void LAPACK_sggesx(
+#define LAPACK_sggesx_base LAPACK_GLOBAL(sggesx,SGGESX)
+void LAPACK_sggesx_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_S_SELECT3 selctg, char const* sense,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3233,10 +4602,19 @@ void LAPACK_sggesx(
     float* rcondv,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggesx(...) LAPACK_sggesx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_sggesx(...) LAPACK_sggesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggesx LAPACK_GLOBAL(zggesx,ZGGESX)
-void LAPACK_zggesx(
+#define LAPACK_zggesx_base LAPACK_GLOBAL(zggesx,ZGGESX)
+void LAPACK_zggesx_base(
     char const* jobvsl, char const* jobvsr, char const* sort, LAPACK_Z_SELECT2 selctg, char const* sense,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3250,10 +4628,19 @@ void LAPACK_zggesx(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggesx(...) LAPACK_zggesx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_zggesx(...) LAPACK_zggesx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggev LAPACK_GLOBAL(cggev,CGGEV)
-void LAPACK_cggev(
+#define LAPACK_cggev_base LAPACK_GLOBAL(cggev,CGGEV)
+void LAPACK_cggev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3264,10 +4651,19 @@ void LAPACK_cggev(
     lapack_complex_float* VR, lapack_int const* ldvr,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggev(...) LAPACK_cggev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cggev(...) LAPACK_cggev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggev LAPACK_GLOBAL(dggev,DGGEV)
-void LAPACK_dggev(
+#define LAPACK_dggev_base LAPACK_GLOBAL(dggev,DGGEV)
+void LAPACK_dggev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3278,10 +4674,19 @@ void LAPACK_dggev(
     double* VL, lapack_int const* ldvl,
     double* VR, lapack_int const* ldvr,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggev(...) LAPACK_dggev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dggev(...) LAPACK_dggev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggev LAPACK_GLOBAL(sggev,SGGEV)
-void LAPACK_sggev(
+#define LAPACK_sggev_base LAPACK_GLOBAL(sggev,SGGEV)
+void LAPACK_sggev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3292,10 +4697,19 @@ void LAPACK_sggev(
     float* VL, lapack_int const* ldvl,
     float* VR, lapack_int const* ldvr,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggev(...) LAPACK_sggev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sggev(...) LAPACK_sggev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggev LAPACK_GLOBAL(zggev,ZGGEV)
-void LAPACK_zggev(
+#define LAPACK_zggev_base LAPACK_GLOBAL(zggev,ZGGEV)
+void LAPACK_zggev_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3306,10 +4720,19 @@ void LAPACK_zggev(
     lapack_complex_double* VR, lapack_int const* ldvr,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggev(...) LAPACK_zggev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zggev(...) LAPACK_zggev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggev3 LAPACK_GLOBAL(cggev3,CGGEV3)
-void LAPACK_cggev3(
+#define LAPACK_cggev3_base LAPACK_GLOBAL(cggev3,CGGEV3)
+void LAPACK_cggev3_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3320,10 +4743,19 @@ void LAPACK_cggev3(
     lapack_complex_float* VR, lapack_int const* ldvr,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggev3(...) LAPACK_cggev3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cggev3(...) LAPACK_cggev3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggev3 LAPACK_GLOBAL(dggev3,DGGEV3)
-void LAPACK_dggev3(
+#define LAPACK_dggev3_base LAPACK_GLOBAL(dggev3,DGGEV3)
+void LAPACK_dggev3_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3334,10 +4766,19 @@ void LAPACK_dggev3(
     double* VL, lapack_int const* ldvl,
     double* VR, lapack_int const* ldvr,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggev3(...) LAPACK_dggev3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dggev3(...) LAPACK_dggev3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggev3 LAPACK_GLOBAL(sggev3,SGGEV3)
-void LAPACK_sggev3(
+#define LAPACK_sggev3_base LAPACK_GLOBAL(sggev3,SGGEV3)
+void LAPACK_sggev3_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3348,10 +4789,19 @@ void LAPACK_sggev3(
     float* VL, lapack_int const* ldvl,
     float* VR, lapack_int const* ldvr,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggev3(...) LAPACK_sggev3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sggev3(...) LAPACK_sggev3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggev3 LAPACK_GLOBAL(zggev3,ZGGEV3)
-void LAPACK_zggev3(
+#define LAPACK_zggev3_base LAPACK_GLOBAL(zggev3,ZGGEV3)
+void LAPACK_zggev3_base(
     char const* jobvl, char const* jobvr,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3362,10 +4812,19 @@ void LAPACK_zggev3(
     lapack_complex_double* VR, lapack_int const* ldvr,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggev3(...) LAPACK_zggev3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zggev3(...) LAPACK_zggev3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggevx LAPACK_GLOBAL(cggevx,CGGEVX)
-void LAPACK_cggevx(
+#define LAPACK_cggevx_base LAPACK_GLOBAL(cggevx,CGGEVX)
+void LAPACK_cggevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3383,10 +4842,19 @@ void LAPACK_cggevx(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggevx(...) LAPACK_cggevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_cggevx(...) LAPACK_cggevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggevx LAPACK_GLOBAL(dggevx,DGGEVX)
-void LAPACK_dggevx(
+#define LAPACK_dggevx_base LAPACK_GLOBAL(dggevx,DGGEVX)
+void LAPACK_dggevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3404,10 +4872,19 @@ void LAPACK_dggevx(
     double* rcondv,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggevx(...) LAPACK_dggevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_dggevx(...) LAPACK_dggevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggevx LAPACK_GLOBAL(sggevx,SGGEVX)
-void LAPACK_sggevx(
+#define LAPACK_sggevx_base LAPACK_GLOBAL(sggevx,SGGEVX)
+void LAPACK_sggevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3425,10 +4902,19 @@ void LAPACK_sggevx(
     float* rcondv,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggevx(...) LAPACK_sggevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_sggevx(...) LAPACK_sggevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggevx LAPACK_GLOBAL(zggevx,ZGGEVX)
-void LAPACK_zggevx(
+#define LAPACK_zggevx_base LAPACK_GLOBAL(zggevx,ZGGEVX)
+void LAPACK_zggevx_base(
     char const* balanc, char const* jobvl, char const* jobvr, char const* sense,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3446,7 +4932,16 @@ void LAPACK_zggevx(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork, lapack_logical* BWORK,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggevx(...) LAPACK_zggevx_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_zggevx(...) LAPACK_zggevx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cggglm LAPACK_GLOBAL(cggglm,CGGGLM)
 void LAPACK_cggglm(
@@ -3492,8 +4987,8 @@ void LAPACK_zggglm(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cgghd3 LAPACK_GLOBAL(cgghd3,CGGHD3)
-void LAPACK_cgghd3(
+#define LAPACK_cgghd3_base LAPACK_GLOBAL(cgghd3,CGGHD3)
+void LAPACK_cgghd3_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3501,10 +4996,19 @@ void LAPACK_cgghd3(
     lapack_complex_float* Q, lapack_int const* ldq,
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgghd3(...) LAPACK_cgghd3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgghd3(...) LAPACK_cgghd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgghd3 LAPACK_GLOBAL(dgghd3,DGGHD3)
-void LAPACK_dgghd3(
+#define LAPACK_dgghd3_base LAPACK_GLOBAL(dgghd3,DGGHD3)
+void LAPACK_dgghd3_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double* A, lapack_int const* lda,
@@ -3512,10 +5016,19 @@ void LAPACK_dgghd3(
     double* Q, lapack_int const* ldq,
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgghd3(...) LAPACK_dgghd3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgghd3(...) LAPACK_dgghd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgghd3 LAPACK_GLOBAL(sgghd3,SGGHD3)
-void LAPACK_sgghd3(
+#define LAPACK_sgghd3_base LAPACK_GLOBAL(sgghd3,SGGHD3)
+void LAPACK_sgghd3_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float* A, lapack_int const* lda,
@@ -3523,10 +5036,19 @@ void LAPACK_sgghd3(
     float* Q, lapack_int const* ldq,
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgghd3(...) LAPACK_sgghd3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgghd3(...) LAPACK_sgghd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgghd3 LAPACK_GLOBAL(zgghd3,ZGGHD3)
-void LAPACK_zgghd3(
+#define LAPACK_zgghd3_base LAPACK_GLOBAL(zgghd3,ZGGHD3)
+void LAPACK_zgghd3_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3534,47 +5056,92 @@ void LAPACK_zgghd3(
     lapack_complex_double* Q, lapack_int const* ldq,
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgghd3(...) LAPACK_zgghd3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgghd3(...) LAPACK_zgghd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgghrd LAPACK_GLOBAL(cgghrd,CGGHRD)
-void LAPACK_cgghrd(
+#define LAPACK_cgghrd_base LAPACK_GLOBAL(cgghrd,CGGHRD)
+void LAPACK_cgghrd_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* Q, lapack_int const* ldq,
     lapack_complex_float* Z, lapack_int const* ldz,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgghrd(...) LAPACK_cgghrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgghrd(...) LAPACK_cgghrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgghrd LAPACK_GLOBAL(dgghrd,DGGHRD)
-void LAPACK_dgghrd(
+#define LAPACK_dgghrd_base LAPACK_GLOBAL(dgghrd,DGGHRD)
+void LAPACK_dgghrd_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* Q, lapack_int const* ldq,
     double* Z, lapack_int const* ldz,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgghrd(...) LAPACK_dgghrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgghrd(...) LAPACK_dgghrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgghrd LAPACK_GLOBAL(sgghrd,SGGHRD)
-void LAPACK_sgghrd(
+#define LAPACK_sgghrd_base LAPACK_GLOBAL(sgghrd,SGGHRD)
+void LAPACK_sgghrd_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
     float* Q, lapack_int const* ldq,
     float* Z, lapack_int const* ldz,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgghrd(...) LAPACK_sgghrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgghrd(...) LAPACK_sgghrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgghrd LAPACK_GLOBAL(zgghrd,ZGGHRD)
-void LAPACK_zgghrd(
+#define LAPACK_zgghrd_base LAPACK_GLOBAL(zgghrd,ZGGHRD)
+void LAPACK_zgghrd_base(
     char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* Q, lapack_int const* ldq,
     lapack_complex_double* Z, lapack_int const* ldz,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgghrd(...) LAPACK_zgghrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgghrd(...) LAPACK_zgghrd_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgglse LAPACK_GLOBAL(cgglse,CGGLSE)
 void LAPACK_cgglse(
@@ -3700,34 +5267,8 @@ void LAPACK_zggrqf(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_sggsvd LAPACK_GLOBAL(sggsvd,SGGSVD)
-lapack_int LAPACK_sggsvd(
-    char const* jobu, char const* jobv, char const* jobq,
-    lapack_int const* m, lapack_int const* n, lapack_int const* p,
-    lapack_int* k, lapack_int* l,
-    float* a, lapack_int const* lda,
-    float* b, lapack_int const* ldb,
-    float* alpha, float* beta,
-    float* u, lapack_int const* ldu,
-    float* v, lapack_int const* ldv,
-    float* q, lapack_int const* ldq,
-    float* work, lapack_int* iwork, lapack_int* info );
-
-#define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
-lapack_int LAPACK_dggsvd(
-    char const* jobu, char const* jobv, char const* jobq,
-    lapack_int const* m, lapack_int const* n, lapack_int const* p,
-    lapack_int* k, lapack_int* l,
-    double* a, lapack_int const* lda,
-    double* b, lapack_int const* ldb,
-    double* alpha, double* beta,
-    double* u, lapack_int const* ldu,
-    double* v, lapack_int const* ldv,
-    double* q, lapack_int const* ldq,
-    double* work, lapack_int* iwork, lapack_int* info );
-
-#define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
-lapack_int LAPACK_cggsvd(
+#define LAPACK_cggsvd_base LAPACK_GLOBAL(cggsvd,CGGSVD)
+lapack_int LAPACK_cggsvd_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* n, lapack_int const* p,
     lapack_int* k, lapack_int* l,
@@ -3738,10 +5279,63 @@ lapack_int LAPACK_cggsvd(
     lapack_complex_float* v, lapack_int const* ldv,
     lapack_complex_float* q, lapack_int const* ldq,
     lapack_complex_float* work, float* rwork,
-    lapack_int* iwork, lapack_int* info );
+    lapack_int* iwork, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggsvd(...) LAPACK_cggsvd_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cggsvd(...) LAPACK_cggsvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
-lapack_int LAPACK_zggsvd(
+#define LAPACK_sggsvd_base LAPACK_GLOBAL(sggsvd,SGGSVD)
+lapack_int LAPACK_sggsvd_base(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    float* a, lapack_int const* lda,
+    float* b, lapack_int const* ldb,
+    float* alpha, float* beta,
+    float* u, lapack_int const* ldu,
+    float* v, lapack_int const* ldv,
+    float* q, lapack_int const* ldq,
+    float* work, lapack_int* iwork, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggsvd(...) LAPACK_sggsvd_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sggsvd(...) LAPACK_sggsvd_base(__VA_ARGS__)
+#endif
+
+#define LAPACK_dggsvd_base LAPACK_GLOBAL(dggsvd,DGGSVD)
+lapack_int LAPACK_dggsvd_base(
+    char const* jobu, char const* jobv, char const* jobq,
+    lapack_int const* m, lapack_int const* n, lapack_int const* p,
+    lapack_int* k, lapack_int* l,
+    double* a, lapack_int const* lda,
+    double* b, lapack_int const* ldb,
+    double* alpha, double* beta,
+    double* u, lapack_int const* ldu,
+    double* v, lapack_int const* ldv,
+    double* q, lapack_int const* ldq,
+    double* work, lapack_int* iwork, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggsvd(...) LAPACK_dggsvd_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dggsvd(...) LAPACK_dggsvd_base(__VA_ARGS__)
+#endif
+
+#define LAPACK_zggsvd_base LAPACK_GLOBAL(zggsvd,ZGGSVD)
+lapack_int LAPACK_zggsvd_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* n, lapack_int const* p,
     lapack_int* k, lapack_int* l,
@@ -3752,10 +5346,19 @@ lapack_int LAPACK_zggsvd(
     lapack_complex_double* v, lapack_int const* ldv,
     lapack_complex_double* q, lapack_int const* ldq,
     lapack_complex_double* work, double* rwork,
-    lapack_int* iwork, lapack_int* info );
+    lapack_int* iwork, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggsvd(...) LAPACK_zggsvd_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zggsvd(...) LAPACK_zggsvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggsvd3 LAPACK_GLOBAL(cggsvd3,CGGSVD3)
-void LAPACK_cggsvd3(
+#define LAPACK_cggsvd3_base LAPACK_GLOBAL(cggsvd3,CGGSVD3)
+void LAPACK_cggsvd3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* n, lapack_int const* p, lapack_int* k, lapack_int* l,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3768,10 +5371,19 @@ void LAPACK_cggsvd3(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggsvd3(...) LAPACK_cggsvd3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cggsvd3(...) LAPACK_cggsvd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggsvd3 LAPACK_GLOBAL(dggsvd3,DGGSVD3)
-void LAPACK_dggsvd3(
+#define LAPACK_dggsvd3_base LAPACK_GLOBAL(dggsvd3,DGGSVD3)
+void LAPACK_dggsvd3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* n, lapack_int const* p, lapack_int* k, lapack_int* l,
     double* A, lapack_int const* lda,
@@ -3783,10 +5395,19 @@ void LAPACK_dggsvd3(
     double* Q, lapack_int const* ldq,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggsvd3(...) LAPACK_dggsvd3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dggsvd3(...) LAPACK_dggsvd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggsvd3 LAPACK_GLOBAL(sggsvd3,SGGSVD3)
-void LAPACK_sggsvd3(
+#define LAPACK_sggsvd3_base LAPACK_GLOBAL(sggsvd3,SGGSVD3)
+void LAPACK_sggsvd3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* n, lapack_int const* p, lapack_int* k, lapack_int* l,
     float* A, lapack_int const* lda,
@@ -3798,10 +5419,19 @@ void LAPACK_sggsvd3(
     float* Q, lapack_int const* ldq,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggsvd3(...) LAPACK_sggsvd3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sggsvd3(...) LAPACK_sggsvd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggsvd3 LAPACK_GLOBAL(zggsvd3,ZGGSVD3)
-void LAPACK_zggsvd3(
+#define LAPACK_zggsvd3_base LAPACK_GLOBAL(zggsvd3,ZGGSVD3)
+void LAPACK_zggsvd3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* n, lapack_int const* p, lapack_int* k, lapack_int* l,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3814,10 +5444,19 @@ void LAPACK_zggsvd3(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggsvd3(...) LAPACK_zggsvd3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zggsvd3(...) LAPACK_zggsvd3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggsvp LAPACK_GLOBAL(sggsvp,SGGSVP)
-lapack_int LAPACK_sggsvp(
+#define LAPACK_sggsvp_base LAPACK_GLOBAL(sggsvp,SGGSVP)
+lapack_int LAPACK_sggsvp_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     float* a, lapack_int const* lda,
@@ -3828,10 +5467,19 @@ lapack_int LAPACK_sggsvp(
     float* v, lapack_int const* ldv,
     float* q, lapack_int const* ldq,
     lapack_int* iwork, float* tau,
-    float* work, lapack_int* info );
+    float* work, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggsvp(...) LAPACK_sggsvp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sggsvp(...) LAPACK_sggsvp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggsvp LAPACK_GLOBAL(dggsvp,DGGSVP)
-lapack_int LAPACK_dggsvp(
+#define LAPACK_dggsvp_base LAPACK_GLOBAL(dggsvp,DGGSVP)
+lapack_int LAPACK_dggsvp_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     double* a, lapack_int const* lda,
@@ -3842,10 +5490,19 @@ lapack_int LAPACK_dggsvp(
     double* v, lapack_int const* ldv,
     double* q, lapack_int const* ldq,
     lapack_int* iwork, double* tau,
-    double* work, lapack_int* info );
+    double* work, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggsvp(...) LAPACK_dggsvp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dggsvp(...) LAPACK_dggsvp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
-lapack_int LAPACK_cggsvp(
+#define LAPACK_cggsvp_base LAPACK_GLOBAL(cggsvp,CGGSVP)
+lapack_int LAPACK_cggsvp_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     lapack_complex_float* a, lapack_int const* lda,
@@ -3855,10 +5512,19 @@ lapack_int LAPACK_cggsvp(
     lapack_complex_float* v, lapack_int const* ldv,
     lapack_complex_float* q, lapack_int const* ldq,
     lapack_int* iwork, float* rwork, lapack_complex_float* tau,
-    lapack_complex_float* work, lapack_int* info );
+    lapack_complex_float* work, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggsvp(...) LAPACK_cggsvp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cggsvp(...) LAPACK_cggsvp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
-lapack_int LAPACK_zggsvp(
+#define LAPACK_zggsvp_base LAPACK_GLOBAL(zggsvp,ZGGSVP)
+lapack_int LAPACK_zggsvp_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     lapack_complex_double* a, lapack_int const* lda,
@@ -3868,10 +5534,19 @@ lapack_int LAPACK_zggsvp(
     lapack_complex_double* v, lapack_int const* ldv,
     lapack_complex_double* q, lapack_int const* ldq,
     lapack_int* iwork, double* rwork, lapack_complex_double* tau,
-    lapack_complex_double* work, lapack_int* info );
+    lapack_complex_double* work, lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggsvp(...) LAPACK_zggsvp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zggsvp(...) LAPACK_zggsvp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cggsvp3 LAPACK_GLOBAL(cggsvp3,CGGSVP3)
-void LAPACK_cggsvp3(
+#define LAPACK_cggsvp3_base LAPACK_GLOBAL(cggsvp3,CGGSVP3)
+void LAPACK_cggsvp3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -3885,10 +5560,19 @@ void LAPACK_cggsvp3(
     float* rwork,
     lapack_complex_float* tau,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cggsvp3(...) LAPACK_cggsvp3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cggsvp3(...) LAPACK_cggsvp3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dggsvp3 LAPACK_GLOBAL(dggsvp3,DGGSVP3)
-void LAPACK_dggsvp3(
+#define LAPACK_dggsvp3_base LAPACK_GLOBAL(dggsvp3,DGGSVP3)
+void LAPACK_dggsvp3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -3901,10 +5585,19 @@ void LAPACK_dggsvp3(
     lapack_int* iwork,
     double* tau,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dggsvp3(...) LAPACK_dggsvp3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dggsvp3(...) LAPACK_dggsvp3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sggsvp3 LAPACK_GLOBAL(sggsvp3,SGGSVP3)
-void LAPACK_sggsvp3(
+#define LAPACK_sggsvp3_base LAPACK_GLOBAL(sggsvp3,SGGSVP3)
+void LAPACK_sggsvp3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -3917,10 +5610,19 @@ void LAPACK_sggsvp3(
     lapack_int* iwork,
     float* tau,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sggsvp3(...) LAPACK_sggsvp3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sggsvp3(...) LAPACK_sggsvp3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zggsvp3 LAPACK_GLOBAL(zggsvp3,ZGGSVP3)
-void LAPACK_zggsvp3(
+#define LAPACK_zggsvp3_base LAPACK_GLOBAL(zggsvp3,ZGGSVP3)
+void LAPACK_zggsvp3_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -3934,10 +5636,19 @@ void LAPACK_zggsvp3(
     double* rwork,
     lapack_complex_double* tau,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zggsvp3(...) LAPACK_zggsvp3_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zggsvp3(...) LAPACK_zggsvp3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgtcon LAPACK_GLOBAL(cgtcon,CGTCON)
-void LAPACK_cgtcon(
+#define LAPACK_cgtcon_base LAPACK_GLOBAL(cgtcon,CGTCON)
+void LAPACK_cgtcon_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_float const* DL,
@@ -3947,10 +5658,19 @@ void LAPACK_cgtcon(
     float const* anorm,
     float* rcond,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgtcon(...) LAPACK_cgtcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgtcon(...) LAPACK_cgtcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgtcon LAPACK_GLOBAL(dgtcon,DGTCON)
-void LAPACK_dgtcon(
+#define LAPACK_dgtcon_base LAPACK_GLOBAL(dgtcon,DGTCON)
+void LAPACK_dgtcon_base(
     char const* norm,
     lapack_int const* n,
     double const* DL,
@@ -3961,10 +5681,19 @@ void LAPACK_dgtcon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgtcon(...) LAPACK_dgtcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgtcon(...) LAPACK_dgtcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgtcon LAPACK_GLOBAL(sgtcon,SGTCON)
-void LAPACK_sgtcon(
+#define LAPACK_sgtcon_base LAPACK_GLOBAL(sgtcon,SGTCON)
+void LAPACK_sgtcon_base(
     char const* norm,
     lapack_int const* n,
     float const* DL,
@@ -3975,10 +5704,19 @@ void LAPACK_sgtcon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgtcon(...) LAPACK_sgtcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgtcon(...) LAPACK_sgtcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgtcon LAPACK_GLOBAL(zgtcon,ZGTCON)
-void LAPACK_zgtcon(
+#define LAPACK_zgtcon_base LAPACK_GLOBAL(zgtcon,ZGTCON)
+void LAPACK_zgtcon_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_double const* DL,
@@ -3988,10 +5726,19 @@ void LAPACK_zgtcon(
     double const* anorm,
     double* rcond,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgtcon(...) LAPACK_zgtcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgtcon(...) LAPACK_zgtcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cgtrfs LAPACK_GLOBAL(cgtrfs,CGTRFS)
-void LAPACK_cgtrfs(
+#define LAPACK_cgtrfs_base LAPACK_GLOBAL(cgtrfs,CGTRFS)
+void LAPACK_cgtrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* DL,
@@ -4007,10 +5754,19 @@ void LAPACK_cgtrfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgtrfs(...) LAPACK_cgtrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgtrfs(...) LAPACK_cgtrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgtrfs LAPACK_GLOBAL(dgtrfs,DGTRFS)
-void LAPACK_dgtrfs(
+#define LAPACK_dgtrfs_base LAPACK_GLOBAL(dgtrfs,DGTRFS)
+void LAPACK_dgtrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double const* DL,
@@ -4026,10 +5782,19 @@ void LAPACK_dgtrfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgtrfs(...) LAPACK_dgtrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgtrfs(...) LAPACK_dgtrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgtrfs LAPACK_GLOBAL(sgtrfs,SGTRFS)
-void LAPACK_sgtrfs(
+#define LAPACK_sgtrfs_base LAPACK_GLOBAL(sgtrfs,SGTRFS)
+void LAPACK_sgtrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float const* DL,
@@ -4045,10 +5810,19 @@ void LAPACK_sgtrfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgtrfs(...) LAPACK_sgtrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgtrfs(...) LAPACK_sgtrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgtrfs LAPACK_GLOBAL(zgtrfs,ZGTRFS)
-void LAPACK_zgtrfs(
+#define LAPACK_zgtrfs_base LAPACK_GLOBAL(zgtrfs,ZGTRFS)
+void LAPACK_zgtrfs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* DL,
@@ -4064,7 +5838,16 @@ void LAPACK_zgtrfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgtrfs(...) LAPACK_zgtrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgtrfs(...) LAPACK_zgtrfs_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgtsv LAPACK_GLOBAL(cgtsv,CGTSV)
 void LAPACK_cgtsv(
@@ -4102,8 +5885,8 @@ void LAPACK_zgtsv(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info );
 
-#define LAPACK_cgtsvx LAPACK_GLOBAL(cgtsvx,CGTSVX)
-void LAPACK_cgtsvx(
+#define LAPACK_cgtsvx_base LAPACK_GLOBAL(cgtsvx,CGTSVX)
+void LAPACK_cgtsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* DL,
@@ -4120,10 +5903,19 @@ void LAPACK_cgtsvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgtsvx(...) LAPACK_cgtsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cgtsvx(...) LAPACK_cgtsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgtsvx LAPACK_GLOBAL(dgtsvx,DGTSVX)
-void LAPACK_dgtsvx(
+#define LAPACK_dgtsvx_base LAPACK_GLOBAL(dgtsvx,DGTSVX)
+void LAPACK_dgtsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double const* DL,
@@ -4140,10 +5932,19 @@ void LAPACK_dgtsvx(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgtsvx(...) LAPACK_dgtsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dgtsvx(...) LAPACK_dgtsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgtsvx LAPACK_GLOBAL(sgtsvx,SGTSVX)
-void LAPACK_sgtsvx(
+#define LAPACK_sgtsvx_base LAPACK_GLOBAL(sgtsvx,SGTSVX)
+void LAPACK_sgtsvx_base(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float const* DL,
@@ -4160,10 +5961,19 @@ void LAPACK_sgtsvx(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgtsvx(...) LAPACK_sgtsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sgtsvx(...) LAPACK_sgtsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgtsvx LAPACK_GLOBAL(zgtsvx,ZGTSVX)
-void LAPACK_zgtsvx(
+#define LAPACK_zgtsvx_base LAPACK_GLOBAL(zgtsvx,ZGTSVX)
+void LAPACK_zgtsv_basex(
     char const* fact, char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* DL,
@@ -4180,7 +5990,16 @@ void LAPACK_zgtsvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgtsvx(...) LAPACK_zgtsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zgtsvx(...) LAPACK_zgtsvx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cgttrf LAPACK_GLOBAL(cgttrf,CGTTRF)
 void LAPACK_cgttrf(
@@ -4218,8 +6037,8 @@ void LAPACK_zgttrf(
     lapack_complex_double* DU2, lapack_int* ipiv,
     lapack_int* info );
 
-#define LAPACK_cgttrs LAPACK_GLOBAL(cgttrs,CGTTRS)
-void LAPACK_cgttrs(
+#define LAPACK_cgttrs_base LAPACK_GLOBAL(cgttrs,CGTTRS)
+void LAPACK_cgttrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* DL,
@@ -4227,10 +6046,19 @@ void LAPACK_cgttrs(
     lapack_complex_float const* DU,
     lapack_complex_float const* DU2, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cgttrs(...) LAPACK_cgttrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cgttrs(...) LAPACK_cgttrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dgttrs LAPACK_GLOBAL(dgttrs,DGTTRS)
-void LAPACK_dgttrs(
+#define LAPACK_dgttrs_base LAPACK_GLOBAL(dgttrs,DGTTRS)
+void LAPACK_dgttrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double const* DL,
@@ -4238,10 +6066,19 @@ void LAPACK_dgttrs(
     double const* DU,
     double const* DU2, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dgttrs(...) LAPACK_dgttrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dgttrs(...) LAPACK_dgttrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sgttrs LAPACK_GLOBAL(sgttrs,SGTTRS)
-void LAPACK_sgttrs(
+#define LAPACK_sgttrs_base LAPACK_GLOBAL(sgttrs,SGTTRS)
+void LAPACK_sgttrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float const* DL,
@@ -4249,10 +6086,19 @@ void LAPACK_sgttrs(
     float const* DU,
     float const* DU2, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sgttrs(...) LAPACK_sgttrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sgttrs(...) LAPACK_sgttrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zgttrs LAPACK_GLOBAL(zgttrs,ZGTTRS)
-void LAPACK_zgttrs(
+#define LAPACK_zgttrs_base LAPACK_GLOBAL(zgttrs,ZGTTRS)
+void LAPACK_zgttrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* DL,
@@ -4260,10 +6106,19 @@ void LAPACK_zgttrs(
     lapack_complex_double const* DU,
     lapack_complex_double const* DU2, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zgttrs(...) LAPACK_zgttrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zgttrs(...) LAPACK_zgttrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbev LAPACK_GLOBAL(chbev,CHBEV)
-void LAPACK_chbev(
+#define LAPACK_chbev_base LAPACK_GLOBAL(chbev,CHBEV)
+void LAPACK_chbev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4271,10 +6126,19 @@ void LAPACK_chbev(
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbev(...) LAPACK_chbev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbev(...) LAPACK_chbev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbev LAPACK_GLOBAL(zhbev,ZHBEV)
-void LAPACK_zhbev(
+#define LAPACK_zhbev_base LAPACK_GLOBAL(zhbev,ZHBEV)
+void LAPACK_zhbev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4282,10 +6146,19 @@ void LAPACK_zhbev(
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbev(...) LAPACK_zhbev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbev(...) LAPACK_zhbev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbev_2stage LAPACK_GLOBAL(chbev_2stage,CHBEV_2STAGE)
-void LAPACK_chbev_2stage(
+#define LAPACK_chbev_2stage_base LAPACK_GLOBAL(chbev_2stage,CHBEV_2STAGE)
+void LAPACK_chbev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4293,10 +6166,19 @@ void LAPACK_chbev_2stage(
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbev_2stage(...) LAPACK_chbev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbev_2stage(...) LAPACK_chbev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbev_2stage LAPACK_GLOBAL(zhbev_2stage,ZHBEV_2STAGE)
-void LAPACK_zhbev_2stage(
+#define LAPACK_zhbev_2stage_base LAPACK_GLOBAL(zhbev_2stage,ZHBEV_2STAGE)
+void LAPACK_zhbev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4304,10 +6186,19 @@ void LAPACK_zhbev_2stage(
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbev_2stage(...) LAPACK_zhbev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbev_2stage(...) LAPACK_zhbev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbevd LAPACK_GLOBAL(chbevd,CHBEVD)
-void LAPACK_chbevd(
+#define LAPACK_chbevd_base LAPACK_GLOBAL(chbevd,CHBEVD)
+void LAPACK_chbevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4316,10 +6207,19 @@ void LAPACK_chbevd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbevd(...) LAPACK_chbevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbevd(...) LAPACK_chbevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbevd LAPACK_GLOBAL(zhbevd,ZHBEVD)
-void LAPACK_zhbevd(
+#define LAPACK_zhbevd_base LAPACK_GLOBAL(zhbevd,ZHBEVD)
+void LAPACK_zhbevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4328,10 +6228,19 @@ void LAPACK_zhbevd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbevd(...) LAPACK_zhbevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbevd(...) LAPACK_zhbevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbevd_2stage LAPACK_GLOBAL(chbevd_2stage,CHBEVD_2STAGE)
-void LAPACK_chbevd_2stage(
+#define LAPACK_chbevd_2stage_base LAPACK_GLOBAL(chbevd_2stage,CHBEVD_2STAGE)
+void LAPACK_chbevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4340,10 +6249,19 @@ void LAPACK_chbevd_2stage(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbevd_2stage(...) LAPACK_chbevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbevd_2stage(...) LAPACK_chbevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbevd_2stage LAPACK_GLOBAL(zhbevd_2stage,ZHBEVD_2STAGE)
-void LAPACK_zhbevd_2stage(
+#define LAPACK_zhbevd_2stage_base LAPACK_GLOBAL(zhbevd_2stage,ZHBEVD_2STAGE)
+void LAPACK_zhbevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4352,10 +6270,19 @@ void LAPACK_zhbevd_2stage(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbevd_2stage(...) LAPACK_zhbevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbevd_2stage(...) LAPACK_zhbevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbevx LAPACK_GLOBAL(chbevx,CHBEVX)
-void LAPACK_chbevx(
+#define LAPACK_chbevx_base LAPACK_GLOBAL(chbevx,CHBEVX)
+void LAPACK_chbevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4368,10 +6295,19 @@ void LAPACK_chbevx(
     lapack_complex_float* work,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbevx(...) LAPACK_chbevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chbevx(...) LAPACK_chbevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbevx LAPACK_GLOBAL(zhbevx,ZHBEVX)
-void LAPACK_zhbevx(
+#define LAPACK_zhbevx_base LAPACK_GLOBAL(zhbevx,ZHBEVX)
+void LAPACK_zhbevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4384,10 +6320,19 @@ void LAPACK_zhbevx(
     lapack_complex_double* work,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbevx(...) LAPACK_zhbevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhbevx(...) LAPACK_zhbevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbevx_2stage LAPACK_GLOBAL(chbevx_2stage,CHBEVX_2STAGE)
-void LAPACK_chbevx_2stage(
+#define LAPACK_chbevx_2stage_base LAPACK_GLOBAL(chbevx_2stage,CHBEVX_2STAGE)
+void LAPACK_chbevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4400,10 +6345,19 @@ void LAPACK_chbevx_2stage(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbevx_2stage(...) LAPACK_chbevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chbevx_2stage(...) LAPACK_chbevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbevx_2stage LAPACK_GLOBAL(zhbevx_2stage,ZHBEVX_2STAGE)
-void LAPACK_zhbevx_2stage(
+#define LAPACK_zhbevx_2stage_base LAPACK_GLOBAL(zhbevx_2stage,ZHBEVX_2STAGE)
+void LAPACK_zhbevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4416,10 +6370,19 @@ void LAPACK_zhbevx_2stage(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbevx_2stage(...) LAPACK_zhbevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhbevx_2stage(...) LAPACK_zhbevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbgst LAPACK_GLOBAL(chbgst,CHBGST)
-void LAPACK_chbgst(
+#define LAPACK_chbgst_base LAPACK_GLOBAL(chbgst,CHBGST)
+void LAPACK_chbgst_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4427,10 +6390,19 @@ void LAPACK_chbgst(
     lapack_complex_float* X, lapack_int const* ldx,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbgst(...) LAPACK_chbgst_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbgst(...) LAPACK_chbgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbgst LAPACK_GLOBAL(zhbgst,ZHBGST)
-void LAPACK_zhbgst(
+#define LAPACK_zhbgst_base LAPACK_GLOBAL(zhbgst,ZHBGST)
+void LAPACK_zhbgst_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4438,10 +6410,19 @@ void LAPACK_zhbgst(
     lapack_complex_double* X, lapack_int const* ldx,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbgst(...) LAPACK_zhbgst_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbgst(...) LAPACK_zhbgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbgv LAPACK_GLOBAL(chbgv,CHBGV)
-void LAPACK_chbgv(
+#define LAPACK_chbgv_base LAPACK_GLOBAL(chbgv,CHBGV)
+void LAPACK_chbgv_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4450,10 +6431,19 @@ void LAPACK_chbgv(
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbgv(...) LAPACK_chbgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbgv(...) LAPACK_chbgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbgv LAPACK_GLOBAL(zhbgv,ZHBGV)
-void LAPACK_zhbgv(
+#define LAPACK_zhbgv_base LAPACK_GLOBAL(zhbgv,ZHBGV)
+void LAPACK_zhbgv_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4462,10 +6452,19 @@ void LAPACK_zhbgv(
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbgv(...) LAPACK_zhbgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbgv(...) LAPACK_zhbgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbgvd LAPACK_GLOBAL(chbgvd,CHBGVD)
-void LAPACK_chbgvd(
+#define LAPACK_chbgvd_base LAPACK_GLOBAL(chbgvd,CHBGVD)
+void LAPACK_chbgvd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4475,10 +6474,19 @@ void LAPACK_chbgvd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbgvd(...) LAPACK_chbgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbgvd(...) LAPACK_chbgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbgvd LAPACK_GLOBAL(zhbgvd,ZHBGVD)
-void LAPACK_zhbgvd(
+#define LAPACK_zhbgvd_base LAPACK_GLOBAL(zhbgvd,ZHBGVD)
+void LAPACK_zhbgvd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4488,10 +6496,19 @@ void LAPACK_zhbgvd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbgvd(...) LAPACK_zhbgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbgvd(...) LAPACK_zhbgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbgvx LAPACK_GLOBAL(chbgvx,CHBGVX)
-void LAPACK_chbgvx(
+#define LAPACK_chbgvx_base LAPACK_GLOBAL(chbgvx,CHBGVX)
+void LAPACK_chbgvx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4505,10 +6522,19 @@ void LAPACK_chbgvx(
     lapack_complex_float* work,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbgvx(...) LAPACK_chbgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chbgvx(...) LAPACK_chbgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbgvx LAPACK_GLOBAL(zhbgvx,ZHBGVX)
-void LAPACK_zhbgvx(
+#define LAPACK_zhbgvx_base LAPACK_GLOBAL(zhbgvx,ZHBGVX)
+void LAPACK_zhbgvx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4522,10 +6548,19 @@ void LAPACK_zhbgvx(
     lapack_complex_double* work,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbgvx(...) LAPACK_zhbgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhbgvx(...) LAPACK_zhbgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chbtrd LAPACK_GLOBAL(chbtrd,CHBTRD)
-void LAPACK_chbtrd(
+#define LAPACK_chbtrd_base LAPACK_GLOBAL(chbtrd,CHBTRD)
+void LAPACK_chbtrd_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -4533,10 +6568,19 @@ void LAPACK_chbtrd(
     float* E,
     lapack_complex_float* Q, lapack_int const* ldq,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chbtrd(...) LAPACK_chbtrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chbtrd(...) LAPACK_chbtrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhbtrd LAPACK_GLOBAL(zhbtrd,ZHBTRD)
-void LAPACK_zhbtrd(
+#define LAPACK_zhbtrd_base LAPACK_GLOBAL(zhbtrd,ZHBTRD)
+void LAPACK_zhbtrd_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -4544,30 +6588,57 @@ void LAPACK_zhbtrd(
     double* E,
     lapack_complex_double* Q, lapack_int const* ldq,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhbtrd(...) LAPACK_zhbtrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhbtrd(...) LAPACK_zhbtrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_checon LAPACK_GLOBAL(checon,CHECON)
-void LAPACK_checon(
+#define LAPACK_checon_base LAPACK_GLOBAL(checon,CHECON)
+void LAPACK_checon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     float const* anorm,
     float* rcond,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_checon(...) LAPACK_checon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_checon(...) LAPACK_checon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhecon LAPACK_GLOBAL(zhecon,ZHECON)
-void LAPACK_zhecon(
+#define LAPACK_zhecon_base LAPACK_GLOBAL(zhecon,ZHECON)
+void LAPACK_zhecon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     double const* anorm,
     double* rcond,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhecon(...) LAPACK_zhecon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhecon(...) LAPACK_zhecon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_checon_3 LAPACK_GLOBAL(checon_3,CHECON_3)
-void LAPACK_checon_3(
+#define LAPACK_checon_3_base LAPACK_GLOBAL(checon_3,CHECON_3)
+void LAPACK_checon_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -4575,10 +6646,19 @@ void LAPACK_checon_3(
     float const* anorm,
     float* rcond,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_checon_3(...) LAPACK_checon_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_checon_3(...) LAPACK_checon_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhecon_3 LAPACK_GLOBAL(zhecon_3,ZHECON_3)
-void LAPACK_zhecon_3(
+#define LAPACK_zhecon_3_base LAPACK_GLOBAL(zhecon_3,ZHECON_3)
+void LAPACK_zhecon_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -4586,10 +6666,19 @@ void LAPACK_zhecon_3(
     double const* anorm,
     double* rcond,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhecon_3(...) LAPACK_zhecon_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhecon_3(...) LAPACK_zhecon_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheequb LAPACK_GLOBAL(cheequb,CHEEQUB)
-void LAPACK_cheequb(
+#define LAPACK_cheequb_base LAPACK_GLOBAL(cheequb,CHEEQUB)
+void LAPACK_cheequb_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -4597,10 +6686,19 @@ void LAPACK_cheequb(
     float* scond,
     float* amax,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheequb(...) LAPACK_cheequb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cheequb(...) LAPACK_cheequb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheequb LAPACK_GLOBAL(zheequb,ZHEEQUB)
-void LAPACK_zheequb(
+#define LAPACK_zheequb_base LAPACK_GLOBAL(zheequb,ZHEEQUB)
+void LAPACK_zheequb_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -4608,50 +6706,95 @@ void LAPACK_zheequb(
     double* scond,
     double* amax,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheequb(...) LAPACK_zheequb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zheequb(...) LAPACK_zheequb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheev LAPACK_GLOBAL(cheev,CHEEV)
-void LAPACK_cheev(
+#define LAPACK_cheev_base LAPACK_GLOBAL(cheev,CHEEV)
+void LAPACK_cheev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     float* W,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheev(...) LAPACK_cheev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cheev(...) LAPACK_cheev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheev LAPACK_GLOBAL(zheev,ZHEEV)
-void LAPACK_zheev(
+#define LAPACK_zheev_base LAPACK_GLOBAL(zheev,ZHEEV)
+void LAPACK_zheev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     double* W,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheev(...) LAPACK_zheev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zheev(...) LAPACK_zheev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheev_2stage LAPACK_GLOBAL(cheev_2stage,CHEEV_2STAGE)
-void LAPACK_cheev_2stage(
+#define LAPACK_cheev_2stage_base LAPACK_GLOBAL(cheev_2stage,CHEEV_2STAGE)
+void LAPACK_cheev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     float* W,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheev_2stage(...) LAPACK_cheev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cheev_2stage(...) LAPACK_cheev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheev_2stage LAPACK_GLOBAL(zheev_2stage,ZHEEV_2STAGE)
-void LAPACK_zheev_2stage(
+#define LAPACK_zheev_2stage_base LAPACK_GLOBAL(zheev_2stage,ZHEEV_2STAGE)
+void LAPACK_zheev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     double* W,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheev_2stage(...) LAPACK_zheev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zheev_2stage(...) LAPACK_zheev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheevd LAPACK_GLOBAL(cheevd,CHEEVD)
-void LAPACK_cheevd(
+#define LAPACK_cheevd_base LAPACK_GLOBAL(cheevd,CHEEVD)
+void LAPACK_cheevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4659,10 +6802,19 @@ void LAPACK_cheevd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheevd(...) LAPACK_cheevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cheevd(...) LAPACK_cheevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheevd LAPACK_GLOBAL(zheevd,ZHEEVD)
-void LAPACK_zheevd(
+#define LAPACK_zheevd_base LAPACK_GLOBAL(zheevd,ZHEEVD)
+void LAPACK_zheevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4670,10 +6822,19 @@ void LAPACK_zheevd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheevd(...) LAPACK_zheevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zheevd(...) LAPACK_zheevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheevd_2stage LAPACK_GLOBAL(cheevd_2stage,CHEEVD_2STAGE)
-void LAPACK_cheevd_2stage(
+#define LAPACK_cheevd_2stage_base LAPACK_GLOBAL(cheevd_2stage,CHEEVD_2STAGE)
+void LAPACK_cheevd_2stag_basee(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4681,10 +6842,19 @@ void LAPACK_cheevd_2stage(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheevd_2stage(...) LAPACK_cheevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cheevd_2stage(...) LAPACK_cheevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheevd_2stage LAPACK_GLOBAL(zheevd_2stage,ZHEEVD_2STAGE)
-void LAPACK_zheevd_2stage(
+#define LAPACK_zheevd_2stage_base LAPACK_GLOBAL(zheevd_2stage,ZHEEVD_2STAGE)
+void LAPACK_zheevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4692,10 +6862,19 @@ void LAPACK_zheevd_2stage(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheevd_2stage(...) LAPACK_zheevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zheevd_2stage(...) LAPACK_zheevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheevr LAPACK_GLOBAL(cheevr,CHEEVR)
-void LAPACK_cheevr(
+#define LAPACK_cheevr_base LAPACK_GLOBAL(cheevr,CHEEVR)
+void LAPACK_cheevr_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4707,10 +6886,19 @@ void LAPACK_cheevr(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheevr(...) LAPACK_cheevr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cheevr(...) LAPACK_cheevr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheevr LAPACK_GLOBAL(zheevr,ZHEEVR)
-void LAPACK_zheevr(
+#define LAPACK_zheevr_base LAPACK_GLOBAL(zheevr,ZHEEVR)
+void LAPACK_zheevr_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4722,10 +6910,19 @@ void LAPACK_zheevr(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheevr(...) LAPACK_zheevr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zheevr(...) LAPACK_zheevr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheevr_2stage LAPACK_GLOBAL(cheevr_2stage,CHEEVR_2STAGE)
-void LAPACK_cheevr_2stage(
+#define LAPACK_cheevr_2stage_base LAPACK_GLOBAL(cheevr_2stage,CHEEVR_2STAGE)
+void LAPACK_cheevr_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4737,10 +6934,19 @@ void LAPACK_cheevr_2stage(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheevr_2stage(...) LAPACK_cheevr_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cheevr_2stage(...) LAPACK_cheevr_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheevr_2stage LAPACK_GLOBAL(zheevr_2stage,ZHEEVR_2STAGE)
-void LAPACK_zheevr_2stage(
+#define LAPACK_zheevr_2stage_base LAPACK_GLOBAL(zheevr_2stage,ZHEEVR_2STAGE)
+void LAPACK_zheevr_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4752,10 +6958,19 @@ void LAPACK_zheevr_2stage(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheevr_2stage(...) LAPACK_zheevr_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zheevr_2stage(...) LAPACK_zheevr_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheevx LAPACK_GLOBAL(cheevx,CHEEVX)
-void LAPACK_cheevx(
+#define LAPACK_cheevx_base LAPACK_GLOBAL(cheevx,CHEEVX)
+void LAPACK_cheevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4767,10 +6982,19 @@ void LAPACK_cheevx(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheevx(...) LAPACK_cheevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cheevx(...) LAPACK_cheevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheevx LAPACK_GLOBAL(zheevx,ZHEEVX)
-void LAPACK_zheevx(
+#define LAPACK_zheevx_base LAPACK_GLOBAL(zheevx,ZHEEVX)
+void LAPACK_zheevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4782,10 +7006,19 @@ void LAPACK_zheevx(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheevx(...) LAPACK_zheevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zheevx(...) LAPACK_zheevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheevx_2stage LAPACK_GLOBAL(cheevx_2stage,CHEEVX_2STAGE)
-void LAPACK_cheevx_2stage(
+#define LAPACK_cheevx_2stage_base LAPACK_GLOBAL(cheevx_2stage,CHEEVX_2STAGE)
+void LAPACK_cheevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4797,10 +7030,19 @@ void LAPACK_cheevx_2stage(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheevx_2stage(...) LAPACK_cheevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cheevx_2stage(...) LAPACK_cheevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheevx_2stage LAPACK_GLOBAL(zheevx_2stage,ZHEEVX_2STAGE)
-void LAPACK_zheevx_2stage(
+#define LAPACK_zheevx_2stage_base LAPACK_GLOBAL(zheevx_2stage,ZHEEVX_2STAGE)
+void LAPACK_zheevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4812,26 +7054,53 @@ void LAPACK_zheevx_2stage(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheevx_2stage(...) LAPACK_zheevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zheevx_2stage(...) LAPACK_zheevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chegst LAPACK_GLOBAL(chegst,CHEGST)
-void LAPACK_chegst(
+#define LAPACK_chegst_base LAPACK_GLOBAL(chegst,CHEGST)
+void LAPACK_chegst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     const lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chegst(...) LAPACK_chegst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chegst(...) LAPACK_chegst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhegst LAPACK_GLOBAL(zhegst,ZHEGST)
-void LAPACK_zhegst(
+#define LAPACK_zhegst_base LAPACK_GLOBAL(zhegst,ZHEGST)
+void LAPACK_zhegst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     const lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhegst(...) LAPACK_zhegst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhegst(...) LAPACK_zhegst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chegv LAPACK_GLOBAL(chegv,CHEGV)
-void LAPACK_chegv(
+#define LAPACK_chegv_base LAPACK_GLOBAL(chegv,CHEGV)
+void LAPACK_chegv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4839,10 +7108,19 @@ void LAPACK_chegv(
     float* W,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chegv(...) LAPACK_chegv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chegv(...) LAPACK_chegv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhegv LAPACK_GLOBAL(zhegv,ZHEGV)
-void LAPACK_zhegv(
+#define LAPACK_zhegv_base LAPACK_GLOBAL(zhegv,ZHEGV)
+void LAPACK_zhegv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4850,10 +7128,19 @@ void LAPACK_zhegv(
     double* W,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhegv(...) LAPACK_zhegv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhegv(...) LAPACK_zhegv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chegv_2stage LAPACK_GLOBAL(chegv_2stage,CHEGV_2STAGE)
-void LAPACK_chegv_2stage(
+#define LAPACK_chegv_2stage_base LAPACK_GLOBAL(chegv_2stage,CHEGV_2STAGE)
+void LAPACK_chegv_2stage_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4861,10 +7148,19 @@ void LAPACK_chegv_2stage(
     float* W,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chegv_2stage(...) LAPACK_chegv_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chegv_2stage(...) LAPACK_chegv_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhegv_2stage LAPACK_GLOBAL(zhegv_2stage,ZHEGV_2STAGE)
-void LAPACK_zhegv_2stage(
+#define LAPACK_zhegv_2stage_base LAPACK_GLOBAL(zhegv_2stage,ZHEGV_2STAGE)
+void LAPACK_zhegv_2stage_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4872,10 +7168,19 @@ void LAPACK_zhegv_2stage(
     double* W,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhegv_2stage(...) LAPACK_zhegv_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhegv_2stage(...) LAPACK_zhegv_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chegvd LAPACK_GLOBAL(chegvd,CHEGVD)
-void LAPACK_chegvd(
+#define LAPACK_chegvd_base LAPACK_GLOBAL(chegvd,CHEGVD)
+void LAPACK_chegvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4884,10 +7189,19 @@ void LAPACK_chegvd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chegvd(...) LAPACK_chegvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chegvd(...) LAPACK_chegvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhegvd LAPACK_GLOBAL(zhegvd,ZHEGVD)
-void LAPACK_zhegvd(
+#define LAPACK_zhegvd_base LAPACK_GLOBAL(zhegvd,ZHEGVD)
+void LAPACK_zhegvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4896,10 +7210,19 @@ void LAPACK_zhegvd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhegvd(...) LAPACK_zhegvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhegvd(...) LAPACK_zhegvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chegvx LAPACK_GLOBAL(chegvx,CHEGVX)
-void LAPACK_chegvx(
+#define LAPACK_chegvx_base LAPACK_GLOBAL(chegvx,CHEGVX)
+void LAPACK_chegvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -4912,10 +7235,19 @@ void LAPACK_chegvx(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chegvx(...) LAPACK_chegvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chegvx(...) LAPACK_chegvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhegvx LAPACK_GLOBAL(zhegvx,ZHEGVX)
-void LAPACK_zhegvx(
+#define LAPACK_zhegvx_base LAPACK_GLOBAL(zhegvx,ZHEGVX)
+void LAPACK_zhegvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -4928,10 +7260,19 @@ void LAPACK_zhegvx(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhegvx(...) LAPACK_zhegvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhegvx(...) LAPACK_zhegvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cherfs LAPACK_GLOBAL(cherfs,CHERFS)
-void LAPACK_cherfs(
+#define LAPACK_cherfs_base LAPACK_GLOBAL(cherfs,CHERFS)
+void LAPACK_cherfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -4942,10 +7283,19 @@ void LAPACK_cherfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cherfs(...) LAPACK_cherfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cherfs(...) LAPACK_cherfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zherfs LAPACK_GLOBAL(zherfs,ZHERFS)
-void LAPACK_zherfs(
+#define LAPACK_zherfs_base LAPACK_GLOBAL(zherfs,ZHERFS)
+void LAPACK_zherfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -4956,10 +7306,19 @@ void LAPACK_zherfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zherfs(...) LAPACK_zherfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zherfs(...) LAPACK_zherfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cherfsx LAPACK_GLOBAL(cherfsx,CHERFSX)
-void LAPACK_cherfsx(
+#define LAPACK_cherfsx_base LAPACK_GLOBAL(cherfsx,CHERFSX)
+void LAPACK_cherfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -4974,10 +7333,19 @@ void LAPACK_cherfsx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cherfsx(...) LAPACK_cherfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cherfsx(...) LAPACK_cherfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zherfsx LAPACK_GLOBAL(zherfsx,ZHERFSX)
-void LAPACK_zherfsx(
+#define LAPACK_zherfsx_base LAPACK_GLOBAL(zherfsx,ZHERFSX)
+void LAPACK_zherfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -4992,104 +7360,203 @@ void LAPACK_zherfsx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zherfsx(...) LAPACK_zherfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zherfsx(...) LAPACK_zherfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chesv LAPACK_GLOBAL(chesv,CHESV)
-void LAPACK_chesv(
+#define LAPACK_chesv_base LAPACK_GLOBAL(chesv,CHESV)
+void LAPACK_chesv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chesv(...) LAPACK_chesv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chesv(...) LAPACK_chesv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhesv LAPACK_GLOBAL(zhesv,ZHESV)
-void LAPACK_zhesv(
+#define LAPACK_zhesv_base LAPACK_GLOBAL(zhesv,ZHESV)
+void LAPACK_zhesv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhesv(...) LAPACK_zhesv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhesv(...) LAPACK_zhesv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chesv_aa LAPACK_GLOBAL(chesv_aa,CHESV_AA)
-void LAPACK_chesv_aa(
+#define LAPACK_chesv_aa_base LAPACK_GLOBAL(chesv_aa,CHESV_AA)
+void LAPACK_chesv_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chesv_aa(...) LAPACK_chesv_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chesv_aa(...) LAPACK_chesv_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhesv_aa LAPACK_GLOBAL(zhesv_aa,ZHESV_AA)
-void LAPACK_zhesv_aa(
+#define LAPACK_zhesv_aa_base LAPACK_GLOBAL(zhesv_aa,ZHESV_AA)
+void LAPACK_zhesv_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhesv_aa(...) LAPACK_zhesv_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhesv_aa(...) LAPACK_zhesv_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chesv_aa_2stage LAPACK_GLOBAL(chesv_aa_2stage,CHESV_AA_2STAGE)
-void LAPACK_chesv_aa_2stage(
+#define LAPACK_chesv_aa_2stage_base LAPACK_GLOBAL(chesv_aa_2stage,CHESV_AA_2STAGE)
+void LAPACK_chesv_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chesv_aa_2stage(...) LAPACK_chesv_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chesv_aa_2stage(...) LAPACK_chesv_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhesv_aa_2stage LAPACK_GLOBAL(zhesv_aa_2stage,ZHESV_AA_2STAGE)
-void LAPACK_zhesv_aa_2stage(
+#define LAPACK_zhesv_aa_2stage_base LAPACK_GLOBAL(zhesv_aa_2stage,ZHESV_AA_2STAGE)
+void LAPACK_zhesv_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhesv_aa_2stage(...) LAPACK_zhesv_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhesv_aa_2stage(...) LAPACK_zhesv_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chesv_rk LAPACK_GLOBAL(chesv_rk,CHESV_RK)
-void LAPACK_chesv_rk(
+#define LAPACK_chesv_rk_base LAPACK_GLOBAL(chesv_rk,CHESV_RK)
+void LAPACK_chesv_rk_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* E, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chesv_rk(...) LAPACK_chesv_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chesv_rk(...) LAPACK_chesv_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhesv_rk LAPACK_GLOBAL(zhesv_rk,ZHESV_RK)
-void LAPACK_zhesv_rk(
+#define LAPACK_zhesv_rk_base LAPACK_GLOBAL(zhesv_rk,ZHESV_RK)
+void LAPACK_zhesv_rk_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* E, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhesv_rk(...) LAPACK_zhesv_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhesv_rk(...) LAPACK_zhesv_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chesv_rook LAPACK_GLOBAL(chesv_rook,CHESV_ROOK)
-void LAPACK_chesv_rook(
+#define LAPACK_chesv_rook_base LAPACK_GLOBAL(chesv_rook,CHESV_ROOK)
+void LAPACK_chesv_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chesv_rook(...) LAPACK_chesv_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chesv_rook(...) LAPACK_chesv_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhesv_rook LAPACK_GLOBAL(zhesv_rook,ZHESV_ROOK)
-void LAPACK_zhesv_rook(
+#define LAPACK_zhesv_rook_base LAPACK_GLOBAL(zhesv_rook,ZHESV_ROOK)
+void LAPACK_zhesv_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhesv_rook(...) LAPACK_zhesv_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhesv_rook(...) LAPACK_zhesv_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chesvx LAPACK_GLOBAL(chesvx,CHESVX)
-void LAPACK_chesvx(
+#define LAPACK_chesvx_base LAPACK_GLOBAL(chesvx,CHESVX)
+void LAPACK_chesvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -5101,10 +7568,19 @@ void LAPACK_chesvx(
     float* berr,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chesvx(...) LAPACK_chesvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chesvx(...) LAPACK_chesvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhesvx LAPACK_GLOBAL(zhesvx,ZHESVX)
-void LAPACK_zhesvx(
+#define LAPACK_zhesvx_base LAPACK_GLOBAL(zhesvx,ZHESVX)
+void LAPACK_zhesvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -5116,10 +7592,19 @@ void LAPACK_zhesvx(
     double* berr,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhesvx(...) LAPACK_zhesvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhesvx(...) LAPACK_zhesvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chesvxx LAPACK_GLOBAL(chesvxx,CHESVXX)
-void LAPACK_chesvxx(
+#define LAPACK_chesvxx_base LAPACK_GLOBAL(chesvxx,CHESVXX)
+void LAPACK_chesvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
@@ -5136,10 +7621,19 @@ void LAPACK_chesvxx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chesvxx(...) LAPACK_chesvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chesvxx(...) LAPACK_chesvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhesvxx LAPACK_GLOBAL(zhesvxx,ZHESVXX)
-void LAPACK_zhesvxx(
+#define LAPACK_zhesvxx_base LAPACK_GLOBAL(zhesvxx,ZHESVXX)
+void LAPACK_zhesvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
@@ -5156,22 +7650,49 @@ void LAPACK_zhesvxx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhesvxx(...) LAPACK_zhesvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhesvxx(...) LAPACK_zhesvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cheswapr LAPACK_GLOBAL(cheswapr,CHESWAPR)
-void LAPACK_cheswapr(
+#define LAPACK_cheswapr_base LAPACK_GLOBAL(cheswapr,CHESWAPR)
+void LAPACK_cheswapr_base(
     char const* uplo,
     lapack_int const* n,
-    lapack_complex_float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2 );
+    lapack_complex_float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cheswapr(...) LAPACK_cheswapr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cheswapr(...) LAPACK_cheswapr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zheswapr LAPACK_GLOBAL(zheswapr,ZHESWAPR)
-void LAPACK_zheswapr(
+#define LAPACK_zheswapr_base LAPACK_GLOBAL(zheswapr,ZHESWAPR)
+void LAPACK_zheswapr_base(
     char const* uplo,
     lapack_int const* n,
-    lapack_complex_double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2 );
+    lapack_complex_double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zheswapr(...) LAPACK_zheswapr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zheswapr(...) LAPACK_zheswapr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrd LAPACK_GLOBAL(chetrd,CHETRD)
-void LAPACK_chetrd(
+#define LAPACK_chetrd_base LAPACK_GLOBAL(chetrd,CHETRD)
+void LAPACK_chetrd_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -5179,10 +7700,19 @@ void LAPACK_chetrd(
     float* E,
     lapack_complex_float* tau,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrd(...) LAPACK_chetrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrd(...) LAPACK_chetrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrd LAPACK_GLOBAL(zhetrd,ZHETRD)
-void LAPACK_zhetrd(
+#define LAPACK_zhetrd_base LAPACK_GLOBAL(zhetrd,ZHETRD)
+void LAPACK_zhetrd_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -5190,10 +7720,19 @@ void LAPACK_zhetrd(
     double* E,
     lapack_complex_double* tau,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrd(...) LAPACK_zhetrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrd(...) LAPACK_zhetrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrd_2stage LAPACK_GLOBAL(chetrd_2stage,CHETRD_2STAGE)
-void LAPACK_chetrd_2stage(
+#define LAPACK_chetrd_2stage_base LAPACK_GLOBAL(chetrd_2stage,CHETRD_2STAGE)
+void LAPACK_chetrd_2stage_base(
     char const* vect, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -5202,10 +7741,19 @@ void LAPACK_chetrd_2stage(
     lapack_complex_float* tau,
     lapack_complex_float* HOUS2, lapack_int const* lhous2,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrd_2stage(...) LAPACK_chetrd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chetrd_2stage(...) LAPACK_chetrd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrd_2stage LAPACK_GLOBAL(zhetrd_2stage,ZHETRD_2STAGE)
-void LAPACK_zhetrd_2stage(
+#define LAPACK_zhetrd_2stage_base LAPACK_GLOBAL(zhetrd_2stage,ZHETRD_2STAGE)
+void LAPACK_zhetrd_2stage_base(
     char const* vect, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -5214,282 +7762,579 @@ void LAPACK_zhetrd_2stage(
     lapack_complex_double* tau,
     lapack_complex_double* HOUS2, lapack_int const* lhous2,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrd_2stage(...) LAPACK_zhetrd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhetrd_2stage(...) LAPACK_zhetrd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrf LAPACK_GLOBAL(chetrf,CHETRF)
-void LAPACK_chetrf(
+#define LAPACK_chetrf_base LAPACK_GLOBAL(chetrf,CHETRF)
+void LAPACK_chetrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrf(...) LAPACK_chetrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrf(...) LAPACK_chetrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrf LAPACK_GLOBAL(zhetrf,ZHETRF)
-void LAPACK_zhetrf(
+#define LAPACK_zhetrf_base LAPACK_GLOBAL(zhetrf,ZHETRF)
+void LAPACK_zhetrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrf(...) LAPACK_zhetrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrf(...) LAPACK_zhetrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrf_aa LAPACK_GLOBAL(chetrf_aa,CHETRF_AA)
-void LAPACK_chetrf_aa(
+#define LAPACK_chetrf_aa_base LAPACK_GLOBAL(chetrf_aa,CHETRF_AA)
+void LAPACK_chetrf_aa_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrf_aa(...) LAPACK_chetrf_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrf_aa(...) LAPACK_chetrf_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrf_aa LAPACK_GLOBAL(zhetrf_aa,ZHETRF_AA)
-void LAPACK_zhetrf_aa(
+#define LAPACK_zhetrf_aa_base LAPACK_GLOBAL(zhetrf_aa,ZHETRF_AA)
+void LAPACK_zhetrf_aa_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrf_aa(...) LAPACK_zhetrf_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrf_aa(...) LAPACK_zhetrf_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrf_aa_2stage LAPACK_GLOBAL(chetrf_aa_2stage,CHETRF_AA_2STAGE)
-void LAPACK_chetrf_aa_2stage(
+#define LAPACK_chetrf_aa_2stage_base LAPACK_GLOBAL(chetrf_aa_2stage,CHETRF_AA_2STAGE)
+void LAPACK_chetrf_aa_2stage_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrf_aa_2stage(...) LAPACK_chetrf_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrf_aa_2stage(...) LAPACK_chetrf_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrf_aa_2stage LAPACK_GLOBAL(zhetrf_aa_2stage,ZHETRF_AA_2STAGE)
-void LAPACK_zhetrf_aa_2stage(
+#define LAPACK_zhetrf_aa_2stage_base LAPACK_GLOBAL(zhetrf_aa_2stage,ZHETRF_AA_2STAGE)
+void LAPACK_zhetrf_aa_2stage_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrf_aa_2stage(...) LAPACK_zhetrf_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrf_aa_2stage(...) LAPACK_zhetrf_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrf_rk LAPACK_GLOBAL(chetrf_rk,CHETRF_RK)
-void LAPACK_chetrf_rk(
+#define LAPACK_chetrf_rk_base LAPACK_GLOBAL(chetrf_rk,CHETRF_RK)
+void LAPACK_chetrf_rk_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* E, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrf_rk(...) LAPACK_chetrf_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrf_rk(...) LAPACK_chetrf_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrf_rk LAPACK_GLOBAL(zhetrf_rk,ZHETRF_RK)
-void LAPACK_zhetrf_rk(
+#define LAPACK_zhetrf_rk_base LAPACK_GLOBAL(zhetrf_rk,ZHETRF_RK)
+void LAPACK_zhetrf_rk_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* E, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrf_rk(...) LAPACK_zhetrf_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrf_rk(...) LAPACK_zhetrf_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrf_rook LAPACK_GLOBAL(chetrf_rook,CHETRF_ROOK)
-void LAPACK_chetrf_rook(
+#define LAPACK_chetrf_rook_base LAPACK_GLOBAL(chetrf_rook,CHETRF_ROOK)
+void LAPACK_chetrf_rook_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrf_rook(...) LAPACK_chetrf_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrf_rook(...) LAPACK_chetrf_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrf_rook LAPACK_GLOBAL(zhetrf_rook,ZHETRF_ROOK)
-void LAPACK_zhetrf_rook(
+#define LAPACK_zhetrf_rook_base LAPACK_GLOBAL(zhetrf_rook,ZHETRF_ROOK)
+void LAPACK_zhetrf_rook_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrf_rook(...) LAPACK_zhetrf_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrf_rook(...) LAPACK_zhetrf_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetri LAPACK_GLOBAL(chetri,CHETRI)
-void LAPACK_chetri(
+#define LAPACK_chetri_base LAPACK_GLOBAL(chetri,CHETRI)
+void LAPACK_chetri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetri(...) LAPACK_chetri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetri(...) LAPACK_chetri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetri LAPACK_GLOBAL(zhetri,ZHETRI)
-void LAPACK_zhetri(
+#define LAPACK_zhetri_base LAPACK_GLOBAL(zhetri,ZHETRI)
+void LAPACK_zhetri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetri(...) LAPACK_zhetri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetri(...) LAPACK_zhetri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetri2 LAPACK_GLOBAL(chetri2,CHETRI2)
-void LAPACK_chetri2(
+#define LAPACK_chetri2_base LAPACK_GLOBAL(chetri2,CHETRI2)
+void LAPACK_chetri2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetri2(...) LAPACK_chetri2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetri2(...) LAPACK_chetri2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetri2 LAPACK_GLOBAL(zhetri2,ZHETRI2)
-void LAPACK_zhetri2(
+#define LAPACK_zhetri2_base LAPACK_GLOBAL(zhetri2,ZHETRI2)
+void LAPACK_zhetri2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetri2(...) LAPACK_zhetri2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetri2(...) LAPACK_zhetri2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetri2x LAPACK_GLOBAL(chetri2x,CHETRI2X)
-void LAPACK_chetri2x(
+#define LAPACK_chetri2x_base LAPACK_GLOBAL(chetri2x,CHETRI2X)
+void LAPACK_chetri2x_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* work, lapack_int const* nb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetri2x(...) LAPACK_chetri2x_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetri2x(...) LAPACK_chetri2x_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetri2x LAPACK_GLOBAL(zhetri2x,ZHETRI2X)
-void LAPACK_zhetri2x(
+#define LAPACK_zhetri2x_base LAPACK_GLOBAL(zhetri2x,ZHETRI2X)
+void LAPACK_zhetri2x_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* work, lapack_int const* nb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetri2x(...) LAPACK_zhetri2x_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetri2x(...) LAPACK_zhetri2x_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetri_3 LAPACK_GLOBAL(chetri_3,CHETRI_3)
-void LAPACK_chetri_3(
+#define LAPACK_chetri_3_base LAPACK_GLOBAL(chetri_3,CHETRI_3)
+void LAPACK_chetri_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float const* E, lapack_int const* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetri_3(...) LAPACK_chetri_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetri_3(...) LAPACK_chetri_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetri_3 LAPACK_GLOBAL(zhetri_3,ZHETRI_3)
-void LAPACK_zhetri_3(
+#define LAPACK_zhetri_3_base LAPACK_GLOBAL(zhetri_3,ZHETRI_3)
+void LAPACK_zhetri_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double const* E, lapack_int const* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetri_3(...) LAPACK_zhetri_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetri_3(...) LAPACK_zhetri_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrs LAPACK_GLOBAL(chetrs,CHETRS)
-void LAPACK_chetrs(
+#define LAPACK_chetrs_base LAPACK_GLOBAL(chetrs,CHETRS)
+void LAPACK_chetrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrs(...) LAPACK_chetrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrs(...) LAPACK_chetrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrs LAPACK_GLOBAL(zhetrs,ZHETRS)
-void LAPACK_zhetrs(
+#define LAPACK_zhetrs_base LAPACK_GLOBAL(zhetrs,ZHETRS)
+void LAPACK_zhetrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrs(...) LAPACK_zhetrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrs(...) LAPACK_zhetrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrs2 LAPACK_GLOBAL(chetrs2,CHETRS2)
-void LAPACK_chetrs2(
+#define LAPACK_chetrs2_base LAPACK_GLOBAL(chetrs2,CHETRS2)
+void LAPACK_chetrs2_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrs2(...) LAPACK_chetrs2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrs2(...) LAPACK_chetrs2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrs2 LAPACK_GLOBAL(zhetrs2,ZHETRS2)
-void LAPACK_zhetrs2(
+#define LAPACK_zhetrs2_base LAPACK_GLOBAL(zhetrs2,ZHETRS2)
+void LAPACK_zhetrs2_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrs2(...) LAPACK_zhetrs2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrs2(...) LAPACK_zhetrs2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrs_3 LAPACK_GLOBAL(chetrs_3,CHETRS_3)
-void LAPACK_chetrs_3(
+#define LAPACK_chetrs_3_base LAPACK_GLOBAL(chetrs_3,CHETRS_3)
+void LAPACK_chetrs_3_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* E, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrs_3(...) LAPACK_chetrs_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrs_3(...) LAPACK_chetrs_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrs_3 LAPACK_GLOBAL(zhetrs_3,ZHETRS_3)
-void LAPACK_zhetrs_3(
+#define LAPACK_zhetrs_3_base LAPACK_GLOBAL(zhetrs_3,ZHETRS_3)
+void LAPACK_zhetrs_3_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* E, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrs_3(...) LAPACK_zhetrs_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrs_3(...) LAPACK_zhetrs_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrs_aa LAPACK_GLOBAL(chetrs_aa,CHETRS_AA)
-void LAPACK_chetrs_aa(
+#define LAPACK_chetrs_aa_base LAPACK_GLOBAL(chetrs_aa,CHETRS_AA)
+void LAPACK_chetrs_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrs_aa(...) LAPACK_chetrs_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrs_aa(...) LAPACK_chetrs_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrs_aa LAPACK_GLOBAL(zhetrs_aa,ZHETRS_AA)
-void LAPACK_zhetrs_aa(
+#define LAPACK_zhetrs_aa_base LAPACK_GLOBAL(zhetrs_aa,ZHETRS_AA)
+void LAPACK_zhetrs_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrs_aa(...) LAPACK_zhetrs_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrs_aa(...) LAPACK_zhetrs_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrs_aa_2stage LAPACK_GLOBAL(chetrs_aa_2stage,CHETRS_AA_2STAGE)
-void LAPACK_chetrs_aa_2stage(
+#define LAPACK_chetrs_aa_2stage_base LAPACK_GLOBAL(chetrs_aa_2stage,CHETRS_AA_2STAGE)
+void LAPACK_chetrs_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float* TB, lapack_int const* ltb, lapack_int const* ipiv, lapack_int const* ipiv2,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrs_aa_2stage(...) LAPACK_chetrs_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrs_aa_2stage(...) LAPACK_chetrs_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrs_aa_2stage LAPACK_GLOBAL(zhetrs_aa_2stage,ZHETRS_AA_2STAGE)
-void LAPACK_zhetrs_aa_2stage(
+#define LAPACK_zhetrs_aa_2stage_base LAPACK_GLOBAL(zhetrs_aa_2stage,ZHETRS_AA_2STAGE)
+void LAPACK_zhetrs_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double* TB, lapack_int const* ltb, lapack_int const* ipiv, lapack_int const* ipiv2,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrs_aa_2stage(...) LAPACK_zhetrs_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrs_aa_2stage(...) LAPACK_zhetrs_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chetrs_rook LAPACK_GLOBAL(chetrs_rook,CHETRS_ROOK)
-void LAPACK_chetrs_rook(
+#define LAPACK_chetrs_rook_base LAPACK_GLOBAL(chetrs_rook,CHETRS_ROOK)
+void LAPACK_chetrs_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chetrs_rook(...) LAPACK_chetrs_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chetrs_rook(...) LAPACK_chetrs_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhetrs_rook LAPACK_GLOBAL(zhetrs_rook,ZHETRS_ROOK)
-void LAPACK_zhetrs_rook(
+#define LAPACK_zhetrs_rook_base LAPACK_GLOBAL(zhetrs_rook,ZHETRS_ROOK)
+void LAPACK_zhetrs_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhetrs_rook(...) LAPACK_zhetrs_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhetrs_rook(...) LAPACK_zhetrs_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chfrk LAPACK_GLOBAL(chfrk,CHFRK)
-void LAPACK_chfrk(
+#define LAPACK_chfrk_base LAPACK_GLOBAL(chfrk,CHFRK)
+void LAPACK_chfrk_base(
     char const* transr, char const* uplo, char const* trans,
     lapack_int const* n, lapack_int const* k,
     float const* alpha,
     lapack_complex_float const* A, lapack_int const* lda,
     float const* beta,
-    lapack_complex_float* C );
+    lapack_complex_float* C
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chfrk(...) LAPACK_chfrk_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chfrk(...) LAPACK_chfrk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhfrk LAPACK_GLOBAL(zhfrk,ZHFRK)
-void LAPACK_zhfrk(
+#define LAPACK_zhfrk_base LAPACK_GLOBAL(zhfrk,ZHFRK)
+void LAPACK_zhfrk_base(
     char const* transr, char const* uplo, char const* trans,
     lapack_int const* n, lapack_int const* k,
     double const* alpha,
     lapack_complex_double const* A, lapack_int const* lda,
     double const* beta,
-    lapack_complex_double* C );
+    lapack_complex_double* C
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhfrk(...) LAPACK_zhfrk_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhfrk(...) LAPACK_zhfrk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chgeqz LAPACK_GLOBAL(chgeqz,CHGEQZ)
-void LAPACK_chgeqz(
+#define LAPACK_chgeqz_base LAPACK_GLOBAL(chgeqz,CHGEQZ)
+void LAPACK_chgeqz_base(
     char const* job, char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_float* H, lapack_int const* ldh,
@@ -5500,10 +8345,19 @@ void LAPACK_chgeqz(
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chgeqz(...) LAPACK_chgeqz_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chgeqz(...) LAPACK_chgeqz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dhgeqz LAPACK_GLOBAL(dhgeqz,DHGEQZ)
-void LAPACK_dhgeqz(
+#define LAPACK_dhgeqz_base LAPACK_GLOBAL(dhgeqz,DHGEQZ)
+void LAPACK_dhgeqz_base(
     char const* job, char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double* H, lapack_int const* ldh,
@@ -5514,10 +8368,19 @@ void LAPACK_dhgeqz(
     double* Q, lapack_int const* ldq,
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dhgeqz(...) LAPACK_dhgeqz_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dhgeqz(...) LAPACK_dhgeqz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_shgeqz LAPACK_GLOBAL(shgeqz,SHGEQZ)
-void LAPACK_shgeqz(
+#define LAPACK_shgeqz_base LAPACK_GLOBAL(shgeqz,SHGEQZ)
+void LAPACK_shgeqz_base(
     char const* job, char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float* H, lapack_int const* ldh,
@@ -5528,10 +8391,19 @@ void LAPACK_shgeqz(
     float* Q, lapack_int const* ldq,
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_shgeqz(...) LAPACK_shgeqz_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_shgeqz(...) LAPACK_shgeqz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhgeqz LAPACK_GLOBAL(zhgeqz,ZHGEQZ)
-void LAPACK_zhgeqz(
+#define LAPACK_zhgeqz_base LAPACK_GLOBAL(zhgeqz,ZHGEQZ)
+void LAPACK_zhgeqz_base(
     char const* job, char const* compq, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_double* H, lapack_int const* ldh,
@@ -5542,30 +8414,57 @@ void LAPACK_zhgeqz(
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhgeqz(...) LAPACK_zhgeqz_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhgeqz(...) LAPACK_zhgeqz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpcon LAPACK_GLOBAL(chpcon,CHPCON)
-void LAPACK_chpcon(
+#define LAPACK_chpcon_base LAPACK_GLOBAL(chpcon,CHPCON)
+void LAPACK_chpcon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP, lapack_int const* ipiv,
     float const* anorm,
     float* rcond,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpcon(...) LAPACK_chpcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chpcon(...) LAPACK_chpcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpcon LAPACK_GLOBAL(zhpcon,ZHPCON)
-void LAPACK_zhpcon(
+#define LAPACK_zhpcon_base LAPACK_GLOBAL(zhpcon,ZHPCON)
+void LAPACK_zhpcon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP, lapack_int const* ipiv,
     double const* anorm,
     double* rcond,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpcon(...) LAPACK_zhpcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhpcon(...) LAPACK_zhpcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpev LAPACK_GLOBAL(chpev,CHPEV)
-void LAPACK_chpev(
+#define LAPACK_chpev_base LAPACK_GLOBAL(chpev,CHPEV)
+void LAPACK_chpev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
@@ -5573,10 +8472,19 @@ void LAPACK_chpev(
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpev(...) LAPACK_chpev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chpev(...) LAPACK_chpev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpev LAPACK_GLOBAL(zhpev,ZHPEV)
-void LAPACK_zhpev(
+#define LAPACK_zhpev_base LAPACK_GLOBAL(zhpev,ZHPEV)
+void LAPACK_zhpev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
@@ -5584,10 +8492,19 @@ void LAPACK_zhpev(
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpev(...) LAPACK_zhpev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhpev(...) LAPACK_zhpev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpevd LAPACK_GLOBAL(chpevd,CHPEVD)
-void LAPACK_chpevd(
+#define LAPACK_chpevd_base LAPACK_GLOBAL(chpevd,CHPEVD)
+void LAPACK_chpevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
@@ -5596,10 +8513,19 @@ void LAPACK_chpevd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpevd(...) LAPACK_chpevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chpevd(...) LAPACK_chpevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpevd LAPACK_GLOBAL(zhpevd,ZHPEVD)
-void LAPACK_zhpevd(
+#define LAPACK_zhpevd_base LAPACK_GLOBAL(zhpevd,ZHPEVD)
+void LAPACK_zhpevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
@@ -5608,10 +8534,19 @@ void LAPACK_zhpevd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpevd(...) LAPACK_zhpevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhpevd(...) LAPACK_zhpevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpevx LAPACK_GLOBAL(chpevx,CHPEVX)
-void LAPACK_chpevx(
+#define LAPACK_chpevx_base LAPACK_GLOBAL(chpevx,CHPEVX)
+void LAPACK_chpevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
@@ -5623,10 +8558,19 @@ void LAPACK_chpevx(
     lapack_complex_float* work,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpevx(...) LAPACK_chpevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chpevx(...) LAPACK_chpevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpevx LAPACK_GLOBAL(zhpevx,ZHPEVX)
-void LAPACK_zhpevx(
+#define LAPACK_zhpevx_base LAPACK_GLOBAL(zhpevx,ZHPEVX)
+void LAPACK_zhpevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
@@ -5638,26 +8582,53 @@ void LAPACK_zhpevx(
     lapack_complex_double* work,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpevx(...) LAPACK_zhpevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhpevx(...) LAPACK_zhpevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpgst LAPACK_GLOBAL(chpgst,CHPGST)
-void LAPACK_chpgst(
+#define LAPACK_chpgst_base LAPACK_GLOBAL(chpgst,CHPGST)
+void LAPACK_chpgst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
     lapack_complex_float const* BP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpgst(...) LAPACK_chpgst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chpgst(...) LAPACK_chpgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpgst LAPACK_GLOBAL(zhpgst,ZHPGST)
-void LAPACK_zhpgst(
+#define LAPACK_zhpgst_base LAPACK_GLOBAL(zhpgst,ZHPGST)
+void LAPACK_zhpgst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
     lapack_complex_double const* BP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpgst(...) LAPACK_zhpgst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhpgst(...) LAPACK_zhpgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpgv LAPACK_GLOBAL(chpgv,CHPGV)
-void LAPACK_chpgv(
+#define LAPACK_chpgv_base LAPACK_GLOBAL(chpgv,CHPGV)
+void LAPACK_chpgv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
@@ -5666,10 +8637,19 @@ void LAPACK_chpgv(
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpgv(...) LAPACK_chpgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chpgv(...) LAPACK_chpgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpgv LAPACK_GLOBAL(zhpgv,ZHPGV)
-void LAPACK_zhpgv(
+#define LAPACK_zhpgv_base LAPACK_GLOBAL(zhpgv,ZHPGV)
+void LAPACK_zhpgv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
@@ -5678,10 +8658,19 @@ void LAPACK_zhpgv(
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpgv(...) LAPACK_zhpgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhpgv(...) LAPACK_zhpgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpgvd LAPACK_GLOBAL(chpgvd,CHPGVD)
-void LAPACK_chpgvd(
+#define LAPACK_chpgvd_base LAPACK_GLOBAL(chpgvd,CHPGVD)
+void LAPACK_chpgvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
@@ -5691,10 +8680,19 @@ void LAPACK_chpgvd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpgvd(...) LAPACK_chpgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chpgvd(...) LAPACK_chpgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpgvd LAPACK_GLOBAL(zhpgvd,ZHPGVD)
-void LAPACK_zhpgvd(
+#define LAPACK_zhpgvd_base LAPACK_GLOBAL(zhpgvd,ZHPGVD)
+void LAPACK_zhpgvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
@@ -5704,10 +8702,19 @@ void LAPACK_zhpgvd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpgvd(...) LAPACK_zhpgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhpgvd(...) LAPACK_zhpgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpgvx LAPACK_GLOBAL(chpgvx,CHPGVX)
-void LAPACK_chpgvx(
+#define LAPACK_chpgvx_base LAPACK_GLOBAL(chpgvx,CHPGVX)
+void LAPACK_chpgvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
@@ -5720,10 +8727,19 @@ void LAPACK_chpgvx(
     lapack_complex_float* work,
     float* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpgvx(...) LAPACK_chpgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chpgvx(...) LAPACK_chpgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpgvx LAPACK_GLOBAL(zhpgvx,ZHPGVX)
-void LAPACK_zhpgvx(
+#define LAPACK_zhpgvx_base LAPACK_GLOBAL(zhpgvx,ZHPGVX)
+void LAPACK_zhpgvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
@@ -5736,10 +8752,19 @@ void LAPACK_zhpgvx(
     lapack_complex_double* work,
     double* rwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpgvx(...) LAPACK_zhpgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhpgvx(...) LAPACK_zhpgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chprfs LAPACK_GLOBAL(chprfs,CHPRFS)
-void LAPACK_chprfs(
+#define LAPACK_chprfs_base LAPACK_GLOBAL(chprfs,CHPRFS)
+void LAPACK_chprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
@@ -5750,10 +8775,19 @@ void LAPACK_chprfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chprfs(...) LAPACK_chprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chprfs(...) LAPACK_chprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhprfs LAPACK_GLOBAL(zhprfs,ZHPRFS)
-void LAPACK_zhprfs(
+#define LAPACK_zhprfs_base LAPACK_GLOBAL(zhprfs,ZHPRFS)
+void LAPACK_zhprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
@@ -5764,26 +8798,53 @@ void LAPACK_zhprfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhprfs(...) LAPACK_zhprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhprfs(...) LAPACK_zhprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpsv LAPACK_GLOBAL(chpsv,CHPSV)
-void LAPACK_chpsv(
+#define LAPACK_chpsv_base LAPACK_GLOBAL(chpsv,CHPSV)
+void LAPACK_chpsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* AP, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpsv(...) LAPACK_chpsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chpsv(...) LAPACK_chpsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpsv LAPACK_GLOBAL(zhpsv,ZHPSV)
-void LAPACK_zhpsv(
+#define LAPACK_zhpsv_base LAPACK_GLOBAL(zhpsv,ZHPSV)
+void LAPACK_zhpsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* AP, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpsv(...) LAPACK_zhpsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhpsv(...) LAPACK_zhpsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chpsvx LAPACK_GLOBAL(chpsvx,CHPSVX)
-void LAPACK_chpsvx(
+#define LAPACK_chpsvx_base LAPACK_GLOBAL(chpsvx,CHPSVX)
+void LAPACK_chpsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
@@ -5795,10 +8856,19 @@ void LAPACK_chpsvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chpsvx(...) LAPACK_chpsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chpsvx(...) LAPACK_chpsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhpsvx LAPACK_GLOBAL(zhpsvx,ZHPSVX)
-void LAPACK_zhpsvx(
+#define LAPACK_zhpsvx_base LAPACK_GLOBAL(zhpsvx,ZHPSVX)
+void LAPACK_zhpsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
@@ -5810,76 +8880,157 @@ void LAPACK_zhpsvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhpsvx(...) LAPACK_zhpsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhpsvx(...) LAPACK_zhpsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chptrd LAPACK_GLOBAL(chptrd,CHPTRD)
-void LAPACK_chptrd(
+#define LAPACK_chptrd_base LAPACK_GLOBAL(chptrd,CHPTRD)
+void LAPACK_chptrd_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
     float* D,
     float* E,
     lapack_complex_float* tau,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chptrd(...) LAPACK_chptrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chptrd(...) LAPACK_chptrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhptrd LAPACK_GLOBAL(zhptrd,ZHPTRD)
-void LAPACK_zhptrd(
+#define LAPACK_zhptrd_base LAPACK_GLOBAL(zhptrd,ZHPTRD)
+void LAPACK_zhptrd_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
     double* D,
     double* E,
     lapack_complex_double* tau,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhptrd(...) LAPACK_zhptrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhptrd(...) LAPACK_zhptrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chptrf LAPACK_GLOBAL(chptrf,CHPTRF)
-void LAPACK_chptrf(
+#define LAPACK_chptrf_base LAPACK_GLOBAL(chptrf,CHPTRF)
+void LAPACK_chptrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP, lapack_int* ipiv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chptrf(...) LAPACK_chptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chptrf(...) LAPACK_chptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhptrf LAPACK_GLOBAL(zhptrf,ZHPTRF)
-void LAPACK_zhptrf(
+#define LAPACK_zhptrf_base LAPACK_GLOBAL(zhptrf,ZHPTRF)
+void LAPACK_zhptrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP, lapack_int* ipiv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhptrf(...) LAPACK_zhptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhptrf(...) LAPACK_zhptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chptri LAPACK_GLOBAL(chptri,CHPTRI)
-void LAPACK_chptri(
+#define LAPACK_chptri_base LAPACK_GLOBAL(chptri,CHPTRI)
+void LAPACK_chptri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP, lapack_int const* ipiv,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chptri(...) LAPACK_chptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chptri(...) LAPACK_chptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhptri LAPACK_GLOBAL(zhptri,ZHPTRI)
-void LAPACK_zhptri(
+#define LAPACK_zhptri_base LAPACK_GLOBAL(zhptri,ZHPTRI)
+void LAPACK_zhptri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP, lapack_int const* ipiv,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhptri(...) LAPACK_zhptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhptri(...) LAPACK_zhptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chptrs LAPACK_GLOBAL(chptrs,CHPTRS)
-void LAPACK_chptrs(
+#define LAPACK_chptrs_base LAPACK_GLOBAL(chptrs,CHPTRS)
+void LAPACK_chptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chptrs(...) LAPACK_chptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_chptrs(...) LAPACK_chptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhptrs LAPACK_GLOBAL(zhptrs,ZHPTRS)
-void LAPACK_zhptrs(
+#define LAPACK_zhptrs_base LAPACK_GLOBAL(zhptrs,ZHPTRS)
+void LAPACK_zhptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhptrs(...) LAPACK_zhptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zhptrs(...) LAPACK_zhptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chsein LAPACK_GLOBAL(chsein,CHSEIN)
-void LAPACK_chsein(
+#define LAPACK_chsein_base LAPACK_GLOBAL(chsein,CHSEIN)
+void LAPACK_chsein_base(
     char const* side, char const* eigsrc, char const* initv,
     lapack_logical const* select,
     lapack_int const* n,
@@ -5889,10 +9040,19 @@ void LAPACK_chsein(
     lapack_complex_float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_float* work,
     float* rwork, lapack_int* IFAILL, lapack_int* IFAILR,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chsein(...) LAPACK_chsein_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_chsein(...) LAPACK_chsein_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dhsein LAPACK_GLOBAL(dhsein,DHSEIN)
-void LAPACK_dhsein(
+#define LAPACK_dhsein_base LAPACK_GLOBAL(dhsein,DHSEIN)
+void LAPACK_dhsein_base(
     char const* side, char const* eigsrc, char const* initv,
     lapack_logical* select,
     lapack_int const* n,
@@ -5902,10 +9062,19 @@ void LAPACK_dhsein(
     double* VL, lapack_int const* ldvl,
     double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     double* work, lapack_int* IFAILL, lapack_int* IFAILR,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dhsein(...) LAPACK_dhsein_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dhsein(...) LAPACK_dhsein_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_shsein LAPACK_GLOBAL(shsein,SHSEIN)
-void LAPACK_shsein(
+#define LAPACK_shsein_base LAPACK_GLOBAL(shsein,SHSEIN)
+void LAPACK_shsein_base(
     char const* side, char const* eigsrc, char const* initv,
     lapack_logical* select,
     lapack_int const* n,
@@ -5915,10 +9084,19 @@ void LAPACK_shsein(
     float* VL, lapack_int const* ldvl,
     float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     float* work, lapack_int* IFAILL, lapack_int* IFAILR,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_shsein(...) LAPACK_shsein_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_shsein(...) LAPACK_shsein_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhsein LAPACK_GLOBAL(zhsein,ZHSEIN)
-void LAPACK_zhsein(
+#define LAPACK_zhsein_base LAPACK_GLOBAL(zhsein,ZHSEIN)
+void LAPACK_zhsein_base(
     char const* side, char const* eigsrc, char const* initv,
     lapack_logical const* select,
     lapack_int const* n,
@@ -5928,20 +9106,38 @@ void LAPACK_zhsein(
     lapack_complex_double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_double* work,
     double* rwork, lapack_int* IFAILL, lapack_int* IFAILR,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhsein(...) LAPACK_zhsein_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zhsein(...) LAPACK_zhsein_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_chseqr LAPACK_GLOBAL(chseqr,CHSEQR)
-void LAPACK_chseqr(
+#define LAPACK_chseqr_base LAPACK_GLOBAL(chseqr,CHSEQR)
+void LAPACK_chseqr_base(
     char const* job, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_float* H, lapack_int const* ldh,
     lapack_complex_float* W,
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_chseqr(...) LAPACK_chseqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_chseqr(...) LAPACK_chseqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dhseqr LAPACK_GLOBAL(dhseqr,DHSEQR)
-void LAPACK_dhseqr(
+#define LAPACK_dhseqr_base LAPACK_GLOBAL(dhseqr,DHSEQR)
+void LAPACK_dhseqr_base(
     char const* job, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double* H, lapack_int const* ldh,
@@ -5949,10 +9145,19 @@ void LAPACK_dhseqr(
     double* WI,
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dhseqr(...) LAPACK_dhseqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dhseqr(...) LAPACK_dhseqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_shseqr LAPACK_GLOBAL(shseqr,SHSEQR)
-void LAPACK_shseqr(
+#define LAPACK_shseqr_base LAPACK_GLOBAL(shseqr,SHSEQR)
+void LAPACK_shseqr_base(
     char const* job, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float* H, lapack_int const* ldh,
@@ -5960,17 +9165,35 @@ void LAPACK_shseqr(
     float* WI,
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_shseqr(...) LAPACK_shseqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_shseqr(...) LAPACK_shseqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zhseqr LAPACK_GLOBAL(zhseqr,ZHSEQR)
-void LAPACK_zhseqr(
+#define LAPACK_zhseqr_base LAPACK_GLOBAL(zhseqr,ZHSEQR)
+void LAPACK_zhseqr_base(
     char const* job, char const* compz,
     lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_double* H, lapack_int const* ldh,
     lapack_complex_double* W,
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zhseqr(...) LAPACK_zhseqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zhseqr(...) LAPACK_zhseqr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_clacgv LAPACK_GLOBAL(clacgv,CLACGV)
 void LAPACK_clacgv(
@@ -6010,47 +9233,101 @@ void LAPACK_zlacn2(
     lapack_complex_double* X,
     double* est, lapack_int* kase, lapack_int* ISAVE );
 
-#define LAPACK_clacp2 LAPACK_GLOBAL(clacp2,CLACP2)
-void LAPACK_clacp2(
+#define LAPACK_clacp2_base LAPACK_GLOBAL(clacp2,CLACP2)
+void LAPACK_clacp2_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     float const* A, lapack_int const* lda,
-    lapack_complex_float* B, lapack_int const* ldb );
+    lapack_complex_float* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clacp2(...) LAPACK_clacp2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clacp2(...) LAPACK_clacp2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlacp2 LAPACK_GLOBAL(zlacp2,ZLACP2)
-void LAPACK_zlacp2(
+#define LAPACK_zlacp2_base LAPACK_GLOBAL(zlacp2,ZLACP2)
+void LAPACK_zlacp2_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     double const* A, lapack_int const* lda,
-    lapack_complex_double* B, lapack_int const* ldb );
+    lapack_complex_double* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlacp2(...) LAPACK_zlacp2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlacp2(...) LAPACK_zlacp2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clacpy LAPACK_GLOBAL(clacpy,CLACPY)
-void LAPACK_clacpy(
+#define LAPACK_clacpy_base LAPACK_GLOBAL(clacpy,CLACPY)
+void LAPACK_clacpy_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
-    lapack_complex_float* B, lapack_int const* ldb );
+    lapack_complex_float* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clacpy(...) LAPACK_clacpy_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clacpy(...) LAPACK_clacpy_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlacpy LAPACK_GLOBAL(dlacpy,DLACPY)
-void LAPACK_dlacpy(
+#define LAPACK_dlacpy_base LAPACK_GLOBAL(dlacpy,DLACPY)
+void LAPACK_dlacpy_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     double const* A, lapack_int const* lda,
-    double* B, lapack_int const* ldb );
+    double* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlacpy(...) LAPACK_dlacpy_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlacpy(...) LAPACK_dlacpy_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slacpy LAPACK_GLOBAL(slacpy,SLACPY)
-void LAPACK_slacpy(
+#define LAPACK_slacpy_base LAPACK_GLOBAL(slacpy,SLACPY)
+void LAPACK_slacpy_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     float const* A, lapack_int const* lda,
-    float* B, lapack_int const* ldb );
+    float* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slacpy(...) LAPACK_slacpy_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slacpy(...) LAPACK_slacpy_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlacpy LAPACK_GLOBAL(zlacpy,ZLACPY)
-void LAPACK_zlacpy(
+#define LAPACK_zlacpy_base LAPACK_GLOBAL(zlacpy,ZLACPY)
+void LAPACK_zlacpy_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
-    lapack_complex_double* B, lapack_int const* ldb );
+    lapack_complex_double* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlacpy(...) LAPACK_zlacpy_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlacpy(...) LAPACK_zlacpy_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_clacrm LAPACK_GLOBAL(clacrm,CLACRM)
 void LAPACK_clacrm(
@@ -6176,367 +9453,835 @@ void LAPACK_zlagsy(
     lapack_complex_double* work,
     lapack_int* info );
 
-#define LAPACK_dlamch LAPACK_GLOBAL(dlamch,DLAMCH)
-double LAPACK_dlamch(
-    char const* cmach );
+#define LAPACK_dlamch_base LAPACK_GLOBAL(dlamch,DLAMCH)
+double LAPACK_dlamch_base(
+    char const* cmach
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlamch(...) LAPACK_dlamch_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlamch(...) LAPACK_dlamch_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slamch LAPACK_GLOBAL(slamch,SLAMCH)
-lapack_float_return LAPACK_slamch(
-    char const* cmach );
+#define LAPACK_slamch_base LAPACK_GLOBAL(slamch,SLAMCH)
+lapack_float_return LAPACK_slamch_base(
+    char const* cmach
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slamch(...) LAPACK_slamch_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slamch(...) LAPACK_slamch_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clangb LAPACK_GLOBAL(clangb,CLANGB)
-lapack_float_return LAPACK_clangb(
+#define LAPACK_clangb_base LAPACK_GLOBAL(clangb,CLANGB)
+lapack_float_return LAPACK_clangb_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     lapack_complex_float const* AB, lapack_int const* ldab,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clangb(...) LAPACK_clangb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clangb(...) LAPACK_clangb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlangb LAPACK_GLOBAL(dlangb,DLANGB)
-double LAPACK_dlangb(
+#define LAPACK_dlangb_base LAPACK_GLOBAL(dlangb,DLANGB)
+double LAPACK_dlangb_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     double const* AB, lapack_int const* ldab,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlangb(...) LAPACK_dlangb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlangb(...) LAPACK_dlangb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slangb LAPACK_GLOBAL(slangb,SLANGB)
-lapack_float_return LAPACK_slangb(
+#define LAPACK_slangb_base LAPACK_GLOBAL(slangb,SLANGB)
+lapack_float_return LAPACK_slangb_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     float const* AB, lapack_int const* ldab,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slangb(...) LAPACK_slangb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slangb(...) LAPACK_slangb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlangb LAPACK_GLOBAL(zlangb,ZLANGB)
-double LAPACK_zlangb(
+#define LAPACK_zlangb_base LAPACK_GLOBAL(zlangb,ZLANGB)
+double LAPACK_zlangb_base(
     char const* norm,
     lapack_int const* n, lapack_int const* kl, lapack_int const* ku,
     lapack_complex_double const* AB, lapack_int const* ldab,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlangb(...) LAPACK_zlangb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlangb(...) LAPACK_zlangb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clange LAPACK_GLOBAL(clange,CLANGE)
-lapack_float_return LAPACK_clange(
+#define LAPACK_clange_base LAPACK_GLOBAL(clange,CLANGE)
+lapack_float_return LAPACK_clange_base(
     char const* norm,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clange(...) LAPACK_clange_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clange(...) LAPACK_clange_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlange LAPACK_GLOBAL(dlange,DLANGE)
-double LAPACK_dlange(
+#define LAPACK_dlange_base LAPACK_GLOBAL(dlange,DLANGE)
+double LAPACK_dlange_base(
     char const* norm,
     lapack_int const* m, lapack_int const* n,
     double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlange(...) LAPACK_dlange_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlange(...) LAPACK_dlange_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slange LAPACK_GLOBAL(slange,SLANGE)
-lapack_float_return LAPACK_slange(
+#define LAPACK_slange_base LAPACK_GLOBAL(slange,SLANGE)
+lapack_float_return LAPACK_slange_base(
     char const* norm,
     lapack_int const* m, lapack_int const* n,
     float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slange(...) LAPACK_slange_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slange(...) LAPACK_slange_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlange LAPACK_GLOBAL(zlange,ZLANGE)
-double LAPACK_zlange(
+#define LAPACK_zlange_base LAPACK_GLOBAL(zlange,ZLANGE)
+double LAPACK_zlange_base(
     char const* norm,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlange(...) LAPACK_zlange_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlange(...) LAPACK_zlange_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clangt LAPACK_GLOBAL(clangt,CLANGT)
-lapack_float_return LAPACK_clangt(
+#define LAPACK_clangt_base LAPACK_GLOBAL(clangt,CLANGT)
+lapack_float_return LAPACK_clangt_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_float const* DL,
     lapack_complex_float const* D,
-    lapack_complex_float const* DU );
+    lapack_complex_float const* DU
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clangt(...) LAPACK_clangt_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clangt(...) LAPACK_clangt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlangt LAPACK_GLOBAL(dlangt,DLANGT)
-double LAPACK_dlangt(
+#define LAPACK_dlangt_base LAPACK_GLOBAL(dlangt,DLANGT)
+double LAPACK_dlangt_base(
     char const* norm,
     lapack_int const* n,
     double const* DL,
     double const* D,
-    double const* DU );
+    double const* DU
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlangt(...) LAPACK_dlangt_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlangt(...) LAPACK_dlangt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slangt LAPACK_GLOBAL(slangt,SLANGT)
-lapack_float_return LAPACK_slangt(
+#define LAPACK_slangt_base LAPACK_GLOBAL(slangt,SLANGT)
+lapack_float_return LAPACK_slangt_base(
     char const* norm,
     lapack_int const* n,
     float const* DL,
     float const* D,
-    float const* DU );
+    float const* DU
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slangt(...) LAPACK_slangt_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slangt(...) LAPACK_slangt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlangt LAPACK_GLOBAL(zlangt,ZLANGT)
-double LAPACK_zlangt(
+#define LAPACK_zlangt_base LAPACK_GLOBAL(zlangt,ZLANGT)
+double LAPACK_zlangt_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_double const* DL,
     lapack_complex_double const* D,
-    lapack_complex_double const* DU );
+    lapack_complex_double const* DU
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlangt(...) LAPACK_zlangt_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlangt(...) LAPACK_zlangt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clanhb LAPACK_GLOBAL(clanhb,CLANHB)
-lapack_float_return LAPACK_clanhb(
+#define LAPACK_clanhb_base LAPACK_GLOBAL(clanhb,CLANHB)
+lapack_float_return LAPACK_clanhb_base(
     char const* norm, char const* uplo,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* AB, lapack_int const* ldab,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clanhb(...) LAPACK_clanhb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_clanhb(...) LAPACK_clanhb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlanhb LAPACK_GLOBAL(zlanhb,ZLANHB)
-double LAPACK_zlanhb(
+#define LAPACK_zlanhb_base LAPACK_GLOBAL(zlanhb,ZLANHB)
+double LAPACK_zlanhb_base(
     char const* norm, char const* uplo,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* AB, lapack_int const* ldab,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlanhb(...) LAPACK_zlanhb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zlanhb(...) LAPACK_zlanhb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clanhe LAPACK_GLOBAL(clanhe,CLANHE)
-lapack_float_return LAPACK_clanhe(
+#define LAPACK_clanhe_base LAPACK_GLOBAL(clanhe,CLANHE)
+lapack_float_return LAPACK_clanhe_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clanhe(...) LAPACK_clanhe_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_clanhe(...) LAPACK_clanhe_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlanhe LAPACK_GLOBAL(zlanhe,ZLANHE)
-double LAPACK_zlanhe(
+#define LAPACK_zlanhe_base LAPACK_GLOBAL(zlanhe,ZLANHE)
+double LAPACK_zlanhe_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlanhe(...) LAPACK_zlanhe_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zlanhe(...) LAPACK_zlanhe_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clanhp LAPACK_GLOBAL(clanhp,CLANHP)
-lapack_float_return LAPACK_clanhp(
+#define LAPACK_clanhp_base LAPACK_GLOBAL(clanhp,CLANHP)
+lapack_float_return LAPACK_clanhp_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clanhp(...) LAPACK_clanhp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_clanhp(...) LAPACK_clanhp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlanhp LAPACK_GLOBAL(zlanhp,ZLANHP)
-double LAPACK_zlanhp(
+#define LAPACK_zlanhp_base LAPACK_GLOBAL(zlanhp,ZLANHP)
+double LAPACK_zlanhp_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlanhp(...) LAPACK_zlanhp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zlanhp(...) LAPACK_zlanhp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clanhs LAPACK_GLOBAL(clanhs,CLANHS)
-lapack_float_return LAPACK_clanhs(
+#define LAPACK_clanhs_base LAPACK_GLOBAL(clanhs,CLANHS)
+lapack_float_return LAPACK_clanhs_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clanhs(...) LAPACK_clanhs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clanhs(...) LAPACK_clanhs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlanhs LAPACK_GLOBAL(dlanhs,DLANHS)
-double LAPACK_dlanhs(
+#define LAPACK_dlanhs_base LAPACK_GLOBAL(dlanhs,DLANHS)
+double LAPACK_dlanhs_base(
     char const* norm,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlanhs(...) LAPACK_dlanhs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlanhs(...) LAPACK_dlanhs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slanhs LAPACK_GLOBAL(slanhs,SLANHS)
-lapack_float_return LAPACK_slanhs(
+#define LAPACK_slanhs_base LAPACK_GLOBAL(slanhs,SLANHS)
+lapack_float_return LAPACK_slanhs_base(
     char const* norm,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slanhs(...) LAPACK_slanhs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slanhs(...) LAPACK_slanhs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlanhs LAPACK_GLOBAL(zlanhs,ZLANHS)
-double LAPACK_zlanhs(
+#define LAPACK_zlanhs_base LAPACK_GLOBAL(zlanhs,ZLANHS)
+double LAPACK_zlanhs_base(
     char const* norm,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlanhs(...) LAPACK_zlanhs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlanhs(...) LAPACK_zlanhs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clanht LAPACK_GLOBAL(clanht,CLANHT)
-lapack_float_return LAPACK_clanht(
+#define LAPACK_clanht_base LAPACK_GLOBAL(clanht,CLANHT)
+lapack_float_return LAPACK_clanht_base(
     char const* norm,
     lapack_int const* n,
     float const* D,
-    lapack_complex_float const* E );
+    lapack_complex_float const* E
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clanht(...) LAPACK_clanht_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clanht(...) LAPACK_clanht_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlanht LAPACK_GLOBAL(zlanht,ZLANHT)
-double LAPACK_zlanht(
+#define LAPACK_zlanht_base LAPACK_GLOBAL(zlanht,ZLANHT)
+double LAPACK_zlanht_base(
     char const* norm,
     lapack_int const* n,
     double const* D,
-    lapack_complex_double const* E );
+    lapack_complex_double const* E
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlanht(...) LAPACK_zlanht_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlanht(...) LAPACK_zlanht_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clansb LAPACK_GLOBAL(clansb,CLANSB)
-lapack_float_return LAPACK_clansb(
+#define LAPACK_clansb_base LAPACK_GLOBAL(clansb,CLANSB)
+lapack_float_return LAPACK_clansb_base(
     char const* norm, char const* uplo,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* AB, lapack_int const* ldab,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clansb(...) LAPACK_clansb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_clansb(...) LAPACK_clansb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlansb LAPACK_GLOBAL(dlansb,DLANSB)
-double LAPACK_dlansb(
+#define LAPACK_dlansb_base LAPACK_GLOBAL(dlansb,DLANSB)
+double LAPACK_dlansb_base(
     char const* norm, char const* uplo,
     lapack_int const* n, lapack_int const* k,
     double const* AB, lapack_int const* ldab,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlansb(...) LAPACK_dlansb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dlansb(...) LAPACK_dlansb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slansb LAPACK_GLOBAL(slansb,SLANSB)
-lapack_float_return LAPACK_slansb(
+#define LAPACK_slansb_base LAPACK_GLOBAL(slansb,SLANSB)
+lapack_float_return LAPACK_slansb_base(
     char const* norm, char const* uplo,
     lapack_int const* n, lapack_int const* k,
     float const* AB, lapack_int const* ldab,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slansb(...) LAPACK_slansb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_slansb(...) LAPACK_slansb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlansb LAPACK_GLOBAL(zlansb,ZLANSB)
-double LAPACK_zlansb(
+#define LAPACK_zlansb_base LAPACK_GLOBAL(zlansb,ZLANSB)
+double LAPACK_zlansb_base(
     char const* norm, char const* uplo,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* AB, lapack_int const* ldab,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlansb(...) LAPACK_zlansb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zlansb(...) LAPACK_zlansb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clansp LAPACK_GLOBAL(clansp,CLANSP)
-lapack_float_return LAPACK_clansp(
+#define LAPACK_clansp_base LAPACK_GLOBAL(clansp,CLANSP)
+lapack_float_return LAPACK_clansp_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clansp(...) LAPACK_clansp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_clansp(...) LAPACK_clansp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlansp LAPACK_GLOBAL(dlansp,DLANSP)
-double LAPACK_dlansp(
+#define LAPACK_dlansp_base LAPACK_GLOBAL(dlansp,DLANSP)
+double LAPACK_dlansp_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     double const* AP,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlansp(...) LAPACK_dlansp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dlansp(...) LAPACK_dlansp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slansp LAPACK_GLOBAL(slansp,SLANSP)
-lapack_float_return LAPACK_slansp(
+#define LAPACK_slansp_base LAPACK_GLOBAL(slansp,SLANSP)
+lapack_float_return LAPACK_slansp_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     float const* AP,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slansp(...) LAPACK_slansp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_slansp(...) LAPACK_slansp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlansp LAPACK_GLOBAL(zlansp,ZLANSP)
-double LAPACK_zlansp(
+#define LAPACK_zlansp_base LAPACK_GLOBAL(zlansp,ZLANSP)
+double LAPACK_zlansp_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlansp(...) LAPACK_zlansp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zlansp(...) LAPACK_zlansp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlanst LAPACK_GLOBAL(dlanst,DLANST)
-double LAPACK_dlanst(
+#define LAPACK_dlanst_base LAPACK_GLOBAL(dlanst,DLANST)
+double LAPACK_dlanst_base(
     char const* norm,
     lapack_int const* n,
     double const* D,
-    double const* E );
+    double const* E
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlanst(...) LAPACK_dlanst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlanst(...) LAPACK_dlanst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slanst LAPACK_GLOBAL(slanst,SLANST)
-lapack_float_return LAPACK_slanst(
+#define LAPACK_slanst_base LAPACK_GLOBAL(slanst,SLANST)
+lapack_float_return LAPACK_slanst_base(
     char const* norm,
     lapack_int const* n,
     float const* D,
-    float const* E );
+    float const* E
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slanst(...) LAPACK_slanst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slanst(...) LAPACK_slanst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clansy LAPACK_GLOBAL(clansy,CLANSY)
-lapack_float_return LAPACK_clansy(
+#define LAPACK_clansy_base LAPACK_GLOBAL(clansy,CLANSY)
+lapack_float_return LAPACK_clansy_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clansy(...) LAPACK_clansy_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_clansy(...) LAPACK_clansy_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlansy LAPACK_GLOBAL(dlansy,DLANSY)
-double LAPACK_dlansy(
+#define LAPACK_dlansy_base LAPACK_GLOBAL(dlansy,DLANSY)
+double LAPACK_dlansy_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlansy(...) LAPACK_dlansy_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dlansy(...) LAPACK_dlansy_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slansy LAPACK_GLOBAL(slansy,SLANSY)
-lapack_float_return LAPACK_slansy(
+#define LAPACK_slansy_base LAPACK_GLOBAL(slansy,SLANSY)
+lapack_float_return LAPACK_slansy_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slansy(...) LAPACK_slansy_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_slansy(...) LAPACK_slansy_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlansy LAPACK_GLOBAL(zlansy,ZLANSY)
-double LAPACK_zlansy(
+#define LAPACK_zlansy_base LAPACK_GLOBAL(zlansy,ZLANSY)
+double LAPACK_zlansy_base(
     char const* norm, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlansy(...) LAPACK_zlansy_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zlansy(...) LAPACK_zlansy_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clantb LAPACK_GLOBAL(clantb,CLANTB)
-lapack_float_return LAPACK_clantb(
+#define LAPACK_clantb_base LAPACK_GLOBAL(clantb,CLANTB)
+lapack_float_return LAPACK_clantb_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* AB, lapack_int const* ldab,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clantb(...) LAPACK_clantb_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_clantb(...) LAPACK_clantb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlantb LAPACK_GLOBAL(dlantb,DLANTB)
-double LAPACK_dlantb(
+#define LAPACK_dlantb_base LAPACK_GLOBAL(dlantb,DLANTB)
+double LAPACK_dlantb_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* k,
     double const* AB, lapack_int const* ldab,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlantb(...) LAPACK_dlantb_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dlantb(...) LAPACK_dlantb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slantb LAPACK_GLOBAL(slantb,SLANTB)
-lapack_float_return LAPACK_slantb(
+#define LAPACK_slantb_base LAPACK_GLOBAL(slantb,SLANTB)
+lapack_float_return LAPACK_slantb_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* k,
     float const* AB, lapack_int const* ldab,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slantb(...) LAPACK_slantb_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_slantb(...) LAPACK_slantb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlantb LAPACK_GLOBAL(zlantb,ZLANTB)
-double LAPACK_zlantb(
+#define LAPACK_zlantb_base LAPACK_GLOBAL(zlantb,ZLANTB)
+double LAPACK_zlantb_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* AB, lapack_int const* ldab,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlantb(...) LAPACK_zlantb_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zlantb(...) LAPACK_zlantb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clantp LAPACK_GLOBAL(clantp,CLANTP)
-lapack_float_return LAPACK_clantp(
+#define LAPACK_clantp_base LAPACK_GLOBAL(clantp,CLANTP)
+lapack_float_return LAPACK_clantp_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_float const* AP,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clantp(...) LAPACK_clantp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_clantp(...) LAPACK_clantp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlantp LAPACK_GLOBAL(dlantp,DLANTP)
-double LAPACK_dlantp(
+#define LAPACK_dlantp_base LAPACK_GLOBAL(dlantp,DLANTP)
+double LAPACK_dlantp_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     double const* AP,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlantp(...) LAPACK_dlantp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dlantp(...) LAPACK_dlantp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slantp LAPACK_GLOBAL(slantp,SLANTP)
-lapack_float_return LAPACK_slantp(
+#define LAPACK_slantp_base LAPACK_GLOBAL(slantp,SLANTP)
+lapack_float_return LAPACK_slantp_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     float const* AP,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slantp(...) LAPACK_slantp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_slantp(...) LAPACK_slantp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlantp LAPACK_GLOBAL(zlantp,ZLANTP)
-double LAPACK_zlantp(
+#define LAPACK_zlantp_base LAPACK_GLOBAL(zlantp,ZLANTP)
+double LAPACK_zlantp_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_double const* AP,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlantp(...) LAPACK_zlantp_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zlantp(...) LAPACK_zlantp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clantr LAPACK_GLOBAL(clantr,CLANTR)
-lapack_float_return LAPACK_clantr(
+#define LAPACK_clantr_base LAPACK_GLOBAL(clantr,CLANTR)
+lapack_float_return LAPACK_clantr_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clantr(...) LAPACK_clantr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_clantr(...) LAPACK_clantr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlantr LAPACK_GLOBAL(dlantr,DLANTR)
-double LAPACK_dlantr(
+#define LAPACK_dlantr_base LAPACK_GLOBAL(dlantr,DLANTR)
+double LAPACK_dlantr_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* m, lapack_int const* n,
     double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlantr(...) LAPACK_dlantr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dlantr(...) LAPACK_dlantr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slantr LAPACK_GLOBAL(slantr,SLANTR)
-lapack_float_return LAPACK_slantr(
+#define LAPACK_slantr_base LAPACK_GLOBAL(slantr,SLANTR)
+lapack_float_return LAPACK_slantr_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* m, lapack_int const* n,
     float const* A, lapack_int const* lda,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slantr(...) LAPACK_slantr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_slantr(...) LAPACK_slantr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlantr LAPACK_GLOBAL(zlantr,ZLANTR)
-double LAPACK_zlantr(
+#define LAPACK_zlantr_base LAPACK_GLOBAL(zlantr,ZLANTR)
+double LAPACK_zlantr_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlantr(...) LAPACK_zlantr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zlantr(...) LAPACK_zlantr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_clapmr LAPACK_GLOBAL(clapmr,CLAPMR)
 void LAPACK_clapmr(
@@ -6616,77 +10361,149 @@ void LAPACK_zlarcm(
     lapack_complex_double* C, lapack_int const* ldc,
     double* rwork );
 
-#define LAPACK_clarf LAPACK_GLOBAL(clarf,CLARF)
-void LAPACK_clarf(
+#define LAPACK_clarf_base LAPACK_GLOBAL(clarf,CLARF)
+void LAPACK_clarf_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* V, lapack_int const* incv,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
-    lapack_complex_float* work );
+    lapack_complex_float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clarf(...) LAPACK_clarf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clarf(...) LAPACK_clarf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlarf LAPACK_GLOBAL(dlarf,DLARF)
-void LAPACK_dlarf(
+#define LAPACK_dlarf_base LAPACK_GLOBAL(dlarf,DLARF)
+void LAPACK_dlarf_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     double const* V, lapack_int const* incv,
     double const* tau,
     double* C, lapack_int const* ldc,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlarf(...) LAPACK_dlarf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlarf(...) LAPACK_dlarf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slarf LAPACK_GLOBAL(slarf,SLARF)
-void LAPACK_slarf(
+#define LAPACK_slarf_base LAPACK_GLOBAL(slarf,SLARF)
+void LAPACK_slarf_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     float const* V, lapack_int const* incv,
     float const* tau,
     float* C, lapack_int const* ldc,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slarf(...) LAPACK_slarf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slarf(...) LAPACK_slarf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlarf LAPACK_GLOBAL(zlarf,ZLARF)
-void LAPACK_zlarf(
+#define LAPACK_zlarf_base LAPACK_GLOBAL(zlarf,ZLARF)
+void LAPACK_zlarf_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* V, lapack_int const* incv,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
-    lapack_complex_double* work );
+    lapack_complex_double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlarf(...) LAPACK_zlarf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlarf(...) LAPACK_zlarf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clarfb LAPACK_GLOBAL(clarfb,CLARFB)
-void LAPACK_clarfb(
+#define LAPACK_clarfb_base LAPACK_GLOBAL(clarfb,CLARFB)
+void LAPACK_clarfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* V, lapack_int const* ldv,
     lapack_complex_float const* T, lapack_int const* ldt,
     lapack_complex_float* C, lapack_int const* ldc,
-    lapack_complex_float* work, lapack_int const* ldwork );
+    lapack_complex_float* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clarfb(...) LAPACK_clarfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_clarfb(...) LAPACK_clarfb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlarfb LAPACK_GLOBAL(dlarfb,DLARFB)
-void LAPACK_dlarfb(
+#define LAPACK_dlarfb_base LAPACK_GLOBAL(dlarfb,DLARFB)
+void LAPACK_dlarfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* V, lapack_int const* ldv,
     double const* T, lapack_int const* ldt,
     double* C, lapack_int const* ldc,
-    double* work, lapack_int const* ldwork );
+    double* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlarfb(...) LAPACK_dlarfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_dlarfb(...) LAPACK_dlarfb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slarfb LAPACK_GLOBAL(slarfb,SLARFB)
-void LAPACK_slarfb(
+#define LAPACK_slarfb_base LAPACK_GLOBAL(slarfb,SLARFB)
+void LAPACK_slarfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* V, lapack_int const* ldv,
     float const* T, lapack_int const* ldt,
     float* C, lapack_int const* ldc,
-    float* work, lapack_int const* ldwork );
+    float* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slarfb(...) LAPACK_slarfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_slarfb(...) LAPACK_slarfb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlarfb LAPACK_GLOBAL(zlarfb,ZLARFB)
-void LAPACK_zlarfb(
+#define LAPACK_zlarfb_base LAPACK_GLOBAL(zlarfb,ZLARFB)
+void LAPACK_zlarfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* V, lapack_int const* ldv,
     lapack_complex_double const* T, lapack_int const* ldt,
     lapack_complex_double* C, lapack_int const* ldc,
-    lapack_complex_double* work, lapack_int const* ldwork );
+    lapack_complex_double* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlarfb(...) LAPACK_zlarfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_zlarfb(...) LAPACK_zlarfb_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_clarfg LAPACK_GLOBAL(clarfg,CLARFG)
 void LAPACK_clarfg(
@@ -6716,73 +10533,145 @@ void LAPACK_zlarfg(
     lapack_complex_double* X, lapack_int const* incx,
     lapack_complex_double* tau );
 
-#define LAPACK_clarft LAPACK_GLOBAL(clarft,CLARFT)
-void LAPACK_clarft(
+#define LAPACK_clarft_base LAPACK_GLOBAL(clarft,CLARFT)
+void LAPACK_clarft_base(
     char const* direct, char const* storev,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* V, lapack_int const* ldv,
     lapack_complex_float const* tau,
-    lapack_complex_float* T, lapack_int const* ldt );
+    lapack_complex_float* T, lapack_int const* ldt
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clarft(...) LAPACK_clarft_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_clarft(...) LAPACK_clarft_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlarft LAPACK_GLOBAL(dlarft,DLARFT)
-void LAPACK_dlarft(
+#define LAPACK_dlarft_base LAPACK_GLOBAL(dlarft,DLARFT)
+void LAPACK_dlarft_base(
     char const* direct, char const* storev,
     lapack_int const* n, lapack_int const* k,
     double const* V, lapack_int const* ldv,
     double const* tau,
-    double* T, lapack_int const* ldt );
+    double* T, lapack_int const* ldt
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlarft(...) LAPACK_dlarft_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dlarft(...) LAPACK_dlarft_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slarft LAPACK_GLOBAL(slarft,SLARFT)
-void LAPACK_slarft(
+#define LAPACK_slarft_base LAPACK_GLOBAL(slarft,SLARFT)
+void LAPACK_slarft_base(
     char const* direct, char const* storev,
     lapack_int const* n, lapack_int const* k,
     float const* V, lapack_int const* ldv,
     float const* tau,
-    float* T, lapack_int const* ldt );
+    float* T, lapack_int const* ldt
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slarft(...) LAPACK_slarft_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_slarft(...) LAPACK_slarft_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlarft LAPACK_GLOBAL(zlarft,ZLARFT)
-void LAPACK_zlarft(
+#define LAPACK_zlarft_base LAPACK_GLOBAL(zlarft,ZLARFT)
+void LAPACK_zlarft_base(
     char const* direct, char const* storev,
     lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* V, lapack_int const* ldv,
     lapack_complex_double const* tau,
-    lapack_complex_double* T, lapack_int const* ldt );
+    lapack_complex_double* T, lapack_int const* ldt
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlarft(...) LAPACK_zlarft_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zlarft(...) LAPACK_zlarft_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clarfx LAPACK_GLOBAL(clarfx,CLARFX)
-void LAPACK_clarfx(
+#define LAPACK_clarfx_base LAPACK_GLOBAL(clarfx,CLARFX)
+void LAPACK_clarfx_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* V,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
-    lapack_complex_float* work );
+    lapack_complex_float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clarfx(...) LAPACK_clarfx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clarfx(...) LAPACK_clarfx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlarfx LAPACK_GLOBAL(dlarfx,DLARFX)
-void LAPACK_dlarfx(
+#define LAPACK_dlarfx_base LAPACK_GLOBAL(dlarfx,DLARFX)
+void LAPACK_dlarfx_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     double const* V,
     double const* tau,
     double* C, lapack_int const* ldc,
-    double* work );
+    double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlarfx(...) LAPACK_dlarfx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlarfx(...) LAPACK_dlarfx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slarfx LAPACK_GLOBAL(slarfx,SLARFX)
-void LAPACK_slarfx(
+#define LAPACK_slarfx_base LAPACK_GLOBAL(slarfx,SLARFX)
+void LAPACK_slarfx_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     float const* V,
     float const* tau,
     float* C, lapack_int const* ldc,
-    float* work );
+    float* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slarfx(...) LAPACK_slarfx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slarfx(...) LAPACK_slarfx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlarfx LAPACK_GLOBAL(zlarfx,ZLARFX)
-void LAPACK_zlarfx(
+#define LAPACK_zlarfx_base LAPACK_GLOBAL(zlarfx,ZLARFX)
+void LAPACK_zlarfx_base(
     char const* side,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* V,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
-    lapack_complex_double* work );
+    lapack_complex_double* work
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlarfx(...) LAPACK_zlarfx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlarfx(...) LAPACK_zlarfx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_clarnv LAPACK_GLOBAL(clarnv,CLARNV)
 void LAPACK_clarnv(
@@ -6836,87 +10725,177 @@ void LAPACK_slartgs(
     float* cs,
     float* sn );
 
-#define LAPACK_clascl LAPACK_GLOBAL(clascl,CLASCL)
-void LAPACK_clascl(
+#define LAPACK_clascl_base LAPACK_GLOBAL(clascl,CLASCL)
+void LAPACK_clascl_base(
     char const* type,
     lapack_int const* kl, lapack_int const* ku,
     float const* cfrom,
     float const* cto, lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clascl(...) LAPACK_clascl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clascl(...) LAPACK_clascl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlascl LAPACK_GLOBAL(dlascl,DLASCL)
-void LAPACK_dlascl(
+#define LAPACK_dlascl_base LAPACK_GLOBAL(dlascl,DLASCL)
+void LAPACK_dlascl_base(
     char const* type,
     lapack_int const* kl, lapack_int const* ku,
     double const* cfrom,
     double const* cto, lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlascl(...) LAPACK_dlascl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlascl(...) LAPACK_dlascl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slascl LAPACK_GLOBAL(slascl,SLASCL)
-void LAPACK_slascl(
+#define LAPACK_slascl_base LAPACK_GLOBAL(slascl,SLASCL)
+void LAPACK_slascl_base(
     char const* type,
     lapack_int const* kl, lapack_int const* ku,
     float const* cfrom,
     float const* cto, lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slascl(...) LAPACK_slascl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slascl(...) LAPACK_slascl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlascl LAPACK_GLOBAL(zlascl,ZLASCL)
-void LAPACK_zlascl(
+#define LAPACK_zlascl_base LAPACK_GLOBAL(zlascl,ZLASCL)
+void LAPACK_zlascl_base(
     char const* type,
     lapack_int const* kl, lapack_int const* ku,
     double const* cfrom,
     double const* cto, lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlascl(...) LAPACK_zlascl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlascl(...) LAPACK_zlascl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_claset LAPACK_GLOBAL(claset,CLASET)
-void LAPACK_claset(
+#define LAPACK_claset_base LAPACK_GLOBAL(claset,CLASET)
+void LAPACK_claset_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* alpha,
     lapack_complex_float const* beta,
-    lapack_complex_float* A, lapack_int const* lda );
+    lapack_complex_float* A, lapack_int const* lda
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_claset(...) LAPACK_claset_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_claset(...) LAPACK_claset_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlaset LAPACK_GLOBAL(dlaset,DLASET)
-void LAPACK_dlaset(
+#define LAPACK_dlaset_base LAPACK_GLOBAL(dlaset,DLASET)
+void LAPACK_dlaset_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     double const* alpha,
     double const* beta,
-    double* A, lapack_int const* lda );
+    double* A, lapack_int const* lda
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlaset(...) LAPACK_dlaset_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlaset(...) LAPACK_dlaset_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slaset LAPACK_GLOBAL(slaset,SLASET)
-void LAPACK_slaset(
+#define LAPACK_slaset_base LAPACK_GLOBAL(slaset,SLASET)
+void LAPACK_slaset_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     float const* alpha,
     float const* beta,
-    float* A, lapack_int const* lda );
+    float* A, lapack_int const* lda
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slaset(...) LAPACK_slaset_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slaset(...) LAPACK_slaset_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlaset LAPACK_GLOBAL(zlaset,ZLASET)
-void LAPACK_zlaset(
+#define LAPACK_zlaset_base LAPACK_GLOBAL(zlaset,ZLASET)
+void LAPACK_zlaset_base(
     char const* uplo,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* alpha,
     lapack_complex_double const* beta,
-    lapack_complex_double* A, lapack_int const* lda );
+    lapack_complex_double* A, lapack_int const* lda
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlaset(...) LAPACK_zlaset_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlaset(...) LAPACK_zlaset_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlasrt LAPACK_GLOBAL(dlasrt,DLASRT)
-void LAPACK_dlasrt(
+#define LAPACK_dlasrt_base LAPACK_GLOBAL(dlasrt,DLASRT)
+void LAPACK_dlasrt_base(
     char const* id,
     lapack_int const* n,
     double* D,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlasrt(...) LAPACK_dlasrt_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlasrt(...) LAPACK_dlasrt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slasrt LAPACK_GLOBAL(slasrt,SLASRT)
-void LAPACK_slasrt(
+#define LAPACK_slasrt_base LAPACK_GLOBAL(slasrt,SLASRT)
+void LAPACK_slasrt_base(
     char const* id,
     lapack_int const* n,
     float* D,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slasrt(...) LAPACK_slasrt_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slasrt(...) LAPACK_slasrt_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_classq LAPACK_GLOBAL(classq,CLASSQ)
 void LAPACK_classq(
@@ -6966,8 +10945,8 @@ void LAPACK_zlaswp(
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
 
-#define LAPACK_clatms LAPACK_GLOBAL(clatms,CLATMS)
-void LAPACK_clatms(
+#define LAPACK_clatms_base LAPACK_GLOBAL(clatms,CLATMS)
+void LAPACK_clatms_base(
     lapack_int const* m, lapack_int const* n, char const* dist,
     lapack_int* iseed, char const* sym,
     float* D,
@@ -6977,10 +10956,19 @@ void LAPACK_clatms(
     lapack_complex_float* A,
     lapack_int const* lda,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clatms(...) LAPACK_clatms_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_clatms(...) LAPACK_clatms_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlatms LAPACK_GLOBAL(dlatms,DLATMS)
-void LAPACK_dlatms(
+#define LAPACK_dlatms_base LAPACK_GLOBAL(dlatms,DLATMS)
+void LAPACK_dlatms_base(
     lapack_int const* m, lapack_int const* n, char const* dist,
     lapack_int* iseed, char const* sym,
     double* D,
@@ -6990,10 +10978,19 @@ void LAPACK_dlatms(
     double* A,
     lapack_int const* lda,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlatms(...) LAPACK_dlatms_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dlatms(...) LAPACK_dlatms_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slatms LAPACK_GLOBAL(slatms,SLATMS)
-void LAPACK_slatms(
+#define LAPACK_slatms_base LAPACK_GLOBAL(slatms,SLATMS)
+void LAPACK_slatms_base(
     lapack_int const* m, lapack_int const* n, char const* dist,
     lapack_int* iseed, char const* sym,
     float* D,
@@ -7003,10 +11000,19 @@ void LAPACK_slatms(
     float* A,
     lapack_int const* lda,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slatms(...) LAPACK_slatms_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_slatms(...) LAPACK_slatms_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlatms LAPACK_GLOBAL(zlatms,ZLATMS)
-void LAPACK_zlatms(
+#define LAPACK_zlatms_base LAPACK_GLOBAL(zlatms,ZLATMS)
+void LAPACK_zlatms_base(
     lapack_int const* m, lapack_int const* n, char const* dist,
     lapack_int* iseed, char const* sym,
     double* D,
@@ -7016,82 +11022,163 @@ void LAPACK_zlatms(
     lapack_complex_double* A,
     lapack_int const* lda,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlatms(...) LAPACK_zlatms_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zlatms(...) LAPACK_zlatms_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_clauum LAPACK_GLOBAL(clauum,CLAUUM)
-void LAPACK_clauum(
+#define LAPACK_clauum_base LAPACK_GLOBAL(clauum,CLAUUM)
+void LAPACK_clauum_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_clauum(...) LAPACK_clauum_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_clauum(...) LAPACK_clauum_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dlauum LAPACK_GLOBAL(dlauum,DLAUUM)
-void LAPACK_dlauum(
+#define LAPACK_dlauum_base LAPACK_GLOBAL(dlauum,DLAUUM)
+void LAPACK_dlauum_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dlauum(...) LAPACK_dlauum_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dlauum(...) LAPACK_dlauum_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_slauum LAPACK_GLOBAL(slauum,SLAUUM)
-void LAPACK_slauum(
+#define LAPACK_slauum_base LAPACK_GLOBAL(slauum,SLAUUM)
+void LAPACK_slauum_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_slauum(...) LAPACK_slauum_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_slauum(...) LAPACK_slauum_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zlauum LAPACK_GLOBAL(zlauum,ZLAUUM)
-void LAPACK_zlauum(
+#define LAPACK_zlauum_base LAPACK_GLOBAL(zlauum,ZLAUUM)
+void LAPACK_zlauum_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zlauum(...) LAPACK_zlauum_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zlauum(...) LAPACK_zlauum_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_ilaver LAPACK_GLOBAL(ilaver,ILAVER)
 void LAPACK_ilaver(
     lapack_int* vers_major, lapack_int* vers_minor, lapack_int* vers_patch );
 
-#define LAPACK_dopgtr LAPACK_GLOBAL(dopgtr,DOPGTR)
-void LAPACK_dopgtr(
+#define LAPACK_dopgtr_base LAPACK_GLOBAL(dopgtr,DOPGTR)
+void LAPACK_dopgtr_base(
     char const* uplo,
     lapack_int const* n,
     double const* AP,
     double const* tau,
     double* Q, lapack_int const* ldq,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dopgtr(...) LAPACK_dopgtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dopgtr(...) LAPACK_dopgtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sopgtr LAPACK_GLOBAL(sopgtr,SOPGTR)
-void LAPACK_sopgtr(
+#define LAPACK_sopgtr_base LAPACK_GLOBAL(sopgtr,SOPGTR)
+void LAPACK_sopgtr_base(
     char const* uplo,
     lapack_int const* n,
     float const* AP,
     float const* tau,
     float* Q, lapack_int const* ldq,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sopgtr(...) LAPACK_sopgtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sopgtr(...) LAPACK_sopgtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dopmtr LAPACK_GLOBAL(dopmtr,DOPMTR)
-void LAPACK_dopmtr(
+#define LAPACK_dopmtr_base LAPACK_GLOBAL(dopmtr,DOPMTR)
+void LAPACK_dopmtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     double const* AP,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dopmtr(...) LAPACK_dopmtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dopmtr(...) LAPACK_dopmtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sopmtr LAPACK_GLOBAL(sopmtr,SOPMTR)
-void LAPACK_sopmtr(
+#define LAPACK_sopmtr_base LAPACK_GLOBAL(sopmtr,SOPMTR)
+void LAPACK_sopmtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     float const* AP,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sopmtr(...) LAPACK_sopmtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sopmtr(...) LAPACK_sopmtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dorbdb LAPACK_GLOBAL(dorbdb,DORBDB)
-void LAPACK_dorbdb(
+#define LAPACK_dorbdb_base LAPACK_GLOBAL(dorbdb,DORBDB)
+void LAPACK_dorbdb_base(
     char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     double* X11, lapack_int const* ldx11,
@@ -7105,10 +11192,19 @@ void LAPACK_dorbdb(
     double* TAUQ1,
     double* TAUQ2,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dorbdb(...) LAPACK_dorbdb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dorbdb(...) LAPACK_dorbdb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sorbdb LAPACK_GLOBAL(sorbdb,SORBDB)
-void LAPACK_sorbdb(
+#define LAPACK_sorbdb_base LAPACK_GLOBAL(sorbdb,SORBDB)
+void LAPACK_sorbdb_base(
     char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     float* X11, lapack_int const* ldx11,
@@ -7122,10 +11218,19 @@ void LAPACK_sorbdb(
     float* TAUQ1,
     float* TAUQ2,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sorbdb(...) LAPACK_sorbdb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sorbdb(...) LAPACK_sorbdb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dorcsd LAPACK_GLOBAL(dorcsd,DORCSD)
-void LAPACK_dorcsd(
+#define LAPACK_dorcsd_base LAPACK_GLOBAL(dorcsd,DORCSD)
+void LAPACK_dorcsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     double* X11, lapack_int const* ldx11,
@@ -7139,10 +11244,19 @@ void LAPACK_dorcsd(
     double* V2T, lapack_int const* ldv2t,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dorcsd(...) LAPACK_dorcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_dorcsd(...) LAPACK_dorcsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sorcsd LAPACK_GLOBAL(sorcsd,SORCSD)
-void LAPACK_sorcsd(
+#define LAPACK_sorcsd_base LAPACK_GLOBAL(sorcsd,SORCSD)
+void LAPACK_sorcsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     float* X11, lapack_int const* ldx11,
@@ -7156,10 +11270,19 @@ void LAPACK_sorcsd(
     float* V2T, lapack_int const* ldv2t,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sorcsd(...) LAPACK_sorcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_sorcsd(...) LAPACK_sorcsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dorcsd2by1 LAPACK_GLOBAL(dorcsd2by1,DORCSD2BY1)
-void LAPACK_dorcsd2by1(
+#define LAPACK_dorcsd2by1_base LAPACK_GLOBAL(dorcsd2by1,DORCSD2BY1)
+void LAPACK_dorcsd2by1_base(
     char const* jobu1, char const* jobu2, char const* jobv1t,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     double* X11, lapack_int const* ldx11,
@@ -7170,10 +11293,19 @@ void LAPACK_dorcsd2by1(
     double* V1T, lapack_int const* ldv1t,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dorcsd2by1(...) LAPACK_dorcsd2by1_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dorcsd2by1(...) LAPACK_dorcsd2by1_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sorcsd2by1 LAPACK_GLOBAL(sorcsd2by1,SORCSD2BY1)
-void LAPACK_sorcsd2by1(
+#define LAPACK_sorcsd2by1_base LAPACK_GLOBAL(sorcsd2by1,SORCSD2BY1)
+void LAPACK_sorcsd2by1_base(
     char const* jobu1, char const* jobu2, char const* jobv1t,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     float* X11, lapack_int const* ldx11,
@@ -7184,25 +11316,52 @@ void LAPACK_sorcsd2by1(
     float* V1T, lapack_int const* ldv1t,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sorcsd2by1(...) LAPACK_sorcsd2by1_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sorcsd2by1(...) LAPACK_sorcsd2by1_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dorgbr LAPACK_GLOBAL(dorgbr,DORGBR)
-void LAPACK_dorgbr(
+#define LAPACK_dorgbr_base LAPACK_GLOBAL(dorgbr,DORGBR)
+void LAPACK_dorgbr_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double* A, lapack_int const* lda,
     double const* tau,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dorgbr(...) LAPACK_dorgbr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dorgbr(...) LAPACK_dorgbr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sorgbr LAPACK_GLOBAL(sorgbr,SORGBR)
-void LAPACK_sorgbr(
+#define LAPACK_sorgbr_base LAPACK_GLOBAL(sorgbr,SORGBR)
+void LAPACK_sorgbr_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float* A, lapack_int const* lda,
     float const* tau,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sorgbr(...) LAPACK_sorgbr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sorgbr(...) LAPACK_sorgbr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_dorghr LAPACK_GLOBAL(dorghr,DORGHR)
 void LAPACK_dorghr(
@@ -7284,23 +11443,41 @@ void LAPACK_sorgrq(
     float* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_dorgtr LAPACK_GLOBAL(dorgtr,DORGTR)
-void LAPACK_dorgtr(
+#define LAPACK_dorgtr_base LAPACK_GLOBAL(dorgtr,DORGTR)
+void LAPACK_dorgtr_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double const* tau,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dorgtr(...) LAPACK_dorgtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dorgtr(...) LAPACK_dorgtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sorgtr LAPACK_GLOBAL(sorgtr,SORGTR)
-void LAPACK_sorgtr(
+#define LAPACK_sorgtr_base LAPACK_GLOBAL(sorgtr,SORGTR)
+void LAPACK_sorgtr_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float const* tau,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sorgtr(...) LAPACK_sorgtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sorgtr(...) LAPACK_sorgtr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_dorgtsqr_row LAPACK_GLOBAL(dorgtsqr_row,DORGTSQR_ROW)
 void LAPACK_dorgtsqr_row(
@@ -7320,168 +11497,312 @@ void LAPACK_sorgtsqr_row(
     float* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_dormbr LAPACK_GLOBAL(dormbr,DORMBR)
-void LAPACK_dormbr(
+#define LAPACK_dormbr_base LAPACK_GLOBAL(dormbr,DORMBR)
+void LAPACK_dormbr_base(
     char const* vect, char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormbr(...) LAPACK_dormbr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dormbr(...) LAPACK_dormbr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormbr LAPACK_GLOBAL(sormbr,SORMBR)
-void LAPACK_sormbr(
+#define LAPACK_sormbr_base LAPACK_GLOBAL(sormbr,SORMBR)
+void LAPACK_sormbr_base(
     char const* vect, char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormbr(...) LAPACK_sormbr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sormbr(...) LAPACK_sormbr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dormhr LAPACK_GLOBAL(dormhr,DORMHR)
-void LAPACK_dormhr(
+#define LAPACK_dormhr_base LAPACK_GLOBAL(dormhr,DORMHR)
+void LAPACK_dormhr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormhr(...) LAPACK_dormhr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dormhr(...) LAPACK_dormhr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormhr LAPACK_GLOBAL(sormhr,SORMHR)
-void LAPACK_sormhr(
+#define LAPACK_sormhr_base LAPACK_GLOBAL(sormhr,SORMHR)
+void LAPACK_sormhr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormhr(...) LAPACK_sormhr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sormhr(...) LAPACK_sormhr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dormlq LAPACK_GLOBAL(dormlq,DORMLQ)
-void LAPACK_dormlq(
+#define LAPACK_dormlq_base LAPACK_GLOBAL(dormlq,DORMLQ)
+void LAPACK_dormlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormlq(...) LAPACK_dormlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dormlq(...) LAPACK_dormlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormlq LAPACK_GLOBAL(sormlq,SORMLQ)
-void LAPACK_sormlq(
+#define LAPACK_sormlq_base LAPACK_GLOBAL(sormlq,SORMLQ)
+void LAPACK_sormlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormlq(...) LAPACK_sormlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sormlq(...) LAPACK_sormlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dormql LAPACK_GLOBAL(dormql,DORMQL)
-void LAPACK_dormql(
+#define LAPACK_dormql_base LAPACK_GLOBAL(dormql,DORMQL)
+void LAPACK_dormql_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormql(...) LAPACK_dormql_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dormql(...) LAPACK_dormql_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormql LAPACK_GLOBAL(sormql,SORMQL)
-void LAPACK_sormql(
+#define LAPACK_sormql_base LAPACK_GLOBAL(sormql,SORMQL)
+void LAPACK_sormql_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormql(...) LAPACK_sormql_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sormql(...) LAPACK_sormql_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dormqr LAPACK_GLOBAL(dormqr,DORMQR)
-void LAPACK_dormqr(
+#define LAPACK_dormqr_base LAPACK_GLOBAL(dormqr,DORMQR)
+void LAPACK_dormqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormqr(...) LAPACK_dormqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dormqr(...) LAPACK_dormqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormqr LAPACK_GLOBAL(sormqr,SORMQR)
-void LAPACK_sormqr(
+#define LAPACK_sormqr_base LAPACK_GLOBAL(sormqr,SORMQR)
+void LAPACK_sormqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormqr(...) LAPACK_sormqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sormqr(...) LAPACK_sormqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dormrq LAPACK_GLOBAL(dormrq,DORMRQ)
-void LAPACK_dormrq(
+#define LAPACK_dormrq_base LAPACK_GLOBAL(dormrq,DORMRQ)
+void LAPACK_dormrq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormrq(...) LAPACK_dormrq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dormrq(...) LAPACK_dormrq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormrq LAPACK_GLOBAL(sormrq,SORMRQ)
-void LAPACK_sormrq(
+#define LAPACK_sormrq_base LAPACK_GLOBAL(sormrq,SORMRQ)
+void LAPACK_sormrq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormrq(...) LAPACK_sormrq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sormrq(...) LAPACK_sormrq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dormrz LAPACK_GLOBAL(dormrz,DORMRZ)
-void LAPACK_dormrz(
+#define LAPACK_dormrz_base LAPACK_GLOBAL(dormrz,DORMRZ)
+void LAPACK_dormrz_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormrz(...) LAPACK_dormrz_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dormrz(...) LAPACK_dormrz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormrz LAPACK_GLOBAL(sormrz,SORMRZ)
-void LAPACK_sormrz(
+#define LAPACK_sormrz_base LAPACK_GLOBAL(sormrz,SORMRZ)
+void LAPACK_sormrz_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormrz(...) LAPACK_sormrz_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sormrz(...) LAPACK_sormrz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dormtr LAPACK_GLOBAL(dormtr,DORMTR)
-void LAPACK_dormtr(
+#define LAPACK_dormtr_base LAPACK_GLOBAL(dormtr,DORMTR)
+void LAPACK_dormtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     double const* A, lapack_int const* lda,
     double const* tau,
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dormtr(...) LAPACK_dormtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dormtr(...) LAPACK_dormtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sormtr LAPACK_GLOBAL(sormtr,SORMTR)
-void LAPACK_sormtr(
+#define LAPACK_sormtr_base LAPACK_GLOBAL(sormtr,SORMTR)
+void LAPACK_sormtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     float const* A, lapack_int const* lda,
     float const* tau,
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sormtr(...) LAPACK_sormtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sormtr(...) LAPACK_sormtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbcon LAPACK_GLOBAL(cpbcon,CPBCON)
-void LAPACK_cpbcon(
+#define LAPACK_cpbcon_base LAPACK_GLOBAL(cpbcon,CPBCON)
+void LAPACK_cpbcon_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float const* AB, lapack_int const* ldab,
@@ -7489,10 +11810,19 @@ void LAPACK_cpbcon(
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbcon(...) LAPACK_cpbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpbcon(...) LAPACK_cpbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbcon LAPACK_GLOBAL(dpbcon,DPBCON)
-void LAPACK_dpbcon(
+#define LAPACK_dpbcon_base LAPACK_GLOBAL(dpbcon,DPBCON)
+void LAPACK_dpbcon_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double const* AB, lapack_int const* ldab,
@@ -7500,10 +11830,19 @@ void LAPACK_dpbcon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbcon(...) LAPACK_dpbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpbcon(...) LAPACK_dpbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbcon LAPACK_GLOBAL(spbcon,SPBCON)
-void LAPACK_spbcon(
+#define LAPACK_spbcon_base LAPACK_GLOBAL(spbcon,SPBCON)
+void LAPACK_spbcon_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float const* AB, lapack_int const* ldab,
@@ -7511,10 +11850,19 @@ void LAPACK_spbcon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbcon(...) LAPACK_spbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spbcon(...) LAPACK_spbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbcon LAPACK_GLOBAL(zpbcon,ZPBCON)
-void LAPACK_zpbcon(
+#define LAPACK_zpbcon_base LAPACK_GLOBAL(zpbcon,ZPBCON)
+void LAPACK_zpbcon_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double const* AB, lapack_int const* ldab,
@@ -7522,50 +11870,95 @@ void LAPACK_zpbcon(
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbcon(...) LAPACK_zpbcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpbcon(...) LAPACK_zpbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbequ LAPACK_GLOBAL(cpbequ,CPBEQU)
-void LAPACK_cpbequ(
+#define LAPACK_cpbequ_base LAPACK_GLOBAL(cpbequ,CPBEQU)
+void LAPACK_cpbequ_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float const* AB, lapack_int const* ldab,
     float* S,
     float* scond,
     float* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbequ(...) LAPACK_cpbequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpbequ(...) LAPACK_cpbequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbequ LAPACK_GLOBAL(dpbequ,DPBEQU)
-void LAPACK_dpbequ(
+#define LAPACK_dpbequ_base LAPACK_GLOBAL(dpbequ,DPBEQU)
+void LAPACK_dpbequ_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double const* AB, lapack_int const* ldab,
     double* S,
     double* scond,
     double* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbequ(...) LAPACK_dpbequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpbequ(...) LAPACK_dpbequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbequ LAPACK_GLOBAL(spbequ,SPBEQU)
-void LAPACK_spbequ(
+#define LAPACK_spbequ_base LAPACK_GLOBAL(spbequ,SPBEQU)
+void LAPACK_spbequ_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float const* AB, lapack_int const* ldab,
     float* S,
     float* scond,
     float* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbequ(...) LAPACK_spbequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spbequ(...) LAPACK_spbequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbequ LAPACK_GLOBAL(zpbequ,ZPBEQU)
-void LAPACK_zpbequ(
+#define LAPACK_zpbequ_base LAPACK_GLOBAL(zpbequ,ZPBEQU)
+void LAPACK_zpbequ_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double const* AB, lapack_int const* ldab,
     double* S,
     double* scond,
     double* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbequ(...) LAPACK_zpbequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpbequ(...) LAPACK_zpbequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbrfs LAPACK_GLOBAL(cpbrfs,CPBRFS)
-void LAPACK_cpbrfs(
+#define LAPACK_cpbrfs_base LAPACK_GLOBAL(cpbrfs,CPBRFS)
+void LAPACK_cpbrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_float const* AB, lapack_int const* ldab,
@@ -7576,10 +11969,19 @@ void LAPACK_cpbrfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbrfs(...) LAPACK_cpbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpbrfs(...) LAPACK_cpbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbrfs LAPACK_GLOBAL(dpbrfs,DPBRFS)
-void LAPACK_dpbrfs(
+#define LAPACK_dpbrfs_base LAPACK_GLOBAL(dpbrfs,DPBRFS)
+void LAPACK_dpbrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     double const* AB, lapack_int const* ldab,
@@ -7590,10 +11992,19 @@ void LAPACK_dpbrfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbrfs(...) LAPACK_dpbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpbrfs(...) LAPACK_dpbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbrfs LAPACK_GLOBAL(spbrfs,SPBRFS)
-void LAPACK_spbrfs(
+#define LAPACK_spbrfs_base LAPACK_GLOBAL(spbrfs,SPBRFS)
+void LAPACK_spbrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     float const* AB, lapack_int const* ldab,
@@ -7604,10 +12015,19 @@ void LAPACK_spbrfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbrfs(...) LAPACK_spbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spbrfs(...) LAPACK_spbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbrfs LAPACK_GLOBAL(zpbrfs,ZPBRFS)
-void LAPACK_zpbrfs(
+#define LAPACK_zpbrfs_base LAPACK_GLOBAL(zpbrfs,ZPBRFS)
+void LAPACK_zpbrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_double const* AB, lapack_int const* ldab,
@@ -7618,70 +12038,151 @@ void LAPACK_zpbrfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbrfs(...) LAPACK_zpbrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpbrfs(...) LAPACK_zpbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbstf LAPACK_GLOBAL(cpbstf,CPBSTF)
-void LAPACK_cpbstf(
+#define LAPACK_cpbstf_base LAPACK_GLOBAL(cpbstf,CPBSTF)
+void LAPACK_cpbstf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbstf(...) LAPACK_cpbstf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpbstf(...) LAPACK_cpbstf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbstf LAPACK_GLOBAL(dpbstf,DPBSTF)
-void LAPACK_dpbstf(
+#define LAPACK_dpbstf_base LAPACK_GLOBAL(dpbstf,DPBSTF)
+void LAPACK_dpbstf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbstf(...) LAPACK_dpbstf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpbstf(...) LAPACK_dpbstf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbstf LAPACK_GLOBAL(spbstf,SPBSTF)
-void LAPACK_spbstf(
+#define LAPACK_spbstf_base LAPACK_GLOBAL(spbstf,SPBSTF)
+void LAPACK_spbstf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbstf(...) LAPACK_spbstf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spbstf(...) LAPACK_spbstf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbstf LAPACK_GLOBAL(zpbstf,ZPBSTF)
-void LAPACK_zpbstf(
+#define LAPACK_zpbstf_base LAPACK_GLOBAL(zpbstf,ZPBSTF)
+void LAPACK_zpbstf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbstf(...) LAPACK_zpbstf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpbstf(...) LAPACK_zpbstf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbsv LAPACK_GLOBAL(cpbsv,CPBSV)
-void LAPACK_cpbsv(
+#define LAPACK_cpbsv_base LAPACK_GLOBAL(cpbsv,CPBSV)
+void LAPACK_cpbsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_float* AB, lapack_int const* ldab,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbsv(...) LAPACK_cpbsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpbsv(...) LAPACK_cpbsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbsv LAPACK_GLOBAL(dpbsv,DPBSV)
-void LAPACK_dpbsv(
+#define LAPACK_dpbsv_base LAPACK_GLOBAL(dpbsv,DPBSV)
+void LAPACK_dpbsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     double* AB, lapack_int const* ldab,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbsv(...) LAPACK_dpbsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpbsv(...) LAPACK_dpbsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbsv LAPACK_GLOBAL(spbsv,SPBSV)
-void LAPACK_spbsv(
+#define LAPACK_spbsv_base LAPACK_GLOBAL(spbsv,SPBSV)
+void LAPACK_spbsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     float* AB, lapack_int const* ldab,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbsv(...) LAPACK_spbsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spbsv(...) LAPACK_spbsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbsv LAPACK_GLOBAL(zpbsv,ZPBSV)
-void LAPACK_zpbsv(
+#define LAPACK_zpbsv_base LAPACK_GLOBAL(zpbsv,ZPBSV)
+void LAPACK_zpbsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_double* AB, lapack_int const* ldab,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbsv(...) LAPACK_zpbsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpbsv(...) LAPACK_zpbsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbsvx LAPACK_GLOBAL(cpbsvx,CPBSVX)
-void LAPACK_cpbsvx(
+#define LAPACK_cpbsvx_base LAPACK_GLOBAL(cpbsvx,CPBSVX)
+void LAPACK_cpbsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_float* AB, lapack_int const* ldab,
@@ -7695,10 +12196,19 @@ void LAPACK_cpbsvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbsvx(...) LAPACK_cpbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cpbsvx(...) LAPACK_cpbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbsvx LAPACK_GLOBAL(dpbsvx,DPBSVX)
-void LAPACK_dpbsvx(
+#define LAPACK_dpbsvx_base LAPACK_GLOBAL(dpbsvx,DPBSVX)
+void LAPACK_dpbsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     double* AB, lapack_int const* ldab,
@@ -7712,10 +12222,19 @@ void LAPACK_dpbsvx(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbsvx(...) LAPACK_dpbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dpbsvx(...) LAPACK_dpbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbsvx LAPACK_GLOBAL(spbsvx,SPBSVX)
-void LAPACK_spbsvx(
+#define LAPACK_spbsvx_base LAPACK_GLOBAL(spbsvx,SPBSVX)
+void LAPACK_spbsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     float* AB, lapack_int const* ldab,
@@ -7729,10 +12248,19 @@ void LAPACK_spbsvx(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbsvx(...) LAPACK_spbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_spbsvx(...) LAPACK_spbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbsvx LAPACK_GLOBAL(zpbsvx,ZPBSVX)
-void LAPACK_zpbsvx(
+#define LAPACK_zpbsvx_base LAPACK_GLOBAL(zpbsvx,ZPBSVX)
+void LAPACK_zpbsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_double* AB, lapack_int const* ldab,
@@ -7746,158 +12274,347 @@ void LAPACK_zpbsvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbsvx(...) LAPACK_zpbsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zpbsvx(...) LAPACK_zpbsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbtrf LAPACK_GLOBAL(cpbtrf,CPBTRF)
-void LAPACK_cpbtrf(
+#define LAPACK_cpbtrf_base LAPACK_GLOBAL(cpbtrf,CPBTRF)
+void LAPACK_cpbtrf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbtrf(...) LAPACK_cpbtrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpbtrf(...) LAPACK_cpbtrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbtrf LAPACK_GLOBAL(dpbtrf,DPBTRF)
-void LAPACK_dpbtrf(
+#define LAPACK_dpbtrf_base LAPACK_GLOBAL(dpbtrf,DPBTRF)
+void LAPACK_dpbtrf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbtrf(...) LAPACK_dpbtrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpbtrf(...) LAPACK_dpbtrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbtrf LAPACK_GLOBAL(spbtrf,SPBTRF)
-void LAPACK_spbtrf(
+#define LAPACK_spbtrf_base LAPACK_GLOBAL(spbtrf,SPBTRF)
+void LAPACK_spbtrf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbtrf(...) LAPACK_spbtrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spbtrf(...) LAPACK_spbtrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbtrf LAPACK_GLOBAL(zpbtrf,ZPBTRF)
-void LAPACK_zpbtrf(
+#define LAPACK_zpbtrf_base LAPACK_GLOBAL(zpbtrf,ZPBTRF)
+void LAPACK_zpbtrf_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double* AB, lapack_int const* ldab,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbtrf(...) LAPACK_zpbtrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpbtrf(...) LAPACK_zpbtrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpbtrs LAPACK_GLOBAL(cpbtrs,CPBTRS)
-void LAPACK_cpbtrs(
+#define LAPACK_cpbtrs_base LAPACK_GLOBAL(cpbtrs,CPBTRS)
+void LAPACK_cpbtrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_float const* AB, lapack_int const* ldab,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpbtrs(...) LAPACK_cpbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpbtrs(...) LAPACK_cpbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpbtrs LAPACK_GLOBAL(dpbtrs,DPBTRS)
-void LAPACK_dpbtrs(
+#define LAPACK_dpbtrs_base LAPACK_GLOBAL(dpbtrs,DPBTRS)
+void LAPACK_dpbtrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     double const* AB, lapack_int const* ldab,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpbtrs(...) LAPACK_dpbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpbtrs(...) LAPACK_dpbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spbtrs LAPACK_GLOBAL(spbtrs,SPBTRS)
-void LAPACK_spbtrs(
+#define LAPACK_spbtrs_base LAPACK_GLOBAL(spbtrs,SPBTRS)
+void LAPACK_spbtrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     float const* AB, lapack_int const* ldab,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spbtrs(...) LAPACK_spbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spbtrs(...) LAPACK_spbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpbtrs LAPACK_GLOBAL(zpbtrs,ZPBTRS)
-void LAPACK_zpbtrs(
+#define LAPACK_zpbtrs_base LAPACK_GLOBAL(zpbtrs,ZPBTRS)
+void LAPACK_zpbtrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_double const* AB, lapack_int const* ldab,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpbtrs(...) LAPACK_zpbtrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpbtrs(...) LAPACK_zpbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpftrf LAPACK_GLOBAL(cpftrf,CPFTRF)
-void LAPACK_cpftrf(
+#define LAPACK_cpftrf_base LAPACK_GLOBAL(cpftrf,CPFTRF)
+void LAPACK_cpftrf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpftrf(...) LAPACK_cpftrf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cpftrf(...) LAPACK_cpftrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpftrf LAPACK_GLOBAL(dpftrf,DPFTRF)
-void LAPACK_dpftrf(
+#define LAPACK_dpftrf_base LAPACK_GLOBAL(dpftrf,DPFTRF)
+void LAPACK_dpftrf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     double* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpftrf(...) LAPACK_dpftrf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dpftrf(...) LAPACK_dpftrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spftrf LAPACK_GLOBAL(spftrf,SPFTRF)
-void LAPACK_spftrf(
+#define LAPACK_spftrf_base LAPACK_GLOBAL(spftrf,SPFTRF)
+void LAPACK_spftrf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     float* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spftrf(...) LAPACK_spftrf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_spftrf(...) LAPACK_spftrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpftrf LAPACK_GLOBAL(zpftrf,ZPFTRF)
-void LAPACK_zpftrf(
+#define LAPACK_zpftrf_base LAPACK_GLOBAL(zpftrf,ZPFTRF)
+void LAPACK_zpftrf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpftrf(...) LAPACK_zpftrf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zpftrf(...) LAPACK_zpftrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpftri LAPACK_GLOBAL(cpftri,CPFTRI)
-void LAPACK_cpftri(
+#define LAPACK_cpftri_base LAPACK_GLOBAL(cpftri,CPFTRI)
+void LAPACK_cpftri_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpftri(...) LAPACK_cpftri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cpftri(...) LAPACK_cpftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpftri LAPACK_GLOBAL(dpftri,DPFTRI)
-void LAPACK_dpftri(
+#define LAPACK_dpftri_base LAPACK_GLOBAL(dpftri,DPFTRI)
+void LAPACK_dpftri_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     double* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpftri(...) LAPACK_dpftri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dpftri(...) LAPACK_dpftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spftri LAPACK_GLOBAL(spftri,SPFTRI)
-void LAPACK_spftri(
+#define LAPACK_spftri_base LAPACK_GLOBAL(spftri,SPFTRI)
+void LAPACK_spftri_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     float* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spftri(...) LAPACK_spftri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_spftri(...) LAPACK_spftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpftri LAPACK_GLOBAL(zpftri,ZPFTRI)
-void LAPACK_zpftri(
+#define LAPACK_zpftri_base LAPACK_GLOBAL(zpftri,ZPFTRI)
+void LAPACK_zpftri_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpftri(...) LAPACK_zpftri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zpftri(...) LAPACK_zpftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpftrs LAPACK_GLOBAL(cpftrs,CPFTRS)
-void LAPACK_cpftrs(
+#define LAPACK_cpftrs_base LAPACK_GLOBAL(cpftrs,CPFTRS)
+void LAPACK_cpftrs_base(
     char const* transr, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpftrs(...) LAPACK_cpftrs_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cpftrs(...) LAPACK_cpftrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpftrs LAPACK_GLOBAL(dpftrs,DPFTRS)
-void LAPACK_dpftrs(
+#define LAPACK_dpftrs_base LAPACK_GLOBAL(dpftrs,DPFTRS)
+void LAPACK_dpftrs_base(
     char const* transr, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpftrs(...) LAPACK_dpftrs_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dpftrs(...) LAPACK_dpftrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spftrs LAPACK_GLOBAL(spftrs,SPFTRS)
-void LAPACK_spftrs(
+#define LAPACK_spftrs_base LAPACK_GLOBAL(spftrs,SPFTRS)
+void LAPACK_spftrs_base(
     char const* transr, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spftrs(...) LAPACK_spftrs_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_spftrs(...) LAPACK_spftrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpftrs LAPACK_GLOBAL(zpftrs,ZPFTRS)
-void LAPACK_zpftrs(
+#define LAPACK_zpftrs_base LAPACK_GLOBAL(zpftrs,ZPFTRS)
+void LAPACK_zpftrs_base(
     char const* transr, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpftrs(...) LAPACK_zpftrs_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zpftrs(...) LAPACK_zpftrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpocon LAPACK_GLOBAL(cpocon,CPOCON)
-void LAPACK_cpocon(
+#define LAPACK_cpocon_base LAPACK_GLOBAL(cpocon,CPOCON)
+void LAPACK_cpocon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -7905,10 +12622,19 @@ void LAPACK_cpocon(
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpocon(...) LAPACK_cpocon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpocon(...) LAPACK_cpocon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpocon LAPACK_GLOBAL(dpocon,DPOCON)
-void LAPACK_dpocon(
+#define LAPACK_dpocon_base LAPACK_GLOBAL(dpocon,DPOCON)
+void LAPACK_dpocon_base(
     char const* uplo,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
@@ -7916,10 +12642,19 @@ void LAPACK_dpocon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpocon(...) LAPACK_dpocon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpocon(...) LAPACK_dpocon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spocon LAPACK_GLOBAL(spocon,SPOCON)
-void LAPACK_spocon(
+#define LAPACK_spocon_base LAPACK_GLOBAL(spocon,SPOCON)
+void LAPACK_spocon_base(
     char const* uplo,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
@@ -7927,10 +12662,19 @@ void LAPACK_spocon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spocon(...) LAPACK_spocon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spocon(...) LAPACK_spocon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpocon LAPACK_GLOBAL(zpocon,ZPOCON)
-void LAPACK_zpocon(
+#define LAPACK_zpocon_base LAPACK_GLOBAL(zpocon,ZPOCON)
+void LAPACK_zpocon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -7938,7 +12682,16 @@ void LAPACK_zpocon(
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpocon(...) LAPACK_zpocon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpocon(...) LAPACK_zpocon_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cpoequ LAPACK_GLOBAL(cpoequ,CPOEQU)
 void LAPACK_cpoequ(
@@ -8012,8 +12765,8 @@ void LAPACK_zpoequb(
     double* amax,
     lapack_int* info );
 
-#define LAPACK_cporfs LAPACK_GLOBAL(cporfs,CPORFS)
-void LAPACK_cporfs(
+#define LAPACK_cporfs_base LAPACK_GLOBAL(cporfs,CPORFS)
+void LAPACK_cporfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -8024,10 +12777,19 @@ void LAPACK_cporfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cporfs(...) LAPACK_cporfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cporfs(...) LAPACK_cporfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dporfs LAPACK_GLOBAL(dporfs,DPORFS)
-void LAPACK_dporfs(
+#define LAPACK_dporfs_base LAPACK_GLOBAL(dporfs,DPORFS)
+void LAPACK_dporfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -8038,10 +12800,19 @@ void LAPACK_dporfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dporfs(...) LAPACK_dporfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dporfs(...) LAPACK_dporfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sporfs LAPACK_GLOBAL(sporfs,SPORFS)
-void LAPACK_sporfs(
+#define LAPACK_sporfs_base LAPACK_GLOBAL(sporfs,SPORFS)
+void LAPACK_sporfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -8052,10 +12823,19 @@ void LAPACK_sporfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sporfs(...) LAPACK_sporfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sporfs(...) LAPACK_sporfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zporfs LAPACK_GLOBAL(zporfs,ZPORFS)
-void LAPACK_zporfs(
+#define LAPACK_zporfs_base LAPACK_GLOBAL(zporfs,ZPORFS)
+void LAPACK_zporfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -8066,10 +12846,19 @@ void LAPACK_zporfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zporfs(...) LAPACK_zporfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zporfs(...) LAPACK_zporfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cporfsx LAPACK_GLOBAL(cporfsx,CPORFSX)
-void LAPACK_cporfsx(
+#define LAPACK_cporfsx_base LAPACK_GLOBAL(cporfsx,CPORFSX)
+void LAPACK_cporfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -8084,10 +12873,19 @@ void LAPACK_cporfsx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cporfsx(...) LAPACK_cporfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cporfsx(...) LAPACK_cporfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dporfsx LAPACK_GLOBAL(dporfsx,DPORFSX)
-void LAPACK_dporfsx(
+#define LAPACK_dporfsx_base LAPACK_GLOBAL(dporfsx,DPORFSX)
+void LAPACK_dporfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -8102,10 +12900,19 @@ void LAPACK_dporfsx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dporfsx(...) LAPACK_dporfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dporfsx(...) LAPACK_dporfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sporfsx LAPACK_GLOBAL(sporfsx,SPORFSX)
-void LAPACK_sporfsx(
+#define LAPACK_sporfsx_base LAPACK_GLOBAL(sporfsx,SPORFSX)
+void LAPACK_sporfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -8120,10 +12927,19 @@ void LAPACK_sporfsx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sporfsx(...) LAPACK_sporfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sporfsx(...) LAPACK_sporfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zporfsx LAPACK_GLOBAL(zporfsx,ZPORFSX)
-void LAPACK_zporfsx(
+#define LAPACK_zporfsx_base LAPACK_GLOBAL(zporfsx,ZPORFSX)
+void LAPACK_zporfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -8138,42 +12954,87 @@ void LAPACK_zporfsx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zporfsx(...) LAPACK_zporfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zporfsx(...) LAPACK_zporfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cposv LAPACK_GLOBAL(cposv,CPOSV)
-void LAPACK_cposv(
+#define LAPACK_cposv_base LAPACK_GLOBAL(cposv,CPOSV)
+void LAPACK_cposv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cposv(...) LAPACK_cposv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cposv(...) LAPACK_cposv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dposv LAPACK_GLOBAL(dposv,DPOSV)
-void LAPACK_dposv(
+#define LAPACK_dposv_base LAPACK_GLOBAL(dposv,DPOSV)
+void LAPACK_dposv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dposv(...) LAPACK_dposv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dposv(...) LAPACK_dposv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sposv LAPACK_GLOBAL(sposv,SPOSV)
-void LAPACK_sposv(
+#define LAPACK_sposv_base LAPACK_GLOBAL(sposv,SPOSV)
+void LAPACK_sposv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sposv(...) LAPACK_sposv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sposv(...) LAPACK_sposv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zposv LAPACK_GLOBAL(zposv,ZPOSV)
-void LAPACK_zposv(
+#define LAPACK_zposv_base LAPACK_GLOBAL(zposv,ZPOSV)
+void LAPACK_zposv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zposv(...) LAPACK_zposv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zposv(...) LAPACK_zposv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsposv LAPACK_GLOBAL(dsposv,DSPOSV)
-void LAPACK_dsposv(
+#define LAPACK_dsposv_base LAPACK_GLOBAL(dsposv,DSPOSV)
+void LAPACK_dsposv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
@@ -8181,10 +13042,19 @@ void LAPACK_dsposv(
     double* X, lapack_int const* ldx,
     double* work,
     float* swork, lapack_int* iter,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsposv(...) LAPACK_dsposv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsposv(...) LAPACK_dsposv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zcposv LAPACK_GLOBAL(zcposv,ZCPOSV)
-void LAPACK_zcposv(
+#define LAPACK_zcposv_base LAPACK_GLOBAL(zcposv,ZCPOSV)
+void LAPACK_zcposv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
@@ -8193,10 +13063,19 @@ void LAPACK_zcposv(
     lapack_complex_double* work,
     lapack_complex_float* swork,
     double* rwork, lapack_int* iter,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zcposv(...) LAPACK_zcposv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zcposv(...) LAPACK_zcposv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cposvx LAPACK_GLOBAL(cposvx,CPOSVX)
-void LAPACK_cposvx(
+#define LAPACK_cposvx_base LAPACK_GLOBAL(cposvx,CPOSVX)
+void LAPACK_cposvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
@@ -8210,10 +13089,19 @@ void LAPACK_cposvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cposvx(...) LAPACK_cposvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cposvx(...) LAPACK_cposvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dposvx LAPACK_GLOBAL(dposvx,DPOSVX)
-void LAPACK_dposvx(
+#define LAPACK_dposvx_base LAPACK_GLOBAL(dposvx,DPOSVX)
+void LAPACK_dposvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
@@ -8227,10 +13115,19 @@ void LAPACK_dposvx(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dposvx(...) LAPACK_dposvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dposvx(...) LAPACK_dposvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sposvx LAPACK_GLOBAL(sposvx,SPOSVX)
-void LAPACK_sposvx(
+#define LAPACK_sposvx_base LAPACK_GLOBAL(sposvx,SPOSVX)
+void LAPACK_sposvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
@@ -8244,10 +13141,19 @@ void LAPACK_sposvx(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sposvx(...) LAPACK_sposvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sposvx(...) LAPACK_sposvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zposvx LAPACK_GLOBAL(zposvx,ZPOSVX)
-void LAPACK_zposvx(
+#define LAPACK_zposvx_base LAPACK_GLOBAL(zposvx,ZPOSVX)
+void LAPACK_zposvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
@@ -8261,10 +13167,19 @@ void LAPACK_zposvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zposvx(...) LAPACK_zposvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zposvx(...) LAPACK_zposvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cposvxx LAPACK_GLOBAL(cposvxx,CPOSVXX)
-void LAPACK_cposvxx(
+#define LAPACK_cposvxx_base LAPACK_GLOBAL(cposvxx,CPOSVXX)
+void LAPACK_cposvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
@@ -8281,10 +13196,19 @@ void LAPACK_cposvxx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cposvxx(...) LAPACK_cposvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cposvxx(...) LAPACK_cposvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dposvxx LAPACK_GLOBAL(dposvxx,DPOSVXX)
-void LAPACK_dposvxx(
+#define LAPACK_dposvxx_base LAPACK_GLOBAL(dposvxx,DPOSVXX)
+void LAPACK_dposvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
@@ -8301,10 +13225,19 @@ void LAPACK_dposvxx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dposvxx(...) LAPACK_dposvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dposvxx(...) LAPACK_dposvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sposvxx LAPACK_GLOBAL(sposvxx,SPOSVXX)
-void LAPACK_sposvxx(
+#define LAPACK_sposvxx_base LAPACK_GLOBAL(sposvxx,SPOSVXX)
+void LAPACK_sposvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
@@ -8321,10 +13254,19 @@ void LAPACK_sposvxx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sposvxx(...) LAPACK_sposvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sposvxx(...) LAPACK_sposvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zposvxx LAPACK_GLOBAL(zposvxx,ZPOSVXX)
-void LAPACK_zposvxx(
+#define LAPACK_zposvxx_base LAPACK_GLOBAL(zposvxx,ZPOSVXX)
+void LAPACK_zposvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
@@ -8341,154 +13283,343 @@ void LAPACK_zposvxx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zposvxx(...) LAPACK_zposvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zposvxx(...) LAPACK_zposvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpotf2 LAPACK_GLOBAL(cpotf2,CPOTF2)
-void LAPACK_cpotf2(
+#define LAPACK_cpotf2_base LAPACK_GLOBAL(cpotf2,CPOTF2)
+void LAPACK_cpotf2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpotf2(...) LAPACK_cpotf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpotf2(...) LAPACK_cpotf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpotf2 LAPACK_GLOBAL(dpotf2,DPOTF2)
-void LAPACK_dpotf2(
+#define LAPACK_dpotf2_base LAPACK_GLOBAL(dpotf2,DPOTF2)
+void LAPACK_dpotf2_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpotf2(...) LAPACK_dpotf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpotf2(...) LAPACK_dpotf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spotf2 LAPACK_GLOBAL(spotf2,SPOTF2)
-void LAPACK_spotf2(
+#define LAPACK_spotf2_base LAPACK_GLOBAL(spotf2,SPOTF2)
+void LAPACK_spotf2_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spotf2(...) LAPACK_spotf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spotf2(...) LAPACK_spotf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpotf2 LAPACK_GLOBAL(zpotf2,ZPOTF2)
-void LAPACK_zpotf2(
+#define LAPACK_zpotf2_base LAPACK_GLOBAL(zpotf2,ZPOTF2)
+void LAPACK_zpotf2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpotf2(...) LAPACK_zpotf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpotf2(...) LAPACK_zpotf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpotrf LAPACK_GLOBAL(cpotrf,CPOTRF)
-void LAPACK_cpotrf(
+#define LAPACK_cpotrf_base LAPACK_GLOBAL(cpotrf,CPOTRF)
+void LAPACK_cpotrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpotrf(...) LAPACK_cpotrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpotrf(...) LAPACK_cpotrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpotrf LAPACK_GLOBAL(dpotrf,DPOTRF)
-void LAPACK_dpotrf(
+#define LAPACK_dpotrf_base LAPACK_GLOBAL(dpotrf,DPOTRF)
+void LAPACK_dpotrf_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpotrf(...) LAPACK_dpotrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpotrf(...) LAPACK_dpotrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spotrf LAPACK_GLOBAL(spotrf,SPOTRF)
-void LAPACK_spotrf(
+#define LAPACK_spotrf_base LAPACK_GLOBAL(spotrf,SPOTRF)
+void LAPACK_spotrf_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spotrf(...) LAPACK_spotrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spotrf(...) LAPACK_spotrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpotrf LAPACK_GLOBAL(zpotrf,ZPOTRF)
-void LAPACK_zpotrf(
+#define LAPACK_zpotrf_base LAPACK_GLOBAL(zpotrf,ZPOTRF)
+void LAPACK_zpotrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpotrf(...) LAPACK_zpotrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpotrf(...) LAPACK_zpotrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpotrf2 LAPACK_GLOBAL(cpotrf2,CPOTRF2)
-void LAPACK_cpotrf2(
+#define LAPACK_cpotrf2_base LAPACK_GLOBAL(cpotrf2,CPOTRF2)
+void LAPACK_cpotrf2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpotrf2(...) LAPACK_cpotrf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpotrf2(...) LAPACK_cpotrf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpotrf2 LAPACK_GLOBAL(dpotrf2,DPOTRF2)
-void LAPACK_dpotrf2(
+#define LAPACK_dpotrf2_base LAPACK_GLOBAL(dpotrf2,DPOTRF2)
+void LAPACK_dpotrf2_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpotrf2(...) LAPACK_dpotrf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpotrf2(...) LAPACK_dpotrf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spotrf2 LAPACK_GLOBAL(spotrf2,SPOTRF2)
-void LAPACK_spotrf2(
+#define LAPACK_spotrf2_base LAPACK_GLOBAL(spotrf2,SPOTRF2)
+void LAPACK_spotrf2_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spotrf2(...) LAPACK_spotrf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spotrf2(...) LAPACK_spotrf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpotrf2 LAPACK_GLOBAL(zpotrf2,ZPOTRF2)
-void LAPACK_zpotrf2(
+#define LAPACK_zpotrf2_base LAPACK_GLOBAL(zpotrf2,ZPOTRF2)
+void LAPACK_zpotrf2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpotrf2(...) LAPACK_zpotrf2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpotrf2(...) LAPACK_zpotrf2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpotri LAPACK_GLOBAL(cpotri,CPOTRI)
-void LAPACK_cpotri(
+#define LAPACK_cpotri_base LAPACK_GLOBAL(cpotri,CPOTRI)
+void LAPACK_cpotri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpotri(...) LAPACK_cpotri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpotri(...) LAPACK_cpotri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpotri LAPACK_GLOBAL(dpotri,DPOTRI)
-void LAPACK_dpotri(
+#define LAPACK_dpotri_base LAPACK_GLOBAL(dpotri,DPOTRI)
+void LAPACK_dpotri_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpotri(...) LAPACK_dpotri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpotri(...) LAPACK_dpotri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spotri LAPACK_GLOBAL(spotri,SPOTRI)
-void LAPACK_spotri(
+#define LAPACK_spotri_base LAPACK_GLOBAL(spotri,SPOTRI)
+void LAPACK_spotri_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spotri(...) LAPACK_spotri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spotri(...) LAPACK_spotri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpotri LAPACK_GLOBAL(zpotri,ZPOTRI)
-void LAPACK_zpotri(
+#define LAPACK_zpotri_base LAPACK_GLOBAL(zpotri,ZPOTRI)
+void LAPACK_zpotri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpotri(...) LAPACK_zpotri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpotri(...) LAPACK_zpotri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpotrs LAPACK_GLOBAL(cpotrs,CPOTRS)
-void LAPACK_cpotrs(
+#define LAPACK_cpotrs_base LAPACK_GLOBAL(cpotrs,CPOTRS)
+void LAPACK_cpotrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpotrs(...) LAPACK_cpotrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpotrs(...) LAPACK_cpotrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpotrs LAPACK_GLOBAL(dpotrs,DPOTRS)
-void LAPACK_dpotrs(
+#define LAPACK_dpotrs_base LAPACK_GLOBAL(dpotrs,DPOTRS)
+void LAPACK_dpotrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpotrs(...) LAPACK_dpotrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpotrs(...) LAPACK_dpotrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spotrs LAPACK_GLOBAL(spotrs,SPOTRS)
-void LAPACK_spotrs(
+#define LAPACK_spotrs_base LAPACK_GLOBAL(spotrs,SPOTRS)
+void LAPACK_spotrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spotrs(...) LAPACK_spotrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spotrs(...) LAPACK_spotrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpotrs LAPACK_GLOBAL(zpotrs,ZPOTRS)
-void LAPACK_zpotrs(
+#define LAPACK_zpotrs_base LAPACK_GLOBAL(zpotrs,ZPOTRS)
+void LAPACK_zpotrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpotrs(...) LAPACK_zpotrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpotrs(...) LAPACK_zpotrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cppcon LAPACK_GLOBAL(cppcon,CPPCON)
-void LAPACK_cppcon(
+#define LAPACK_cppcon_base LAPACK_GLOBAL(cppcon,CPPCON)
+void LAPACK_cppcon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP,
@@ -8496,10 +13627,19 @@ void LAPACK_cppcon(
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cppcon(...) LAPACK_cppcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cppcon(...) LAPACK_cppcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dppcon LAPACK_GLOBAL(dppcon,DPPCON)
-void LAPACK_dppcon(
+#define LAPACK_dppcon_base LAPACK_GLOBAL(dppcon,DPPCON)
+void LAPACK_dppcon_base(
     char const* uplo,
     lapack_int const* n,
     double const* AP,
@@ -8507,10 +13647,19 @@ void LAPACK_dppcon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dppcon(...) LAPACK_dppcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dppcon(...) LAPACK_dppcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sppcon LAPACK_GLOBAL(sppcon,SPPCON)
-void LAPACK_sppcon(
+#define LAPACK_sppcon_base LAPACK_GLOBAL(sppcon,SPPCON)
+void LAPACK_sppcon_base(
     char const* uplo,
     lapack_int const* n,
     float const* AP,
@@ -8518,10 +13667,19 @@ void LAPACK_sppcon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sppcon(...) LAPACK_sppcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sppcon(...) LAPACK_sppcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zppcon LAPACK_GLOBAL(zppcon,ZPPCON)
-void LAPACK_zppcon(
+#define LAPACK_zppcon_base LAPACK_GLOBAL(zppcon,ZPPCON)
+void LAPACK_zppcon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP,
@@ -8529,50 +13687,95 @@ void LAPACK_zppcon(
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zppcon(...) LAPACK_zppcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zppcon(...) LAPACK_zppcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cppequ LAPACK_GLOBAL(cppequ,CPPEQU)
-void LAPACK_cppequ(
+#define LAPACK_cppequ_base LAPACK_GLOBAL(cppequ,CPPEQU)
+void LAPACK_cppequ_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP,
     float* S,
     float* scond,
     float* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cppequ(...) LAPACK_cppequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cppequ(...) LAPACK_cppequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dppequ LAPACK_GLOBAL(dppequ,DPPEQU)
-void LAPACK_dppequ(
+#define LAPACK_dppequ_base LAPACK_GLOBAL(dppequ,DPPEQU)
+void LAPACK_dppequ_base(
     char const* uplo,
     lapack_int const* n,
     double const* AP,
     double* S,
     double* scond,
     double* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dppequ(...) LAPACK_dppequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dppequ(...) LAPACK_dppequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sppequ LAPACK_GLOBAL(sppequ,SPPEQU)
-void LAPACK_sppequ(
+#define LAPACK_sppequ_base LAPACK_GLOBAL(sppequ,SPPEQU)
+void LAPACK_sppequ_base(
     char const* uplo,
     lapack_int const* n,
     float const* AP,
     float* S,
     float* scond,
     float* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sppequ(...) LAPACK_sppequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sppequ(...) LAPACK_sppequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zppequ LAPACK_GLOBAL(zppequ,ZPPEQU)
-void LAPACK_zppequ(
+#define LAPACK_zppequ_base LAPACK_GLOBAL(zppequ,ZPPEQU)
+void LAPACK_zppequ_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP,
     double* S,
     double* scond,
     double* amax,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zppequ(...) LAPACK_zppequ_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zppequ(...) LAPACK_zppequ_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpprfs LAPACK_GLOBAL(cpprfs,CPPRFS)
-void LAPACK_cpprfs(
+#define LAPACK_cpprfs_base LAPACK_GLOBAL(cpprfs,CPPRFS)
+void LAPACK_cpprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
@@ -8583,10 +13786,19 @@ void LAPACK_cpprfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpprfs(...) LAPACK_cpprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpprfs(...) LAPACK_cpprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpprfs LAPACK_GLOBAL(dpprfs,DPPRFS)
-void LAPACK_dpprfs(
+#define LAPACK_dpprfs_base LAPACK_GLOBAL(dpprfs,DPPRFS)
+void LAPACK_dpprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* AP,
@@ -8597,10 +13809,19 @@ void LAPACK_dpprfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpprfs(...) LAPACK_dpprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpprfs(...) LAPACK_dpprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spprfs LAPACK_GLOBAL(spprfs,SPPRFS)
-void LAPACK_spprfs(
+#define LAPACK_spprfs_base LAPACK_GLOBAL(spprfs,SPPRFS)
+void LAPACK_spprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* AP,
@@ -8611,10 +13832,19 @@ void LAPACK_spprfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spprfs(...) LAPACK_spprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spprfs(...) LAPACK_spprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpprfs LAPACK_GLOBAL(zpprfs,ZPPRFS)
-void LAPACK_zpprfs(
+#define LAPACK_zpprfs_base LAPACK_GLOBAL(zpprfs,ZPPRFS)
+void LAPACK_zpprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
@@ -8625,42 +13855,87 @@ void LAPACK_zpprfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpprfs(...) LAPACK_zpprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpprfs(...) LAPACK_zpprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cppsv LAPACK_GLOBAL(cppsv,CPPSV)
-void LAPACK_cppsv(
+#define LAPACK_cppsv_base LAPACK_GLOBAL(cppsv,CPPSV)
+void LAPACK_cppsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* AP,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cppsv(...) LAPACK_cppsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cppsv(...) LAPACK_cppsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dppsv LAPACK_GLOBAL(dppsv,DPPSV)
-void LAPACK_dppsv(
+#define LAPACK_dppsv_base LAPACK_GLOBAL(dppsv,DPPSV)
+void LAPACK_dppsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* AP,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dppsv(...) LAPACK_dppsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dppsv(...) LAPACK_dppsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sppsv LAPACK_GLOBAL(sppsv,SPPSV)
-void LAPACK_sppsv(
+#define LAPACK_sppsv_base LAPACK_GLOBAL(sppsv,SPPSV)
+void LAPACK_sppsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* AP,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sppsv(...) LAPACK_sppsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sppsv(...) LAPACK_sppsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zppsv LAPACK_GLOBAL(zppsv,ZPPSV)
-void LAPACK_zppsv(
+#define LAPACK_zppsv_base LAPACK_GLOBAL(zppsv,ZPPSV)
+void LAPACK_zppsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* AP,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zppsv(...) LAPACK_zppsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zppsv(...) LAPACK_zppsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cppsvx LAPACK_GLOBAL(cppsvx,CPPSVX)
-void LAPACK_cppsvx(
+#define LAPACK_cppsvx_base LAPACK_GLOBAL(cppsvx,CPPSVX)
+void LAPACK_cppsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* AP,
@@ -8674,10 +13949,19 @@ void LAPACK_cppsvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cppsvx(...) LAPACK_cppsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cppsvx(...) LAPACK_cppsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dppsvx LAPACK_GLOBAL(dppsvx,DPPSVX)
-void LAPACK_dppsvx(
+#define LAPACK_dppsvx_base LAPACK_GLOBAL(dppsvx,DPPSVX)
+void LAPACK_dppsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* AP,
@@ -8691,10 +13975,19 @@ void LAPACK_dppsvx(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dppsvx(...) LAPACK_dppsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dppsvx(...) LAPACK_dppsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sppsvx LAPACK_GLOBAL(sppsvx,SPPSVX)
-void LAPACK_sppsvx(
+#define LAPACK_sppsvx_base LAPACK_GLOBAL(sppsvx,SPPSVX)
+void LAPACK_sppsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* AP,
@@ -8708,10 +14001,19 @@ void LAPACK_sppsvx(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sppsvx(...) LAPACK_sppsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sppsvx(...) LAPACK_sppsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zppsvx LAPACK_GLOBAL(zppsvx,ZPPSVX)
-void LAPACK_zppsvx(
+#define LAPACK_zppsvx_base LAPACK_GLOBAL(zppsvx,ZPPSVX)
+void LAPACK_zppsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* AP,
@@ -8725,131 +14027,284 @@ void LAPACK_zppsvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zppsvx(...) LAPACK_zppsvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zppsvx(...) LAPACK_zppsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpptrf LAPACK_GLOBAL(cpptrf,CPPTRF)
-void LAPACK_cpptrf(
+#define LAPACK_cpptrf_base LAPACK_GLOBAL(cpptrf,CPPTRF)
+void LAPACK_cpptrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpptrf(...) LAPACK_cpptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpptrf(...) LAPACK_cpptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpptrf LAPACK_GLOBAL(dpptrf,DPPTRF)
-void LAPACK_dpptrf(
+#define LAPACK_dpptrf_base LAPACK_GLOBAL(dpptrf,DPPTRF)
+void LAPACK_dpptrf_base(
     char const* uplo,
     lapack_int const* n,
     double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpptrf(...) LAPACK_dpptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpptrf(...) LAPACK_dpptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spptrf LAPACK_GLOBAL(spptrf,SPPTRF)
-void LAPACK_spptrf(
+#define LAPACK_spptrf_base LAPACK_GLOBAL(spptrf,SPPTRF)
+void LAPACK_spptrf_base(
     char const* uplo,
     lapack_int const* n,
     float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spptrf(...) LAPACK_spptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spptrf(...) LAPACK_spptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpptrf LAPACK_GLOBAL(zpptrf,ZPPTRF)
-void LAPACK_zpptrf(
+#define LAPACK_zpptrf_base LAPACK_GLOBAL(zpptrf,ZPPTRF)
+void LAPACK_zpptrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpptrf(...) LAPACK_zpptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpptrf(...) LAPACK_zpptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpptri LAPACK_GLOBAL(cpptri,CPPTRI)
-void LAPACK_cpptri(
+#define LAPACK_cpptri_base LAPACK_GLOBAL(cpptri,CPPTRI)
+void LAPACK_cpptri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpptri(...) LAPACK_cpptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpptri(...) LAPACK_cpptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpptri LAPACK_GLOBAL(dpptri,DPPTRI)
-void LAPACK_dpptri(
+#define LAPACK_dpptri_base LAPACK_GLOBAL(dpptri,DPPTRI)
+void LAPACK_dpptri_base(
     char const* uplo,
     lapack_int const* n,
     double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpptri(...) LAPACK_dpptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpptri(...) LAPACK_dpptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spptri LAPACK_GLOBAL(spptri,SPPTRI)
-void LAPACK_spptri(
+#define LAPACK_spptri_base LAPACK_GLOBAL(spptri,SPPTRI)
+void LAPACK_spptri_base(
     char const* uplo,
     lapack_int const* n,
     float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spptri(...) LAPACK_spptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spptri(...) LAPACK_spptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpptri LAPACK_GLOBAL(zpptri,ZPPTRI)
-void LAPACK_zpptri(
+#define LAPACK_zpptri_base LAPACK_GLOBAL(zpptri,ZPPTRI)
+void LAPACK_zpptri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpptri(...) LAPACK_zpptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpptri(...) LAPACK_zpptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpptrs LAPACK_GLOBAL(cpptrs,CPPTRS)
-void LAPACK_cpptrs(
+#define LAPACK_cpptrs_base LAPACK_GLOBAL(cpptrs,CPPTRS)
+void LAPACK_cpptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpptrs(...) LAPACK_cpptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpptrs(...) LAPACK_cpptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpptrs LAPACK_GLOBAL(dpptrs,DPPTRS)
-void LAPACK_dpptrs(
+#define LAPACK_dpptrs_base LAPACK_GLOBAL(dpptrs,DPPTRS)
+void LAPACK_dpptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* AP,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpptrs(...) LAPACK_dpptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpptrs(...) LAPACK_dpptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spptrs LAPACK_GLOBAL(spptrs,SPPTRS)
-void LAPACK_spptrs(
+#define LAPACK_spptrs_base LAPACK_GLOBAL(spptrs,SPPTRS)
+void LAPACK_spptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* AP,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spptrs(...) LAPACK_spptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spptrs(...) LAPACK_spptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpptrs LAPACK_GLOBAL(zpptrs,ZPPTRS)
-void LAPACK_zpptrs(
+#define LAPACK_zpptrs_base LAPACK_GLOBAL(zpptrs,ZPPTRS)
+void LAPACK_zpptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpptrs(...) LAPACK_zpptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpptrs(...) LAPACK_zpptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cpstrf LAPACK_GLOBAL(cpstrf,CPSTRF)
-void LAPACK_cpstrf(
+#define LAPACK_cpstrf_base LAPACK_GLOBAL(cpstrf,CPSTRF)
+void LAPACK_cpstrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* piv, lapack_int* rank,
     float const* tol,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpstrf(...) LAPACK_cpstrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpstrf(...) LAPACK_cpstrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpstrf LAPACK_GLOBAL(dpstrf,DPSTRF)
-void LAPACK_dpstrf(
+#define LAPACK_dpstrf_base LAPACK_GLOBAL(dpstrf,DPSTRF)
+void LAPACK_dpstrf_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* piv, lapack_int* rank,
     double const* tol,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpstrf(...) LAPACK_dpstrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpstrf(...) LAPACK_dpstrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spstrf LAPACK_GLOBAL(spstrf,SPSTRF)
-void LAPACK_spstrf(
+#define LAPACK_spstrf_base LAPACK_GLOBAL(spstrf,SPSTRF)
+void LAPACK_spstrf_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* piv, lapack_int* rank,
     float const* tol,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spstrf(...) LAPACK_spstrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spstrf(...) LAPACK_spstrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpstrf LAPACK_GLOBAL(zpstrf,ZPSTRF)
-void LAPACK_zpstrf(
+#define LAPACK_zpstrf_base LAPACK_GLOBAL(zpstrf,ZPSTRF)
+void LAPACK_zpstrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* piv, lapack_int* rank,
     double const* tol,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpstrf(...) LAPACK_zpstrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpstrf(...) LAPACK_zpstrf_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cptcon LAPACK_GLOBAL(cptcon,CPTCON)
 void LAPACK_cptcon(
@@ -8891,48 +14346,84 @@ void LAPACK_zptcon(
     double* rwork,
     lapack_int* info );
 
-#define LAPACK_cpteqr LAPACK_GLOBAL(cpteqr,CPTEQR)
-void LAPACK_cpteqr(
+#define LAPACK_cpteqr_base LAPACK_GLOBAL(cpteqr,CPTEQR)
+void LAPACK_cpteqr_base(
     char const* compz,
     lapack_int const* n,
     float* D,
     float* E,
     lapack_complex_float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpteqr(...) LAPACK_cpteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpteqr(...) LAPACK_cpteqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dpteqr LAPACK_GLOBAL(dpteqr,DPTEQR)
-void LAPACK_dpteqr(
+#define LAPACK_dpteqr_base LAPACK_GLOBAL(dpteqr,DPTEQR)
+void LAPACK_dpteqr_base(
     char const* compz,
     lapack_int const* n,
     double* D,
     double* E,
     double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dpteqr(...) LAPACK_dpteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dpteqr(...) LAPACK_dpteqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_spteqr LAPACK_GLOBAL(spteqr,SPTEQR)
-void LAPACK_spteqr(
+#define LAPACK_spteqr_base LAPACK_GLOBAL(spteqr,SPTEQR)
+void LAPACK_spteqr_base(
     char const* compz,
     lapack_int const* n,
     float* D,
     float* E,
     float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_spteqr(...) LAPACK_spteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_spteqr(...) LAPACK_spteqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zpteqr LAPACK_GLOBAL(zpteqr,ZPTEQR)
-void LAPACK_zpteqr(
+#define LAPACK_zpteqr_base LAPACK_GLOBAL(zpteqr,ZPTEQR)
+void LAPACK_zpteqr_base(
     char const* compz,
     lapack_int const* n,
     double* D,
     double* E,
     lapack_complex_double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpteqr(...) LAPACK_zpteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpteqr(...) LAPACK_zpteqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cptrfs LAPACK_GLOBAL(cptrfs,CPTRFS)
-void LAPACK_cptrfs(
+#define LAPACK_cptrfs_base LAPACK_GLOBAL(cptrfs,CPTRFS)
+void LAPACK_cptrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* D,
@@ -8945,7 +14436,16 @@ void LAPACK_cptrfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cptrfs(...) LAPACK_cptrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cptrfs(...) LAPACK_cptrfs_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_dptrfs LAPACK_GLOBAL(dptrfs,DPTRFS)
 void LAPACK_dptrfs(
@@ -8975,8 +14475,8 @@ void LAPACK_sptrfs(
     float* work,
     lapack_int* info );
 
-#define LAPACK_zptrfs LAPACK_GLOBAL(zptrfs,ZPTRFS)
-void LAPACK_zptrfs(
+#define LAPACK_zptrfs_base LAPACK_GLOBAL(zptrfs,ZPTRFS)
+void LAPACK_zptrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* D,
@@ -8989,7 +14489,16 @@ void LAPACK_zptrfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zptrfs(...) LAPACK_zptrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zptrfs(...) LAPACK_zptrfs_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cptsv LAPACK_GLOBAL(cptsv,CPTSV)
 void LAPACK_cptsv(
@@ -9023,8 +14532,8 @@ void LAPACK_zptsv(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info );
 
-#define LAPACK_cptsvx LAPACK_GLOBAL(cptsvx,CPTSVX)
-void LAPACK_cptsvx(
+#define LAPACK_cptsvx_base LAPACK_GLOBAL(cptsvx,CPTSVX)
+void LAPACK_cptsvx_base(
     char const* fact,
     lapack_int const* n, lapack_int const* nrhs,
     float const* D,
@@ -9038,10 +14547,19 @@ void LAPACK_cptsvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cptsvx(...) LAPACK_cptsvx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cptsvx(...) LAPACK_cptsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dptsvx LAPACK_GLOBAL(dptsvx,DPTSVX)
-void LAPACK_dptsvx(
+#define LAPACK_dptsvx_base LAPACK_GLOBAL(dptsvx,DPTSVX)
+void LAPACK_dptsvx_base(
     char const* fact,
     lapack_int const* n, lapack_int const* nrhs,
     double const* D,
@@ -9054,10 +14572,19 @@ void LAPACK_dptsvx(
     double* ferr,
     double* berr,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dptsvx(...) LAPACK_dptsvx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dptsvx(...) LAPACK_dptsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sptsvx LAPACK_GLOBAL(sptsvx,SPTSVX)
-void LAPACK_sptsvx(
+#define LAPACK_sptsvx_base LAPACK_GLOBAL(sptsvx,SPTSVX)
+void LAPACK_sptsvx_base(
     char const* fact,
     lapack_int const* n, lapack_int const* nrhs,
     float const* D,
@@ -9070,10 +14597,19 @@ void LAPACK_sptsvx(
     float* ferr,
     float* berr,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sptsvx(...) LAPACK_sptsvx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sptsvx(...) LAPACK_sptsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zptsvx LAPACK_GLOBAL(zptsvx,ZPTSVX)
-void LAPACK_zptsvx(
+#define LAPACK_zptsvx_base LAPACK_GLOBAL(zptsvx,ZPTSVX)
+void LAPACK_zptsvx_base(
     char const* fact,
     lapack_int const* n, lapack_int const* nrhs,
     double const* D,
@@ -9087,7 +14623,16 @@ void LAPACK_zptsvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zptsvx(...) LAPACK_zptsvx_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zptsvx(...) LAPACK_zptsvx_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cpttrf LAPACK_GLOBAL(cpttrf,CPTTRF)
 void LAPACK_cpttrf(
@@ -9117,14 +14662,23 @@ void LAPACK_zpttrf(
     lapack_complex_double* E,
     lapack_int* info );
 
-#define LAPACK_cpttrs LAPACK_GLOBAL(cpttrs,CPTTRS)
-void LAPACK_cpttrs(
+#define LAPACK_cpttrs_base LAPACK_GLOBAL(cpttrs,CPTTRS)
+void LAPACK_cpttrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* D,
     lapack_complex_float const* E,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cpttrs(...) LAPACK_cpttrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cpttrs(...) LAPACK_cpttrs_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_dpttrs LAPACK_GLOBAL(dpttrs,DPTTRS)
 void LAPACK_dpttrs(
@@ -9142,57 +14696,102 @@ void LAPACK_spttrs(
     float* B, lapack_int const* ldb,
     lapack_int* info );
 
-#define LAPACK_zpttrs LAPACK_GLOBAL(zpttrs,ZPTTRS)
-void LAPACK_zpttrs(
+#define LAPACK_zpttrs_base LAPACK_GLOBAL(zpttrs,ZPTTRS)
+void LAPACK_zpttrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* D,
     lapack_complex_double const* E,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zpttrs(...) LAPACK_zpttrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zpttrs(...) LAPACK_zpttrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbev LAPACK_GLOBAL(dsbev,DSBEV)
-void LAPACK_dsbev(
+#define LAPACK_dsbev_base LAPACK_GLOBAL(dsbev,DSBEV)
+void LAPACK_dsbev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
     double* W,
     double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbev(...) LAPACK_dsbev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbev(...) LAPACK_dsbev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbev LAPACK_GLOBAL(ssbev,SSBEV)
-void LAPACK_ssbev(
+#define LAPACK_ssbev_base LAPACK_GLOBAL(ssbev,SSBEV)
+void LAPACK_ssbev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
     float* W,
     float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbev(...) LAPACK_ssbev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbev(...) LAPACK_ssbev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbev_2stage LAPACK_GLOBAL(dsbev_2stage,DSBEV_2STAGE)
-void LAPACK_dsbev_2stage(
+#define LAPACK_dsbev_2stage_base LAPACK_GLOBAL(dsbev_2stage,DSBEV_2STAGE)
+void LAPACK_dsbev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
     double* W,
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbev_2stage(...) LAPACK_dsbev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbev_2stage(...) LAPACK_dsbev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbev_2stage LAPACK_GLOBAL(ssbev_2stage,SSBEV_2STAGE)
-void LAPACK_ssbev_2stage(
+#define LAPACK_ssbev_2stage_base LAPACK_GLOBAL(ssbev_2stage,SSBEV_2STAGE)
+void LAPACK_ssbev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
     float* W,
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbev_2stage(...) LAPACK_ssbev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbev_2stage(...) LAPACK_ssbev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbevd LAPACK_GLOBAL(dsbevd,DSBEVD)
-void LAPACK_dsbevd(
+#define LAPACK_dsbevd_base LAPACK_GLOBAL(dsbevd,DSBEVD)
+void LAPACK_dsbevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
@@ -9200,10 +14799,19 @@ void LAPACK_dsbevd(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbevd(...) LAPACK_dsbevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbevd(...) LAPACK_dsbevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbevd LAPACK_GLOBAL(ssbevd,SSBEVD)
-void LAPACK_ssbevd(
+#define LAPACK_ssbevd_base LAPACK_GLOBAL(ssbevd,SSBEVD)
+void LAPACK_ssbevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
@@ -9211,10 +14819,19 @@ void LAPACK_ssbevd(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbevd(...) LAPACK_ssbevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbevd(...) LAPACK_ssbevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbevd_2stage LAPACK_GLOBAL(dsbevd_2stage,DSBEVD_2STAGE)
-void LAPACK_dsbevd_2stage(
+#define LAPACK_dsbevd_2stage_base LAPACK_GLOBAL(dsbevd_2stage,DSBEVD_2STAGE)
+void LAPACK_dsbevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
@@ -9222,10 +14839,19 @@ void LAPACK_dsbevd_2stage(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbevd_2stage(...) LAPACK_dsbevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbevd_2stage(...) LAPACK_dsbevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbevd_2stage LAPACK_GLOBAL(ssbevd_2stage,SSBEVD_2STAGE)
-void LAPACK_ssbevd_2stage(
+#define LAPACK_ssbevd_2stage_base LAPACK_GLOBAL(ssbevd_2stage,SSBEVD_2STAGE)
+void LAPACK_ssbevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
@@ -9233,10 +14859,19 @@ void LAPACK_ssbevd_2stage(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbevd_2stage(...) LAPACK_ssbevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbevd_2stage(...) LAPACK_ssbevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbevx LAPACK_GLOBAL(dsbevx,DSBEVX)
-void LAPACK_dsbevx(
+#define LAPACK_dsbevx_base LAPACK_GLOBAL(dsbevx,DSBEVX)
+void LAPACK_dsbevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
@@ -9248,10 +14883,19 @@ void LAPACK_dsbevx(
     double* Z, lapack_int const* ldz,
     double* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbevx(...) LAPACK_dsbevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsbevx(...) LAPACK_dsbevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbevx LAPACK_GLOBAL(ssbevx,SSBEVX)
-void LAPACK_ssbevx(
+#define LAPACK_ssbevx_base LAPACK_GLOBAL(ssbevx,SSBEVX)
+void LAPACK_ssbevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
@@ -9263,10 +14907,19 @@ void LAPACK_ssbevx(
     float* Z, lapack_int const* ldz,
     float* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbevx(...) LAPACK_ssbevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssbevx(...) LAPACK_ssbevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbevx_2stage LAPACK_GLOBAL(dsbevx_2stage,DSBEVX_2STAGE)
-void LAPACK_dsbevx_2stage(
+#define LAPACK_dsbevx_2stage_base LAPACK_GLOBAL(dsbevx_2stage,DSBEVX_2STAGE)
+void LAPACK_dsbevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
@@ -9278,10 +14931,19 @@ void LAPACK_dsbevx_2stage(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbevx_2stage(...) LAPACK_dsbevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsbevx_2stage(...) LAPACK_dsbevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbevx_2stage LAPACK_GLOBAL(ssbevx_2stage,SSBEVX_2STAGE)
-void LAPACK_ssbevx_2stage(
+#define LAPACK_ssbevx_2stage_base LAPACK_GLOBAL(ssbevx_2stage,SSBEVX_2STAGE)
+void LAPACK_ssbevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
@@ -9293,30 +14955,57 @@ void LAPACK_ssbevx_2stage(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbevx_2stage(...) LAPACK_ssbevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssbevx_2stage(...) LAPACK_ssbevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbgst LAPACK_GLOBAL(dsbgst,DSBGST)
-void LAPACK_dsbgst(
+#define LAPACK_dsbgst_base LAPACK_GLOBAL(dsbgst,DSBGST)
+void LAPACK_dsbgst_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     double* AB, lapack_int const* ldab,
     double const* BB, lapack_int const* ldbb,
     double* X, lapack_int const* ldx,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbgst(...) LAPACK_dsbgst_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbgst(...) LAPACK_dsbgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbgst LAPACK_GLOBAL(ssbgst,SSBGST)
-void LAPACK_ssbgst(
+#define LAPACK_ssbgst_base LAPACK_GLOBAL(ssbgst,SSBGST)
+void LAPACK_ssbgst_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     float* AB, lapack_int const* ldab,
     float const* BB, lapack_int const* ldbb,
     float* X, lapack_int const* ldx,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbgst(...) LAPACK_ssbgst_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbgst(...) LAPACK_ssbgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbgv LAPACK_GLOBAL(dsbgv,DSBGV)
-void LAPACK_dsbgv(
+#define LAPACK_dsbgv_base LAPACK_GLOBAL(dsbgv,DSBGV)
+void LAPACK_dsbgv_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     double* AB, lapack_int const* ldab,
@@ -9324,10 +15013,19 @@ void LAPACK_dsbgv(
     double* W,
     double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbgv(...) LAPACK_dsbgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbgv(...) LAPACK_dsbgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbgv LAPACK_GLOBAL(ssbgv,SSBGV)
-void LAPACK_ssbgv(
+#define LAPACK_ssbgv_base LAPACK_GLOBAL(ssbgv,SSBGV)
+void LAPACK_ssbgv_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     float* AB, lapack_int const* ldab,
@@ -9335,10 +15033,19 @@ void LAPACK_ssbgv(
     float* W,
     float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbgv(...) LAPACK_ssbgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbgv(...) LAPACK_ssbgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbgvd LAPACK_GLOBAL(dsbgvd,DSBGVD)
-void LAPACK_dsbgvd(
+#define LAPACK_dsbgvd_base LAPACK_GLOBAL(dsbgvd,DSBGVD)
+void LAPACK_dsbgvd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     double* AB, lapack_int const* ldab,
@@ -9347,10 +15054,19 @@ void LAPACK_dsbgvd(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbgvd(...) LAPACK_dsbgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbgvd(...) LAPACK_dsbgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbgvd LAPACK_GLOBAL(ssbgvd,SSBGVD)
-void LAPACK_ssbgvd(
+#define LAPACK_ssbgvd_base LAPACK_GLOBAL(ssbgvd,SSBGVD)
+void LAPACK_ssbgvd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     float* AB, lapack_int const* ldab,
@@ -9359,10 +15075,19 @@ void LAPACK_ssbgvd(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbgvd(...) LAPACK_ssbgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbgvd(...) LAPACK_ssbgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbgvx LAPACK_GLOBAL(dsbgvx,DSBGVX)
-void LAPACK_dsbgvx(
+#define LAPACK_dsbgvx_base LAPACK_GLOBAL(dsbgvx,DSBGVX)
+void LAPACK_dsbgvx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     double* AB, lapack_int const* ldab,
@@ -9375,10 +15100,19 @@ void LAPACK_dsbgvx(
     double* Z, lapack_int const* ldz,
     double* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbgvx(...) LAPACK_dsbgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsbgvx(...) LAPACK_dsbgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbgvx LAPACK_GLOBAL(ssbgvx,SSBGVX)
-void LAPACK_ssbgvx(
+#define LAPACK_ssbgvx_base LAPACK_GLOBAL(ssbgvx,SSBGVX)
+void LAPACK_ssbgvx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n, lapack_int const* ka, lapack_int const* kb,
     float* AB, lapack_int const* ldab,
@@ -9391,10 +15125,19 @@ void LAPACK_ssbgvx(
     float* Z, lapack_int const* ldz,
     float* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbgvx(...) LAPACK_ssbgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssbgvx(...) LAPACK_ssbgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsbtrd LAPACK_GLOBAL(dsbtrd,DSBTRD)
-void LAPACK_dsbtrd(
+#define LAPACK_dsbtrd_base LAPACK_GLOBAL(dsbtrd,DSBTRD)
+void LAPACK_dsbtrd_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     double* AB, lapack_int const* ldab,
@@ -9402,10 +15145,19 @@ void LAPACK_dsbtrd(
     double* E,
     double* Q, lapack_int const* ldq,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsbtrd(...) LAPACK_dsbtrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsbtrd(...) LAPACK_dsbtrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssbtrd LAPACK_GLOBAL(ssbtrd,SSBTRD)
-void LAPACK_ssbtrd(
+#define LAPACK_ssbtrd_base LAPACK_GLOBAL(ssbtrd,SSBTRD)
+void LAPACK_ssbtrd_base(
     char const* vect, char const* uplo,
     lapack_int const* n, lapack_int const* kd,
     float* AB, lapack_int const* ldab,
@@ -9413,38 +15165,74 @@ void LAPACK_ssbtrd(
     float* E,
     float* Q, lapack_int const* ldq,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssbtrd(...) LAPACK_ssbtrd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssbtrd(...) LAPACK_ssbtrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsfrk LAPACK_GLOBAL(dsfrk,DSFRK)
-void LAPACK_dsfrk(
+#define LAPACK_dsfrk_base LAPACK_GLOBAL(dsfrk,DSFRK)
+void LAPACK_dsfrk_base(
     char const* transr, char const* uplo, char const* trans,
     lapack_int const* n, lapack_int const* k,
     double const* alpha,
     double const* A, lapack_int const* lda,
     double const* beta,
-    double* C );
+    double* C
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsfrk(...) LAPACK_dsfrk_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsfrk(...) LAPACK_dsfrk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssfrk LAPACK_GLOBAL(ssfrk,SSFRK)
-void LAPACK_ssfrk(
+#define LAPACK_ssfrk_base LAPACK_GLOBAL(ssfrk,SSFRK)
+void LAPACK_ssfrk_base(
     char const* transr, char const* uplo, char const* trans,
     lapack_int const* n, lapack_int const* k,
     float const* alpha,
     float const* A, lapack_int const* lda,
     float const* beta,
-    float* C );
+    float* C
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssfrk(...) LAPACK_ssfrk_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssfrk(...) LAPACK_ssfrk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cspcon LAPACK_GLOBAL(cspcon,CSPCON)
-void LAPACK_cspcon(
+#define LAPACK_cspcon_base LAPACK_GLOBAL(cspcon,CSPCON)
+void LAPACK_cspcon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP, lapack_int const* ipiv,
     float const* anorm,
     float* rcond,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cspcon(...) LAPACK_cspcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cspcon(...) LAPACK_cspcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspcon LAPACK_GLOBAL(dspcon,DSPCON)
-void LAPACK_dspcon(
+#define LAPACK_dspcon_base LAPACK_GLOBAL(dspcon,DSPCON)
+void LAPACK_dspcon_base(
     char const* uplo,
     lapack_int const* n,
     double const* AP, lapack_int const* ipiv,
@@ -9452,10 +15240,19 @@ void LAPACK_dspcon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspcon(...) LAPACK_dspcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dspcon(...) LAPACK_dspcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspcon LAPACK_GLOBAL(sspcon,SSPCON)
-void LAPACK_sspcon(
+#define LAPACK_sspcon_base LAPACK_GLOBAL(sspcon,SSPCON)
+void LAPACK_sspcon_base(
     char const* uplo,
     lapack_int const* n,
     float const* AP, lapack_int const* ipiv,
@@ -9463,40 +15260,76 @@ void LAPACK_sspcon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspcon(...) LAPACK_sspcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sspcon(...) LAPACK_sspcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zspcon LAPACK_GLOBAL(zspcon,ZSPCON)
-void LAPACK_zspcon(
+#define LAPACK_zspcon_base LAPACK_GLOBAL(zspcon,ZSPCON)
+void LAPACK_zspcon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP, lapack_int const* ipiv,
     double const* anorm,
     double* rcond,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zspcon(...) LAPACK_zspcon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zspcon(...) LAPACK_zspcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspev LAPACK_GLOBAL(dspev,DSPEV)
-void LAPACK_dspev(
+#define LAPACK_dspev_base LAPACK_GLOBAL(dspev,DSPEV)
+void LAPACK_dspev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     double* AP,
     double* W,
     double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspev(...) LAPACK_dspev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dspev(...) LAPACK_dspev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspev LAPACK_GLOBAL(sspev,SSPEV)
-void LAPACK_sspev(
+#define LAPACK_sspev_base LAPACK_GLOBAL(sspev,SSPEV)
+void LAPACK_sspev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     float* AP,
     float* W,
     float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspev(...) LAPACK_sspev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sspev(...) LAPACK_sspev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspevd LAPACK_GLOBAL(dspevd,DSPEVD)
-void LAPACK_dspevd(
+#define LAPACK_dspevd_base LAPACK_GLOBAL(dspevd,DSPEVD)
+void LAPACK_dspevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     double* AP,
@@ -9504,10 +15337,19 @@ void LAPACK_dspevd(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspevd(...) LAPACK_dspevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dspevd(...) LAPACK_dspevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspevd LAPACK_GLOBAL(sspevd,SSPEVD)
-void LAPACK_sspevd(
+#define LAPACK_sspevd_base LAPACK_GLOBAL(sspevd,SSPEVD)
+void LAPACK_sspevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     float* AP,
@@ -9515,10 +15357,19 @@ void LAPACK_sspevd(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspevd(...) LAPACK_sspevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sspevd(...) LAPACK_sspevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspevx LAPACK_GLOBAL(dspevx,DSPEVX)
-void LAPACK_dspevx(
+#define LAPACK_dspevx_base LAPACK_GLOBAL(dspevx,DSPEVX)
+void LAPACK_dspevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     double* AP,
@@ -9529,10 +15380,19 @@ void LAPACK_dspevx(
     double* Z, lapack_int const* ldz,
     double* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspevx(...) LAPACK_dspevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dspevx(...) LAPACK_dspevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspevx LAPACK_GLOBAL(sspevx,SSPEVX)
-void LAPACK_sspevx(
+#define LAPACK_sspevx_base LAPACK_GLOBAL(sspevx,SSPEVX)
+void LAPACK_sspevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     float* AP,
@@ -9543,26 +15403,53 @@ void LAPACK_sspevx(
     float* Z, lapack_int const* ldz,
     float* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspevx(...) LAPACK_sspevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sspevx(...) LAPACK_sspevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspgst LAPACK_GLOBAL(dspgst,DSPGST)
-void LAPACK_dspgst(
+#define LAPACK_dspgst_base LAPACK_GLOBAL(dspgst,DSPGST)
+void LAPACK_dspgst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     double* AP,
     double const* BP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspgst(...) LAPACK_dspgst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dspgst(...) LAPACK_dspgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspgst LAPACK_GLOBAL(sspgst,SSPGST)
-void LAPACK_sspgst(
+#define LAPACK_sspgst_base LAPACK_GLOBAL(sspgst,SSPGST)
+void LAPACK_sspgst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     float* AP,
     float const* BP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspgst(...) LAPACK_sspgst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sspgst(...) LAPACK_sspgst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspgv LAPACK_GLOBAL(dspgv,DSPGV)
-void LAPACK_dspgv(
+#define LAPACK_dspgv_base LAPACK_GLOBAL(dspgv,DSPGV)
+void LAPACK_dspgv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     double* AP,
@@ -9570,10 +15457,19 @@ void LAPACK_dspgv(
     double* W,
     double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspgv(...) LAPACK_dspgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dspgv(...) LAPACK_dspgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspgv LAPACK_GLOBAL(sspgv,SSPGV)
-void LAPACK_sspgv(
+#define LAPACK_sspgv_base LAPACK_GLOBAL(sspgv,SSPGV)
+void LAPACK_sspgv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     float* AP,
@@ -9581,10 +15477,19 @@ void LAPACK_sspgv(
     float* W,
     float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspgv(...) LAPACK_sspgv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sspgv(...) LAPACK_sspgv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspgvd LAPACK_GLOBAL(dspgvd,DSPGVD)
-void LAPACK_dspgvd(
+#define LAPACK_dspgvd_base LAPACK_GLOBAL(dspgvd,DSPGVD)
+void LAPACK_dspgvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     double* AP,
@@ -9593,10 +15498,19 @@ void LAPACK_dspgvd(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspgvd(...) LAPACK_dspgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dspgvd(...) LAPACK_dspgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspgvd LAPACK_GLOBAL(sspgvd,SSPGVD)
-void LAPACK_sspgvd(
+#define LAPACK_sspgvd_base LAPACK_GLOBAL(sspgvd,SSPGVD)
+void LAPACK_sspgvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     float* AP,
@@ -9605,10 +15519,19 @@ void LAPACK_sspgvd(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspgvd(...) LAPACK_sspgvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sspgvd(...) LAPACK_sspgvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspgvx LAPACK_GLOBAL(dspgvx,DSPGVX)
-void LAPACK_dspgvx(
+#define LAPACK_dspgvx_base LAPACK_GLOBAL(dspgvx,DSPGVX)
+void LAPACK_dspgvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     double* AP,
@@ -9620,10 +15543,19 @@ void LAPACK_dspgvx(
     double* Z, lapack_int const* ldz,
     double* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspgvx(...) LAPACK_dspgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dspgvx(...) LAPACK_dspgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspgvx LAPACK_GLOBAL(sspgvx,SSPGVX)
-void LAPACK_sspgvx(
+#define LAPACK_sspgvx_base LAPACK_GLOBAL(sspgvx,SSPGVX)
+void LAPACK_sspgvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     float* AP,
@@ -9635,10 +15567,19 @@ void LAPACK_sspgvx(
     float* Z, lapack_int const* ldz,
     float* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspgvx(...) LAPACK_sspgvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_sspgvx(...) LAPACK_sspgvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csprfs LAPACK_GLOBAL(csprfs,CSPRFS)
-void LAPACK_csprfs(
+#define LAPACK_csprfs_base LAPACK_GLOBAL(csprfs,CSPRFS)
+void LAPACK_csprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
@@ -9649,10 +15590,19 @@ void LAPACK_csprfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csprfs(...) LAPACK_csprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csprfs(...) LAPACK_csprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsprfs LAPACK_GLOBAL(dsprfs,DSPRFS)
-void LAPACK_dsprfs(
+#define LAPACK_dsprfs_base LAPACK_GLOBAL(dsprfs,DSPRFS)
+void LAPACK_dsprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* AP,
@@ -9663,10 +15613,19 @@ void LAPACK_dsprfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsprfs(...) LAPACK_dsprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsprfs(...) LAPACK_dsprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssprfs LAPACK_GLOBAL(ssprfs,SSPRFS)
-void LAPACK_ssprfs(
+#define LAPACK_ssprfs_base LAPACK_GLOBAL(ssprfs,SSPRFS)
+void LAPACK_ssprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* AP,
@@ -9677,10 +15636,19 @@ void LAPACK_ssprfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssprfs(...) LAPACK_ssprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssprfs(...) LAPACK_ssprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsprfs LAPACK_GLOBAL(zsprfs,ZSPRFS)
-void LAPACK_zsprfs(
+#define LAPACK_zsprfs_base LAPACK_GLOBAL(zsprfs,ZSPRFS)
+void LAPACK_zsprfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
@@ -9691,42 +15659,87 @@ void LAPACK_zsprfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsprfs(...) LAPACK_zsprfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsprfs(...) LAPACK_zsprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cspsv LAPACK_GLOBAL(cspsv,CSPSV)
-void LAPACK_cspsv(
+#define LAPACK_cspsv_base LAPACK_GLOBAL(cspsv,CSPSV)
+void LAPACK_cspsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* AP, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cspsv(...) LAPACK_cspsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cspsv(...) LAPACK_cspsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspsv LAPACK_GLOBAL(dspsv,DSPSV)
-void LAPACK_dspsv(
+#define LAPACK_dspsv_base LAPACK_GLOBAL(dspsv,DSPSV)
+void LAPACK_dspsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* AP, lapack_int* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspsv(...) LAPACK_dspsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dspsv(...) LAPACK_dspsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspsv LAPACK_GLOBAL(sspsv,SSPSV)
-void LAPACK_sspsv(
+#define LAPACK_sspsv_base LAPACK_GLOBAL(sspsv,SSPSV)
+void LAPACK_sspsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* AP, lapack_int* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspsv(...) LAPACK_sspsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sspsv(...) LAPACK_sspsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zspsv LAPACK_GLOBAL(zspsv,ZSPSV)
-void LAPACK_zspsv(
+#define LAPACK_zspsv_base LAPACK_GLOBAL(zspsv,ZSPSV)
+void LAPACK_zspsv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* AP, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zspsv(...) LAPACK_zspsv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zspsv(...) LAPACK_zspsv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cspsvx LAPACK_GLOBAL(cspsvx,CSPSVX)
-void LAPACK_cspsvx(
+#define LAPACK_cspsvx_base LAPACK_GLOBAL(cspsvx,CSPSVX)
+void LAPACK_cspsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
@@ -9738,10 +15751,19 @@ void LAPACK_cspsvx(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cspsvx(...) LAPACK_cspsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cspsvx(...) LAPACK_cspsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dspsvx LAPACK_GLOBAL(dspsvx,DSPSVX)
-void LAPACK_dspsvx(
+#define LAPACK_dspsvx_base LAPACK_GLOBAL(dspsvx,DSPSVX)
+void LAPACK_dspsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* AP,
@@ -9753,10 +15775,19 @@ void LAPACK_dspsvx(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dspsvx(...) LAPACK_dspsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dspsvx(...) LAPACK_dspsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sspsvx LAPACK_GLOBAL(sspsvx,SSPSVX)
-void LAPACK_sspsvx(
+#define LAPACK_sspsvx_base LAPACK_GLOBAL(sspsvx,SSPSVX)
+void LAPACK_sspsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* AP,
@@ -9768,10 +15799,19 @@ void LAPACK_sspsvx(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sspsvx(...) LAPACK_sspsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sspsvx(...) LAPACK_sspsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zspsvx LAPACK_GLOBAL(zspsvx,ZSPSVX)
-void LAPACK_zspsvx(
+#define LAPACK_zspsvx_base LAPACK_GLOBAL(zspsvx,ZSPSVX)
+void LAPACK_zspsvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
@@ -9783,122 +15823,257 @@ void LAPACK_zspsvx(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zspsvx(...) LAPACK_zspsvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zspsvx(...) LAPACK_zspsvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsptrd LAPACK_GLOBAL(dsptrd,DSPTRD)
-void LAPACK_dsptrd(
+#define LAPACK_dsptrd_base LAPACK_GLOBAL(dsptrd,DSPTRD)
+void LAPACK_dsptrd_base(
     char const* uplo,
     lapack_int const* n,
     double* AP,
     double* D,
     double* E,
     double* tau,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsptrd(...) LAPACK_dsptrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsptrd(...) LAPACK_dsptrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssptrd LAPACK_GLOBAL(ssptrd,SSPTRD)
-void LAPACK_ssptrd(
+#define LAPACK_ssptrd_base LAPACK_GLOBAL(ssptrd,SSPTRD)
+void LAPACK_ssptrd_base(
     char const* uplo,
     lapack_int const* n,
     float* AP,
     float* D,
     float* E,
     float* tau,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssptrd(...) LAPACK_ssptrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssptrd(...) LAPACK_ssptrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csptrf LAPACK_GLOBAL(csptrf,CSPTRF)
-void LAPACK_csptrf(
+#define LAPACK_csptrf_base LAPACK_GLOBAL(csptrf,CSPTRF)
+void LAPACK_csptrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP, lapack_int* ipiv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csptrf(...) LAPACK_csptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csptrf(...) LAPACK_csptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsptrf LAPACK_GLOBAL(dsptrf,DSPTRF)
-void LAPACK_dsptrf(
+#define LAPACK_dsptrf_base LAPACK_GLOBAL(dsptrf,DSPTRF)
+void LAPACK_dsptrf_base(
     char const* uplo,
     lapack_int const* n,
     double* AP, lapack_int* ipiv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsptrf(...) LAPACK_dsptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsptrf(...) LAPACK_dsptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssptrf LAPACK_GLOBAL(ssptrf,SSPTRF)
-void LAPACK_ssptrf(
+#define LAPACK_ssptrf_base LAPACK_GLOBAL(ssptrf,SSPTRF)
+void LAPACK_ssptrf_base(
     char const* uplo,
     lapack_int const* n,
     float* AP, lapack_int* ipiv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssptrf(...) LAPACK_ssptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssptrf(...) LAPACK_ssptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsptrf LAPACK_GLOBAL(zsptrf,ZSPTRF)
-void LAPACK_zsptrf(
+#define LAPACK_zsptrf_base LAPACK_GLOBAL(zsptrf,ZSPTRF)
+void LAPACK_zsptrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP, lapack_int* ipiv,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsptrf(...) LAPACK_zsptrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsptrf(...) LAPACK_zsptrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csptri LAPACK_GLOBAL(csptri,CSPTRI)
-void LAPACK_csptri(
+#define LAPACK_csptri_base LAPACK_GLOBAL(csptri,CSPTRI)
+void LAPACK_csptri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* AP, lapack_int const* ipiv,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csptri(...) LAPACK_csptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csptri(...) LAPACK_csptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsptri LAPACK_GLOBAL(dsptri,DSPTRI)
-void LAPACK_dsptri(
+#define LAPACK_dsptri_base LAPACK_GLOBAL(dsptri,DSPTRI)
+void LAPACK_dsptri_base(
     char const* uplo,
     lapack_int const* n,
     double* AP, lapack_int const* ipiv,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsptri(...) LAPACK_dsptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsptri(...) LAPACK_dsptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssptri LAPACK_GLOBAL(ssptri,SSPTRI)
-void LAPACK_ssptri(
+#define LAPACK_ssptri_base LAPACK_GLOBAL(ssptri,SSPTRI)
+void LAPACK_ssptri_base(
     char const* uplo,
     lapack_int const* n,
     float* AP, lapack_int const* ipiv,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssptri(...) LAPACK_ssptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssptri(...) LAPACK_ssptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsptri LAPACK_GLOBAL(zsptri,ZSPTRI)
-void LAPACK_zsptri(
+#define LAPACK_zsptri_base LAPACK_GLOBAL(zsptri,ZSPTRI)
+void LAPACK_zsptri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* AP, lapack_int const* ipiv,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsptri(...) LAPACK_zsptri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsptri(...) LAPACK_zsptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csptrs LAPACK_GLOBAL(csptrs,CSPTRS)
-void LAPACK_csptrs(
+#define LAPACK_csptrs_base LAPACK_GLOBAL(csptrs,CSPTRS)
+void LAPACK_csptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csptrs(...) LAPACK_csptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csptrs(...) LAPACK_csptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsptrs LAPACK_GLOBAL(dsptrs,DSPTRS)
-void LAPACK_dsptrs(
+#define LAPACK_dsptrs_base LAPACK_GLOBAL(dsptrs,DSPTRS)
+void LAPACK_dsptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* AP, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsptrs(...) LAPACK_dsptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsptrs(...) LAPACK_dsptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssptrs LAPACK_GLOBAL(ssptrs,SSPTRS)
-void LAPACK_ssptrs(
+#define LAPACK_ssptrs_base LAPACK_GLOBAL(ssptrs,SSPTRS)
+void LAPACK_ssptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* AP, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssptrs(...) LAPACK_ssptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssptrs(...) LAPACK_ssptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsptrs LAPACK_GLOBAL(zsptrs,ZSPTRS)
-void LAPACK_zsptrs(
+#define LAPACK_zsptrs_base LAPACK_GLOBAL(zsptrs,ZSPTRS)
+void LAPACK_zsptrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsptrs(...) LAPACK_zsptrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsptrs(...) LAPACK_zsptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dstebz LAPACK_GLOBAL(dstebz,DSTEBZ)
-void LAPACK_dstebz(
+#define LAPACK_dstebz_base LAPACK_GLOBAL(dstebz,DSTEBZ)
+void LAPACK_dstebz_base(
     char const* range, char const* order,
     lapack_int const* n,
     double const* vl,
@@ -9909,10 +16084,19 @@ void LAPACK_dstebz(
     double* W, lapack_int* IBLOCK, lapack_int* ISPLIT,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstebz(...) LAPACK_dstebz_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dstebz(...) LAPACK_dstebz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstebz LAPACK_GLOBAL(sstebz,SSTEBZ)
-void LAPACK_sstebz(
+#define LAPACK_sstebz_base LAPACK_GLOBAL(sstebz,SSTEBZ)
+void LAPACK_sstebz_base(
     char const* range, char const* order,
     lapack_int const* n,
     float const* vl,
@@ -9923,10 +16107,19 @@ void LAPACK_sstebz(
     float* W, lapack_int* IBLOCK, lapack_int* ISPLIT,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstebz(...) LAPACK_sstebz_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sstebz(...) LAPACK_sstebz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cstedc LAPACK_GLOBAL(cstedc,CSTEDC)
-void LAPACK_cstedc(
+#define LAPACK_cstedc_base LAPACK_GLOBAL(cstedc,CSTEDC)
+void LAPACK_cstedc_base(
     char const* compz,
     lapack_int const* n,
     float* D,
@@ -9935,10 +16128,19 @@ void LAPACK_cstedc(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cstedc(...) LAPACK_cstedc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cstedc(...) LAPACK_cstedc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dstedc LAPACK_GLOBAL(dstedc,DSTEDC)
-void LAPACK_dstedc(
+#define LAPACK_dstedc_base LAPACK_GLOBAL(dstedc,DSTEDC)
+void LAPACK_dstedc_base(
     char const* compz,
     lapack_int const* n,
     double* D,
@@ -9946,10 +16148,19 @@ void LAPACK_dstedc(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstedc(...) LAPACK_dstedc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dstedc(...) LAPACK_dstedc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstedc LAPACK_GLOBAL(sstedc,SSTEDC)
-void LAPACK_sstedc(
+#define LAPACK_sstedc_base LAPACK_GLOBAL(sstedc,SSTEDC)
+void LAPACK_sstedc_base(
     char const* compz,
     lapack_int const* n,
     float* D,
@@ -9957,10 +16168,19 @@ void LAPACK_sstedc(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstedc(...) LAPACK_sstedc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sstedc(...) LAPACK_sstedc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zstedc LAPACK_GLOBAL(zstedc,ZSTEDC)
-void LAPACK_zstedc(
+#define LAPACK_zstedc_base LAPACK_GLOBAL(zstedc,ZSTEDC)
+void LAPACK_zstedc_base(
     char const* compz,
     lapack_int const* n,
     double* D,
@@ -9969,10 +16189,19 @@ void LAPACK_zstedc(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zstedc(...) LAPACK_zstedc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zstedc(...) LAPACK_zstedc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cstegr LAPACK_GLOBAL(cstegr,CSTEGR)
-void LAPACK_cstegr(
+#define LAPACK_cstegr_base LAPACK_GLOBAL(cstegr,CSTEGR)
+void LAPACK_cstegr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     float* D,
@@ -9984,10 +16213,19 @@ void LAPACK_cstegr(
     lapack_complex_float* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cstegr(...) LAPACK_cstegr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cstegr(...) LAPACK_cstegr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dstegr LAPACK_GLOBAL(dstegr,DSTEGR)
-void LAPACK_dstegr(
+#define LAPACK_dstegr_base LAPACK_GLOBAL(dstegr,DSTEGR)
+void LAPACK_dstegr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     double* D,
@@ -9999,10 +16237,19 @@ void LAPACK_dstegr(
     double* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstegr(...) LAPACK_dstegr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dstegr(...) LAPACK_dstegr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstegr LAPACK_GLOBAL(sstegr,SSTEGR)
-void LAPACK_sstegr(
+#define LAPACK_sstegr_base LAPACK_GLOBAL(sstegr,SSTEGR)
+void LAPACK_sstegr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     float* D,
@@ -10014,10 +16261,19 @@ void LAPACK_sstegr(
     float* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstegr(...) LAPACK_sstegr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sstegr(...) LAPACK_sstegr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zstegr LAPACK_GLOBAL(zstegr,ZSTEGR)
-void LAPACK_zstegr(
+#define LAPACK_zstegr_base LAPACK_GLOBAL(zstegr,ZSTEGR)
+void LAPACK_zstegr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     double* D,
@@ -10029,7 +16285,16 @@ void LAPACK_zstegr(
     lapack_complex_double* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zstegr(...) LAPACK_zstegr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zstegr(...) LAPACK_zstegr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cstein LAPACK_GLOBAL(cstein,CSTEIN)
 void LAPACK_cstein(
@@ -10075,8 +16340,8 @@ void LAPACK_zstein(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info );
 
-#define LAPACK_cstemr LAPACK_GLOBAL(cstemr,CSTEMR)
-void LAPACK_cstemr(
+#define LAPACK_cstemr_base LAPACK_GLOBAL(cstemr,CSTEMR)
+void LAPACK_cstemr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     float* D,
@@ -10087,10 +16352,19 @@ void LAPACK_cstemr(
     lapack_complex_float* Z, lapack_int const* ldz, lapack_int const* nzc, lapack_int* ISUPPZ, lapack_logical* tryrac,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cstemr(...) LAPACK_cstemr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cstemr(...) LAPACK_cstemr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dstemr LAPACK_GLOBAL(dstemr,DSTEMR)
-void LAPACK_dstemr(
+#define LAPACK_dstemr_base LAPACK_GLOBAL(dstemr,DSTEMR)
+void LAPACK_dstemr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     double* D,
@@ -10101,10 +16375,19 @@ void LAPACK_dstemr(
     double* Z, lapack_int const* ldz, lapack_int const* nzc, lapack_int* ISUPPZ, lapack_logical* tryrac,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstemr(...) LAPACK_dstemr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dstemr(...) LAPACK_dstemr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstemr LAPACK_GLOBAL(sstemr,SSTEMR)
-void LAPACK_sstemr(
+#define LAPACK_sstemr_base LAPACK_GLOBAL(sstemr,SSTEMR)
+void LAPACK_sstemr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     float* D,
@@ -10115,10 +16398,19 @@ void LAPACK_sstemr(
     float* Z, lapack_int const* ldz, lapack_int const* nzc, lapack_int* ISUPPZ, lapack_logical* tryrac,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstemr(...) LAPACK_sstemr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sstemr(...) LAPACK_sstemr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zstemr LAPACK_GLOBAL(zstemr,ZSTEMR)
-void LAPACK_zstemr(
+#define LAPACK_zstemr_base LAPACK_GLOBAL(zstemr,ZSTEMR)
+void LAPACK_zstemr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     double* D,
@@ -10129,47 +16421,92 @@ void LAPACK_zstemr(
     lapack_complex_double* Z, lapack_int const* ldz, lapack_int const* nzc, lapack_int* ISUPPZ, lapack_logical* tryrac,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zstemr(...) LAPACK_zstemr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zstemr(...) LAPACK_zstemr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csteqr LAPACK_GLOBAL(csteqr,CSTEQR)
-void LAPACK_csteqr(
+#define LAPACK_csteqr_base LAPACK_GLOBAL(csteqr,CSTEQR)
+void LAPACK_csteqr_base(
     char const* compz,
     lapack_int const* n,
     float* D,
     float* E,
     lapack_complex_float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csteqr(...) LAPACK_csteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csteqr(...) LAPACK_csteqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsteqr LAPACK_GLOBAL(dsteqr,DSTEQR)
-void LAPACK_dsteqr(
+#define LAPACK_dsteqr_base LAPACK_GLOBAL(dsteqr,DSTEQR)
+void LAPACK_dsteqr_base(
     char const* compz,
     lapack_int const* n,
     double* D,
     double* E,
     double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsteqr(...) LAPACK_dsteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsteqr(...) LAPACK_dsteqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssteqr LAPACK_GLOBAL(ssteqr,SSTEQR)
-void LAPACK_ssteqr(
+#define LAPACK_ssteqr_base LAPACK_GLOBAL(ssteqr,SSTEQR)
+void LAPACK_ssteqr_base(
     char const* compz,
     lapack_int const* n,
     float* D,
     float* E,
     float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssteqr(...) LAPACK_ssteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssteqr(...) LAPACK_ssteqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsteqr LAPACK_GLOBAL(zsteqr,ZSTEQR)
-void LAPACK_zsteqr(
+#define LAPACK_zsteqr_base LAPACK_GLOBAL(zsteqr,ZSTEQR)
+void LAPACK_zsteqr_base(
     char const* compz,
     lapack_int const* n,
     double* D,
     double* E,
     lapack_complex_double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsteqr(...) LAPACK_zsteqr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsteqr(...) LAPACK_zsteqr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_dsterf LAPACK_GLOBAL(dsterf,DSTERF)
 void LAPACK_dsterf(
@@ -10185,28 +16522,46 @@ void LAPACK_ssterf(
     float* E,
     lapack_int* info );
 
-#define LAPACK_dstev LAPACK_GLOBAL(dstev,DSTEV)
-void LAPACK_dstev(
+#define LAPACK_dstev_base LAPACK_GLOBAL(dstev,DSTEV)
+void LAPACK_dstev_base(
     char const* jobz,
     lapack_int const* n,
     double* D,
     double* E,
     double* Z, lapack_int const* ldz,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstev(...) LAPACK_dstev_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dstev(...) LAPACK_dstev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstev LAPACK_GLOBAL(sstev,SSTEV)
-void LAPACK_sstev(
+#define LAPACK_sstev_base LAPACK_GLOBAL(sstev,SSTEV)
+void LAPACK_sstev_base(
     char const* jobz,
     lapack_int const* n,
     float* D,
     float* E,
     float* Z, lapack_int const* ldz,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstev(...) LAPACK_sstev_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sstev(...) LAPACK_sstev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dstevd LAPACK_GLOBAL(dstevd,DSTEVD)
-void LAPACK_dstevd(
+#define LAPACK_dstevd_base LAPACK_GLOBAL(dstevd,DSTEVD)
+void LAPACK_dstevd_base(
     char const* jobz,
     lapack_int const* n,
     double* D,
@@ -10214,10 +16569,19 @@ void LAPACK_dstevd(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstevd(...) LAPACK_dstevd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dstevd(...) LAPACK_dstevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstevd LAPACK_GLOBAL(sstevd,SSTEVD)
-void LAPACK_sstevd(
+#define LAPACK_sstevd_base LAPACK_GLOBAL(sstevd,SSTEVD)
+void LAPACK_sstevd_base(
     char const* jobz,
     lapack_int const* n,
     float* D,
@@ -10225,10 +16589,19 @@ void LAPACK_sstevd(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstevd(...) LAPACK_sstevd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_sstevd(...) LAPACK_sstevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dstevr LAPACK_GLOBAL(dstevr,DSTEVR)
-void LAPACK_dstevr(
+#define LAPACK_dstevr_base LAPACK_GLOBAL(dstevr,DSTEVR)
+void LAPACK_dstevr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     double* D,
@@ -10240,10 +16613,19 @@ void LAPACK_dstevr(
     double* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstevr(...) LAPACK_dstevr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dstevr(...) LAPACK_dstevr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstevr LAPACK_GLOBAL(sstevr,SSTEVR)
-void LAPACK_sstevr(
+#define LAPACK_sstevr_base LAPACK_GLOBAL(sstevr,SSTEVR)
+void LAPACK_sstevr_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     float* D,
@@ -10255,10 +16637,19 @@ void LAPACK_sstevr(
     float* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstevr(...) LAPACK_sstevr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sstevr(...) LAPACK_sstevr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dstevx LAPACK_GLOBAL(dstevx,DSTEVX)
-void LAPACK_dstevx(
+#define LAPACK_dstevx_base LAPACK_GLOBAL(dstevx,DSTEVX)
+void LAPACK_dstevx_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     double* D,
@@ -10270,10 +16661,19 @@ void LAPACK_dstevx(
     double* Z, lapack_int const* ldz,
     double* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dstevx(...) LAPACK_dstevx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dstevx(...) LAPACK_dstevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_sstevx LAPACK_GLOBAL(sstevx,SSTEVX)
-void LAPACK_sstevx(
+#define LAPACK_sstevx_base LAPACK_GLOBAL(sstevx,SSTEVX)
+void LAPACK_sstevx_base(
     char const* jobz, char const* range,
     lapack_int const* n,
     float* D,
@@ -10285,20 +16685,38 @@ void LAPACK_sstevx(
     float* Z, lapack_int const* ldz,
     float* work,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_sstevx(...) LAPACK_sstevx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_sstevx(...) LAPACK_sstevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csycon LAPACK_GLOBAL(csycon,CSYCON)
-void LAPACK_csycon(
+#define LAPACK_csycon_base LAPACK_GLOBAL(csycon,CSYCON)
+void LAPACK_csycon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     float const* anorm,
     float* rcond,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csycon(...) LAPACK_csycon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csycon(...) LAPACK_csycon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsycon LAPACK_GLOBAL(dsycon,DSYCON)
-void LAPACK_dsycon(
+#define LAPACK_dsycon_base LAPACK_GLOBAL(dsycon,DSYCON)
+void LAPACK_dsycon_base(
     char const* uplo,
     lapack_int const* n,
     double const* A, lapack_int const* lda, lapack_int const* ipiv,
@@ -10306,10 +16724,19 @@ void LAPACK_dsycon(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsycon(...) LAPACK_dsycon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsycon(...) LAPACK_dsycon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssycon LAPACK_GLOBAL(ssycon,SSYCON)
-void LAPACK_ssycon(
+#define LAPACK_ssycon_base LAPACK_GLOBAL(ssycon,SSYCON)
+void LAPACK_ssycon_base(
     char const* uplo,
     lapack_int const* n,
     float const* A, lapack_int const* lda, lapack_int const* ipiv,
@@ -10317,20 +16744,38 @@ void LAPACK_ssycon(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssycon(...) LAPACK_ssycon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssycon(...) LAPACK_ssycon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsycon LAPACK_GLOBAL(zsycon,ZSYCON)
-void LAPACK_zsycon(
+#define LAPACK_zsycon_base LAPACK_GLOBAL(zsycon,ZSYCON)
+void LAPACK_zsycon_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     double const* anorm,
     double* rcond,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsycon(...) LAPACK_zsycon_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsycon(...) LAPACK_zsycon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csycon_3 LAPACK_GLOBAL(csycon_3,CSYCON_3)
-void LAPACK_csycon_3(
+#define LAPACK_csycon_3_base LAPACK_GLOBAL(csycon_3,CSYCON_3)
+void LAPACK_csycon_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -10338,10 +16783,19 @@ void LAPACK_csycon_3(
     float const* anorm,
     float* rcond,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csycon_3(...) LAPACK_csycon_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csycon_3(...) LAPACK_csycon_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsycon_3 LAPACK_GLOBAL(dsycon_3,DSYCON_3)
-void LAPACK_dsycon_3(
+#define LAPACK_dsycon_3_base LAPACK_GLOBAL(dsycon_3,DSYCON_3)
+void LAPACK_dsycon_3_base(
     char const* uplo,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
@@ -10350,10 +16804,19 @@ void LAPACK_dsycon_3(
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsycon_3(...) LAPACK_dsycon_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsycon_3(...) LAPACK_dsycon_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssycon_3 LAPACK_GLOBAL(ssycon_3,SSYCON_3)
-void LAPACK_ssycon_3(
+#define LAPACK_ssycon_3_base LAPACK_GLOBAL(ssycon_3,SSYCON_3)
+void LAPACK_ssycon_3_base(
     char const* uplo,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
@@ -10362,10 +16825,19 @@ void LAPACK_ssycon_3(
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssycon_3(...) LAPACK_ssycon_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssycon_3(...) LAPACK_ssycon_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsycon_3 LAPACK_GLOBAL(zsycon_3,ZSYCON_3)
-void LAPACK_zsycon_3(
+#define LAPACK_zsycon_3_base LAPACK_GLOBAL(zsycon_3,ZSYCON_3)
+void LAPACK_zsycon_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -10373,42 +16845,87 @@ void LAPACK_zsycon_3(
     double const* anorm,
     double* rcond,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsycon_3(...) LAPACK_zsycon_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsycon_3(...) LAPACK_zsycon_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csyconv LAPACK_GLOBAL(csyconv,CSYCONV)
-void LAPACK_csyconv(
+#define LAPACK_csyconv_base LAPACK_GLOBAL(csyconv,CSYCONV)
+void LAPACK_csyconv_base(
     char const* uplo, char const* way,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* E,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csyconv(...) LAPACK_csyconv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_csyconv(...) LAPACK_csyconv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyconv LAPACK_GLOBAL(dsyconv,DSYCONV)
-void LAPACK_dsyconv(
+#define LAPACK_dsyconv_base LAPACK_GLOBAL(dsyconv,DSYCONV)
+void LAPACK_dsyconv_base(
     char const* uplo, char const* way,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int const* ipiv,
     double* E,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyconv(...) LAPACK_dsyconv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsyconv(...) LAPACK_dsyconv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyconv LAPACK_GLOBAL(ssyconv,SSYCONV)
-void LAPACK_ssyconv(
+#define LAPACK_ssyconv_base LAPACK_GLOBAL(ssyconv,SSYCONV)
+void LAPACK_ssyconv_base(
     char const* uplo, char const* way,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int const* ipiv,
     float* E,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyconv(...) LAPACK_ssyconv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssyconv(...) LAPACK_ssyconv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsyconv LAPACK_GLOBAL(zsyconv,ZSYCONV)
-void LAPACK_zsyconv(
+#define LAPACK_zsyconv_base LAPACK_GLOBAL(zsyconv,ZSYCONV)
+void LAPACK_zsyconv_base(
     char const* uplo, char const* way,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* E,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsyconv(...) LAPACK_zsyconv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zsyconv(...) LAPACK_zsyconv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csyequb LAPACK_GLOBAL(csyequb,CSYEQUB)
-void LAPACK_csyequb(
+#define LAPACK_csyequb_base LAPACK_GLOBAL(csyequb,CSYEQUB)
+void LAPACK_csyequb_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -10416,10 +16933,19 @@ void LAPACK_csyequb(
     float* scond,
     float* amax,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csyequb(...) LAPACK_csyequb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csyequb(...) LAPACK_csyequb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyequb LAPACK_GLOBAL(dsyequb,DSYEQUB)
-void LAPACK_dsyequb(
+#define LAPACK_dsyequb_base LAPACK_GLOBAL(dsyequb,DSYEQUB)
+void LAPACK_dsyequb_base(
     char const* uplo,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
@@ -10427,10 +16953,19 @@ void LAPACK_dsyequb(
     double* scond,
     double* amax,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyequb(...) LAPACK_dsyequb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsyequb(...) LAPACK_dsyequb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyequb LAPACK_GLOBAL(ssyequb,SSYEQUB)
-void LAPACK_ssyequb(
+#define LAPACK_ssyequb_base LAPACK_GLOBAL(ssyequb,SSYEQUB)
+void LAPACK_ssyequb_base(
     char const* uplo,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
@@ -10438,10 +16973,19 @@ void LAPACK_ssyequb(
     float* scond,
     float* amax,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyequb(...) LAPACK_ssyequb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssyequb(...) LAPACK_ssyequb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsyequb LAPACK_GLOBAL(zsyequb,ZSYEQUB)
-void LAPACK_zsyequb(
+#define LAPACK_zsyequb_base LAPACK_GLOBAL(zsyequb,ZSYEQUB)
+void LAPACK_zsyequb_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -10449,86 +16993,167 @@ void LAPACK_zsyequb(
     double* scond,
     double* amax,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsyequb(...) LAPACK_zsyequb_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsyequb(...) LAPACK_zsyequb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyev LAPACK_GLOBAL(dsyev,DSYEV)
-void LAPACK_dsyev(
+#define LAPACK_dsyev_base LAPACK_GLOBAL(dsyev,DSYEV)
+void LAPACK_dsyev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* W,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyev(...) LAPACK_dsyev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsyev(...) LAPACK_dsyev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyev LAPACK_GLOBAL(ssyev,SSYEV)
-void LAPACK_ssyev(
+#define LAPACK_ssyev_base LAPACK_GLOBAL(ssyev,SSYEV)
+void LAPACK_ssyev_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* W,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyev(...) LAPACK_ssyev_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssyev(...) LAPACK_ssyev_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyev_2stage LAPACK_GLOBAL(dsyev_2stage,DSYEV_2STAGE)
-void LAPACK_dsyev_2stage(
+#define LAPACK_dsyev_2stage_base LAPACK_GLOBAL(dsyev_2stage,DSYEV_2STAGE)
+void LAPACK_dsyev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* W,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyev_2stage(...) LAPACK_dsyev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsyev_2stage(...) LAPACK_dsyev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyev_2stage LAPACK_GLOBAL(ssyev_2stage,SSYEV_2STAGE)
-void LAPACK_ssyev_2stage(
+#define LAPACK_ssyev_2stage_base LAPACK_GLOBAL(ssyev_2stage,SSYEV_2STAGE)
+void LAPACK_ssyev_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* W,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyev_2stage(...) LAPACK_ssyev_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssyev_2stage(...) LAPACK_ssyev_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyevd LAPACK_GLOBAL(dsyevd,DSYEVD)
-void LAPACK_dsyevd(
+#define LAPACK_dsyevd_base LAPACK_GLOBAL(dsyevd,DSYEVD)
+void LAPACK_dsyevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* W,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyevd(...) LAPACK_dsyevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsyevd(...) LAPACK_dsyevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyevd LAPACK_GLOBAL(ssyevd,SSYEVD)
-void LAPACK_ssyevd(
+#define LAPACK_ssyevd_base LAPACK_GLOBAL(ssyevd,SSYEVD)
+void LAPACK_ssyevd_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* W,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyevd(...) LAPACK_ssyevd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssyevd(...) LAPACK_ssyevd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyevd_2stage LAPACK_GLOBAL(dsyevd_2stage,DSYEVD_2STAGE)
-void LAPACK_dsyevd_2stage(
+#define LAPACK_dsyevd_2stage_base LAPACK_GLOBAL(dsyevd_2stage,DSYEVD_2STAGE)
+void LAPACK_dsyevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* W,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyevd_2stage(...) LAPACK_dsyevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsyevd_2stage(...) LAPACK_dsyevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyevd_2stage LAPACK_GLOBAL(ssyevd_2stage,SSYEVD_2STAGE)
-void LAPACK_ssyevd_2stage(
+#define LAPACK_ssyevd_2stage_base LAPACK_GLOBAL(ssyevd_2stage,SSYEVD_2STAGE)
+void LAPACK_ssyevd_2stage_base(
     char const* jobz, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* W,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyevd_2stage(...) LAPACK_ssyevd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssyevd_2stage(...) LAPACK_ssyevd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyevr LAPACK_GLOBAL(dsyevr,DSYEVR)
-void LAPACK_dsyevr(
+#define LAPACK_dsyevr_base LAPACK_GLOBAL(dsyevr,DSYEVR)
+void LAPACK_dsyevr_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -10539,10 +17164,19 @@ void LAPACK_dsyevr(
     double* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyevr(...) LAPACK_dsyevr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsyevr(...) LAPACK_dsyevr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyevr LAPACK_GLOBAL(ssyevr,SSYEVR)
-void LAPACK_ssyevr(
+#define LAPACK_ssyevr_base LAPACK_GLOBAL(ssyevr,SSYEVR)
+void LAPACK_ssyevr_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -10553,10 +17187,19 @@ void LAPACK_ssyevr(
     float* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyevr(...) LAPACK_ssyevr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssyevr(...) LAPACK_ssyevr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyevr_2stage LAPACK_GLOBAL(dsyevr_2stage,DSYEVR_2STAGE)
-void LAPACK_dsyevr_2stage(
+#define LAPACK_dsyevr_2stage_base LAPACK_GLOBAL(dsyevr_2stage,DSYEVR_2STAGE)
+void LAPACK_dsyevr_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -10567,10 +17210,19 @@ void LAPACK_dsyevr_2stage(
     double* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyevr_2stage(...) LAPACK_dsyevr_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsyevr_2stage(...) LAPACK_dsyevr_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyevr_2stage LAPACK_GLOBAL(ssyevr_2stage,SSYEVR_2STAGE)
-void LAPACK_ssyevr_2stage(
+#define LAPACK_ssyevr_2stage_base LAPACK_GLOBAL(ssyevr_2stage,SSYEVR_2STAGE)
+void LAPACK_ssyevr_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -10581,10 +17233,19 @@ void LAPACK_ssyevr_2stage(
     float* Z, lapack_int const* ldz, lapack_int* ISUPPZ,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyevr_2stage(...) LAPACK_ssyevr_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssyevr_2stage(...) LAPACK_ssyevr_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyevx LAPACK_GLOBAL(dsyevx,DSYEVX)
-void LAPACK_dsyevx(
+#define LAPACK_dsyevx_base LAPACK_GLOBAL(dsyevx,DSYEVX)
+void LAPACK_dsyevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -10595,10 +17256,19 @@ void LAPACK_dsyevx(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyevx(...) LAPACK_dsyevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsyevx(...) LAPACK_dsyevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyevx LAPACK_GLOBAL(ssyevx,SSYEVX)
-void LAPACK_ssyevx(
+#define LAPACK_ssyevx_base LAPACK_GLOBAL(ssyevx,SSYEVX)
+void LAPACK_ssyevx_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -10609,10 +17279,19 @@ void LAPACK_ssyevx(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyevx(...) LAPACK_ssyevx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssyevx(...) LAPACK_ssyevx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyevx_2stage LAPACK_GLOBAL(dsyevx_2stage,DSYEVX_2STAGE)
-void LAPACK_dsyevx_2stage(
+#define LAPACK_dsyevx_2stage_base LAPACK_GLOBAL(dsyevx_2stage,DSYEVX_2STAGE)
+void LAPACK_dsyevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -10623,10 +17302,19 @@ void LAPACK_dsyevx_2stage(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyevx_2stage(...) LAPACK_dsyevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsyevx_2stage(...) LAPACK_dsyevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyevx_2stage LAPACK_GLOBAL(ssyevx_2stage,SSYEVX_2STAGE)
-void LAPACK_ssyevx_2stage(
+#define LAPACK_ssyevx_2stage_base LAPACK_GLOBAL(ssyevx_2stage,SSYEVX_2STAGE)
+void LAPACK_ssyevx_2stage_base(
     char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -10637,66 +17325,129 @@ void LAPACK_ssyevx_2stage(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyevx_2stage(...) LAPACK_ssyevx_2stage_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssyevx_2stage(...) LAPACK_ssyevx_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsygst LAPACK_GLOBAL(dsygst,DSYGST)
-void LAPACK_dsygst(
+#define LAPACK_dsygst_base LAPACK_GLOBAL(dsygst,DSYGST)
+void LAPACK_dsygst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double const* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsygst(...) LAPACK_dsygst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsygst(...) LAPACK_dsygst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssygst LAPACK_GLOBAL(ssygst,SSYGST)
-void LAPACK_ssygst(
+#define LAPACK_ssygst_base LAPACK_GLOBAL(ssygst,SSYGST)
+void LAPACK_ssygst_base(
     lapack_int const* itype, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float const* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssygst(...) LAPACK_ssygst_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssygst(...) LAPACK_ssygst_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsygv LAPACK_GLOBAL(dsygv,DSYGV)
-void LAPACK_dsygv(
+#define LAPACK_dsygv_base LAPACK_GLOBAL(dsygv,DSYGV)
+void LAPACK_dsygv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* W,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsygv(...) LAPACK_dsygv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsygv(...) LAPACK_dsygv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssygv LAPACK_GLOBAL(ssygv,SSYGV)
-void LAPACK_ssygv(
+#define LAPACK_ssygv_base LAPACK_GLOBAL(ssygv,SSYGV)
+void LAPACK_ssygv_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
     float* W,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssygv(...) LAPACK_ssygv_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssygv(...) LAPACK_ssygv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsygv_2stage LAPACK_GLOBAL(dsygv_2stage,DSYGV_2STAGE)
-void LAPACK_dsygv_2stage(
+#define LAPACK_dsygv_2stage_base LAPACK_GLOBAL(dsygv_2stage,DSYGV_2STAGE)
+void LAPACK_dsygv_2stage_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* W,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsygv_2stage(...) LAPACK_dsygv_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsygv_2stage(...) LAPACK_dsygv_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssygv_2stage LAPACK_GLOBAL(ssygv_2stage,SSYGV_2STAGE)
-void LAPACK_ssygv_2stage(
+#define LAPACK_ssygv_2stage_base LAPACK_GLOBAL(ssygv_2stage,SSYGV_2STAGE)
+void LAPACK_ssygv_2stage_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
     float* W,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssygv_2stage(...) LAPACK_ssygv_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssygv_2stage(...) LAPACK_ssygv_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsygvd LAPACK_GLOBAL(dsygvd,DSYGVD)
-void LAPACK_dsygvd(
+#define LAPACK_dsygvd_base LAPACK_GLOBAL(dsygvd,DSYGVD)
+void LAPACK_dsygvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -10704,10 +17455,19 @@ void LAPACK_dsygvd(
     double* W,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsygvd(...) LAPACK_dsygvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsygvd(...) LAPACK_dsygvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssygvd LAPACK_GLOBAL(ssygvd,SSYGVD)
-void LAPACK_ssygvd(
+#define LAPACK_ssygvd_base LAPACK_GLOBAL(ssygvd,SSYGVD)
+void LAPACK_ssygvd_base(
     lapack_int const* itype, char const* jobz, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -10715,10 +17475,19 @@ void LAPACK_ssygvd(
     float* W,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssygvd(...) LAPACK_ssygvd_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssygvd(...) LAPACK_ssygvd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsygvx LAPACK_GLOBAL(dsygvx,DSYGVX)
-void LAPACK_dsygvx(
+#define LAPACK_dsygvx_base LAPACK_GLOBAL(dsygvx,DSYGVX)
+void LAPACK_dsygvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -10730,10 +17499,19 @@ void LAPACK_dsygvx(
     double* Z, lapack_int const* ldz,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsygvx(...) LAPACK_dsygvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsygvx(...) LAPACK_dsygvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssygvx LAPACK_GLOBAL(ssygvx,SSYGVX)
-void LAPACK_ssygvx(
+#define LAPACK_ssygvx_base LAPACK_GLOBAL(ssygvx,SSYGVX)
+void LAPACK_ssygvx_base(
     lapack_int const* itype, char const* jobz, char const* range, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -10745,26 +17523,53 @@ void LAPACK_ssygvx(
     float* Z, lapack_int const* ldz,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int* IFAIL,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssygvx(...) LAPACK_ssygvx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssygvx(...) LAPACK_ssygvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csyr LAPACK_GLOBAL(csyr,CSYR)
-void LAPACK_csyr(
+#define LAPACK_csyr_base LAPACK_GLOBAL(csyr,CSYR)
+void LAPACK_csyr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* alpha,
     lapack_complex_float const* X, lapack_int const* incx,
-    lapack_complex_float* A, lapack_int const* lda );
+    lapack_complex_float* A, lapack_int const* lda
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csyr(...) LAPACK_csyr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csyr(...) LAPACK_csyr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsyr LAPACK_GLOBAL(zsyr,ZSYR)
-void LAPACK_zsyr(
+#define LAPACK_zsyr_base LAPACK_GLOBAL(zsyr,ZSYR)
+void LAPACK_zsyr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* alpha,
     lapack_complex_double const* X, lapack_int const* incx,
-    lapack_complex_double* A, lapack_int const* lda );
+    lapack_complex_double* A, lapack_int const* lda
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsyr(...) LAPACK_zsyr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsyr(...) LAPACK_zsyr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csyrfs LAPACK_GLOBAL(csyrfs,CSYRFS)
-void LAPACK_csyrfs(
+#define LAPACK_csyrfs_base LAPACK_GLOBAL(csyrfs,CSYRFS)
+void LAPACK_csyrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -10775,10 +17580,19 @@ void LAPACK_csyrfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csyrfs(...) LAPACK_csyrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csyrfs(...) LAPACK_csyrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyrfs LAPACK_GLOBAL(dsyrfs,DSYRFS)
-void LAPACK_dsyrfs(
+#define LAPACK_dsyrfs_base LAPACK_GLOBAL(dsyrfs,DSYRFS)
+void LAPACK_dsyrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -10789,10 +17603,19 @@ void LAPACK_dsyrfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyrfs(...) LAPACK_dsyrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsyrfs(...) LAPACK_dsyrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyrfs LAPACK_GLOBAL(ssyrfs,SSYRFS)
-void LAPACK_ssyrfs(
+#define LAPACK_ssyrfs_base LAPACK_GLOBAL(ssyrfs,SSYRFS)
+void LAPACK_ssyrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -10803,10 +17626,19 @@ void LAPACK_ssyrfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyrfs(...) LAPACK_ssyrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssyrfs(...) LAPACK_ssyrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsyrfs LAPACK_GLOBAL(zsyrfs,ZSYRFS)
-void LAPACK_zsyrfs(
+#define LAPACK_zsyrfs_base LAPACK_GLOBAL(zsyrfs,ZSYRFS)
+void LAPACK_zsyrfs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -10817,10 +17649,19 @@ void LAPACK_zsyrfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsyrfs(...) LAPACK_zsyrfs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsyrfs(...) LAPACK_zsyrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csyrfsx LAPACK_GLOBAL(csyrfsx,CSYRFSX)
-void LAPACK_csyrfsx(
+#define LAPACK_csyrfsx_base LAPACK_GLOBAL(csyrfsx,CSYRFSX)
+void LAPACK_csyrfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -10835,10 +17676,19 @@ void LAPACK_csyrfsx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csyrfsx(...) LAPACK_csyrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_csyrfsx(...) LAPACK_csyrfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyrfsx LAPACK_GLOBAL(dsyrfsx,DSYRFSX)
-void LAPACK_dsyrfsx(
+#define LAPACK_dsyrfsx_base LAPACK_GLOBAL(dsyrfsx,DSYRFSX)
+void LAPACK_dsyrfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -10853,10 +17703,19 @@ void LAPACK_dsyrfsx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyrfsx(...) LAPACK_dsyrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsyrfsx(...) LAPACK_dsyrfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyrfsx LAPACK_GLOBAL(ssyrfsx,SSYRFSX)
-void LAPACK_ssyrfsx(
+#define LAPACK_ssyrfsx_base LAPACK_GLOBAL(ssyrfsx,SSYRFSX)
+void LAPACK_ssyrfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -10871,10 +17730,19 @@ void LAPACK_ssyrfsx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyrfsx(...) LAPACK_ssyrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssyrfsx(...) LAPACK_ssyrfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsyrfsx LAPACK_GLOBAL(zsyrfsx,ZSYRFSX)
-void LAPACK_zsyrfsx(
+#define LAPACK_zsyrfsx_base LAPACK_GLOBAL(zsyrfsx,ZSYRFSX)
+void LAPACK_zsyrfsx_base(
     char const* uplo, char const* equed,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -10889,198 +17757,387 @@ void LAPACK_zsyrfsx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsyrfsx(...) LAPACK_zsyrfsx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zsyrfsx(...) LAPACK_zsyrfsx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csysv LAPACK_GLOBAL(csysv,CSYSV)
-void LAPACK_csysv(
+#define LAPACK_csysv_base LAPACK_GLOBAL(csysv,CSYSV)
+void LAPACK_csysv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csysv(...) LAPACK_csysv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csysv(...) LAPACK_csysv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsysv LAPACK_GLOBAL(dsysv,DSYSV)
-void LAPACK_dsysv(
+#define LAPACK_dsysv_base LAPACK_GLOBAL(dsysv,DSYSV)
+void LAPACK_dsysv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsysv(...) LAPACK_dsysv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsysv(...) LAPACK_dsysv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssysv LAPACK_GLOBAL(ssysv,SSYSV)
-void LAPACK_ssysv(
+#define LAPACK_ssysv_base LAPACK_GLOBAL(ssysv,SSYSV)
+void LAPACK_ssysv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssysv(...) LAPACK_ssysv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssysv(...) LAPACK_ssysv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsysv LAPACK_GLOBAL(zsysv,ZSYSV)
-void LAPACK_zsysv(
+#define LAPACK_zsysv_base LAPACK_GLOBAL(zsysv,ZSYSV)
+void LAPACK_zsysv_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsysv(...) LAPACK_zsysv_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsysv(...) LAPACK_zsysv_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csysv_aa LAPACK_GLOBAL(csysv_aa,CSYSV_AA)
-void LAPACK_csysv_aa(
+#define LAPACK_csysv_aa_base LAPACK_GLOBAL(csysv_aa,CSYSV_AA)
+void LAPACK_csysv_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csysv_aa(...) LAPACK_csysv_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csysv_aa(...) LAPACK_csysv_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsysv_aa LAPACK_GLOBAL(dsysv_aa,DSYSV_AA)
-void LAPACK_dsysv_aa(
+#define LAPACK_dsysv_aa_base LAPACK_GLOBAL(dsysv_aa,DSYSV_AA)
+void LAPACK_dsysv_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsysv_aa(...) LAPACK_dsysv_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsysv_aa(...) LAPACK_dsysv_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssysv_aa LAPACK_GLOBAL(ssysv_aa,SSYSV_AA)
-void LAPACK_ssysv_aa(
+#define LAPACK_ssysv_aa_base LAPACK_GLOBAL(ssysv_aa,SSYSV_AA)
+void LAPACK_ssysv_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssysv_aa(...) LAPACK_ssysv_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssysv_aa(...) LAPACK_ssysv_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsysv_aa LAPACK_GLOBAL(zsysv_aa,ZSYSV_AA)
-void LAPACK_zsysv_aa(
+#define LAPACK_zsysv_aa_base LAPACK_GLOBAL(zsysv_aa,ZSYSV_AA)
+void LAPACK_zsysv_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsysv_aa(...) LAPACK_zsysv_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsysv_aa(...) LAPACK_zsysv_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csysv_aa_2stage LAPACK_GLOBAL(csysv_aa_2stage,CSYSV_AA_2STAGE)
-void LAPACK_csysv_aa_2stage(
+#define LAPACK_csysv_aa_2stage_base LAPACK_GLOBAL(csysv_aa_2stage,CSYSV_AA_2STAGE)
+void LAPACK_csysv_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csysv_aa_2stage(...) LAPACK_csysv_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csysv_aa_2stage(...) LAPACK_csysv_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsysv_aa_2stage LAPACK_GLOBAL(dsysv_aa_2stage,DSYSV_AA_2STAGE)
-void LAPACK_dsysv_aa_2stage(
+#define LAPACK_dsysv_aa_2stage_base LAPACK_GLOBAL(dsysv_aa_2stage,DSYSV_AA_2STAGE)
+void LAPACK_dsysv_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
     double* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsysv_aa_2stage(...) LAPACK_dsysv_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsysv_aa_2stage(...) LAPACK_dsysv_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssysv_aa_2stage LAPACK_GLOBAL(ssysv_aa_2stage,SSYSV_AA_2STAGE)
-void LAPACK_ssysv_aa_2stage(
+#define LAPACK_ssysv_aa_2stage_base LAPACK_GLOBAL(ssysv_aa_2stage,SSYSV_AA_2STAGE)
+void LAPACK_ssysv_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
     float* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssysv_aa_2stage(...) LAPACK_ssysv_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssysv_aa_2stage(...) LAPACK_ssysv_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsysv_aa_2stage LAPACK_GLOBAL(zsysv_aa_2stage,ZSYSV_AA_2STAGE)
-void LAPACK_zsysv_aa_2stage(
+#define LAPACK_zsysv_aa_2stage_base LAPACK_GLOBAL(zsysv_aa_2stage,ZSYSV_AA_2STAGE)
+void LAPACK_zsysv_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsysv_aa_2stage(...) LAPACK_zsysv_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsysv_aa_2stage(...) LAPACK_zsysv_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csysv_rk LAPACK_GLOBAL(csysv_rk,CSYSV_RK)
-void LAPACK_csysv_rk(
+#define LAPACK_csysv_rk_base LAPACK_GLOBAL(csysv_rk,CSYSV_RK)
+void LAPACK_csysv_rk_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* E, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csysv_rk(...) LAPACK_csysv_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csysv_rk(...) LAPACK_csysv_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsysv_rk LAPACK_GLOBAL(dsysv_rk,DSYSV_RK)
-void LAPACK_dsysv_rk(
+#define LAPACK_dsysv_rk_base LAPACK_GLOBAL(dsysv_rk,DSYSV_RK)
+void LAPACK_dsysv_rk_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
     double* E, lapack_int* ipiv,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsysv_rk(...) LAPACK_dsysv_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsysv_rk(...) LAPACK_dsysv_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssysv_rk LAPACK_GLOBAL(ssysv_rk,SSYSV_RK)
-void LAPACK_ssysv_rk(
+#define LAPACK_ssysv_rk_base LAPACK_GLOBAL(ssysv_rk,SSYSV_RK)
+void LAPACK_ssysv_rk_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
     float* E, lapack_int* ipiv,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssysv_rk(...) LAPACK_ssysv_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssysv_rk(...) LAPACK_ssysv_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsysv_rk LAPACK_GLOBAL(zsysv_rk,ZSYSV_RK)
-void LAPACK_zsysv_rk(
+#define LAPACK_zsysv_rk_base LAPACK_GLOBAL(zsysv_rk,ZSYSV_RK)
+void LAPACK_zsysv_rk_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* E, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsysv_rk(...) LAPACK_zsysv_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsysv_rk(...) LAPACK_zsysv_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csysv_rook LAPACK_GLOBAL(csysv_rook,CSYSV_ROOK)
-void LAPACK_csysv_rook(
+#define LAPACK_csysv_rook_base LAPACK_GLOBAL(csysv_rook,CSYSV_ROOK)
+void LAPACK_csysv_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csysv_rook(...) LAPACK_csysv_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csysv_rook(...) LAPACK_csysv_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsysv_rook LAPACK_GLOBAL(dsysv_rook,DSYSV_ROOK)
-void LAPACK_dsysv_rook(
+#define LAPACK_dsysv_rook_base LAPACK_GLOBAL(dsysv_rook,DSYSV_ROOK)
+void LAPACK_dsysv_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsysv_rook(...) LAPACK_dsysv_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsysv_rook(...) LAPACK_dsysv_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssysv_rook LAPACK_GLOBAL(ssysv_rook,SSYSV_ROOK)
-void LAPACK_ssysv_rook(
+#define LAPACK_ssysv_rook_base LAPACK_GLOBAL(ssysv_rook,SSYSV_ROOK)
+void LAPACK_ssysv_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssysv_rook(...) LAPACK_ssysv_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssysv_rook(...) LAPACK_ssysv_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsysv_rook LAPACK_GLOBAL(zsysv_rook,ZSYSV_ROOK)
-void LAPACK_zsysv_rook(
+#define LAPACK_zsysv_rook_base LAPACK_GLOBAL(zsysv_rook,ZSYSV_ROOK)
+void LAPACK_zsysv_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsysv_rook(...) LAPACK_zsysv_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsysv_rook(...) LAPACK_zsysv_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csysvx LAPACK_GLOBAL(csysvx,CSYSVX)
-void LAPACK_csysvx(
+#define LAPACK_csysvx_base LAPACK_GLOBAL(csysvx,CSYSVX)
+void LAPACK_csysvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -11092,10 +18149,19 @@ void LAPACK_csysvx(
     float* berr,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csysvx(...) LAPACK_csysvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_csysvx(...) LAPACK_csysvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsysvx LAPACK_GLOBAL(dsysvx,DSYSVX)
-void LAPACK_dsysvx(
+#define LAPACK_dsysvx_base LAPACK_GLOBAL(dsysvx,DSYSVX)
+void LAPACK_dsysvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -11107,10 +18173,19 @@ void LAPACK_dsysvx(
     double* berr,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsysvx(...) LAPACK_dsysvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsysvx(...) LAPACK_dsysvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssysvx LAPACK_GLOBAL(ssysvx,SSYSVX)
-void LAPACK_ssysvx(
+#define LAPACK_ssysvx_base LAPACK_GLOBAL(ssysvx,SSYSVX)
+void LAPACK_ssysvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -11122,10 +18197,19 @@ void LAPACK_ssysvx(
     float* berr,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssysvx(...) LAPACK_ssysvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssysvx(...) LAPACK_ssysvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsysvx LAPACK_GLOBAL(zsysvx,ZSYSVX)
-void LAPACK_zsysvx(
+#define LAPACK_zsysvx_base LAPACK_GLOBAL(zsysvx,ZSYSVX)
+void LAPACK_zsysvx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -11137,10 +18221,19 @@ void LAPACK_zsysvx(
     double* berr,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsysvx(...) LAPACK_zsysvx_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zsysvx(...) LAPACK_zsysvx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csysvxx LAPACK_GLOBAL(csysvxx,CSYSVXX)
-void LAPACK_csysvxx(
+#define LAPACK_csysvxx_base LAPACK_GLOBAL(csysvxx,CSYSVXX)
+void LAPACK_csysvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda,
@@ -11157,10 +18250,19 @@ void LAPACK_csysvxx(
     float* params,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csysvxx(...) LAPACK_csysvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_csysvxx(...) LAPACK_csysvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsysvxx LAPACK_GLOBAL(dsysvxx,DSYSVXX)
-void LAPACK_dsysvxx(
+#define LAPACK_dsysvxx_base LAPACK_GLOBAL(dsysvxx,DSYSVXX)
+void LAPACK_dsysvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda,
@@ -11177,10 +18279,19 @@ void LAPACK_dsysvxx(
     double* params,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsysvxx(...) LAPACK_dsysvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dsysvxx(...) LAPACK_dsysvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssysvxx LAPACK_GLOBAL(ssysvxx,SSYSVXX)
-void LAPACK_ssysvxx(
+#define LAPACK_ssysvxx_base LAPACK_GLOBAL(ssysvxx,SSYSVXX)
+void LAPACK_ssysvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda,
@@ -11197,10 +18308,19 @@ void LAPACK_ssysvxx(
     float* params,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssysvxx(...) LAPACK_ssysvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ssysvxx(...) LAPACK_ssysvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsysvxx LAPACK_GLOBAL(zsysvxx,ZSYSVXX)
-void LAPACK_zsysvxx(
+#define LAPACK_zsysvxx_base LAPACK_GLOBAL(zsysvxx,ZSYSVXX)
+void LAPACK_zsysvxx_base(
     char const* fact, char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda,
@@ -11217,34 +18337,79 @@ void LAPACK_zsysvxx(
     double* params,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsysvxx(...) LAPACK_zsysvxx_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zsysvxx(...) LAPACK_zsysvxx_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csyswapr LAPACK_GLOBAL(csyswapr,CSYSWAPR)
-void LAPACK_csyswapr(
+#define LAPACK_csyswapr_base LAPACK_GLOBAL(csyswapr,CSYSWAPR)
+void LAPACK_csyswapr_base(
     char const* uplo,
     lapack_int const* n,
-    lapack_complex_float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2 );
+    lapack_complex_float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csyswapr(...) LAPACK_csyswapr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csyswapr(...) LAPACK_csyswapr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsyswapr LAPACK_GLOBAL(dsyswapr,DSYSWAPR)
-void LAPACK_dsyswapr(
+#define LAPACK_dsyswapr_base LAPACK_GLOBAL(dsyswapr,DSYSWAPR)
+void LAPACK_dsyswapr_base(
     char const* uplo,
     lapack_int const* n,
-    double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2 );
+    double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsyswapr(...) LAPACK_dsyswapr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsyswapr(...) LAPACK_dsyswapr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssyswapr LAPACK_GLOBAL(ssyswapr,SSYSWAPR)
-void LAPACK_ssyswapr(
+#define LAPACK_ssyswapr_base LAPACK_GLOBAL(ssyswapr,SSYSWAPR)
+void LAPACK_ssyswapr_base(
     char const* uplo,
     lapack_int const* n,
-    float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2 );
+    float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssyswapr(...) LAPACK_ssyswapr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssyswapr(...) LAPACK_ssyswapr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsyswapr LAPACK_GLOBAL(zsyswapr,ZSYSWAPR)
-void LAPACK_zsyswapr(
+#define LAPACK_zsyswapr_base LAPACK_GLOBAL(zsyswapr,ZSYSWAPR)
+void LAPACK_zsyswapr_base(
     char const* uplo,
     lapack_int const* n,
-    lapack_complex_double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2 );
+    lapack_complex_double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsyswapr(...) LAPACK_zsyswapr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsyswapr(...) LAPACK_zsyswapr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrd LAPACK_GLOBAL(dsytrd,DSYTRD)
-void LAPACK_dsytrd(
+#define LAPACK_dsytrd_base LAPACK_GLOBAL(dsytrd,DSYTRD)
+void LAPACK_dsytrd_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -11252,10 +18417,19 @@ void LAPACK_dsytrd(
     double* E,
     double* tau,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrd(...) LAPACK_dsytrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrd(...) LAPACK_dsytrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrd LAPACK_GLOBAL(ssytrd,SSYTRD)
-void LAPACK_ssytrd(
+#define LAPACK_ssytrd_base LAPACK_GLOBAL(ssytrd,SSYTRD)
+void LAPACK_ssytrd_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -11263,10 +18437,19 @@ void LAPACK_ssytrd(
     float* E,
     float* tau,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrd(...) LAPACK_ssytrd_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrd(...) LAPACK_ssytrd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrd_2stage LAPACK_GLOBAL(dsytrd_2stage,DSYTRD_2STAGE)
-void LAPACK_dsytrd_2stage(
+#define LAPACK_dsytrd_2stage_base LAPACK_GLOBAL(dsytrd_2stage,DSYTRD_2STAGE)
+void LAPACK_dsytrd_2stage_base(
     char const* vect, char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -11275,10 +18458,19 @@ void LAPACK_dsytrd_2stage(
     double* tau,
     double* HOUS2, lapack_int const* lhous2,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrd_2stage(...) LAPACK_dsytrd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dsytrd_2stage(...) LAPACK_dsytrd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrd_2stage LAPACK_GLOBAL(ssytrd_2stage,SSYTRD_2STAGE)
-void LAPACK_ssytrd_2stage(
+#define LAPACK_ssytrd_2stage_base LAPACK_GLOBAL(ssytrd_2stage,SSYTRD_2STAGE)
+void LAPACK_ssytrd_2stage_base(
     char const* vect, char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -11287,558 +18479,1143 @@ void LAPACK_ssytrd_2stage(
     float* tau,
     float* HOUS2, lapack_int const* lhous2,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrd_2stage(...) LAPACK_ssytrd_2stage_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ssytrd_2stage(...) LAPACK_ssytrd_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrf LAPACK_GLOBAL(csytrf,CSYTRF)
-void LAPACK_csytrf(
+#define LAPACK_csytrf_base LAPACK_GLOBAL(csytrf,CSYTRF)
+void LAPACK_csytrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrf(...) LAPACK_csytrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrf(...) LAPACK_csytrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrf LAPACK_GLOBAL(dsytrf,DSYTRF)
-void LAPACK_dsytrf(
+#define LAPACK_dsytrf_base LAPACK_GLOBAL(dsytrf,DSYTRF)
+void LAPACK_dsytrf_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrf(...) LAPACK_dsytrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrf(...) LAPACK_dsytrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrf LAPACK_GLOBAL(ssytrf,SSYTRF)
-void LAPACK_ssytrf(
+#define LAPACK_ssytrf_base LAPACK_GLOBAL(ssytrf,SSYTRF)
+void LAPACK_ssytrf_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrf(...) LAPACK_ssytrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrf(...) LAPACK_ssytrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrf LAPACK_GLOBAL(zsytrf,ZSYTRF)
-void LAPACK_zsytrf(
+#define LAPACK_zsytrf_base LAPACK_GLOBAL(zsytrf,ZSYTRF)
+void LAPACK_zsytrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrf(...) LAPACK_zsytrf_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrf(...) LAPACK_zsytrf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrf_aa LAPACK_GLOBAL(csytrf_aa,CSYTRF_AA)
-void LAPACK_csytrf_aa(
+#define LAPACK_csytrf_aa_base LAPACK_GLOBAL(csytrf_aa,CSYTRF_AA)
+void LAPACK_csytrf_aa_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrf_aa(...) LAPACK_csytrf_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrf_aa(...) LAPACK_csytrf_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrf_aa LAPACK_GLOBAL(dsytrf_aa,DSYTRF_AA)
-void LAPACK_dsytrf_aa(
+#define LAPACK_dsytrf_aa_base LAPACK_GLOBAL(dsytrf_aa,DSYTRF_AA)
+void LAPACK_dsytrf_aa_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrf_aa(...) LAPACK_dsytrf_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrf_aa(...) LAPACK_dsytrf_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrf_aa LAPACK_GLOBAL(ssytrf_aa,SSYTRF_AA)
-void LAPACK_ssytrf_aa(
+#define LAPACK_ssytrf_aa_base LAPACK_GLOBAL(ssytrf_aa,SSYTRF_AA)
+void LAPACK_ssytrf_aa_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrf_aa(...) LAPACK_ssytrf_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrf_aa(...) LAPACK_ssytrf_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrf_aa LAPACK_GLOBAL(zsytrf_aa,ZSYTRF_AA)
-void LAPACK_zsytrf_aa(
+#define LAPACK_zsytrf_aa_base LAPACK_GLOBAL(zsytrf_aa,ZSYTRF_AA)
+void LAPACK_zsytrf_aa_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrf_aa(...) LAPACK_zsytrf_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrf_aa(...) LAPACK_zsytrf_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrf_aa_2stage LAPACK_GLOBAL(csytrf_aa_2stage,CSYTRF_AA_2STAGE)
-void LAPACK_csytrf_aa_2stage(
+#define LAPACK_csytrf_aa_2stage_base LAPACK_GLOBAL(csytrf_aa_2stage,CSYTRF_AA_2STAGE)
+void LAPACK_csytrf_aa_2stage_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrf_aa_2stage(...) LAPACK_csytrf_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrf_aa_2stage(...) LAPACK_csytrf_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrf_aa_2stage LAPACK_GLOBAL(dsytrf_aa_2stage,DSYTRF_AA_2STAGE)
-void LAPACK_dsytrf_aa_2stage(
+#define LAPACK_dsytrf_aa_2stage_base LAPACK_GLOBAL(dsytrf_aa_2stage,DSYTRF_AA_2STAGE)
+void LAPACK_dsytrf_aa_2stage_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrf_aa_2stage(...) LAPACK_dsytrf_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrf_aa_2stage(...) LAPACK_dsytrf_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrf_aa_2stage LAPACK_GLOBAL(ssytrf_aa_2stage,SSYTRF_AA_2STAGE)
-void LAPACK_ssytrf_aa_2stage(
+#define LAPACK_ssytrf_aa_2stage_base LAPACK_GLOBAL(ssytrf_aa_2stage,SSYTRF_AA_2STAGE)
+void LAPACK_ssytrf_aa_2stage_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrf_aa_2stage(...) LAPACK_ssytrf_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrf_aa_2stage(...) LAPACK_ssytrf_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrf_aa_2stage LAPACK_GLOBAL(zsytrf_aa_2stage,ZSYTRF_AA_2STAGE)
-void LAPACK_zsytrf_aa_2stage(
+#define LAPACK_zsytrf_aa_2stage_base LAPACK_GLOBAL(zsytrf_aa_2stage,ZSYTRF_AA_2STAGE)
+void LAPACK_zsytrf_aa_2stage_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* TB, lapack_int const* ltb, lapack_int* ipiv, lapack_int* ipiv2,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrf_aa_2stage(...) LAPACK_zsytrf_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrf_aa_2stage(...) LAPACK_zsytrf_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrf_rk LAPACK_GLOBAL(csytrf_rk,CSYTRF_RK)
-void LAPACK_csytrf_rk(
+#define LAPACK_csytrf_rk_base LAPACK_GLOBAL(csytrf_rk,CSYTRF_RK)
+void LAPACK_csytrf_rk_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* E, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrf_rk(...) LAPACK_csytrf_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrf_rk(...) LAPACK_csytrf_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrf_rk LAPACK_GLOBAL(dsytrf_rk,DSYTRF_RK)
-void LAPACK_dsytrf_rk(
+#define LAPACK_dsytrf_rk_base LAPACK_GLOBAL(dsytrf_rk,DSYTRF_RK)
+void LAPACK_dsytrf_rk_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double* E, lapack_int* ipiv,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrf_rk(...) LAPACK_dsytrf_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrf_rk(...) LAPACK_dsytrf_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrf_rk LAPACK_GLOBAL(ssytrf_rk,SSYTRF_RK)
-void LAPACK_ssytrf_rk(
+#define LAPACK_ssytrf_rk_base LAPACK_GLOBAL(ssytrf_rk,SSYTRF_RK)
+void LAPACK_ssytrf_rk_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float* E, lapack_int* ipiv,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrf_rk(...) LAPACK_ssytrf_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrf_rk(...) LAPACK_ssytrf_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrf_rk LAPACK_GLOBAL(zsytrf_rk,ZSYTRF_RK)
-void LAPACK_zsytrf_rk(
+#define LAPACK_zsytrf_rk_base LAPACK_GLOBAL(zsytrf_rk,ZSYTRF_RK)
+void LAPACK_zsytrf_rk_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* E, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrf_rk(...) LAPACK_zsytrf_rk_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrf_rk(...) LAPACK_zsytrf_rk_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrf_rook LAPACK_GLOBAL(csytrf_rook,CSYTRF_ROOK)
-void LAPACK_csytrf_rook(
+#define LAPACK_csytrf_rook_base LAPACK_GLOBAL(csytrf_rook,CSYTRF_ROOK)
+void LAPACK_csytrf_rook_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrf_rook(...) LAPACK_csytrf_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrf_rook(...) LAPACK_csytrf_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrf_rook LAPACK_GLOBAL(dsytrf_rook,DSYTRF_ROOK)
-void LAPACK_dsytrf_rook(
+#define LAPACK_dsytrf_rook_base LAPACK_GLOBAL(dsytrf_rook,DSYTRF_ROOK)
+void LAPACK_dsytrf_rook_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrf_rook(...) LAPACK_dsytrf_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrf_rook(...) LAPACK_dsytrf_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrf_rook LAPACK_GLOBAL(ssytrf_rook,SSYTRF_ROOK)
-void LAPACK_ssytrf_rook(
+#define LAPACK_ssytrf_rook_base LAPACK_GLOBAL(ssytrf_rook,SSYTRF_ROOK)
+void LAPACK_ssytrf_rook_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrf_rook(...) LAPACK_ssytrf_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrf_rook(...) LAPACK_ssytrf_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrf_rook LAPACK_GLOBAL(zsytrf_rook,ZSYTRF_ROOK)
-void LAPACK_zsytrf_rook(
+#define LAPACK_zsytrf_rook_base LAPACK_GLOBAL(zsytrf_rook,ZSYTRF_ROOK)
+void LAPACK_zsytrf_rook_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrf_rook(...) LAPACK_zsytrf_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrf_rook(...) LAPACK_zsytrf_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytri LAPACK_GLOBAL(csytri,CSYTRI)
-void LAPACK_csytri(
+#define LAPACK_csytri_base LAPACK_GLOBAL(csytri,CSYTRI)
+void LAPACK_csytri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytri(...) LAPACK_csytri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytri(...) LAPACK_csytri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytri LAPACK_GLOBAL(dsytri,DSYTRI)
-void LAPACK_dsytri(
+#define LAPACK_dsytri_base LAPACK_GLOBAL(dsytri,DSYTRI)
+void LAPACK_dsytri_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int const* ipiv,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytri(...) LAPACK_dsytri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytri(...) LAPACK_dsytri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytri LAPACK_GLOBAL(ssytri,SSYTRI)
-void LAPACK_ssytri(
+#define LAPACK_ssytri_base LAPACK_GLOBAL(ssytri,SSYTRI)
+void LAPACK_ssytri_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int const* ipiv,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytri(...) LAPACK_ssytri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytri(...) LAPACK_ssytri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytri LAPACK_GLOBAL(zsytri,ZSYTRI)
-void LAPACK_zsytri(
+#define LAPACK_zsytri_base LAPACK_GLOBAL(zsytri,ZSYTRI)
+void LAPACK_zsytri_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytri(...) LAPACK_zsytri_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytri(...) LAPACK_zsytri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytri2 LAPACK_GLOBAL(csytri2,CSYTRI2)
-void LAPACK_csytri2(
+#define LAPACK_csytri2_base LAPACK_GLOBAL(csytri2,CSYTRI2)
+void LAPACK_csytri2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytri2(...) LAPACK_csytri2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytri2(...) LAPACK_csytri2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytri2 LAPACK_GLOBAL(dsytri2,DSYTRI2)
-void LAPACK_dsytri2(
+#define LAPACK_dsytri2_base LAPACK_GLOBAL(dsytri2,DSYTRI2)
+void LAPACK_dsytri2_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int const* ipiv,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytri2(...) LAPACK_dsytri2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytri2(...) LAPACK_dsytri2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytri2 LAPACK_GLOBAL(ssytri2,SSYTRI2)
-void LAPACK_ssytri2(
+#define LAPACK_ssytri2_base LAPACK_GLOBAL(ssytri2,SSYTRI2)
+void LAPACK_ssytri2_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int const* ipiv,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytri2(...) LAPACK_ssytri2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytri2(...) LAPACK_ssytri2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytri2 LAPACK_GLOBAL(zsytri2,ZSYTRI2)
-void LAPACK_zsytri2(
+#define LAPACK_zsytri2_base LAPACK_GLOBAL(zsytri2,ZSYTRI2)
+void LAPACK_zsytri2_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytri2(...) LAPACK_zsytri2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytri2(...) LAPACK_zsytri2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytri2x LAPACK_GLOBAL(csytri2x,CSYTRI2X)
-void LAPACK_csytri2x(
+#define LAPACK_csytri2x_base LAPACK_GLOBAL(csytri2x,CSYTRI2X)
+void LAPACK_csytri2x_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* work, lapack_int const* nb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytri2x(...) LAPACK_csytri2x_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytri2x(...) LAPACK_csytri2x_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytri2x LAPACK_GLOBAL(dsytri2x,DSYTRI2X)
-void LAPACK_dsytri2x(
+#define LAPACK_dsytri2x_base LAPACK_GLOBAL(dsytri2x,DSYTRI2X)
+void LAPACK_dsytri2x_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int const* ipiv,
     double* work, lapack_int const* nb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytri2x(...) LAPACK_dsytri2x_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytri2x(...) LAPACK_dsytri2x_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytri2x LAPACK_GLOBAL(ssytri2x,SSYTRI2X)
-void LAPACK_ssytri2x(
+#define LAPACK_ssytri2x_base LAPACK_GLOBAL(ssytri2x,SSYTRI2X)
+void LAPACK_ssytri2x_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int const* ipiv,
     float* work, lapack_int const* nb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytri2x(...) LAPACK_ssytri2x_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytri2x(...) LAPACK_ssytri2x_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytri2x LAPACK_GLOBAL(zsytri2x,ZSYTRI2X)
-void LAPACK_zsytri2x(
+#define LAPACK_zsytri2x_base LAPACK_GLOBAL(zsytri2x,ZSYTRI2X)
+void LAPACK_zsytri2x_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* work, lapack_int const* nb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytri2x(...) LAPACK_zsytri2x_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytri2x(...) LAPACK_zsytri2x_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytri_3 LAPACK_GLOBAL(csytri_3,CSYTRI_3)
-void LAPACK_csytri_3(
+#define LAPACK_csytri_3_base LAPACK_GLOBAL(csytri_3,CSYTRI_3)
+void LAPACK_csytri_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float const* E, lapack_int const* ipiv,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytri_3(...) LAPACK_csytri_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytri_3(...) LAPACK_csytri_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytri_3 LAPACK_GLOBAL(dsytri_3,DSYTRI_3)
-void LAPACK_dsytri_3(
+#define LAPACK_dsytri_3_base LAPACK_GLOBAL(dsytri_3,DSYTRI_3)
+void LAPACK_dsytri_3_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
     double const* E, lapack_int const* ipiv,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytri_3(...) LAPACK_dsytri_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytri_3(...) LAPACK_dsytri_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytri_3 LAPACK_GLOBAL(ssytri_3,SSYTRI_3)
-void LAPACK_ssytri_3(
+#define LAPACK_ssytri_3_base LAPACK_GLOBAL(ssytri_3,SSYTRI_3)
+void LAPACK_ssytri_3_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
     float const* E, lapack_int const* ipiv,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytri_3(...) LAPACK_ssytri_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytri_3(...) LAPACK_ssytri_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytri_3 LAPACK_GLOBAL(zsytri_3,ZSYTRI_3)
-void LAPACK_zsytri_3(
+#define LAPACK_zsytri_3_base LAPACK_GLOBAL(zsytri_3,ZSYTRI_3)
+void LAPACK_zsytri_3_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double const* E, lapack_int const* ipiv,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytri_3(...) LAPACK_zsytri_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytri_3(...) LAPACK_zsytri_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrs LAPACK_GLOBAL(csytrs,CSYTRS)
-void LAPACK_csytrs(
+#define LAPACK_csytrs_base LAPACK_GLOBAL(csytrs,CSYTRS)
+void LAPACK_csytrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrs(...) LAPACK_csytrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrs(...) LAPACK_csytrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrs LAPACK_GLOBAL(dsytrs,DSYTRS)
-void LAPACK_dsytrs(
+#define LAPACK_dsytrs_base LAPACK_GLOBAL(dsytrs,DSYTRS)
+void LAPACK_dsytrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrs(...) LAPACK_dsytrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrs(...) LAPACK_dsytrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrs LAPACK_GLOBAL(ssytrs,SSYTRS)
-void LAPACK_ssytrs(
+#define LAPACK_ssytrs_base LAPACK_GLOBAL(ssytrs,SSYTRS)
+void LAPACK_ssytrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrs(...) LAPACK_ssytrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrs(...) LAPACK_ssytrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrs LAPACK_GLOBAL(zsytrs,ZSYTRS)
-void LAPACK_zsytrs(
+#define LAPACK_zsytrs_base LAPACK_GLOBAL(zsytrs,ZSYTRS)
+void LAPACK_zsytrs_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrs(...) LAPACK_zsytrs_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrs(...) LAPACK_zsytrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrs2 LAPACK_GLOBAL(csytrs2,CSYTRS2)
-void LAPACK_csytrs2(
+#define LAPACK_csytrs2_base LAPACK_GLOBAL(csytrs2,CSYTRS2)
+void LAPACK_csytrs2_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     const lapack_complex_float* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrs2(...) LAPACK_csytrs2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrs2(...) LAPACK_csytrs2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrs2 LAPACK_GLOBAL(dsytrs2,DSYTRS2)
-void LAPACK_dsytrs2(
+#define LAPACK_dsytrs2_base LAPACK_GLOBAL(dsytrs2,DSYTRS2)
+void LAPACK_dsytrs2_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     const double* A, lapack_int const* lda, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrs2(...) LAPACK_dsytrs2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrs2(...) LAPACK_dsytrs2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrs2 LAPACK_GLOBAL(ssytrs2,SSYTRS2)
-void LAPACK_ssytrs2(
+#define LAPACK_ssytrs2_base LAPACK_GLOBAL(ssytrs2,SSYTRS2)
+void LAPACK_ssytrs2_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     const float* A, lapack_int const* lda, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrs2(...) LAPACK_ssytrs2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrs2(...) LAPACK_ssytrs2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrs2 LAPACK_GLOBAL(zsytrs2,ZSYTRS2)
-void LAPACK_zsytrs2(
+#define LAPACK_zsytrs2_base LAPACK_GLOBAL(zsytrs2,ZSYTRS2)
+void LAPACK_zsytrs2_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     const lapack_complex_double* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrs2(...) LAPACK_zsytrs2_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrs2(...) LAPACK_zsytrs2_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrs_3 LAPACK_GLOBAL(csytrs_3,CSYTRS_3)
-void LAPACK_csytrs_3(
+#define LAPACK_csytrs_3_base LAPACK_GLOBAL(csytrs_3,CSYTRS_3)
+void LAPACK_csytrs_3_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* E, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrs_3(...) LAPACK_csytrs_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrs_3(...) LAPACK_csytrs_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrs_3 LAPACK_GLOBAL(dsytrs_3,DSYTRS_3)
-void LAPACK_dsytrs_3(
+#define LAPACK_dsytrs_3_base LAPACK_GLOBAL(dsytrs_3,DSYTRS_3)
+void LAPACK_dsytrs_3_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
     double const* E, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrs_3(...) LAPACK_dsytrs_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrs_3(...) LAPACK_dsytrs_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrs_3 LAPACK_GLOBAL(ssytrs_3,SSYTRS_3)
-void LAPACK_ssytrs_3(
+#define LAPACK_ssytrs_3_base LAPACK_GLOBAL(ssytrs_3,SSYTRS_3)
+void LAPACK_ssytrs_3_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
     float const* E, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrs_3(...) LAPACK_ssytrs_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrs_3(...) LAPACK_ssytrs_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrs_3 LAPACK_GLOBAL(zsytrs_3,ZSYTRS_3)
-void LAPACK_zsytrs_3(
+#define LAPACK_zsytrs_3_base LAPACK_GLOBAL(zsytrs_3,ZSYTRS_3)
+void LAPACK_zsytrs_3_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* E, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrs_3(...) LAPACK_zsytrs_3_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrs_3(...) LAPACK_zsytrs_3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrs_aa LAPACK_GLOBAL(csytrs_aa,CSYTRS_AA)
-void LAPACK_csytrs_aa(
+#define LAPACK_csytrs_aa_base LAPACK_GLOBAL(csytrs_aa,CSYTRS_AA)
+void LAPACK_csytrs_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrs_aa(...) LAPACK_csytrs_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrs_aa(...) LAPACK_csytrs_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrs_aa LAPACK_GLOBAL(dsytrs_aa,DSYTRS_AA)
-void LAPACK_dsytrs_aa(
+#define LAPACK_dsytrs_aa_base LAPACK_GLOBAL(dsytrs_aa,DSYTRS_AA)
+void LAPACK_dsytrs_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrs_aa(...) LAPACK_dsytrs_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrs_aa(...) LAPACK_dsytrs_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrs_aa LAPACK_GLOBAL(ssytrs_aa,SSYTRS_AA)
-void LAPACK_ssytrs_aa(
+#define LAPACK_ssytrs_aa_base LAPACK_GLOBAL(ssytrs_aa,SSYTRS_AA)
+void LAPACK_ssytrs_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrs_aa(...) LAPACK_ssytrs_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrs_aa(...) LAPACK_ssytrs_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrs_aa LAPACK_GLOBAL(zsytrs_aa,ZSYTRS_AA)
-void LAPACK_zsytrs_aa(
+#define LAPACK_zsytrs_aa_base LAPACK_GLOBAL(zsytrs_aa,ZSYTRS_AA)
+void LAPACK_zsytrs_aa_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrs_aa(...) LAPACK_zsytrs_aa_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrs_aa(...) LAPACK_zsytrs_aa_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrs_aa_2stage LAPACK_GLOBAL(csytrs_aa_2stage,CSYTRS_AA_2STAGE)
-void LAPACK_csytrs_aa_2stage(
+#define LAPACK_csytrs_aa_2stage_base LAPACK_GLOBAL(csytrs_aa_2stage,CSYTRS_AA_2STAGE)
+void LAPACK_csytrs_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float* TB, lapack_int const* ltb, lapack_int const* ipiv, lapack_int const* ipiv2,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrs_aa_2stage(...) LAPACK_csytrs_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrs_aa_2stage(...) LAPACK_csytrs_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrs_aa_2stage LAPACK_GLOBAL(dsytrs_aa_2stage,DSYTRS_AA_2STAGE)
-void LAPACK_dsytrs_aa_2stage(
+#define LAPACK_dsytrs_aa_2stage_base LAPACK_GLOBAL(dsytrs_aa_2stage,DSYTRS_AA_2STAGE)
+void LAPACK_dsytrs_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
     double* TB, lapack_int const* ltb, lapack_int const* ipiv, lapack_int const* ipiv2,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrs_aa_2stage(...) LAPACK_dsytrs_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrs_aa_2stage(...) LAPACK_dsytrs_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrs_aa_2stage LAPACK_GLOBAL(ssytrs_aa_2stage,SSYTRS_AA_2STAGE)
-void LAPACK_ssytrs_aa_2stage(
+#define LAPACK_ssytrs_aa_2stage_base LAPACK_GLOBAL(ssytrs_aa_2stage,SSYTRS_AA_2STAGE)
+void LAPACK_ssytrs_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
     float* TB, lapack_int const* ltb, lapack_int const* ipiv, lapack_int const* ipiv2,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrs_aa_2stage(...) LAPACK_ssytrs_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrs_aa_2stage(...) LAPACK_ssytrs_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrs_aa_2stage LAPACK_GLOBAL(zsytrs_aa_2stage,ZSYTRS_AA_2STAGE)
-void LAPACK_zsytrs_aa_2stage(
+#define LAPACK_zsytrs_aa_2stage_base LAPACK_GLOBAL(zsytrs_aa_2stage,ZSYTRS_AA_2STAGE)
+void LAPACK_zsytrs_aa_2stage_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double* TB, lapack_int const* ltb, lapack_int const* ipiv, lapack_int const* ipiv2,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrs_aa_2stage(...) LAPACK_zsytrs_aa_2stage_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrs_aa_2stage(...) LAPACK_zsytrs_aa_2stage_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_csytrs_rook LAPACK_GLOBAL(csytrs_rook,CSYTRS_ROOK)
-void LAPACK_csytrs_rook(
+#define LAPACK_csytrs_rook_base LAPACK_GLOBAL(csytrs_rook,CSYTRS_ROOK)
+void LAPACK_csytrs_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_csytrs_rook(...) LAPACK_csytrs_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_csytrs_rook(...) LAPACK_csytrs_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dsytrs_rook LAPACK_GLOBAL(dsytrs_rook,DSYTRS_ROOK)
-void LAPACK_dsytrs_rook(
+#define LAPACK_dsytrs_rook_base LAPACK_GLOBAL(dsytrs_rook,DSYTRS_ROOK)
+void LAPACK_dsytrs_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda, lapack_int const* ipiv,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dsytrs_rook(...) LAPACK_dsytrs_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dsytrs_rook(...) LAPACK_dsytrs_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ssytrs_rook LAPACK_GLOBAL(ssytrs_rook,SSYTRS_ROOK)
-void LAPACK_ssytrs_rook(
+#define LAPACK_ssytrs_rook_base LAPACK_GLOBAL(ssytrs_rook,SSYTRS_ROOK)
+void LAPACK_ssytrs_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda, lapack_int const* ipiv,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ssytrs_rook(...) LAPACK_ssytrs_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ssytrs_rook(...) LAPACK_ssytrs_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zsytrs_rook LAPACK_GLOBAL(zsytrs_rook,ZSYTRS_ROOK)
-void LAPACK_zsytrs_rook(
+#define LAPACK_zsytrs_rook_base LAPACK_GLOBAL(zsytrs_rook,ZSYTRS_ROOK)
+void LAPACK_zsytrs_rook_base(
     char const* uplo,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zsytrs_rook(...) LAPACK_zsytrs_rook_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zsytrs_rook(...) LAPACK_zsytrs_rook_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctbcon LAPACK_GLOBAL(ctbcon,CTBCON)
-void LAPACK_ctbcon(
+#define LAPACK_ctbcon_base LAPACK_GLOBAL(ctbcon,CTBCON)
+void LAPACK_ctbcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_float const* AB, lapack_int const* ldab,
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctbcon(...) LAPACK_ctbcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctbcon(...) LAPACK_ctbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtbcon LAPACK_GLOBAL(dtbcon,DTBCON)
-void LAPACK_dtbcon(
+#define LAPACK_dtbcon_base LAPACK_GLOBAL(dtbcon,DTBCON)
+void LAPACK_dtbcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* kd,
     double const* AB, lapack_int const* ldab,
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtbcon(...) LAPACK_dtbcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtbcon(...) LAPACK_dtbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stbcon LAPACK_GLOBAL(stbcon,STBCON)
-void LAPACK_stbcon(
+#define LAPACK_stbcon_base LAPACK_GLOBAL(stbcon,STBCON)
+void LAPACK_stbcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* kd,
     float const* AB, lapack_int const* ldab,
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stbcon(...) LAPACK_stbcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stbcon(...) LAPACK_stbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztbcon LAPACK_GLOBAL(ztbcon,ZTBCON)
-void LAPACK_ztbcon(
+#define LAPACK_ztbcon_base LAPACK_GLOBAL(ztbcon,ZTBCON)
+void LAPACK_ztbcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n, lapack_int const* kd,
     lapack_complex_double const* AB, lapack_int const* ldab,
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztbcon(...) LAPACK_ztbcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztbcon(...) LAPACK_ztbcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctbrfs LAPACK_GLOBAL(ctbrfs,CTBRFS)
-void LAPACK_ctbrfs(
+#define LAPACK_ctbrfs_base LAPACK_GLOBAL(ctbrfs,CTBRFS)
+void LAPACK_ctbrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_float const* AB, lapack_int const* ldab,
@@ -11848,10 +19625,19 @@ void LAPACK_ctbrfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctbrfs(...) LAPACK_ctbrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctbrfs(...) LAPACK_ctbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtbrfs LAPACK_GLOBAL(dtbrfs,DTBRFS)
-void LAPACK_dtbrfs(
+#define LAPACK_dtbrfs_base LAPACK_GLOBAL(dtbrfs,DTBRFS)
+void LAPACK_dtbrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     double const* AB, lapack_int const* ldab,
@@ -11861,10 +19647,19 @@ void LAPACK_dtbrfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtbrfs(...) LAPACK_dtbrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtbrfs(...) LAPACK_dtbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stbrfs LAPACK_GLOBAL(stbrfs,STBRFS)
-void LAPACK_stbrfs(
+#define LAPACK_stbrfs_base LAPACK_GLOBAL(stbrfs,STBRFS)
+void LAPACK_stbrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     float const* AB, lapack_int const* ldab,
@@ -11874,10 +19669,19 @@ void LAPACK_stbrfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stbrfs(...) LAPACK_stbrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stbrfs(...) LAPACK_stbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztbrfs LAPACK_GLOBAL(ztbrfs,ZTBRFS)
-void LAPACK_ztbrfs(
+#define LAPACK_ztbrfs_base LAPACK_GLOBAL(ztbrfs,ZTBRFS)
+void LAPACK_ztbrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_double const* AB, lapack_int const* ldab,
@@ -11887,166 +19691,355 @@ void LAPACK_ztbrfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztbrfs(...) LAPACK_ztbrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztbrfs(...) LAPACK_ztbrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctbtrs LAPACK_GLOBAL(ctbtrs,CTBTRS)
-void LAPACK_ctbtrs(
+#define LAPACK_ctbtrs_base LAPACK_GLOBAL(ctbtrs,CTBTRS)
+void LAPACK_ctbtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_float const* AB, lapack_int const* ldab,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctbtrs(...) LAPACK_ctbtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctbtrs(...) LAPACK_ctbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtbtrs LAPACK_GLOBAL(dtbtrs,DTBTRS)
-void LAPACK_dtbtrs(
+#define LAPACK_dtbtrs_base LAPACK_GLOBAL(dtbtrs,DTBTRS)
+void LAPACK_dtbtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     double const* AB, lapack_int const* ldab,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtbtrs(...) LAPACK_dtbtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtbtrs(...) LAPACK_dtbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stbtrs LAPACK_GLOBAL(stbtrs,STBTRS)
-void LAPACK_stbtrs(
+#define LAPACK_stbtrs_base LAPACK_GLOBAL(stbtrs,STBTRS)
+void LAPACK_stbtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     float const* AB, lapack_int const* ldab,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stbtrs(...) LAPACK_stbtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stbtrs(...) LAPACK_stbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztbtrs LAPACK_GLOBAL(ztbtrs,ZTBTRS)
-void LAPACK_ztbtrs(
+#define LAPACK_ztbtrs_base LAPACK_GLOBAL(ztbtrs,ZTBTRS)
+void LAPACK_ztbtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* kd, lapack_int const* nrhs,
     lapack_complex_double const* AB, lapack_int const* ldab,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztbtrs(...) LAPACK_ztbtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztbtrs(...) LAPACK_ztbtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctfsm LAPACK_GLOBAL(ctfsm,CTFSM)
-void LAPACK_ctfsm(
+#define LAPACK_ctfsm_base LAPACK_GLOBAL(ctfsm,CTFSM)
+void LAPACK_ctfsm_base(
     char const* transr, char const* side, char const* uplo, char const* trans, char const* diag,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* alpha,
     lapack_complex_float const* A,
-    lapack_complex_float* B, lapack_int const* ldb );
+    lapack_complex_float* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctfsm(...) LAPACK_ctfsm_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_ctfsm(...) LAPACK_ctfsm_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtfsm LAPACK_GLOBAL(dtfsm,DTFSM)
-void LAPACK_dtfsm(
+#define LAPACK_dtfsm_base LAPACK_GLOBAL(dtfsm,DTFSM)
+void LAPACK_dtfsm_base(
     char const* transr, char const* side, char const* uplo, char const* trans, char const* diag,
     lapack_int const* m, lapack_int const* n,
     double const* alpha,
     double const* A,
-    double* B, lapack_int const* ldb );
+    double* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtfsm(...) LAPACK_dtfsm_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_dtfsm(...) LAPACK_dtfsm_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stfsm LAPACK_GLOBAL(stfsm,STFSM)
-void LAPACK_stfsm(
+#define LAPACK_stfsm_base LAPACK_GLOBAL(stfsm,STFSM)
+void LAPACK_stfsm_base(
     char const* transr, char const* side, char const* uplo, char const* trans, char const* diag,
     lapack_int const* m, lapack_int const* n,
     float const* alpha,
     float const* A,
-    float* B, lapack_int const* ldb );
+    float* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stfsm(...) LAPACK_stfsm_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_stfsm(...) LAPACK_stfsm_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztfsm LAPACK_GLOBAL(ztfsm,ZTFSM)
-void LAPACK_ztfsm(
+#define LAPACK_ztfsm_base LAPACK_GLOBAL(ztfsm,ZTFSM)
+void LAPACK_ztfsm_base(
     char const* transr, char const* side, char const* uplo, char const* trans, char const* diag,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* alpha,
     lapack_complex_double const* A,
-    lapack_complex_double* B, lapack_int const* ldb );
+    lapack_complex_double* B, lapack_int const* ldb
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztfsm(...) LAPACK_ztfsm_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_ztfsm(...) LAPACK_ztfsm_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctftri LAPACK_GLOBAL(ctftri,CTFTRI)
-void LAPACK_ctftri(
+#define LAPACK_ctftri_base LAPACK_GLOBAL(ctftri,CTFTRI)
+void LAPACK_ctftri_base(
     char const* transr, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_float* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctftri(...) LAPACK_ctftri_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctftri(...) LAPACK_ctftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtftri LAPACK_GLOBAL(dtftri,DTFTRI)
-void LAPACK_dtftri(
+#define LAPACK_dtftri_base LAPACK_GLOBAL(dtftri,DTFTRI)
+void LAPACK_dtftri_base(
     char const* transr, char const* uplo, char const* diag,
     lapack_int const* n,
     double* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtftri(...) LAPACK_dtftri_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtftri(...) LAPACK_dtftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stftri LAPACK_GLOBAL(stftri,STFTRI)
-void LAPACK_stftri(
+#define LAPACK_stftri_base LAPACK_GLOBAL(stftri,STFTRI)
+void LAPACK_stftri_base(
     char const* transr, char const* uplo, char const* diag,
     lapack_int const* n,
     float* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stftri(...) LAPACK_stftri_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stftri(...) LAPACK_stftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztftri LAPACK_GLOBAL(ztftri,ZTFTRI)
-void LAPACK_ztftri(
+#define LAPACK_ztftri_base LAPACK_GLOBAL(ztftri,ZTFTRI)
+void LAPACK_ztftri_base(
     char const* transr, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_double* A,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztftri(...) LAPACK_ztftri_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztftri(...) LAPACK_ztftri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctfttp LAPACK_GLOBAL(ctfttp,CTFTTP)
-void LAPACK_ctfttp(
+#define LAPACK_ctfttp_base LAPACK_GLOBAL(ctfttp,CTFTTP)
+void LAPACK_ctfttp_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* ARF,
     lapack_complex_float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctfttp(...) LAPACK_ctfttp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctfttp(...) LAPACK_ctfttp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtfttp LAPACK_GLOBAL(dtfttp,DTFTTP)
-void LAPACK_dtfttp(
+#define LAPACK_dtfttp_base LAPACK_GLOBAL(dtfttp,DTFTTP)
+void LAPACK_dtfttp_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     double const* ARF,
     double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtfttp(...) LAPACK_dtfttp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtfttp(...) LAPACK_dtfttp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stfttp LAPACK_GLOBAL(stfttp,STFTTP)
-void LAPACK_stfttp(
+#define LAPACK_stfttp_base LAPACK_GLOBAL(stfttp,STFTTP)
+void LAPACK_stfttp_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     float const* ARF,
     float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stfttp(...) LAPACK_stfttp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stfttp(...) LAPACK_stfttp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztfttp LAPACK_GLOBAL(ztfttp,ZTFTTP)
-void LAPACK_ztfttp(
+#define LAPACK_ztfttp_base LAPACK_GLOBAL(ztfttp,ZTFTTP)
+void LAPACK_ztfttp_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* ARF,
     lapack_complex_double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztfttp(...) LAPACK_ztfttp_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztfttp(...) LAPACK_ztfttp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctfttr LAPACK_GLOBAL(ctfttr,CTFTTR)
-void LAPACK_ctfttr(
+#define LAPACK_ctfttr_base LAPACK_GLOBAL(ctfttr,CTFTTR)
+void LAPACK_ctfttr_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* ARF,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctfttr(...) LAPACK_ctfttr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctfttr(...) LAPACK_ctfttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtfttr LAPACK_GLOBAL(dtfttr,DTFTTR)
-void LAPACK_dtfttr(
+#define LAPACK_dtfttr_base LAPACK_GLOBAL(dtfttr,DTFTTR)
+void LAPACK_dtfttr_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     double const* ARF,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtfttr(...) LAPACK_dtfttr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtfttr(...) LAPACK_dtfttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stfttr LAPACK_GLOBAL(stfttr,STFTTR)
-void LAPACK_stfttr(
+#define LAPACK_stfttr_base LAPACK_GLOBAL(stfttr,STFTTR)
+void LAPACK_stfttr_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     float const* ARF,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stfttr(...) LAPACK_stfttr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stfttr(...) LAPACK_stfttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztfttr LAPACK_GLOBAL(ztfttr,ZTFTTR)
-void LAPACK_ztfttr(
+#define LAPACK_ztfttr_base LAPACK_GLOBAL(ztfttr,ZTFTTR)
+void LAPACK_ztfttr_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* ARF,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztfttr(...) LAPACK_ztfttr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztfttr(...) LAPACK_ztfttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctgevc LAPACK_GLOBAL(ctgevc,CTGEVC)
-void LAPACK_ctgevc(
+#define LAPACK_ctgevc_base LAPACK_GLOBAL(ctgevc,CTGEVC)
+void LAPACK_ctgevc_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12056,10 +20049,19 @@ void LAPACK_ctgevc(
     lapack_complex_float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctgevc(...) LAPACK_ctgevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctgevc(...) LAPACK_ctgevc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtgevc LAPACK_GLOBAL(dtgevc,DTGEVC)
-void LAPACK_dtgevc(
+#define LAPACK_dtgevc_base LAPACK_GLOBAL(dtgevc,DTGEVC)
+void LAPACK_dtgevc_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12068,10 +20070,19 @@ void LAPACK_dtgevc(
     double* VL, lapack_int const* ldvl,
     double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtgevc(...) LAPACK_dtgevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtgevc(...) LAPACK_dtgevc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stgevc LAPACK_GLOBAL(stgevc,STGEVC)
-void LAPACK_stgevc(
+#define LAPACK_stgevc_base LAPACK_GLOBAL(stgevc,STGEVC)
+void LAPACK_stgevc_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12080,10 +20091,19 @@ void LAPACK_stgevc(
     float* VL, lapack_int const* ldvl,
     float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stgevc(...) LAPACK_stgevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stgevc(...) LAPACK_stgevc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztgevc LAPACK_GLOBAL(ztgevc,ZTGEVC)
-void LAPACK_ztgevc(
+#define LAPACK_ztgevc_base LAPACK_GLOBAL(ztgevc,ZTGEVC)
+void LAPACK_ztgevc_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12093,7 +20113,16 @@ void LAPACK_ztgevc(
     lapack_complex_double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztgevc(...) LAPACK_ztgevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztgevc(...) LAPACK_ztgevc_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_ctgexc LAPACK_GLOBAL(ctgexc,CTGEXC)
 void LAPACK_ctgexc(
@@ -12199,8 +20228,8 @@ void LAPACK_ztgsen(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info );
 
-#define LAPACK_ctgsja LAPACK_GLOBAL(ctgsja,CTGSJA)
-void LAPACK_ctgsja(
+#define LAPACK_ctgsja_base LAPACK_GLOBAL(ctgsja,CTGSJA)
+void LAPACK_ctgsja_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     lapack_complex_float* A, lapack_int const* lda,
@@ -12213,10 +20242,19 @@ void LAPACK_ctgsja(
     lapack_complex_float* V, lapack_int const* ldv,
     lapack_complex_float* Q, lapack_int const* ldq,
     lapack_complex_float* work, lapack_int* ncycle,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctgsja(...) LAPACK_ctgsja_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctgsja(...) LAPACK_ctgsja_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtgsja LAPACK_GLOBAL(dtgsja,DTGSJA)
-void LAPACK_dtgsja(
+#define LAPACK_dtgsja_base LAPACK_GLOBAL(dtgsja,DTGSJA)
+void LAPACK_dtgsja_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     double* A, lapack_int const* lda,
@@ -12229,10 +20267,19 @@ void LAPACK_dtgsja(
     double* V, lapack_int const* ldv,
     double* Q, lapack_int const* ldq,
     double* work, lapack_int* ncycle,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtgsja(...) LAPACK_dtgsja_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtgsja(...) LAPACK_dtgsja_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stgsja LAPACK_GLOBAL(stgsja,STGSJA)
-void LAPACK_stgsja(
+#define LAPACK_stgsja_base LAPACK_GLOBAL(stgsja,STGSJA)
+void LAPACK_stgsja_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     float* A, lapack_int const* lda,
@@ -12245,10 +20292,19 @@ void LAPACK_stgsja(
     float* V, lapack_int const* ldv,
     float* Q, lapack_int const* ldq,
     float* work, lapack_int* ncycle,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stgsja(...) LAPACK_stgsja_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stgsja(...) LAPACK_stgsja_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztgsja LAPACK_GLOBAL(ztgsja,ZTGSJA)
-void LAPACK_ztgsja(
+#define LAPACK_ztgsja_base LAPACK_GLOBAL(ztgsja,ZTGSJA)
+void LAPACK_ztgsja_base(
     char const* jobu, char const* jobv, char const* jobq,
     lapack_int const* m, lapack_int const* p, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     lapack_complex_double* A, lapack_int const* lda,
@@ -12261,10 +20317,19 @@ void LAPACK_ztgsja(
     lapack_complex_double* V, lapack_int const* ldv,
     lapack_complex_double* Q, lapack_int const* ldq,
     lapack_complex_double* work, lapack_int* ncycle,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztgsja(...) LAPACK_ztgsja_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztgsja(...) LAPACK_ztgsja_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctgsna LAPACK_GLOBAL(ctgsna,CTGSNA)
-void LAPACK_ctgsna(
+#define LAPACK_ctgsna_base LAPACK_GLOBAL(ctgsna,CTGSNA)
+void LAPACK_ctgsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12276,10 +20341,19 @@ void LAPACK_ctgsna(
     float* DIF, lapack_int const* mm, lapack_int* m,
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctgsna(...) LAPACK_ctgsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctgsna(...) LAPACK_ctgsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtgsna LAPACK_GLOBAL(dtgsna,DTGSNA)
-void LAPACK_dtgsna(
+#define LAPACK_dtgsna_base LAPACK_GLOBAL(dtgsna,DTGSNA)
+void LAPACK_dtgsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12291,10 +20365,19 @@ void LAPACK_dtgsna(
     double* DIF, lapack_int const* mm, lapack_int* m,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtgsna(...) LAPACK_dtgsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtgsna(...) LAPACK_dtgsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stgsna LAPACK_GLOBAL(stgsna,STGSNA)
-void LAPACK_stgsna(
+#define LAPACK_stgsna_base LAPACK_GLOBAL(stgsna,STGSNA)
+void LAPACK_stgsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12306,10 +20389,19 @@ void LAPACK_stgsna(
     float* DIF, lapack_int const* mm, lapack_int* m,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stgsna(...) LAPACK_stgsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stgsna(...) LAPACK_stgsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztgsna LAPACK_GLOBAL(ztgsna,ZTGSNA)
-void LAPACK_ztgsna(
+#define LAPACK_ztgsna_base LAPACK_GLOBAL(ztgsna,ZTGSNA)
+void LAPACK_ztgsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12321,10 +20413,19 @@ void LAPACK_ztgsna(
     double* DIF, lapack_int const* mm, lapack_int* m,
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztgsna(...) LAPACK_ztgsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztgsna(...) LAPACK_ztgsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctgsyl LAPACK_GLOBAL(ctgsyl,CTGSYL)
-void LAPACK_ctgsyl(
+#define LAPACK_ctgsyl_base LAPACK_GLOBAL(ctgsyl,CTGSYL)
+void LAPACK_ctgsyl_base(
     char const* trans,
     lapack_int const* ijob, lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -12337,10 +20438,19 @@ void LAPACK_ctgsyl(
     float* scale,
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctgsyl(...) LAPACK_ctgsyl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ctgsyl(...) LAPACK_ctgsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtgsyl LAPACK_GLOBAL(dtgsyl,DTGSYL)
-void LAPACK_dtgsyl(
+#define LAPACK_dtgsyl_base LAPACK_GLOBAL(dtgsyl,DTGSYL)
+void LAPACK_dtgsyl_base(
     char const* trans,
     lapack_int const* ijob, lapack_int const* m, lapack_int const* n,
     double const* A, lapack_int const* lda,
@@ -12353,10 +20463,19 @@ void LAPACK_dtgsyl(
     double* scale,
     double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtgsyl(...) LAPACK_dtgsyl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dtgsyl(...) LAPACK_dtgsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stgsyl LAPACK_GLOBAL(stgsyl,STGSYL)
-void LAPACK_stgsyl(
+#define LAPACK_stgsyl_base LAPACK_GLOBAL(stgsyl,STGSYL)
+void LAPACK_stgsyl_base(
     char const* trans,
     lapack_int const* ijob, lapack_int const* m, lapack_int const* n,
     float const* A, lapack_int const* lda,
@@ -12369,10 +20488,19 @@ void LAPACK_stgsyl(
     float* scale,
     float* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stgsyl(...) LAPACK_stgsyl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_stgsyl(...) LAPACK_stgsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztgsyl LAPACK_GLOBAL(ztgsyl,ZTGSYL)
-void LAPACK_ztgsyl(
+#define LAPACK_ztgsyl_base LAPACK_GLOBAL(ztgsyl,ZTGSYL)
+void LAPACK_ztgsyl_base(
     char const* trans,
     lapack_int const* ijob, lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -12385,47 +20513,92 @@ void LAPACK_ztgsyl(
     double* scale,
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztgsyl(...) LAPACK_ztgsyl_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ztgsyl(...) LAPACK_ztgsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctpcon LAPACK_GLOBAL(ctpcon,CTPCON)
-void LAPACK_ctpcon(
+#define LAPACK_ctpcon_base LAPACK_GLOBAL(ctpcon,CTPCON)
+void LAPACK_ctpcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_float const* AP,
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctpcon(...) LAPACK_ctpcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctpcon(...) LAPACK_ctpcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtpcon LAPACK_GLOBAL(dtpcon,DTPCON)
-void LAPACK_dtpcon(
+#define LAPACK_dtpcon_base LAPACK_GLOBAL(dtpcon,DTPCON)
+void LAPACK_dtpcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     double const* AP,
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtpcon(...) LAPACK_dtpcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtpcon(...) LAPACK_dtpcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stpcon LAPACK_GLOBAL(stpcon,STPCON)
-void LAPACK_stpcon(
+#define LAPACK_stpcon_base LAPACK_GLOBAL(stpcon,STPCON)
+void LAPACK_stpcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     float const* AP,
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stpcon(...) LAPACK_stpcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stpcon(...) LAPACK_stpcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztpcon LAPACK_GLOBAL(ztpcon,ZTPCON)
-void LAPACK_ztpcon(
+#define LAPACK_ztpcon_base LAPACK_GLOBAL(ztpcon,ZTPCON)
+void LAPACK_ztpcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_double const* AP,
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztpcon(...) LAPACK_ztpcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztpcon(...) LAPACK_ztpcon_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_ctplqt LAPACK_GLOBAL(ctplqt,CTPLQT)
 void LAPACK_ctplqt(
@@ -12495,8 +20668,8 @@ void LAPACK_ztplqt2(
     lapack_complex_double* T, lapack_int const* ldt,
     lapack_int* info );
 
-#define LAPACK_ctpmlqt LAPACK_GLOBAL(ctpmlqt,CTPMLQT)
-void LAPACK_ctpmlqt(
+#define LAPACK_ctpmlqt_base LAPACK_GLOBAL(ctpmlqt,CTPMLQT)
+void LAPACK_ctpmlqt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* mb,
     lapack_complex_float const* V, lapack_int const* ldv,
@@ -12504,10 +20677,19 @@ void LAPACK_ctpmlqt(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctpmlqt(...) LAPACK_ctpmlqt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctpmlqt(...) LAPACK_ctpmlqt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtpmlqt LAPACK_GLOBAL(dtpmlqt,DTPMLQT)
-void LAPACK_dtpmlqt(
+#define LAPACK_dtpmlqt_base LAPACK_GLOBAL(dtpmlqt,DTPMLQT)
+void LAPACK_dtpmlqt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* mb,
     double const* V, lapack_int const* ldv,
@@ -12515,10 +20697,19 @@ void LAPACK_dtpmlqt(
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtpmlqt(...) LAPACK_dtpmlqt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtpmlqt(...) LAPACK_dtpmlqt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stpmlqt LAPACK_GLOBAL(stpmlqt,STPMLQT)
-void LAPACK_stpmlqt(
+#define LAPACK_stpmlqt_base LAPACK_GLOBAL(stpmlqt,STPMLQT)
+void LAPACK_stpmlqt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* mb,
     float const* V, lapack_int const* ldv,
@@ -12526,10 +20717,19 @@ void LAPACK_stpmlqt(
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stpmlqt(...) LAPACK_stpmlqt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stpmlqt(...) LAPACK_stpmlqt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztpmlqt LAPACK_GLOBAL(ztpmlqt,ZTPMLQT)
-void LAPACK_ztpmlqt(
+#define LAPACK_ztpmlqt_base LAPACK_GLOBAL(ztpmlqt,ZTPMLQT)
+void LAPACK_ztpmlqt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* mb,
     lapack_complex_double const* V, lapack_int const* ldv,
@@ -12537,10 +20737,19 @@ void LAPACK_ztpmlqt(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztpmlqt(...) LAPACK_ztpmlqt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztpmlqt(...) LAPACK_ztpmlqt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctpmqrt LAPACK_GLOBAL(ctpmqrt,CTPMQRT)
-void LAPACK_ctpmqrt(
+#define LAPACK_ctpmqrt_base LAPACK_GLOBAL(ctpmqrt,CTPMQRT)
+void LAPACK_ctpmqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* nb,
     lapack_complex_float const* V, lapack_int const* ldv,
@@ -12548,10 +20757,19 @@ void LAPACK_ctpmqrt(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctpmqrt(...) LAPACK_ctpmqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctpmqrt(...) LAPACK_ctpmqrt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtpmqrt LAPACK_GLOBAL(dtpmqrt,DTPMQRT)
-void LAPACK_dtpmqrt(
+#define LAPACK_dtpmqrt_base LAPACK_GLOBAL(dtpmqrt,DTPMQRT)
+void LAPACK_dtpmqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* nb,
     double const* V, lapack_int const* ldv,
@@ -12559,10 +20777,19 @@ void LAPACK_dtpmqrt(
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtpmqrt(...) LAPACK_dtpmqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtpmqrt(...) LAPACK_dtpmqrt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stpmqrt LAPACK_GLOBAL(stpmqrt,STPMQRT)
-void LAPACK_stpmqrt(
+#define LAPACK_stpmqrt_base LAPACK_GLOBAL(stpmqrt,STPMQRT)
+void LAPACK_stpmqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* nb,
     float const* V, lapack_int const* ldv,
@@ -12570,10 +20797,19 @@ void LAPACK_stpmqrt(
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stpmqrt(...) LAPACK_stpmqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stpmqrt(...) LAPACK_stpmqrt_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztpmqrt LAPACK_GLOBAL(ztpmqrt,ZTPMQRT)
-void LAPACK_ztpmqrt(
+#define LAPACK_ztpmqrt_base LAPACK_GLOBAL(ztpmqrt,ZTPMQRT)
+void LAPACK_ztpmqrt_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l, lapack_int const* nb,
     lapack_complex_double const* V, lapack_int const* ldv,
@@ -12581,7 +20817,16 @@ void LAPACK_ztpmqrt(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztpmqrt(...) LAPACK_ztpmqrt_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztpmqrt(...) LAPACK_ztpmqrt_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_ctpqrt LAPACK_GLOBAL(ctpqrt,CTPQRT)
 void LAPACK_ctpqrt(
@@ -12651,48 +20896,84 @@ void LAPACK_ztpqrt2(
     lapack_complex_double* T, lapack_int const* ldt,
     lapack_int* info );
 
-#define LAPACK_ctprfb LAPACK_GLOBAL(ctprfb,CTPRFB)
-void LAPACK_ctprfb(
+#define LAPACK_ctprfb_base LAPACK_GLOBAL(ctprfb,CTPRFB)
+void LAPACK_ctprfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     lapack_complex_float const* V, lapack_int const* ldv,
     lapack_complex_float const* T, lapack_int const* ldt,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_complex_float* work, lapack_int const* ldwork );
+    lapack_complex_float* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctprfb(...) LAPACK_ctprfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_ctprfb(...) LAPACK_ctprfb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtprfb LAPACK_GLOBAL(dtprfb,DTPRFB)
-void LAPACK_dtprfb(
+#define LAPACK_dtprfb_base LAPACK_GLOBAL(dtprfb,DTPRFB)
+void LAPACK_dtprfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     double const* V, lapack_int const* ldv,
     double const* T, lapack_int const* ldt,
     double* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
-    double* work, lapack_int const* ldwork );
+    double* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtprfb(...) LAPACK_dtprfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_dtprfb(...) LAPACK_dtprfb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stprfb LAPACK_GLOBAL(stprfb,STPRFB)
-void LAPACK_stprfb(
+#define LAPACK_stprfb_base LAPACK_GLOBAL(stprfb,STPRFB)
+void LAPACK_stprfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     float const* V, lapack_int const* ldv,
     float const* T, lapack_int const* ldt,
     float* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
-    float* work, lapack_int const* ldwork );
+    float* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stprfb(...) LAPACK_stprfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_stprfb(...) LAPACK_stprfb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztprfb LAPACK_GLOBAL(ztprfb,ZTPRFB)
-void LAPACK_ztprfb(
+#define LAPACK_ztprfb_base LAPACK_GLOBAL(ztprfb,ZTPRFB)
+void LAPACK_ztprfb_base(
     char const* side, char const* trans, char const* direct, char const* storev,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     lapack_complex_double const* V, lapack_int const* ldv,
     lapack_complex_double const* T, lapack_int const* ldt,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_complex_double* work, lapack_int const* ldwork );
+    lapack_complex_double* work, lapack_int const* ldwork
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztprfb(...) LAPACK_ztprfb_base(__VA_ARGS__, 1, 1, 1, 1)
+#else
+    #define LAPACK_ztprfb(...) LAPACK_ztprfb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctprfs LAPACK_GLOBAL(ctprfs,CTPRFS)
-void LAPACK_ctprfs(
+#define LAPACK_ctprfs_base LAPACK_GLOBAL(ctprfs,CTPRFS)
+void LAPACK_ctprfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
@@ -12702,10 +20983,19 @@ void LAPACK_ctprfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctprfs(...) LAPACK_ctprfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctprfs(...) LAPACK_ctprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtprfs LAPACK_GLOBAL(dtprfs,DTPRFS)
-void LAPACK_dtprfs(
+#define LAPACK_dtprfs_base LAPACK_GLOBAL(dtprfs,DTPRFS)
+void LAPACK_dtprfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     double const* AP,
@@ -12715,10 +21005,19 @@ void LAPACK_dtprfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtprfs(...) LAPACK_dtprfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtprfs(...) LAPACK_dtprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stprfs LAPACK_GLOBAL(stprfs,STPRFS)
-void LAPACK_stprfs(
+#define LAPACK_stprfs_base LAPACK_GLOBAL(stprfs,STPRFS)
+void LAPACK_stprfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     float const* AP,
@@ -12728,10 +21027,19 @@ void LAPACK_stprfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stprfs(...) LAPACK_stprfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stprfs(...) LAPACK_stprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztprfs LAPACK_GLOBAL(ztprfs,ZTPRFS)
-void LAPACK_ztprfs(
+#define LAPACK_ztprfs_base LAPACK_GLOBAL(ztprfs,ZTPRFS)
+void LAPACK_ztprfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
@@ -12741,174 +21049,363 @@ void LAPACK_ztprfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztprfs(...) LAPACK_ztprfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztprfs(...) LAPACK_ztprfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctptri LAPACK_GLOBAL(ctptri,CTPTRI)
-void LAPACK_ctptri(
+#define LAPACK_ctptri_base LAPACK_GLOBAL(ctptri,CTPTRI)
+void LAPACK_ctptri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctptri(...) LAPACK_ctptri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctptri(...) LAPACK_ctptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtptri LAPACK_GLOBAL(dtptri,DTPTRI)
-void LAPACK_dtptri(
+#define LAPACK_dtptri_base LAPACK_GLOBAL(dtptri,DTPTRI)
+void LAPACK_dtptri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtptri(...) LAPACK_dtptri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtptri(...) LAPACK_dtptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stptri LAPACK_GLOBAL(stptri,STPTRI)
-void LAPACK_stptri(
+#define LAPACK_stptri_base LAPACK_GLOBAL(stptri,STPTRI)
+void LAPACK_stptri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stptri(...) LAPACK_stptri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stptri(...) LAPACK_stptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztptri LAPACK_GLOBAL(ztptri,ZTPTRI)
-void LAPACK_ztptri(
+#define LAPACK_ztptri_base LAPACK_GLOBAL(ztptri,ZTPTRI)
+void LAPACK_ztptri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztptri(...) LAPACK_ztptri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztptri(...) LAPACK_ztptri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctptrs LAPACK_GLOBAL(ctptrs,CTPTRS)
-void LAPACK_ctptrs(
+#define LAPACK_ctptrs_base LAPACK_GLOBAL(ctptrs,CTPTRS)
+void LAPACK_ctptrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* AP,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctptrs(...) LAPACK_ctptrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctptrs(...) LAPACK_ctptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtptrs LAPACK_GLOBAL(dtptrs,DTPTRS)
-void LAPACK_dtptrs(
+#define LAPACK_dtptrs_base LAPACK_GLOBAL(dtptrs,DTPTRS)
+void LAPACK_dtptrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     double const* AP,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtptrs(...) LAPACK_dtptrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtptrs(...) LAPACK_dtptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stptrs LAPACK_GLOBAL(stptrs,STPTRS)
-void LAPACK_stptrs(
+#define LAPACK_stptrs_base LAPACK_GLOBAL(stptrs,STPTRS)
+void LAPACK_stptrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     float const* AP,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stptrs(...) LAPACK_stptrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_stptrs(...) LAPACK_stptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztptrs LAPACK_GLOBAL(ztptrs,ZTPTRS)
-void LAPACK_ztptrs(
+#define LAPACK_ztptrs_base LAPACK_GLOBAL(ztptrs,ZTPTRS)
+void LAPACK_ztptrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* AP,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztptrs(...) LAPACK_ztptrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztptrs(...) LAPACK_ztptrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctpttf LAPACK_GLOBAL(ctpttf,CTPTTF)
-void LAPACK_ctpttf(
+#define LAPACK_ctpttf_base LAPACK_GLOBAL(ctpttf,CTPTTF)
+void LAPACK_ctpttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP,
     lapack_complex_float* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctpttf(...) LAPACK_ctpttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctpttf(...) LAPACK_ctpttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtpttf LAPACK_GLOBAL(dtpttf,DTPTTF)
-void LAPACK_dtpttf(
+#define LAPACK_dtpttf_base LAPACK_GLOBAL(dtpttf,DTPTTF)
+void LAPACK_dtpttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     double const* AP,
     double* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtpttf(...) LAPACK_dtpttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtpttf(...) LAPACK_dtpttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stpttf LAPACK_GLOBAL(stpttf,STPTTF)
-void LAPACK_stpttf(
+#define LAPACK_stpttf_base LAPACK_GLOBAL(stpttf,STPTTF)
+void LAPACK_stpttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     float const* AP,
     float* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stpttf(...) LAPACK_stpttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_stpttf(...) LAPACK_stpttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztpttf LAPACK_GLOBAL(ztpttf,ZTPTTF)
-void LAPACK_ztpttf(
+#define LAPACK_ztpttf_base LAPACK_GLOBAL(ztpttf,ZTPTTF)
+void LAPACK_ztpttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP,
     lapack_complex_double* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztpttf(...) LAPACK_ztpttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztpttf(...) LAPACK_ztpttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctpttr LAPACK_GLOBAL(ctpttr,CTPTTR)
-void LAPACK_ctpttr(
+#define LAPACK_ctpttr_base LAPACK_GLOBAL(ctpttr,CTPTTR)
+void LAPACK_ctpttr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctpttr(...) LAPACK_ctpttr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ctpttr(...) LAPACK_ctpttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtpttr LAPACK_GLOBAL(dtpttr,DTPTTR)
-void LAPACK_dtpttr(
+#define LAPACK_dtpttr_base LAPACK_GLOBAL(dtpttr,DTPTTR)
+void LAPACK_dtpttr_base(
     char const* uplo,
     lapack_int const* n,
     double const* AP,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtpttr(...) LAPACK_dtpttr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dtpttr(...) LAPACK_dtpttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_stpttr LAPACK_GLOBAL(stpttr,STPTTR)
-void LAPACK_stpttr(
+#define LAPACK_stpttr_base LAPACK_GLOBAL(stpttr,STPTTR)
+void LAPACK_stpttr_base(
     char const* uplo,
     lapack_int const* n,
     float const* AP,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_stpttr(...) LAPACK_stpttr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_stpttr(...) LAPACK_stpttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztpttr LAPACK_GLOBAL(ztpttr,ZTPTTR)
-void LAPACK_ztpttr(
+#define LAPACK_ztpttr_base LAPACK_GLOBAL(ztpttr,ZTPTTR)
+void LAPACK_ztpttr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztpttr(...) LAPACK_ztpttr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ztpttr(...) LAPACK_ztpttr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrcon LAPACK_GLOBAL(ctrcon,CTRCON)
-void LAPACK_ctrcon(
+#define LAPACK_ctrcon_base LAPACK_GLOBAL(ctrcon,CTRCON)
+void LAPACK_ctrcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
     float* rcond,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrcon(...) LAPACK_ctrcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctrcon(...) LAPACK_ctrcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrcon LAPACK_GLOBAL(dtrcon,DTRCON)
-void LAPACK_dtrcon(
+#define LAPACK_dtrcon_base LAPACK_GLOBAL(dtrcon,DTRCON)
+void LAPACK_dtrcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
     double* rcond,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrcon(...) LAPACK_dtrcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtrcon(...) LAPACK_dtrcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strcon LAPACK_GLOBAL(strcon,STRCON)
-void LAPACK_strcon(
+#define LAPACK_strcon_base LAPACK_GLOBAL(strcon,STRCON)
+void LAPACK_strcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
     float* rcond,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strcon(...) LAPACK_strcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_strcon(...) LAPACK_strcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrcon LAPACK_GLOBAL(ztrcon,ZTRCON)
-void LAPACK_ztrcon(
+#define LAPACK_ztrcon_base LAPACK_GLOBAL(ztrcon,ZTRCON)
+void LAPACK_ztrcon_base(
     char const* norm, char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
     double* rcond,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrcon(...) LAPACK_ztrcon_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztrcon(...) LAPACK_ztrcon_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrevc LAPACK_GLOBAL(ctrevc,CTREVC)
-void LAPACK_ctrevc(
+#define LAPACK_ctrevc_base LAPACK_GLOBAL(ctrevc,CTREVC)
+void LAPACK_ctrevc_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12917,10 +21414,19 @@ void LAPACK_ctrevc(
     lapack_complex_float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrevc(...) LAPACK_ctrevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctrevc(...) LAPACK_ctrevc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrevc LAPACK_GLOBAL(dtrevc,DTREVC)
-void LAPACK_dtrevc(
+#define LAPACK_dtrevc_base LAPACK_GLOBAL(dtrevc,DTREVC)
+void LAPACK_dtrevc_base(
     char const* side, char const* howmny,
     lapack_logical* select,
     lapack_int const* n,
@@ -12928,10 +21434,19 @@ void LAPACK_dtrevc(
     double* VL, lapack_int const* ldvl,
     double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrevc(...) LAPACK_dtrevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtrevc(...) LAPACK_dtrevc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strevc LAPACK_GLOBAL(strevc,STREVC)
-void LAPACK_strevc(
+#define LAPACK_strevc_base LAPACK_GLOBAL(strevc,STREVC)
+void LAPACK_strevc_base(
     char const* side, char const* howmny,
     lapack_logical* select,
     lapack_int const* n,
@@ -12939,10 +21454,19 @@ void LAPACK_strevc(
     float* VL, lapack_int const* ldvl,
     float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strevc(...) LAPACK_strevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_strevc(...) LAPACK_strevc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrevc LAPACK_GLOBAL(ztrevc,ZTREVC)
-void LAPACK_ztrevc(
+#define LAPACK_ztrevc_base LAPACK_GLOBAL(ztrevc,ZTREVC)
+void LAPACK_ztrevc_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12951,10 +21475,19 @@ void LAPACK_ztrevc(
     lapack_complex_double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrevc(...) LAPACK_ztrevc_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztrevc(...) LAPACK_ztrevc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrevc3 LAPACK_GLOBAL(ctrevc3,CTREVC3)
-void LAPACK_ctrevc3(
+#define LAPACK_ctrevc3_base LAPACK_GLOBAL(ctrevc3,CTREVC3)
+void LAPACK_ctrevc3_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12963,10 +21496,19 @@ void LAPACK_ctrevc3(
     lapack_complex_float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrevc3(...) LAPACK_ctrevc3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctrevc3(...) LAPACK_ctrevc3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrevc3 LAPACK_GLOBAL(dtrevc3,DTREVC3)
-void LAPACK_dtrevc3(
+#define LAPACK_dtrevc3_base LAPACK_GLOBAL(dtrevc3,DTREVC3)
+void LAPACK_dtrevc3_base(
     char const* side, char const* howmny,
     lapack_logical* select,
     lapack_int const* n,
@@ -12974,10 +21516,19 @@ void LAPACK_dtrevc3(
     double* VL, lapack_int const* ldvl,
     double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrevc3(...) LAPACK_dtrevc3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtrevc3(...) LAPACK_dtrevc3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strevc3 LAPACK_GLOBAL(strevc3,STREVC3)
-void LAPACK_strevc3(
+#define LAPACK_strevc3_base LAPACK_GLOBAL(strevc3,STREVC3)
+void LAPACK_strevc3_base(
     char const* side, char const* howmny,
     lapack_logical* select,
     lapack_int const* n,
@@ -12985,10 +21536,19 @@ void LAPACK_strevc3(
     float* VL, lapack_int const* ldvl,
     float* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strevc3(...) LAPACK_strevc3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_strevc3(...) LAPACK_strevc3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrevc3 LAPACK_GLOBAL(ztrevc3,ZTREVC3)
-void LAPACK_ztrevc3(
+#define LAPACK_ztrevc3_base LAPACK_GLOBAL(ztrevc3,ZTREVC3)
+void LAPACK_ztrevc3_base(
     char const* side, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -12997,44 +21557,89 @@ void LAPACK_ztrevc3(
     lapack_complex_double* VR, lapack_int const* ldvr, lapack_int const* mm, lapack_int* m,
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrevc3(...) LAPACK_ztrevc3_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztrevc3(...) LAPACK_ztrevc3_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrexc LAPACK_GLOBAL(ctrexc,CTREXC)
-void LAPACK_ctrexc(
+#define LAPACK_ctrexc_base LAPACK_GLOBAL(ctrexc,CTREXC)
+void LAPACK_ctrexc_base(
     char const* compq,
     lapack_int const* n,
     lapack_complex_float* T, lapack_int const* ldt,
     lapack_complex_float* Q, lapack_int const* ldq, lapack_int const* ifst, lapack_int const* ilst,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrexc(...) LAPACK_ctrexc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ctrexc(...) LAPACK_ctrexc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrexc LAPACK_GLOBAL(dtrexc,DTREXC)
-void LAPACK_dtrexc(
+#define LAPACK_dtrexc_base LAPACK_GLOBAL(dtrexc,DTREXC)
+void LAPACK_dtrexc_base(
     char const* compq,
     lapack_int const* n,
     double* T, lapack_int const* ldt,
     double* Q, lapack_int const* ldq, lapack_int* ifst, lapack_int* ilst,
     double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrexc(...) LAPACK_dtrexc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dtrexc(...) LAPACK_dtrexc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strexc LAPACK_GLOBAL(strexc,STREXC)
-void LAPACK_strexc(
+#define LAPACK_strexc_base LAPACK_GLOBAL(strexc,STREXC)
+void LAPACK_strexc_base(
     char const* compq,
     lapack_int const* n,
     float* T, lapack_int const* ldt,
     float* Q, lapack_int const* ldq, lapack_int* ifst, lapack_int* ilst,
     float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strexc(...) LAPACK_strexc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_strexc(...) LAPACK_strexc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrexc LAPACK_GLOBAL(ztrexc,ZTREXC)
-void LAPACK_ztrexc(
+#define LAPACK_ztrexc_base LAPACK_GLOBAL(ztrexc,ZTREXC)
+void LAPACK_ztrexc_base(
     char const* compq,
     lapack_int const* n,
     lapack_complex_double* T, lapack_int const* ldt,
     lapack_complex_double* Q, lapack_int const* ldq, lapack_int const* ifst, lapack_int const* ilst,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrexc(...) LAPACK_ztrexc_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ztrexc(...) LAPACK_ztrexc_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrrfs LAPACK_GLOBAL(ctrrfs,CTRRFS)
-void LAPACK_ctrrfs(
+#define LAPACK_ctrrfs_base LAPACK_GLOBAL(ctrrfs,CTRRFS)
+void LAPACK_ctrrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -13044,10 +21649,19 @@ void LAPACK_ctrrfs(
     float* berr,
     lapack_complex_float* work,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrrfs(...) LAPACK_ctrrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctrrfs(...) LAPACK_ctrrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrrfs LAPACK_GLOBAL(dtrrfs,DTRRFS)
-void LAPACK_dtrrfs(
+#define LAPACK_dtrrfs_base LAPACK_GLOBAL(dtrrfs,DTRRFS)
+void LAPACK_dtrrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -13057,10 +21671,19 @@ void LAPACK_dtrrfs(
     double* berr,
     double* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrrfs(...) LAPACK_dtrrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtrrfs(...) LAPACK_dtrrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strrfs LAPACK_GLOBAL(strrfs,STRRFS)
-void LAPACK_strrfs(
+#define LAPACK_strrfs_base LAPACK_GLOBAL(strrfs,STRRFS)
+void LAPACK_strrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -13070,10 +21693,19 @@ void LAPACK_strrfs(
     float* berr,
     float* work,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strrfs(...) LAPACK_strrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_strrfs(...) LAPACK_strrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrrfs LAPACK_GLOBAL(ztrrfs,ZTRRFS)
-void LAPACK_ztrrfs(
+#define LAPACK_ztrrfs_base LAPACK_GLOBAL(ztrrfs,ZTRRFS)
+void LAPACK_ztrrfs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
@@ -13083,10 +21715,19 @@ void LAPACK_ztrrfs(
     double* berr,
     lapack_complex_double* work,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrrfs(...) LAPACK_ztrrfs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztrrfs(...) LAPACK_ztrrfs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrsen LAPACK_GLOBAL(ctrsen,CTRSEN)
-void LAPACK_ctrsen(
+#define LAPACK_ctrsen_base LAPACK_GLOBAL(ctrsen,CTRSEN)
+void LAPACK_ctrsen_base(
     char const* job, char const* compq,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13096,10 +21737,19 @@ void LAPACK_ctrsen(
     float* s,
     float* sep,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrsen(...) LAPACK_ctrsen_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctrsen(...) LAPACK_ctrsen_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrsen LAPACK_GLOBAL(dtrsen,DTRSEN)
-void LAPACK_dtrsen(
+#define LAPACK_dtrsen_base LAPACK_GLOBAL(dtrsen,DTRSEN)
+void LAPACK_dtrsen_base(
     char const* job, char const* compq,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13111,10 +21761,19 @@ void LAPACK_dtrsen(
     double* sep,
     double* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrsen(...) LAPACK_dtrsen_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtrsen(...) LAPACK_dtrsen_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strsen LAPACK_GLOBAL(strsen,STRSEN)
-void LAPACK_strsen(
+#define LAPACK_strsen_base LAPACK_GLOBAL(strsen,STRSEN)
+void LAPACK_strsen_base(
     char const* job, char const* compq,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13126,10 +21785,19 @@ void LAPACK_strsen(
     float* sep,
     float* work, lapack_int const* lwork,
     lapack_int* iwork, lapack_int const* liwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strsen(...) LAPACK_strsen_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_strsen(...) LAPACK_strsen_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrsen LAPACK_GLOBAL(ztrsen,ZTRSEN)
-void LAPACK_ztrsen(
+#define LAPACK_ztrsen_base LAPACK_GLOBAL(ztrsen,ZTRSEN)
+void LAPACK_ztrsen_base(
     char const* job, char const* compq,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13139,10 +21807,19 @@ void LAPACK_ztrsen(
     double* s,
     double* sep,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrsen(...) LAPACK_ztrsen_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztrsen(...) LAPACK_ztrsen_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrsna LAPACK_GLOBAL(ctrsna,CTRSNA)
-void LAPACK_ctrsna(
+#define LAPACK_ctrsna_base LAPACK_GLOBAL(ctrsna,CTRSNA)
+void LAPACK_ctrsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13153,10 +21830,19 @@ void LAPACK_ctrsna(
     float* SEP, lapack_int const* mm, lapack_int* m,
     lapack_complex_float* work, lapack_int const* ldwork,
     float* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrsna(...) LAPACK_ctrsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctrsna(...) LAPACK_ctrsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrsna LAPACK_GLOBAL(dtrsna,DTRSNA)
-void LAPACK_dtrsna(
+#define LAPACK_dtrsna_base LAPACK_GLOBAL(dtrsna,DTRSNA)
+void LAPACK_dtrsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13167,10 +21853,19 @@ void LAPACK_dtrsna(
     double* SEP, lapack_int const* mm, lapack_int* m,
     double* work, lapack_int const* ldwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrsna(...) LAPACK_dtrsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtrsna(...) LAPACK_dtrsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strsna LAPACK_GLOBAL(strsna,STRSNA)
-void LAPACK_strsna(
+#define LAPACK_strsna_base LAPACK_GLOBAL(strsna,STRSNA)
+void LAPACK_strsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13181,10 +21876,19 @@ void LAPACK_strsna(
     float* SEP, lapack_int const* mm, lapack_int* m,
     float* work, lapack_int const* ldwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strsna(...) LAPACK_strsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_strsna(...) LAPACK_strsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrsna LAPACK_GLOBAL(ztrsna,ZTRSNA)
-void LAPACK_ztrsna(
+#define LAPACK_ztrsna_base LAPACK_GLOBAL(ztrsna,ZTRSNA)
+void LAPACK_ztrsna_base(
     char const* job, char const* howmny,
     lapack_logical const* select,
     lapack_int const* n,
@@ -13195,171 +21899,360 @@ void LAPACK_ztrsna(
     double* SEP, lapack_int const* mm, lapack_int* m,
     lapack_complex_double* work, lapack_int const* ldwork,
     double* rwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrsna(...) LAPACK_ztrsna_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztrsna(...) LAPACK_ztrsna_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrsyl LAPACK_GLOBAL(ctrsyl,CTRSYL)
-void LAPACK_ctrsyl(
+#define LAPACK_ctrsyl_base LAPACK_GLOBAL(ctrsyl,CTRSYL)
+void LAPACK_ctrsyl_base(
     char const* trana, char const* tranb,
     lapack_int const* isgn, lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* B, lapack_int const* ldb,
     lapack_complex_float* C, lapack_int const* ldc,
     float* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrsyl(...) LAPACK_ctrsyl_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctrsyl(...) LAPACK_ctrsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrsyl LAPACK_GLOBAL(dtrsyl,DTRSYL)
-void LAPACK_dtrsyl(
+#define LAPACK_dtrsyl_base LAPACK_GLOBAL(dtrsyl,DTRSYL)
+void LAPACK_dtrsyl_base(
     char const* trana, char const* tranb,
     lapack_int const* isgn, lapack_int const* m, lapack_int const* n,
     double const* A, lapack_int const* lda,
     double const* B, lapack_int const* ldb,
     double* C, lapack_int const* ldc,
     double* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrsyl(...) LAPACK_dtrsyl_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtrsyl(...) LAPACK_dtrsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strsyl LAPACK_GLOBAL(strsyl,STRSYL)
-void LAPACK_strsyl(
+#define LAPACK_strsyl_base LAPACK_GLOBAL(strsyl,STRSYL)
+void LAPACK_strsyl_base(
     char const* trana, char const* tranb,
     lapack_int const* isgn, lapack_int const* m, lapack_int const* n,
     float const* A, lapack_int const* lda,
     float const* B, lapack_int const* ldb,
     float* C, lapack_int const* ldc,
     float* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strsyl(...) LAPACK_strsyl_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_strsyl(...) LAPACK_strsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrsyl LAPACK_GLOBAL(ztrsyl,ZTRSYL)
-void LAPACK_ztrsyl(
+#define LAPACK_ztrsyl_base LAPACK_GLOBAL(ztrsyl,ZTRSYL)
+void LAPACK_ztrsyl_base(
     char const* trana, char const* tranb,
     lapack_int const* isgn, lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* B, lapack_int const* ldb,
     lapack_complex_double* C, lapack_int const* ldc,
     double* scale,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrsyl(...) LAPACK_ztrsyl_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztrsyl(...) LAPACK_ztrsyl_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrtri LAPACK_GLOBAL(ctrtri,CTRTRI)
-void LAPACK_ctrtri(
+#define LAPACK_ctrtri_base LAPACK_GLOBAL(ctrtri,CTRTRI)
+void LAPACK_ctrtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrtri(...) LAPACK_ctrtri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctrtri(...) LAPACK_ctrtri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrtri LAPACK_GLOBAL(dtrtri,DTRTRI)
-void LAPACK_dtrtri(
+#define LAPACK_dtrtri_base LAPACK_GLOBAL(dtrtri,DTRTRI)
+void LAPACK_dtrtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrtri(...) LAPACK_dtrtri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtrtri(...) LAPACK_dtrtri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strtri LAPACK_GLOBAL(strtri,STRTRI)
-void LAPACK_strtri(
+#define LAPACK_strtri_base LAPACK_GLOBAL(strtri,STRTRI)
+void LAPACK_strtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     float* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strtri(...) LAPACK_strtri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_strtri(...) LAPACK_strtri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrtri LAPACK_GLOBAL(ztrtri,ZTRTRI)
-void LAPACK_ztrtri(
+#define LAPACK_ztrtri_base LAPACK_GLOBAL(ztrtri,ZTRTRI)
+void LAPACK_ztrtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrtri(...) LAPACK_ztrtri_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztrtri(...) LAPACK_ztrtri_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrtrs LAPACK_GLOBAL(ctrtrs,CTRTRS)
-void LAPACK_ctrtrs(
+#define LAPACK_ctrtrs_base LAPACK_GLOBAL(ctrtrs,CTRTRS)
+void LAPACK_ctrtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrtrs(...) LAPACK_ctrtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ctrtrs(...) LAPACK_ctrtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrtrs LAPACK_GLOBAL(dtrtrs,DTRTRS)
-void LAPACK_dtrtrs(
+#define LAPACK_dtrtrs_base LAPACK_GLOBAL(dtrtrs,DTRTRS)
+void LAPACK_dtrtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
     double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrtrs(...) LAPACK_dtrtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_dtrtrs(...) LAPACK_dtrtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strtrs LAPACK_GLOBAL(strtrs,STRTRS)
-void LAPACK_strtrs(
+#define LAPACK_strtrs_base LAPACK_GLOBAL(strtrs,STRTRS)
+void LAPACK_strtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
     float* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strtrs(...) LAPACK_strtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_strtrs(...) LAPACK_strtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrtrs LAPACK_GLOBAL(ztrtrs,ZTRTRS)
-void LAPACK_ztrtrs(
+#define LAPACK_ztrtrs_base LAPACK_GLOBAL(ztrtrs,ZTRTRS)
+void LAPACK_ztrtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrtrs(...) LAPACK_ztrtrs_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_ztrtrs(...) LAPACK_ztrtrs_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrttf LAPACK_GLOBAL(ctrttf,CTRTTF)
-void LAPACK_ctrttf(
+#define LAPACK_ctrttf_base LAPACK_GLOBAL(ctrttf,CTRTTF)
+void LAPACK_ctrttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrttf(...) LAPACK_ctrttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ctrttf(...) LAPACK_ctrttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrttf LAPACK_GLOBAL(dtrttf,DTRTTF)
-void LAPACK_dtrttf(
+#define LAPACK_dtrttf_base LAPACK_GLOBAL(dtrttf,DTRTTF)
+void LAPACK_dtrttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
     double* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrttf(...) LAPACK_dtrttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_dtrttf(...) LAPACK_dtrttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strttf LAPACK_GLOBAL(strttf,STRTTF)
-void LAPACK_strttf(
+#define LAPACK_strttf_base LAPACK_GLOBAL(strttf,STRTTF)
+void LAPACK_strttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
     float* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strttf(...) LAPACK_strttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_strttf(...) LAPACK_strttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrttf LAPACK_GLOBAL(ztrttf,ZTRTTF)
-void LAPACK_ztrttf(
+#define LAPACK_ztrttf_base LAPACK_GLOBAL(ztrttf,ZTRTTF)
+void LAPACK_ztrttf_base(
     char const* transr, char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double* ARF,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrttf(...) LAPACK_ztrttf_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_ztrttf(...) LAPACK_ztrttf_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ctrttp LAPACK_GLOBAL(ctrttp,CTRTTP)
-void LAPACK_ctrttp(
+#define LAPACK_ctrttp_base LAPACK_GLOBAL(ctrttp,CTRTTP)
+void LAPACK_ctrttp_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ctrttp(...) LAPACK_ctrttp_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ctrttp(...) LAPACK_ctrttp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_dtrttp LAPACK_GLOBAL(dtrttp,DTRTTP)
-void LAPACK_dtrttp(
+#define LAPACK_dtrttp_base LAPACK_GLOBAL(dtrttp,DTRTTP)
+void LAPACK_dtrttp_base(
     char const* uplo,
     lapack_int const* n,
     double const* A, lapack_int const* lda,
     double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_dtrttp(...) LAPACK_dtrttp_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_dtrttp(...) LAPACK_dtrttp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_strttp LAPACK_GLOBAL(strttp,STRTTP)
-void LAPACK_strttp(
+#define LAPACK_strttp_base LAPACK_GLOBAL(strttp,STRTTP)
+void LAPACK_strttp_base(
     char const* uplo,
     lapack_int const* n,
     float const* A, lapack_int const* lda,
     float* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_strttp(...) LAPACK_strttp_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_strttp(...) LAPACK_strttp_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_ztrttp LAPACK_GLOBAL(ztrttp,ZTRTTP)
-void LAPACK_ztrttp(
+#define LAPACK_ztrttp_base LAPACK_GLOBAL(ztrttp,ZTRTTP)
+void LAPACK_ztrttp_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double* AP,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_ztrttp(...) LAPACK_ztrttp_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_ztrttp(...) LAPACK_ztrttp_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_ctzrzf LAPACK_GLOBAL(ctzrzf,CTZRZF)
 void LAPACK_ctzrzf(
@@ -13393,8 +22286,8 @@ void LAPACK_ztzrzf(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cunbdb LAPACK_GLOBAL(cunbdb,CUNBDB)
-void LAPACK_cunbdb(
+#define LAPACK_cunbdb_base LAPACK_GLOBAL(cunbdb,CUNBDB)
+void LAPACK_cunbdb_base(
     char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     lapack_complex_float* X11, lapack_int const* ldx11,
@@ -13408,10 +22301,19 @@ void LAPACK_cunbdb(
     lapack_complex_float* TAUQ1,
     lapack_complex_float* TAUQ2,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunbdb(...) LAPACK_cunbdb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cunbdb(...) LAPACK_cunbdb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunbdb LAPACK_GLOBAL(zunbdb,ZUNBDB)
-void LAPACK_zunbdb(
+#define LAPACK_zunbdb_base LAPACK_GLOBAL(zunbdb,ZUNBDB)
+void LAPACK_zunbdb_base(
     char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     lapack_complex_double* X11, lapack_int const* ldx11,
@@ -13425,10 +22327,19 @@ void LAPACK_zunbdb(
     lapack_complex_double* TAUQ1,
     lapack_complex_double* TAUQ2,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunbdb(...) LAPACK_zunbdb_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zunbdb(...) LAPACK_zunbdb_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cuncsd LAPACK_GLOBAL(cuncsd,CUNCSD)
-void LAPACK_cuncsd(
+#define LAPACK_cuncsd_base LAPACK_GLOBAL(cuncsd,CUNCSD)
+void LAPACK_cuncsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     lapack_complex_float* X11, lapack_int const* ldx11,
@@ -13443,10 +22354,19 @@ void LAPACK_cuncsd(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cuncsd(...) LAPACK_cuncsd_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_cuncsd(...) LAPACK_cuncsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zuncsd LAPACK_GLOBAL(zuncsd,ZUNCSD)
-void LAPACK_zuncsd(
+#define LAPACK_zuncsd_base LAPACK_GLOBAL(zuncsd,ZUNCSD)
+void LAPACK_zuncsd_base(
     char const* jobu1, char const* jobu2, char const* jobv1t, char const* jobv2t, char const* trans, char const* signs,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     lapack_complex_double* X11, lapack_int const* ldx11,
@@ -13461,10 +22381,19 @@ void LAPACK_zuncsd(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t, size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zuncsd(...) LAPACK_zuncsd_base(__VA_ARGS__, 1, 1, 1, 1, 1, 1)
+#else
+    #define LAPACK_zuncsd(...) LAPACK_zuncsd_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cuncsd2by1 LAPACK_GLOBAL(cuncsd2by1,CUNCSD2BY1)
-void LAPACK_cuncsd2by1(
+#define LAPACK_cuncsd2by1_base LAPACK_GLOBAL(cuncsd2by1,CUNCSD2BY1)
+void LAPACK_cuncsd2by1_base(
     char const* jobu1, char const* jobu2, char const* jobv1t,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     lapack_complex_float* X11, lapack_int const* ldx11,
@@ -13476,10 +22405,19 @@ void LAPACK_cuncsd2by1(
     lapack_complex_float* work, lapack_int const* lwork,
     float* rwork, lapack_int const* lrwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cuncsd2by1(...) LAPACK_cuncsd2by1_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cuncsd2by1(...) LAPACK_cuncsd2by1_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zuncsd2by1 LAPACK_GLOBAL(zuncsd2by1,ZUNCSD2BY1)
-void LAPACK_zuncsd2by1(
+#define LAPACK_zuncsd2by1_base LAPACK_GLOBAL(zuncsd2by1,ZUNCSD2BY1)
+void LAPACK_zuncsd2by1_base(
     char const* jobu1, char const* jobu2, char const* jobv1t,
     lapack_int const* m, lapack_int const* p, lapack_int const* q,
     lapack_complex_double* X11, lapack_int const* ldx11,
@@ -13491,25 +22429,52 @@ void LAPACK_zuncsd2by1(
     lapack_complex_double* work, lapack_int const* lwork,
     double* rwork, lapack_int const* lrwork,
     lapack_int* iwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zuncsd2by1(...) LAPACK_zuncsd2by1_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zuncsd2by1(...) LAPACK_zuncsd2by1_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cungbr LAPACK_GLOBAL(cungbr,CUNGBR)
-void LAPACK_cungbr(
+#define LAPACK_cungbr_base LAPACK_GLOBAL(cungbr,CUNGBR)
+void LAPACK_cungbr_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cungbr(...) LAPACK_cungbr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cungbr(...) LAPACK_cungbr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zungbr LAPACK_GLOBAL(zungbr,ZUNGBR)
-void LAPACK_zungbr(
+#define LAPACK_zungbr_base LAPACK_GLOBAL(zungbr,ZUNGBR)
+void LAPACK_zungbr_base(
     char const* vect,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zungbr(...) LAPACK_zungbr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zungbr(...) LAPACK_zungbr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cunghr LAPACK_GLOBAL(cunghr,CUNGHR)
 void LAPACK_cunghr(
@@ -13591,23 +22556,41 @@ void LAPACK_zungrq(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cungtr LAPACK_GLOBAL(cungtr,CUNGTR)
-void LAPACK_cungtr(
+#define LAPACK_cungtr_base LAPACK_GLOBAL(cungtr,CUNGTR)
+void LAPACK_cungtr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cungtr(...) LAPACK_cungtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cungtr(...) LAPACK_cungtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zungtr LAPACK_GLOBAL(zungtr,ZUNGTR)
-void LAPACK_zungtr(
+#define LAPACK_zungtr_base LAPACK_GLOBAL(zungtr,ZUNGTR)
+void LAPACK_zungtr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zungtr(...) LAPACK_zungtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zungtr(...) LAPACK_zungtr_base(__VA_ARGS__)
+#endif
 
 #define LAPACK_cungtsqr_row LAPACK_GLOBAL(cungtsqr_row,CUNGTSQR_ROW)
 void LAPACK_cungtsqr_row(
@@ -13627,205 +22610,385 @@ void LAPACK_zungtsqr_row(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info );
 
-#define LAPACK_cunmbr LAPACK_GLOBAL(cunmbr,CUNMBR)
-void LAPACK_cunmbr(
+#define LAPACK_cunmbr_base LAPACK_GLOBAL(cunmbr,CUNMBR)
+void LAPACK_cunmbr_base(
     char const* vect, char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmbr(...) LAPACK_cunmbr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cunmbr(...) LAPACK_cunmbr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmbr LAPACK_GLOBAL(zunmbr,ZUNMBR)
-void LAPACK_zunmbr(
+#define LAPACK_zunmbr_base LAPACK_GLOBAL(zunmbr,ZUNMBR)
+void LAPACK_zunmbr_base(
     char const* vect, char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmbr(...) LAPACK_zunmbr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zunmbr(...) LAPACK_zunmbr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cunmhr LAPACK_GLOBAL(cunmhr,CUNMHR)
-void LAPACK_cunmhr(
+#define LAPACK_cunmhr_base LAPACK_GLOBAL(cunmhr,CUNMHR)
+void LAPACK_cunmhr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmhr(...) LAPACK_cunmhr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cunmhr(...) LAPACK_cunmhr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmhr LAPACK_GLOBAL(zunmhr,ZUNMHR)
-void LAPACK_zunmhr(
+#define LAPACK_zunmhr_base LAPACK_GLOBAL(zunmhr,ZUNMHR)
+void LAPACK_zunmhr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* ilo, lapack_int const* ihi,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmhr(...) LAPACK_zunmhr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zunmhr(...) LAPACK_zunmhr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cunmlq LAPACK_GLOBAL(cunmlq,CUNMLQ)
-void LAPACK_cunmlq(
+#define LAPACK_cunmlq_base LAPACK_GLOBAL(cunmlq,CUNMLQ)
+void LAPACK_cunmlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmlq(...) LAPACK_cunmlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cunmlq(...) LAPACK_cunmlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmlq LAPACK_GLOBAL(zunmlq,ZUNMLQ)
-void LAPACK_zunmlq(
+#define LAPACK_zunmlq_base LAPACK_GLOBAL(zunmlq,ZUNMLQ)
+void LAPACK_zunmlq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmlq(...) LAPACK_zunmlq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zunmlq(...) LAPACK_zunmlq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cunmql LAPACK_GLOBAL(cunmql,CUNMQL)
-void LAPACK_cunmql(
+#define LAPACK_cunmql_base LAPACK_GLOBAL(cunmql,CUNMQL)
+void LAPACK_cunmql_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmql(...) LAPACK_cunmql_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cunmql(...) LAPACK_cunmql_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmql LAPACK_GLOBAL(zunmql,ZUNMQL)
-void LAPACK_zunmql(
+#define LAPACK_zunmql_base LAPACK_GLOBAL(zunmql,ZUNMQL)
+void LAPACK_zunmql_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmql(...) LAPACK_zunmql_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zunmql(...) LAPACK_zunmql_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cunmqr LAPACK_GLOBAL(cunmqr,CUNMQR)
-void LAPACK_cunmqr(
+#define LAPACK_cunmqr_base LAPACK_GLOBAL(cunmqr,CUNMQR)
+void LAPACK_cunmqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmqr(...) LAPACK_cunmqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cunmqr(...) LAPACK_cunmqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmqr LAPACK_GLOBAL(zunmqr,ZUNMQR)
-void LAPACK_zunmqr(
+#define LAPACK_zunmqr_base LAPACK_GLOBAL(zunmqr,ZUNMQR)
+void LAPACK_zunmqr_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmqr(...) LAPACK_zunmqr_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zunmqr(...) LAPACK_zunmqr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cunmrq LAPACK_GLOBAL(cunmrq,CUNMRQ)
-void LAPACK_cunmrq(
+#define LAPACK_cunmrq_base LAPACK_GLOBAL(cunmrq,CUNMRQ)
+void LAPACK_cunmrq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmrq(...) LAPACK_cunmrq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cunmrq(...) LAPACK_cunmrq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmrq LAPACK_GLOBAL(zunmrq,ZUNMRQ)
-void LAPACK_zunmrq(
+#define LAPACK_zunmrq_base LAPACK_GLOBAL(zunmrq,ZUNMRQ)
+void LAPACK_zunmrq_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmrq(...) LAPACK_zunmrq_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zunmrq(...) LAPACK_zunmrq_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cunmrz LAPACK_GLOBAL(cunmrz,CUNMRZ)
-void LAPACK_cunmrz(
+#define LAPACK_cunmrz_base LAPACK_GLOBAL(cunmrz,CUNMRZ)
+void LAPACK_cunmrz_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmrz(...) LAPACK_cunmrz_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_cunmrz(...) LAPACK_cunmrz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmrz LAPACK_GLOBAL(zunmrz,ZUNMRZ)
-void LAPACK_zunmrz(
+#define LAPACK_zunmrz_base LAPACK_GLOBAL(zunmrz,ZUNMRZ)
+void LAPACK_zunmrz_base(
     char const* side, char const* trans,
     lapack_int const* m, lapack_int const* n, lapack_int const* k, lapack_int const* l,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmrz(...) LAPACK_zunmrz_base(__VA_ARGS__, 1, 1)
+#else
+    #define LAPACK_zunmrz(...) LAPACK_zunmrz_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cunmtr LAPACK_GLOBAL(cunmtr,CUNMTR)
-void LAPACK_cunmtr(
+#define LAPACK_cunmtr_base LAPACK_GLOBAL(cunmtr,CUNMTR)
+void LAPACK_cunmtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cunmtr(...) LAPACK_cunmtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cunmtr(...) LAPACK_cunmtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zunmtr LAPACK_GLOBAL(zunmtr,ZUNMTR)
-void LAPACK_zunmtr(
+#define LAPACK_zunmtr_base LAPACK_GLOBAL(zunmtr,ZUNMTR)
+void LAPACK_zunmtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* lwork,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zunmtr(...) LAPACK_zunmtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zunmtr(...) LAPACK_zunmtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cupgtr LAPACK_GLOBAL(cupgtr,CUPGTR)
-void LAPACK_cupgtr(
+#define LAPACK_cupgtr_base LAPACK_GLOBAL(cupgtr,CUPGTR)
+void LAPACK_cupgtr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float const* AP,
     lapack_complex_float const* tau,
     lapack_complex_float* Q, lapack_int const* ldq,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cupgtr(...) LAPACK_cupgtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_cupgtr(...) LAPACK_cupgtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zupgtr LAPACK_GLOBAL(zupgtr,ZUPGTR)
-void LAPACK_zupgtr(
+#define LAPACK_zupgtr_base LAPACK_GLOBAL(zupgtr,ZUPGTR)
+void LAPACK_zupgtr_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double const* AP,
     lapack_complex_double const* tau,
     lapack_complex_double* Q, lapack_int const* ldq,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zupgtr(...) LAPACK_zupgtr_base(__VA_ARGS__, 1)
+#else
+    #define LAPACK_zupgtr(...) LAPACK_zupgtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_cupmtr LAPACK_GLOBAL(cupmtr,CUPMTR)
-void LAPACK_cupmtr(
+#define LAPACK_cupmtr_base LAPACK_GLOBAL(cupmtr,CUPMTR)
+void LAPACK_cupmtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float const* AP,
     lapack_complex_float const* tau,
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_cupmtr(...) LAPACK_cupmtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_cupmtr(...) LAPACK_cupmtr_base(__VA_ARGS__)
+#endif
 
-#define LAPACK_zupmtr LAPACK_GLOBAL(zupmtr,ZUPMTR)
-void LAPACK_zupmtr(
+#define LAPACK_zupmtr_base LAPACK_GLOBAL(zupmtr,ZUPMTR)
+void LAPACK_zupmtr_base(
     char const* side, char const* uplo, char const* trans,
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double const* AP,
     lapack_complex_double const* tau,
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work,
-    lapack_int* info );
+    lapack_int* info
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    , size_t, size_t, size_t
+#endif
+);
+#ifdef LAPACK_FORTRAN_STRLEN_END
+    #define LAPACK_zupmtr(...) LAPACK_zupmtr_base(__VA_ARGS__, 1, 1, 1)
+#else
+    #define LAPACK_zupmtr(...) LAPACK_zupmtr_base(__VA_ARGS__)
+#endif
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
**Description**

I've added the hidden arguments of type size_t to the function prototypes in LAPACKE/include/lapack.h, controlled by defining LAPACK_FORTRAN_STRLEN_END. This should hopefully solve https://github.com/Reference-LAPACK/lapack/issues/339 for almost all current systems, although note that Win32 + stdcall has a different calling convention that is not supported by these LAPACKE and CBLAS headers.

