### PR TITLE
modify xGBT02 and xGET02 to use 1-norm of op(A) not A (no.2 from PR #562)

### DIFF
--- a/TESTING/EIG/cget02.f
+++ b/TESTING/EIG/cget02.f
@@ -28,9 +28,10 @@
 *> \verbatim
 *>
 *> CGET02 computes the residual for a solution of a system of linear
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm(B - A*X) / ( norm(A) * norm(X) * EPS ),
-*> where EPS is the machine epsilon.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A, A**T, or A**H, depending on TRANS, and EPS is the
+*> machine epsilon.
 *> \endverbatim
 *
 *  Arguments:
@@ -40,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A^T*x = b, where A^T is the transpose of A
-*>          = 'C':  A^H*x = b, where A^H is the conjugate transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -114,7 +115,7 @@
 *> \verbatim
 *>          RESID is REAL
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -188,19 +189,23 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = SLAMCH( 'Epsilon' )
-      ANORM = CLANGE( '1', M, N, A, LDA, RWORK )
+      IF( LSAME( TRANS, 'N' ) ) THEN
+         ANORM = CLANGE( '1', M, N, A, LDA, RWORK )
+      ELSE
+         ANORM = CLANGE( 'I', M, N, A, LDA, RWORK )
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
       END IF
 *
-*     Compute  B - A*X  (or  B - A'*X ) and store in B.
+*     Compute B - op(A)*X and store in B.
 *
       CALL CGEMM( TRANS, 'No transpose', N1, NRHS, N2, -CONE, A, LDA, X,
      $            LDX, CONE, B, LDB )
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ) .
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ) .
 *
       RESID = ZERO
       DO 10 J = 1, NRHS

--- a/TESTING/EIG/dget02.f
+++ b/TESTING/EIG/dget02.f
@@ -28,9 +28,10 @@
 *> \verbatim
 *>
 *> DGET02 computes the residual for a solution of a system of linear
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm(B - A*X) / ( norm(A) * norm(X) * EPS ),
-*> where EPS is the machine epsilon.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A or A**T, depending on TRANS, and EPS is the
+*> machine epsilon.
 *> \endverbatim
 *
 *  Arguments:
@@ -40,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A'*x = b, where A' is the transpose of A
-*>          = 'C':  A'*x = b, where A' is the transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose = Transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -114,7 +115,7 @@
 *> \verbatim
 *>          RESID is DOUBLE PRECISION
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -186,19 +187,23 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = DLAMCH( 'Epsilon' )
-      ANORM = DLANGE( '1', M, N, A, LDA, RWORK )
+      IF( LSAME( TRANS, 'N' ) ) THEN
+         ANORM = DLANGE( '1', M, N, A, LDA, RWORK )
+      ELSE
+         ANORM = DLANGE( 'I', M, N, A, LDA, RWORK )
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
       END IF
 *
-*     Compute  B - A*X  (or  B - A'*X ) and store in B.
+*     Compute B - op(A)*X and store in B.
 *
       CALL DGEMM( TRANS, 'No transpose', N1, NRHS, N2, -ONE, A, LDA, X,
      $            LDX, ONE, B, LDB )
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ) .
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ) .
 *
       RESID = ZERO
       DO 10 J = 1, NRHS

--- a/TESTING/EIG/zget02.f
+++ b/TESTING/EIG/zget02.f
@@ -28,9 +28,10 @@
 *> \verbatim
 *>
 *> ZGET02 computes the residual for a solution of a system of linear
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm(B - A*X) / ( norm(A) * norm(X) * EPS ),
-*> where EPS is the machine epsilon.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A, A**T, or A**H, depending on TRANS, and EPS is the
+*> machine epsilon.
 *> \endverbatim
 *
 *  Arguments:
@@ -40,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A^T*x = b, where A^T is the transpose of A
-*>          = 'C':  A^H*x = b, where A^H is the conjugate transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -114,7 +115,7 @@
 *> \verbatim
 *>          RESID is DOUBLE PRECISION
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -188,19 +189,23 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = DLAMCH( 'Epsilon' )
-      ANORM = ZLANGE( '1', M, N, A, LDA, RWORK )
+      IF( LSAME( TRANS, 'N' ) ) THEN
+         ANORM = ZLANGE( '1', M, N, A, LDA, RWORK )
+      ELSE
+         ANORM = ZLANGE( 'I', M, N, A, LDA, RWORK )
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
       END IF
 *
-*     Compute  B - A*X  (or  B - A'*X ) and store in B.
+*     Compute B - op(A)*X and store in B.
 *
       CALL ZGEMM( TRANS, 'No transpose', N1, NRHS, N2, -CONE, A, LDA, X,
      $            LDX, CONE, B, LDB )
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ) .
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ) .
 *
       RESID = ZERO
       DO 10 J = 1, NRHS

--- a/TESTING/LIN/cchkgb.f
+++ b/TESTING/LIN/cchkgb.f
@@ -160,7 +160,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is REAL array, dimension
-*>                      (max(NMAX,2*NSMAX))
+*>                      (NMAX+2*NSMAX)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/cchkgb.f
+++ b/TESTING/LIN/cchkgb.f
@@ -563,7 +563,7 @@
                               END IF
 *
 *+    TEST 2:
-*                             Solve and compute residual for A * X = B.
+*                             Solve and compute residual for op(A) * X = B.
 *
                               SRNAMT = 'CLARHS'
                               CALL CLARHS( PATH, XTYPE, ' ', TRANS, N,
@@ -589,7 +589,7 @@
      $                                     WORK, LDB )
                               CALL CGBT02( TRANS, M, N, KL, KU, NRHS, A,
      $                                     LDA, X, LDB, WORK, LDB,
-     $                                     RESULT( 2 ) )
+     $                                     RWORK, RESULT( 2 ) )
 *
 *+    TEST 3:
 *                             Check solution from generated exact

--- a/TESTING/LIN/cdrvgb.f
+++ b/TESTING/LIN/cdrvgb.f
@@ -141,7 +141,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is REAL array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (NMAX+2*NRHS)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/cdrvgb.f
+++ b/TESTING/LIN/cdrvgb.f
@@ -582,7 +582,8 @@
      $                                        WORK, LDB )
                                  CALL CGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -699,6 +700,7 @@
      $                                     WORK, LDB )
                               CALL CGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact

--- a/TESTING/LIN/cdrvgbx.f
+++ b/TESTING/LIN/cdrvgbx.f
@@ -144,7 +144,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is REAL array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (max(2*NMAX,NMAX+2*NRHS))
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/cdrvgbx.f
+++ b/TESTING/LIN/cdrvgbx.f
@@ -590,7 +590,8 @@
      $                                        WORK, LDB )
                                  CALL CGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -708,6 +709,7 @@
      $                                     WORK, LDB )
                               CALL CGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact
