### PR TITLE
Fix bug in (s,d)COMBSSQ

### DIFF
--- a/SRC/classq.f90
+++ b/SRC/classq.f90
@@ -241,7 +241,7 @@ subroutine CLASSQ( n, x, incx, scl, sumsq )
       end if
    else
 !
-!     Otherwise all values are mid-range
+!     Otherwise all values are mid-range or zero
 !
       scl = one
       sumsq = amed

--- a/SRC/dcombssq.f
+++ b/SRC/dcombssq.f
@@ -75,6 +75,9 @@
 *     ..
 *     .. Executable Statements ..
 *
+*     A zero sum V2 shall not modify the scaling factor of V1
+      IF( V2( 2 ).EQ.ZERO ) RETURN
+*
       IF( V1( 1 ).GE.V2( 1 ) ) THEN
          IF( V1( 1 ).NE.ZERO ) THEN
             V1( 2 ) = V1( 2 ) + ( V2( 1 ) / V1( 1 ) )**2 * V2( 2 )

--- a/SRC/dlassq.f90
+++ b/SRC/dlassq.f90
@@ -232,7 +232,7 @@ subroutine DLASSQ( n, x, incx, scl, sumsq )
       end if
    else
 !
-!     Otherwise all values are mid-range
+!     Otherwise all values are mid-range or zero
 !
       scl = one
       sumsq = amed

--- a/SRC/scombssq.f
+++ b/SRC/scombssq.f
@@ -75,6 +75,9 @@
 *     ..
 *     .. Executable Statements ..
 *
+*     A zero sum V2 shall not modify the scaling factor of V1
+      IF( V2( 2 ).EQ.ZERO ) RETURN
+*
       IF( V1( 1 ).GE.V2( 1 ) ) THEN
          IF( V1( 1 ).NE.ZERO ) THEN
             V1( 2 ) = V1( 2 ) + ( V2( 1 ) / V1( 1 ) )**2 * V2( 2 )

--- a/SRC/slassq.f90
+++ b/SRC/slassq.f90
@@ -232,7 +232,7 @@ subroutine SLASSQ( n, x, incx, scl, sumsq )
       end if
    else
 !
-!     Otherwise all values are mid-range
+!     Otherwise all values are mid-range or zero
 !
       scl = one
       sumsq = amed

--- a/SRC/zlassq.f90
+++ b/SRC/zlassq.f90
@@ -241,7 +241,7 @@ subroutine ZLASSQ( n, x, incx, scl, sumsq )
       end if
    else
 !
-!     Otherwise all values are mid-range
+!     Otherwise all values are mid-range or zero
 !
       scl = one
       sumsq = amed


### PR DESCRIPTION
**Description**
The default behavior of `(s,d)COMBSSQ` is to always update the sum `V1` even if `V2` is null. The problem is that it also changes the scaling factor of `V1`. Note that a null sum is a representable floating-point number no matter its scaling factor. For instance, if `V1 = (smallScale, smallNum)` and `V2 = (bigNum, 0)`, `SCOMBSSQ( V1, V2 )` may result in `V1 = (bigNum, 0)`.

This PR:

1. adds

```fortran
*     A zero sum V2 shall not modify the scaling factor of V1
      IF( V2( 2 ).EQ.ZERO ) RETURN
*
```

to `(s,d)COMBSSQ` to prevent the scaling factor of `V1` from being updated when the second sum is zero.

2. improve the comments in the xLASSQ routines.

This PR closes #565.