### PR TITLE
IPARMS(1) and IPARMS(2) set to 0 before calling xERRTSQR in xCHKTSQR subroutines

### DIFF
--- a/TESTING/LIN/cchktsqr.f
+++ b/TESTING/LIN/cchktsqr.f
@@ -156,6 +156,8 @@
 *
 *     Test the error exits
 *
+      CALL XLAENV( 1, 0 )
+      CALL XLAENV( 2, 0 ) 
       IF( TSTERR ) CALL CERRTSQR( PATH, NOUT )
       INFOT = 0
 *

--- a/TESTING/LIN/dchktsqr.f
+++ b/TESTING/LIN/dchktsqr.f
@@ -156,6 +156,8 @@
 *
 *     Test the error exits
 *
+      CALL XLAENV( 1, 0 )
+      CALL XLAENV( 2, 0 )            
       IF( TSTERR ) CALL DERRTSQR( PATH, NOUT )
       INFOT = 0
 *

--- a/TESTING/LIN/schktsqr.f
+++ b/TESTING/LIN/schktsqr.f
@@ -156,6 +156,8 @@
 *
 *     Test the error exits
 *
+      CALL XLAENV( 1, 0 )
+      CALL XLAENV( 2, 0 ) 
       IF( TSTERR ) CALL SERRTSQR( PATH, NOUT )
       INFOT = 0
 *

--- a/TESTING/LIN/zchktsqr.f
+++ b/TESTING/LIN/zchktsqr.f
@@ -156,6 +156,8 @@
 *
 *     Test the error exits
 *
+      CALL XLAENV( 1, 0 )
+      CALL XLAENV( 2, 0 ) 
       IF( TSTERR ) CALL ZERRTSQR( PATH, NOUT )
       INFOT = 0
 *


### PR DESCRIPTION
Fixes #563 thanks to @nakatamaho.

**Description**

IPARMS(1) and IPARMS(2) need to be set before calling xERRTSQR in the xCHKTSQR subroutines. More details at #563.