@@ -897,7 +899,8 @@ c                     write(*,*) 'begin cgbsvxx testing'
                         CALL CLACPY( 'Full', N, NRHS, BSAV, LDB, WORK,
      $                               LDB )
                         CALL CGBT02( TRANS, N, N, KL, KU, NRHS, ASAV,
-     $                       LDA, X, LDB, WORK, LDB, RESULT( 2 ) )
+     $                               LDA, X, LDB, WORK, LDB, RWORK,
+     $                               RESULT( 2 ) )
 *
 *                       Check solution from generated exact solution.
 *

--- a/TESTING/LIN/cgbt02.f
+++ b/TESTING/LIN/cgbt02.f
@@ -190,7 +190,8 @@
       DO 10 J = 1, N
          I1 = MAX( KD+1-J, 1 )
          I2 = MIN( KD+M-J, KL+KD )
-         ANORM = MAX( ANORM, SCASUM( I2-I1+1, A( I1, J ), 1 ) )
+         IF( I2.GE.I1 )
+     $      ANORM = MAX( ANORM, SCASUM( I2-I1+1, A( I1, J ), 1 ) )
    10 CONTINUE
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS

--- a/TESTING/LIN/cgbt02.f
+++ b/TESTING/LIN/cgbt02.f
@@ -170,13 +170,13 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            I1, I2, J, KD, N1
-      REAL               ANORM, BNORM, EPS, XNORM
+      REAL               ANORM, BNORM, EPS, TEMP, XNORM
       COMPLEX            CDUM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       REAL               SCASUM, SLAMCH
-      EXTERNAL           LSAME, SCASUM, SLAMCH
+      EXTERNAL           LSAME, SCASUM, SISNAN, SLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CGBMV
@@ -211,8 +211,10 @@
          DO 10 J = 1, N
             I1 = MAX( KD+1-J, 1 )
             I2 = MIN( KD+M-J, KL+KD )
-            IF( I2.GE.I1 )
-     $         ANORM = MAX( ANORM, SCASUM( I2-I1+1, A( I1, J ), 1 ) )
+            IF( I2.GE.I1 ) THEN
+               TEMP = SCASUM( I2-I1+1, A( I1, J ), 1 )
+               IF( ANORM.LT.TEMP .OR. SISNAN( TEMP ) ) ANORM = TEMP
+            END IF
    10    CONTINUE
       ELSE
 *
@@ -228,7 +230,8 @@
    14       CONTINUE
    16    CONTINUE
          DO 18 I1 = 1, M
-            ANORM = MAX( ANORM, RWORK( I1 ) )
+            TEMP = RWORK( I1 )
+            IF( ANORM.LT.TEMP .OR. SISNAN( TEMP ) ) ANORM = TEMP
    18    CONTINUE
       END IF
       IF( ANORM.LE.ZERO ) THEN

--- a/TESTING/LIN/cgbt02.f
+++ b/TESTING/LIN/cgbt02.f
@@ -9,7 +9,7 @@
 *  ===========
 *
 *       SUBROUTINE CGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-*                          LDB, RESID )
+*                          LDB, RWORK, RESID )
 *
 *       .. Scalar Arguments ..
 *       CHARACTER          TRANS
@@ -17,6 +17,7 @@
 *       REAL               RESID
 *       ..
 *       .. Array Arguments ..
+*       REAL               RWORK( * )
 *       COMPLEX            A( LDA, * ), B( LDB, * ), X( LDX, * )
 *       ..
 *
@@ -27,9 +28,10 @@
 *> \verbatim
 *>
 *> CGBT02 computes the residual for a solution of a banded system of
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm( B - A*X ) / ( norm(A) * norm(X) * EPS).
-*> where EPS is the machine precision.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A, A**T, or A**H, depending on TRANS, and EPS is the
+*> machine precision.
 *> \endverbatim
 *
 *  Arguments:
@@ -39,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A'*x = b, where A' is the transpose of A
-*>          = 'C':  A'*x = b, where A' is the transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -116,11 +118,18 @@
 *>          LDB >= max(1,M); if TRANS = 'T' or 'C', LDB >= max(1,N).
 *> \endverbatim
 *>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is REAL array, dimension (MAX(1,LRWORK)),
+*>          where LRWORK >= M when TRANS = 'T' or 'C'; otherwise, RWORK
+*>          is not referenced.
+*> \endverbatim
+*
 *> \param[out] RESID
 *> \verbatim
 *>          RESID is REAL
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -135,7 +144,7 @@
 *
 *  =====================================================================
       SUBROUTINE CGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-     $                   LDB, RESID )
+     $                   LDB, RWORK, RESID )
 *
 *  -- LAPACK test routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -147,6 +156,7 @@
       REAL               RESID
 *     ..
 *     .. Array Arguments ..
+      REAL               RWORK( * )
       COMPLEX            A( LDA, * ), B( LDB, * ), X( LDX, * )
 *     ..
 *
@@ -161,6 +171,7 @@
 *     .. Local Scalars ..
       INTEGER            I1, I2, J, KD, N1
       REAL               ANORM, BNORM, EPS, XNORM
+      COMPLEX            CDUM
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -170,8 +181,14 @@
 *     .. External Subroutines ..
       EXTERNAL           CGBMV
 *     ..
+*     .. Statement Functions ..
+      REAL               CABS1
+*     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          MAX, MIN
+      INTRINSIC          ABS, AIMAG, MAX, MIN, REAL
+*     ..
+*     .. Statement Function definitions ..
+      CABS1( CDUM ) = ABS( REAL( CDUM ) ) + ABS( AIMAG( CDUM ) )
 *     ..
 *     .. Executable Statements ..
 *
@@ -185,14 +202,35 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = SLAMCH( 'Epsilon' )
-      KD = KU + 1
       ANORM = ZERO
-      DO 10 J = 1, N
-         I1 = MAX( KD+1-J, 1 )
-         I2 = MIN( KD+M-J, KL+KD )
-         IF( I2.GE.I1 )
-     $      ANORM = MAX( ANORM, SCASUM( I2-I1+1, A( I1, J ), 1 ) )
-   10 CONTINUE
+      IF( LSAME( TRANS, 'N' ) ) THEN
+*
+*        Find norm1(A).
+*
+         KD = KU + 1
+         DO 10 J = 1, N
+            I1 = MAX( KD+1-J, 1 )
+            I2 = MIN( KD+M-J, KL+KD )
+            IF( I2.GE.I1 )
+     $         ANORM = MAX( ANORM, SCASUM( I2-I1+1, A( I1, J ), 1 ) )
+   10    CONTINUE
+      ELSE
+*
+*        Find normI(A).
+*
+         DO 12 I1 = 1, M
+            RWORK( I1 ) = ZERO
+   12    CONTINUE
+         DO 16 J = 1, N
+            KD = KU + 1 - J
+            DO 14 I1 = MAX( 1, J-KU ), MIN( M, J+KL )
+               RWORK( I1 ) = RWORK( I1 ) + CABS1( A( KD+I1, J ) )
+   14       CONTINUE
+   16    CONTINUE
+         DO 18 I1 = 1, M
+            ANORM = MAX( ANORM, RWORK( I1 ) )
+   18    CONTINUE
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
@@ -204,7 +242,7 @@
          N1 = M
       END IF
 *
