### PR TITLE
Update the documentation of INFO in xGESDD

### DIFF
--- a/SRC/cgesdd.f
+++ b/SRC/cgesdd.f
@@ -199,9 +199,10 @@
 *> \param[out] INFO
 *> \verbatim
 *>          INFO is INTEGER
-*>          = 0:  successful exit.
-*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
-*>          > 0:  The updating process of SBDSDC did not converge.
+*>          <  0:  if INFO = -i, the i-th argument had an illegal value.
+*>          = -4:  if A had a NAN entry.
+*>          >  0:  The updating process of SBDSDC did not converge.
+*>          =  0:  successful exit.
 *> \endverbatim
 *
 *  Authors:

--- a/SRC/dgesdd.f
+++ b/SRC/dgesdd.f
@@ -191,9 +191,10 @@
 *> \param[out] INFO
 *> \verbatim
 *>          INFO is INTEGER
-*>          = 0:  successful exit.
-*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
-*>          > 0:  DBDSDC did not converge, updating process failed.
+*>          <  0:  if INFO = -i, the i-th argument had an illegal value.
+*>          = -4:  if A had a NAN entry.
+*>          >  0:  DBDSDC did not converge, updating process failed.
+*>          =  0:  successful exit.
 *> \endverbatim
 *
 *  Authors:

--- a/SRC/sgesdd.f
+++ b/SRC/sgesdd.f
@@ -191,9 +191,10 @@
 *> \param[out] INFO
 *> \verbatim
 *>          INFO is INTEGER
-*>          = 0:  successful exit.
-*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
-*>          > 0:  SBDSDC did not converge, updating process failed.
+*>          <  0:  if INFO = -i, the i-th argument had an illegal value.
+*>          = -4:  if A had a NAN entry.
+*>          >  0:  SBDSDC did not converge, updating process failed.
+*>          =  0:  successful exit.
 *> \endverbatim
 *
 *  Authors:

--- a/SRC/zgesdd.f
+++ b/SRC/zgesdd.f
@@ -199,9 +199,10 @@
 *> \param[out] INFO
 *> \verbatim
 *>          INFO is INTEGER
-*>          = 0:  successful exit.
-*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
-*>          > 0:  The updating process of DBDSDC did not converge.
+*>          <  0:  if INFO = -i, the i-th argument had an illegal value.
+*>          = -4:  if A had a NAN entry.
+*>          >  0:  The updating process of DBDSDC did not converge.
+*>          =  0:  successful exit.
 *> \endverbatim
 *
 *  Authors:


### PR DESCRIPTION
**Description**
Since 02b8bc63578448ae049490f031d19c1c1edfdfbe, the routines xGESDD return with `INFO=-4` if the matrix `A` has any NAN entry. This PR clarifies the documentation on this regard.

This PR closes #469.
This PR also relates to https://github.com/numpy/numpy/issues/18914.