-*     Compute  B - A*X (or  B - A'*X )
+*     Compute B - op(A)*X
 *
       DO 20 J = 1, NRHS
          CALL CGBMV( TRANS, M, N, KL, KU, -CONE, A, LDA, X( 1, J ), 1,
@@ -212,7 +250,7 @@
    20 CONTINUE
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *
       RESID = ZERO
       DO 30 J = 1, NRHS

--- a/TESTING/LIN/cget02.f
+++ b/TESTING/LIN/cget02.f
@@ -28,9 +28,10 @@
 *> \verbatim
 *>
 *> CGET02 computes the residual for a solution of a system of linear
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm(B - A*X) / ( norm(A) * norm(X) * EPS ),
-*> where EPS is the machine epsilon.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A, A**T, or A**H, depending on TRANS, and EPS is the
+*> machine epsilon.
 *> \endverbatim
 *
 *  Arguments:
@@ -40,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A^T*x = b, where A^T is the transpose of A
-*>          = 'C':  A^H*x = b, where A^H is the conjugate transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -95,7 +96,7 @@
 *>          B is COMPLEX array, dimension (LDB,NRHS)
 *>          On entry, the right hand side vectors for the system of
 *>          linear equations.
-*>          On exit, B is overwritten with the difference B - A*X.
+*>          On exit, B is overwritten with the difference B - op(A)*X.
 *> \endverbatim
 *>
 *> \param[in] LDB
@@ -114,7 +115,7 @@
 *> \verbatim
 *>          RESID is REAL
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -188,19 +189,23 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = SLAMCH( 'Epsilon' )
-      ANORM = CLANGE( '1', M, N, A, LDA, RWORK )
+      IF( LSAME( TRANS, 'N' ) ) THEN
+         ANORM = CLANGE( '1', M, N, A, LDA, RWORK )
+      ELSE
+         ANORM = CLANGE( 'I', M, N, A, LDA, RWORK )
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
       END IF
 *
-*     Compute  B - A*X  (or  B - A'*X ) and store in B.
+*     Compute B - op(A)*X and store in B.
 *
       CALL CGEMM( TRANS, 'No transpose', N1, NRHS, N2, -CONE, A, LDA, X,
      $            LDX, CONE, B, LDB )
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ) .
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ) .
 *
       RESID = ZERO
       DO 10 J = 1, NRHS

--- a/TESTING/LIN/dchkgb.f
+++ b/TESTING/LIN/dchkgb.f
@@ -563,7 +563,7 @@
                               END IF
 *
 *+    TEST 2:
-*                             Solve and compute residual for A * X = B.
+*                             Solve and compute residual for op(A) * X = B.
 *
                               SRNAMT = 'DLARHS'
                               CALL DLARHS( PATH, XTYPE, ' ', TRANS, N,
@@ -589,7 +589,7 @@
      $                                     WORK, LDB )
                               CALL DGBT02( TRANS, M, N, KL, KU, NRHS, A,
      $                                     LDA, X, LDB, WORK, LDB,
-     $                                     RESULT( 2 ) )
+     $                                     RWORK, RESULT( 2 ) )
 *
 *+    TEST 3:
 *                             Check solution from generated exact

--- a/TESTING/LIN/dchkgb.f
+++ b/TESTING/LIN/dchkgb.f
@@ -160,7 +160,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is DOUBLE PRECISION array, dimension
-*>                      (max(NMAX,2*NSMAX))
+*>                      (NMAX+2*NSMAX)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/ddrvgb.f
+++ b/TESTING/LIN/ddrvgb.f
@@ -582,7 +582,8 @@
      $                                        WORK, LDB )
                                  CALL DGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -699,6 +700,7 @@
      $                                     WORK, LDB )
                               CALL DGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact

--- a/TESTING/LIN/ddrvgb.f
+++ b/TESTING/LIN/ddrvgb.f
@@ -141,7 +141,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is DOUBLE PRECISION array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (NMAX+2*NRHS)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/ddrvgbx.f
+++ b/TESTING/LIN/ddrvgbx.f
@@ -144,7 +144,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is DOUBLE PRECISION array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (max(2*NMAX,NMAX+2*NRHS))
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/ddrvgbx.f
+++ b/TESTING/LIN/ddrvgbx.f
@@ -590,7 +590,8 @@
      $                                        WORK, LDB )
                                  CALL DGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -707,6 +708,7 @@
      $                                     WORK, LDB )
                               CALL DGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact
@@ -892,7 +894,7 @@
                         CALL DLACPY( 'Full', N, NRHS, BSAV, LDB, WORK,
      $                               LDB )
                         CALL DGBT02( TRANS, N, N, KL, KU, NRHS, ASAV,
-     $                               LDA, X, LDB, WORK, LDB,
+     $                               LDA, X, LDB, WORK, LDB, RWORK,
      $                               RESULT( 2 ) )
 *
 *                       Check solution from generated exact solution.

--- a/TESTING/LIN/dgbt02.f
+++ b/TESTING/LIN/dgbt02.f
@@ -188,7 +188,8 @@
       DO 10 J = 1, N
          I1 = MAX( KD+1-J, 1 )
          I2 = MIN( KD+M-J, KL+KD )
-         ANORM = MAX( ANORM, DASUM( I2-I1+1, A( I1, J ), 1 ) )
+         IF( I2.GE.I1 )
+     $      ANORM = MAX( ANORM, DASUM( I2-I1+1, A( I1, J ), 1 ) )
    10 CONTINUE
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS

--- a/TESTING/LIN/dgbt02.f
+++ b/TESTING/LIN/dgbt02.f
@@ -9,7 +9,7 @@
 *  ===========
 *
 *       SUBROUTINE DGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-*                          LDB, RESID )
+*                          LDB, RWORK, RESID )
 *
 *       .. Scalar Arguments ..
 *       CHARACTER          TRANS
@@ -17,7 +17,8 @@
 *       DOUBLE PRECISION   RESID
 *       ..
 *       .. Array Arguments ..
-*       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), X( LDX, * )
+*       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), X( LDX, * ),
+*                          RWORK( * )
 *       ..
 *
 *
@@ -27,9 +28,10 @@
 *> \verbatim
 *>
 *> DGBT02 computes the residual for a solution of a banded system of
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm( B - A*X ) / ( norm(A) * norm(X) * EPS).
-*> where EPS is the machine precision.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A or A**T, depending on TRANS, and EPS is the
+*> machine precision.
 *> \endverbatim
 *
 *  Arguments:
@@ -39,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A'*x = b, where A' is the transpose of A
-*>          = 'C':  A'*x = b, where A' is the transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose = Transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -116,11 +118,18 @@
 *>          LDB >= max(1,M); if TRANS = 'T' or 'C', LDB >= max(1,N).
 *> \endverbatim
 *>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is DOUBLE PRECISION array, dimension (MAX(1,LRWORK)),
+*>          where LRWORK >= M when TRANS = 'T' or 'C'; otherwise, RWORK
+*>          is not referenced.
+*> \endverbatim
+*
 *> \param[out] RESID
 *> \verbatim
 *>          RESID is DOUBLE PRECISION
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -135,7 +144,7 @@
 *
 *  =====================================================================
       SUBROUTINE DGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-     $                   LDB, RESID )
+     $                   LDB, RWORK, RESID )
 *
 *  -- LAPACK test routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -147,7 +156,8 @@
       DOUBLE PRECISION   RESID
 *     ..
 *     .. Array Arguments ..
-      DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), X( LDX, * )
+      DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), X( LDX, * ),
+     $                   RWORK( * )
 *     ..
 *
 *  =====================================================================
@@ -169,7 +179,7 @@
       EXTERNAL           DGBMV
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          MAX, MIN
+      INTRINSIC          ABS, MAX, MIN
 *     ..
 *     .. Executable Statements ..
 *
@@ -183,14 +193,35 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = DLAMCH( 'Epsilon' )
-      KD = KU + 1
       ANORM = ZERO
-      DO 10 J = 1, N
-         I1 = MAX( KD+1-J, 1 )
-         I2 = MIN( KD+M-J, KL+KD )
-         IF( I2.GE.I1 )
-     $      ANORM = MAX( ANORM, DASUM( I2-I1+1, A( I1, J ), 1 ) )
-   10 CONTINUE
+      IF( LSAME( TRANS, 'N' ) ) THEN
+*
+*        Find norm1(A).
+*
+         KD = KU + 1
+         DO 10 J = 1, N
+            I1 = MAX( KD+1-J, 1 )
+            I2 = MIN( KD+M-J, KL+KD )
+            IF( I2.GE.I1 )
+     $         ANORM = MAX( ANORM, DASUM( I2-I1+1, A( I1, J ), 1 ) )
+   10    CONTINUE
+      ELSE
+*
+*        Find normI(A).
+*
+         DO 12 I1 = 1, M
+            RWORK( I1 ) = ZERO
+   12    CONTINUE
+         DO 16 J = 1, N
+            KD = KU + 1 - J
+            DO 14 I1 = MAX( 1, J-KU ), MIN( M, J+KL )
+               RWORK( I1 ) = RWORK( I1 ) + ABS( A( KD+I1, J ) )
+   14       CONTINUE
+   16    CONTINUE
+         DO 18 I1 = 1, M
+            ANORM = MAX( ANORM, RWORK( I1 ) )
+   18    CONTINUE
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
@@ -202,7 +233,7 @@
          N1 = M
       END IF
 *
-*     Compute  B - A*X (or  B - A'*X )
+*     Compute B - op(A)*X
 *
       DO 20 J = 1, NRHS
          CALL DGBMV( TRANS, M, N, KL, KU, -ONE, A, LDA, X( 1, J ), 1,
@@ -210,7 +241,7 @@
    20 CONTINUE
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *
       RESID = ZERO
       DO 30 J = 1, NRHS

--- a/TESTING/LIN/dgbt02.f
+++ b/TESTING/LIN/dgbt02.f
@@ -168,12 +168,12 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            I1, I2, J, KD, N1
-      DOUBLE PRECISION   ANORM, BNORM, EPS, XNORM
+      DOUBLE PRECISION   ANORM, BNORM, EPS, TEMP, XNORM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            DISNAN, LSAME
       DOUBLE PRECISION   DASUM, DLAMCH
-      EXTERNAL           LSAME, DASUM, DLAMCH
+      EXTERNAL           DASUM, DISNAN, DLAMCH, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DGBMV
@@ -202,8 +202,10 @@
          DO 10 J = 1, N
             I1 = MAX( KD+1-J, 1 )
             I2 = MIN( KD+M-J, KL+KD )
-            IF( I2.GE.I1 )
-     $         ANORM = MAX( ANORM, DASUM( I2-I1+1, A( I1, J ), 1 ) )
+            IF( I2.GE.I1 ) THEN
+               TEMP = DASUM( I2-I1+1, A( I1, J ), 1 )
+               IF( ANORM.LT.TEMP .OR. DISNAN( TEMP ) ) ANORM = TEMP
+            END IF
    10    CONTINUE
       ELSE
 *
@@ -219,7 +221,8 @@
    14       CONTINUE
    16    CONTINUE
          DO 18 I1 = 1, M
-            ANORM = MAX( ANORM, RWORK( I1 ) )
+            TEMP = RWORK( I1 )
+            IF( ANORM.LT.TEMP .OR. DISNAN( TEMP ) ) ANORM = TEMP
    18    CONTINUE
       END IF
       IF( ANORM.LE.ZERO ) THEN

--- a/TESTING/LIN/dget02.f
+++ b/TESTING/LIN/dget02.f
@@ -28,9 +28,10 @@
 *> \verbatim
 *>
 *> DGET02 computes the residual for a solution of a system of linear
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm(B - A*X) / ( norm(A) * norm(X) * EPS ),
-*> where EPS is the machine epsilon.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A or A**T, depending on TRANS, and EPS is the
+*> machine epsilon.
 *> \endverbatim
 *
 *  Arguments:
@@ -40,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A'*x = b, where A' is the transpose of A
-*>          = 'C':  A'*x = b, where A' is the transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose = Transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -95,7 +96,7 @@
 *>          B is DOUBLE PRECISION array, dimension (LDB,NRHS)
 *>          On entry, the right hand side vectors for the system of
 *>          linear equations.
-*>          On exit, B is overwritten with the difference B - A*X.
+*>          On exit, B is overwritten with the difference B - op(A)*X.
 *> \endverbatim
 *>
 *> \param[in] LDB
@@ -114,7 +115,7 @@
 *> \verbatim
 *>          RESID is DOUBLE PRECISION
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -186,19 +187,23 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = DLAMCH( 'Epsilon' )
-      ANORM = DLANGE( '1', M, N, A, LDA, RWORK )
+      IF( LSAME( TRANS, 'N' ) ) THEN
+         ANORM = DLANGE( '1', M, N, A, LDA, RWORK )
+      ELSE
+         ANORM = DLANGE( 'I', M, N, A, LDA, RWORK )
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
       END IF
 *
-*     Compute  B - A*X  (or  B - A'*X ) and store in B.
+*     Compute B - op(A)*X and store in B.
 *
       CALL DGEMM( TRANS, 'No transpose', N1, NRHS, N2, -ONE, A, LDA, X,
      $            LDX, ONE, B, LDB )
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ) .
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ) .
 *
       RESID = ZERO
       DO 10 J = 1, NRHS

--- a/TESTING/LIN/schkgb.f
+++ b/TESTING/LIN/schkgb.f
@@ -563,7 +563,7 @@
                               END IF
 *
 *+    TEST 2:
-*                             Solve and compute residual for A * X = B.
+*                             Solve and compute residual for op(A) * X = B.
 *
                               SRNAMT = 'SLARHS'
                               CALL SLARHS( PATH, XTYPE, ' ', TRANS, N,
@@ -589,7 +589,7 @@
      $                                     WORK, LDB )
                               CALL SGBT02( TRANS, M, N, KL, KU, NRHS, A,
      $                                     LDA, X, LDB, WORK, LDB,
-     $                                     RESULT( 2 ) )
+     $                                     RWORK, RESULT( 2 ) )
 *
 *+    TEST 3:
 *                             Check solution from generated exact

--- a/TESTING/LIN/schkgb.f
+++ b/TESTING/LIN/schkgb.f
@@ -160,7 +160,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is REAL array, dimension
-*>                      (max(NMAX,2*NSMAX))
+*>                      (NMAX+2*NSMAX)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/sdrvgb.f
+++ b/TESTING/LIN/sdrvgb.f
@@ -141,7 +141,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is REAL array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (NMAX+2*NRHS)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/sdrvgb.f
+++ b/TESTING/LIN/sdrvgb.f
@@ -582,7 +582,8 @@
      $                                        WORK, LDB )
                                  CALL SGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -699,6 +700,7 @@
      $                                     WORK, LDB )
                               CALL SGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact

--- a/TESTING/LIN/sdrvgbx.f
+++ b/TESTING/LIN/sdrvgbx.f
@@ -144,7 +144,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is REAL array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (max(2*NMAX,NMAX+2*NRHS))
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/sdrvgbx.f
+++ b/TESTING/LIN/sdrvgbx.f
@@ -590,7 +590,8 @@
      $                                        WORK, LDB )
                                  CALL SGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -707,6 +708,7 @@
      $                                     WORK, LDB )
                               CALL SGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact
@@ -893,7 +895,7 @@
                         CALL SLACPY( 'Full', N, NRHS, BSAV, LDB, WORK,
      $                               LDB )
                         CALL SGBT02( TRANS, N, N, KL, KU, NRHS, ASAV,
-     $                               LDA, X, LDB, WORK, LDB,
+     $                               LDA, X, LDB, WORK, LDB, RWORK,
      $                               RESULT( 2 ) )
 *
 *                       Check solution from generated exact solution.

--- a/TESTING/LIN/sgbt02.f
+++ b/TESTING/LIN/sgbt02.f
@@ -188,7 +188,8 @@
       DO 10 J = 1, N
          I1 = MAX( KD+1-J, 1 )
          I2 = MIN( KD+M-J, KL+KD )
-         ANORM = MAX( ANORM, SASUM( I2-I1+1, A( I1, J ), 1 ) )
+         IF( I2.GE.I1 )
+     $      ANORM = MAX( ANORM, SASUM( I2-I1+1, A( I1, J ), 1 ) )
    10 CONTINUE
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS

--- a/TESTING/LIN/sgbt02.f
+++ b/TESTING/LIN/sgbt02.f
@@ -9,7 +9,7 @@
 *  ===========
 *
 *       SUBROUTINE SGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-*                          LDB, RESID )
+*                          LDB, RWORK, RESID )
 *
 *       .. Scalar Arguments ..
 *       CHARACTER          TRANS
@@ -17,7 +17,8 @@
 *       REAL               RESID
 *       ..
 *       .. Array Arguments ..
-*       REAL               A( LDA, * ), B( LDB, * ), X( LDX, * )
+*       REAL               A( LDA, * ), B( LDB, * ), X( LDX, * ),
+*                          RWORK( * )
 *       ..
 *
 *
@@ -27,9 +28,10 @@
 *> \verbatim
 *>
 *> SGBT02 computes the residual for a solution of a banded system of
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm( B - A*X ) / ( norm(A) * norm(X) * EPS).
-*> where EPS is the machine precision.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A or A**T, depending on TRANS, and EPS is the
+*> machine precision.
 *> \endverbatim
 *
 *  Arguments:
@@ -39,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A'*x = b, where A' is the transpose of A
-*>          = 'C':  A'*x = b, where A' is the transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose = Transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -116,11 +118,18 @@
 *>          LDB >= max(1,M); if TRANS = 'T' or 'C', LDB >= max(1,N).
 *> \endverbatim
 *>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is REAL array, dimension (MAX(1,LRWORK)),
+*>          where LRWORK >= M when TRANS = 'T' or 'C'; otherwise, RWORK
+*>          is not referenced.
+*> \endverbatim
+*
 *> \param[out] RESID
 *> \verbatim
 *>          RESID is REAL
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -135,7 +144,7 @@
 *
 *  =====================================================================
       SUBROUTINE SGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-     $                   LDB, RESID )
+     $                   LDB, RWORK, RESID )
 *
 *  -- LAPACK test routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -147,7 +156,8 @@
       REAL               RESID
 *     ..
 *     .. Array Arguments ..
-      REAL               A( LDA, * ), B( LDB, * ), X( LDX, * )
+      REAL               A( LDA, * ), B( LDB, * ), X( LDX, * ),
+     $                   RWORK( * )
 *     ..
 *
 *  =====================================================================
@@ -169,7 +179,7 @@
       EXTERNAL           SGBMV
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          MAX, MIN
+      INTRINSIC          ABS, MAX, MIN
 *     ..
 *     .. Executable Statements ..
 *
@@ -183,14 +193,35 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = SLAMCH( 'Epsilon' )
-      KD = KU + 1
       ANORM = ZERO
-      DO 10 J = 1, N
-         I1 = MAX( KD+1-J, 1 )
-         I2 = MIN( KD+M-J, KL+KD )
-         IF( I2.GE.I1 )
-     $      ANORM = MAX( ANORM, SASUM( I2-I1+1, A( I1, J ), 1 ) )
-   10 CONTINUE
+      IF( LSAME( TRANS, 'N' ) ) THEN
+*
+*        Find norm1(A).
+*
+         KD = KU + 1
+         DO 10 J = 1, N
+            I1 = MAX( KD+1-J, 1 )
+            I2 = MIN( KD+M-J, KL+KD )
+            IF( I2.GE.I1 )
+     $         ANORM = MAX( ANORM, SASUM( I2-I1+1, A( I1, J ), 1 ) )
+   10    CONTINUE
+      ELSE
+*
+*        Find normI(A).
+*
+         DO 12 I1 = 1, M
+            RWORK( I1 ) = ZERO
+   12    CONTINUE
+         DO 16 J = 1, N
+            KD = KU + 1 - J
+            DO 14 I1 = MAX( 1, J-KU ), MIN( M, J+KL )
+               RWORK( I1 ) = RWORK( I1 ) + ABS( A( KD+I1, J ) )
+   14       CONTINUE
+   16    CONTINUE
+         DO 18 I1 = 1, M
+            ANORM = MAX( ANORM, RWORK( I1 ) )
+   18    CONTINUE
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
@@ -202,7 +233,7 @@
          N1 = M
       END IF
 *
-*     Compute  B - A*X (or  B - A'*X )
+*     Compute B - op(A)*X
 *
       DO 20 J = 1, NRHS
          CALL SGBMV( TRANS, M, N, KL, KU, -ONE, A, LDA, X( 1, J ), 1,
@@ -210,7 +241,7 @@
    20 CONTINUE
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *
       RESID = ZERO
       DO 30 J = 1, NRHS

--- a/TESTING/LIN/sgbt02.f
+++ b/TESTING/LIN/sgbt02.f
@@ -168,12 +168,12 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            I1, I2, J, KD, N1
-      REAL               ANORM, BNORM, EPS, XNORM
+      REAL               ANORM, BNORM, EPS, TEMP, XNORM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       REAL               SASUM, SLAMCH
-      EXTERNAL           LSAME, SASUM, SLAMCH
+      EXTERNAL           LSAME, SASUM, SISNAN, SLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SGBMV
@@ -202,8 +202,10 @@
          DO 10 J = 1, N
             I1 = MAX( KD+1-J, 1 )
             I2 = MIN( KD+M-J, KL+KD )
-            IF( I2.GE.I1 )
-     $         ANORM = MAX( ANORM, SASUM( I2-I1+1, A( I1, J ), 1 ) )
+            IF( I2.GE.I1 ) THEN
+               TEMP = SASUM( I2-I1+1, A( I1, J ), 1 )
+               IF( ANORM.LT.TEMP .OR. SISNAN( TEMP ) ) ANORM = TEMP
+            END IF
    10    CONTINUE
       ELSE
 *
@@ -219,7 +221,8 @@
    14       CONTINUE
    16    CONTINUE
          DO 18 I1 = 1, M
-            ANORM = MAX( ANORM, RWORK( I1 ) )
+            TEMP = RWORK( I1 )
+            IF( ANORM.LT.TEMP .OR. SISNAN( TEMP ) ) ANORM = TEMP
    18    CONTINUE
       END IF
       IF( ANORM.LE.ZERO ) THEN

--- a/TESTING/LIN/sget02.f
+++ b/TESTING/LIN/sget02.f
@@ -28,9 +28,10 @@
 *> \verbatim
 *>
 *> SGET02 computes the residual for a solution of a system of linear
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm(B - A*X) / ( norm(A) * norm(X) * EPS ),
-*> where EPS is the machine epsilon.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A or A**T, depending on TRANS, and EPS is the
+*> machine epsilon.
 *> \endverbatim
 *
 *  Arguments:
@@ -40,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A'*x = b, where A' is the transpose of A
-*>          = 'C':  A'*x = b, where A' is the transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose = Transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -95,7 +96,7 @@
 *>          B is REAL array, dimension (LDB,NRHS)
 *>          On entry, the right hand side vectors for the system of
 *>          linear equations.
-*>          On exit, B is overwritten with the difference B - A*X.
+*>          On exit, B is overwritten with the difference B - op(A)*X.
 *> \endverbatim
 *>
 *> \param[in] LDB
@@ -114,7 +115,7 @@
 *> \verbatim
 *>          RESID is REAL
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -186,19 +187,23 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = SLAMCH( 'Epsilon' )
-      ANORM = SLANGE( '1', M, N, A, LDA, RWORK )
+      IF( LSAME( TRANS, 'N' ) ) THEN
+         ANORM = SLANGE( '1', M, N, A, LDA, RWORK )
+      ELSE
+         ANORM = SLANGE( 'I', M, N, A, LDA, RWORK )
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
       END IF
 *
-*     Compute  B - A*X  (or  B - A'*X ) and store in B.
+*     Compute B - op(A)*X and store in B.
 *
       CALL SGEMM( TRANS, 'No transpose', N1, NRHS, N2, -ONE, A, LDA, X,
      $            LDX, ONE, B, LDB )
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ) .
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ) .
 *
       RESID = ZERO
       DO 10 J = 1, NRHS

--- a/TESTING/LIN/zchkgb.f
+++ b/TESTING/LIN/zchkgb.f
@@ -160,7 +160,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is DOUBLE PRECISION array, dimension
-*>                      (max(NMAX,2*NSMAX))
+*>                      (NMAX+2*NSMAX)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/zchkgb.f
+++ b/TESTING/LIN/zchkgb.f
@@ -563,7 +563,7 @@
                               END IF
 *
 *+    TEST 2:
-*                             Solve and compute residual for A * X = B.
+*                             Solve and compute residual for op(A) * X = B.
 *
                               SRNAMT = 'ZLARHS'
                               CALL ZLARHS( PATH, XTYPE, ' ', TRANS, N,
@@ -589,7 +589,7 @@
      $                                     WORK, LDB )
                               CALL ZGBT02( TRANS, M, N, KL, KU, NRHS, A,
      $                                     LDA, X, LDB, WORK, LDB,
-     $                                     RESULT( 2 ) )
+     $                                     RWORK, RESULT( 2 ) )
 *
 *+    TEST 3:
 *                             Check solution from generated exact

--- a/TESTING/LIN/zdrvgb.f
+++ b/TESTING/LIN/zdrvgb.f
@@ -582,7 +582,8 @@
      $                                        WORK, LDB )
                                  CALL ZGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -699,6 +700,7 @@
      $                                     WORK, LDB )
                               CALL ZGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact

--- a/TESTING/LIN/zdrvgb.f
+++ b/TESTING/LIN/zdrvgb.f
@@ -141,7 +141,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is DOUBLE PRECISION array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (NMAX+2*NRHS)
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/zdrvgbx.f
+++ b/TESTING/LIN/zdrvgbx.f
@@ -590,7 +590,8 @@
      $                                        WORK, LDB )
                                  CALL ZGBT02( 'No transpose', N, N, KL,
      $                                        KU, NRHS, A, LDA, X, LDB,
-     $                                        WORK, LDB, RESULT( 2 ) )
+     $                                        WORK, LDB, RWORK,
+     $                                        RESULT( 2 ) )
 *
 *                                Check solution from generated exact
 *                                solution.
@@ -708,6 +709,7 @@
      $                                     WORK, LDB )
                               CALL ZGBT02( TRANS, N, N, KL, KU, NRHS,
      $                                     ASAV, LDA, X, LDB, WORK, LDB,
+     $                                     RWORK( 2*NRHS+1 ),
      $                                     RESULT( 2 ) )
 *
 *                             Check solution from generated exact
@@ -897,7 +899,8 @@ c                     write(*,*) 'begin zgbsvxx testing'
                         CALL ZLACPY( 'Full', N, NRHS, BSAV, LDB, WORK,
      $                               LDB )
                         CALL ZGBT02( TRANS, N, N, KL, KU, NRHS, ASAV,
-     $                       LDA, X, LDB, WORK, LDB, RESULT( 2 ) )
+     $                               LDA, X, LDB, WORK, LDB, RWORK,
+     $                               RESULT( 2 ) )
 *
 *                       Check solution from generated exact solution.
 *

--- a/TESTING/LIN/zdrvgbx.f
+++ b/TESTING/LIN/zdrvgbx.f
@@ -144,7 +144,7 @@
 *> \param[out] RWORK
 *> \verbatim
 *>          RWORK is DOUBLE PRECISION array, dimension
-*>                      (max(NMAX,2*NRHS))
+*>                      (max(2*NMAX,NMAX+2*NRHS))
 *> \endverbatim
 *>
 *> \param[out] IWORK

--- a/TESTING/LIN/zgbt02.f
+++ b/TESTING/LIN/zgbt02.f
@@ -190,7 +190,8 @@
       DO 10 J = 1, N
          I1 = MAX( KD+1-J, 1 )
          I2 = MIN( KD+M-J, KL+KD )
-         ANORM = MAX( ANORM, DZASUM( I2-I1+1, A( I1, J ), 1 ) )
+         IF( I2.GE.I1 )
+     $      ANORM = MAX( ANORM, DZASUM( I2-I1+1, A( I1, J ), 1 ) )
    10 CONTINUE
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS

--- a/TESTING/LIN/zgbt02.f
+++ b/TESTING/LIN/zgbt02.f
@@ -170,13 +170,13 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            I1, I2, J, KD, N1
-      DOUBLE PRECISION   ANORM, BNORM, EPS, XNORM
+      DOUBLE PRECISION   ANORM, BNORM, EPS, TEMP, XNORM
       COMPLEX*16         ZDUM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            DISNAN, LSAME
       DOUBLE PRECISION   DLAMCH, DZASUM
-      EXTERNAL           LSAME, DLAMCH, DZASUM
+      EXTERNAL           DISNAN, DLAMCH, DZASUM, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           ZGBMV
@@ -211,8 +211,10 @@
          DO 10 J = 1, N
             I1 = MAX( KD+1-J, 1 )
             I2 = MIN( KD+M-J, KL+KD )
-            IF( I2.GE.I1 )
-     $         ANORM = MAX( ANORM, DZASUM( I2-I1+1, A( I1, J ), 1 ) )
+            IF( I2.GE.I1 ) THEN
+               TEMP = DZASUM( I2-I1+1, A( I1, J ), 1 )
+               IF( ANORM.LT.TEMP .OR. DISNAN( TEMP ) ) ANORM = TEMP
+            END IF
    10    CONTINUE
       ELSE
 *
@@ -228,7 +230,8 @@
    14       CONTINUE
    16    CONTINUE
          DO 18 I1 = 1, M
-            ANORM = MAX( ANORM, RWORK( I1 ) )
+            TEMP = RWORK( I1 )
+            IF( ANORM.LT.TEMP .OR. DISNAN( TEMP ) ) ANORM = TEMP
    18    CONTINUE
       END IF
       IF( ANORM.LE.ZERO ) THEN

--- a/TESTING/LIN/zgbt02.f
+++ b/TESTING/LIN/zgbt02.f
@@ -9,7 +9,7 @@
 *  ===========
 *
 *       SUBROUTINE ZGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-*                          LDB, RESID )
+*                          LDB, RWORK, RESID )
 *
 *       .. Scalar Arguments ..
 *       CHARACTER          TRANS
@@ -17,6 +17,7 @@
 *       DOUBLE PRECISION   RESID
 *       ..
 *       .. Array Arguments ..
+*       DOUBLE PRECISION   RWORK( * )
 *       COMPLEX*16         A( LDA, * ), B( LDB, * ), X( LDX, * )
 *       ..
 *
@@ -27,9 +28,10 @@
 *> \verbatim
 *>
 *> ZGBT02 computes the residual for a solution of a banded system of
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm( B - A*X ) / ( norm(A) * norm(X) * EPS).
-*> where EPS is the machine precision.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A, A**T, or A**H, depending on TRANS, and EPS is the
+*> machine precision.
 *> \endverbatim
 *
 *  Arguments:
@@ -39,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A'*x = b, where A' is the transpose of A
-*>          = 'C':  A'*x = b, where A' is the transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -116,11 +118,18 @@
 *>          LDB >= max(1,M); if TRANS = 'T' or 'C', LDB >= max(1,N).
 *> \endverbatim
 *>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is DOUBLE PRECISION array, dimension (MAX(1,LRWORK)),
+*>          where LRWORK >= M when TRANS = 'T' or 'C'; otherwise, RWORK
+*>          is not referenced.
+*> \endverbatim
+*
 *> \param[out] RESID
 *> \verbatim
 *>          RESID is DOUBLE PRECISION
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -135,7 +144,7 @@
 *
 *  =====================================================================
       SUBROUTINE ZGBT02( TRANS, M, N, KL, KU, NRHS, A, LDA, X, LDX, B,
-     $                   LDB, RESID )
+     $                   LDB, RWORK, RESID )
 *
 *  -- LAPACK test routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -147,6 +156,7 @@
       DOUBLE PRECISION   RESID
 *     ..
 *     .. Array Arguments ..
+      DOUBLE PRECISION   RWORK( * )
       COMPLEX*16         A( LDA, * ), B( LDB, * ), X( LDX, * )
 *     ..
 *
@@ -161,6 +171,7 @@
 *     .. Local Scalars ..
       INTEGER            I1, I2, J, KD, N1
       DOUBLE PRECISION   ANORM, BNORM, EPS, XNORM
+      COMPLEX*16         ZDUM
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -170,8 +181,14 @@
 *     .. External Subroutines ..
       EXTERNAL           ZGBMV
 *     ..
+*     .. Statement Functions ..
+      DOUBLE PRECISION   CABS1
+*     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          MAX, MIN
+      INTRINSIC          ABS, DBLE, DIMAG, MAX, MIN
+*     ..
+*     .. Statement Function definitions ..
+      CABS1( ZDUM ) = ABS( DBLE( ZDUM ) ) + ABS( DIMAG( ZDUM ) )
 *     ..
 *     .. Executable Statements ..
 *
@@ -185,14 +202,35 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = DLAMCH( 'Epsilon' )
-      KD = KU + 1
       ANORM = ZERO
-      DO 10 J = 1, N
-         I1 = MAX( KD+1-J, 1 )
-         I2 = MIN( KD+M-J, KL+KD )
-         IF( I2.GE.I1 )
-     $      ANORM = MAX( ANORM, DZASUM( I2-I1+1, A( I1, J ), 1 ) )
-   10 CONTINUE
+      IF( LSAME( TRANS, 'N' ) ) THEN
+*
+*        Find norm1(A).
+*
+         KD = KU + 1
+         DO 10 J = 1, N
+            I1 = MAX( KD+1-J, 1 )
+            I2 = MIN( KD+M-J, KL+KD )
+            IF( I2.GE.I1 )
+     $         ANORM = MAX( ANORM, DZASUM( I2-I1+1, A( I1, J ), 1 ) )
+   10    CONTINUE
+      ELSE
+*
+*        Find normI(A).
+*
+         DO 12 I1 = 1, M
+            RWORK( I1 ) = ZERO
+   12    CONTINUE
+         DO 16 J = 1, N
+            KD = KU + 1 - J
+            DO 14 I1 = MAX( 1, J-KU ), MIN( M, J+KL )
+               RWORK( I1 ) = RWORK( I1 ) + CABS1( A( KD+I1, J ) )
+   14       CONTINUE
+   16    CONTINUE
+         DO 18 I1 = 1, M
+            ANORM = MAX( ANORM, RWORK( I1 ) )
+   18    CONTINUE
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
@@ -204,7 +242,7 @@
          N1 = M
       END IF
 *
-*     Compute  B - A*X (or  B - A'*X )
+*     Compute B - op(A)*X
 *
       DO 20 J = 1, NRHS
          CALL ZGBMV( TRANS, M, N, KL, KU, -CONE, A, LDA, X( 1, J ), 1,
@@ -212,7 +250,7 @@
    20 CONTINUE
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *
       RESID = ZERO
       DO 30 J = 1, NRHS

--- a/TESTING/LIN/zget02.f
+++ b/TESTING/LIN/zget02.f
@@ -28,9 +28,10 @@
 *> \verbatim
 *>
 *> ZGET02 computes the residual for a solution of a system of linear
-*> equations  A*x = b  or  A'*x = b:
-*>    RESID = norm(B - A*X) / ( norm(A) * norm(X) * EPS ),
-*> where EPS is the machine epsilon.
+*> equations op(A)*X = B:
+*>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
+*> where op(A) = A, A**T, or A**H, depending on TRANS, and EPS is the
+*> machine epsilon.
 *> \endverbatim
 *
 *  Arguments:
@@ -40,9 +41,9 @@
 *> \verbatim
 *>          TRANS is CHARACTER*1
 *>          Specifies the form of the system of equations:
-*>          = 'N':  A *x = b
-*>          = 'T':  A^T*x = b, where A^T is the transpose of A
-*>          = 'C':  A^H*x = b, where A^H is the conjugate transpose of A
+*>          = 'N':  A    * X = B  (No transpose)
+*>          = 'T':  A**T * X = B  (Transpose)
+*>          = 'C':  A**H * X = B  (Conjugate transpose)
 *> \endverbatim
 *>
 *> \param[in] M
@@ -95,7 +96,7 @@
 *>          B is COMPLEX*16 array, dimension (LDB,NRHS)
 *>          On entry, the right hand side vectors for the system of
 *>          linear equations.
-*>          On exit, B is overwritten with the difference B - A*X.
+*>          On exit, B is overwritten with the difference B - op(A)*X.
 *> \endverbatim
 *>
 *> \param[in] LDB
@@ -114,7 +115,7 @@
 *> \verbatim
 *>          RESID is DOUBLE PRECISION
 *>          The maximum over the number of right hand sides of
-*>          norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
+*>          norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ).
 *> \endverbatim
 *
 *  Authors:
@@ -188,19 +189,23 @@
 *     Exit with RESID = 1/EPS if ANORM = 0.
 *
       EPS = DLAMCH( 'Epsilon' )
-      ANORM = ZLANGE( '1', M, N, A, LDA, RWORK )
+      IF( LSAME( TRANS, 'N' ) ) THEN
+         ANORM = ZLANGE( '1', M, N, A, LDA, RWORK )
+      ELSE
+         ANORM = ZLANGE( 'I', M, N, A, LDA, RWORK )
+      END IF
       IF( ANORM.LE.ZERO ) THEN
          RESID = ONE / EPS
          RETURN
       END IF
 *
-*     Compute  B - A*X  (or  B - A'*X ) and store in B.
+*     Compute B - op(A)*X and store in B.
 *
       CALL ZGEMM( TRANS, 'No transpose', N1, NRHS, N2, -CONE, A, LDA, X,
      $            LDX, CONE, B, LDB )
 *
 *     Compute the maximum over the number of right hand sides of
-*        norm(B - A*X) / ( norm(A) * norm(X) * EPS ) .
+*        norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ) .
 *
       RESID = ZERO
       DO 10 J = 1, NRHS


### PR DESCRIPTION
1. Comments improved, unified and fixed.
2. Code improved and fixed.

To unify with routines xGBT01, xGTT02, xLANGB, xTBT02, xTPT02, and xTRT02.

Some remarks:
1. It turned out that xLANGB, xLANGT, xLANTB, and xLANTP subroutines accept only a square matrix A, unlike xLANGE and xLANTR which allow A to be non-square.
2. xLANGB uses inline loop not SCSUM1/DZSUM1 for 1-norm and inf-norm computing.
3. xGET02 uses magnitude-based norms |y| unlike xGBT02 which uses taxicab-based norms |Re(y)| + |Im(y)|.
