### PR TITLE
Improving comments in GELQT3, LAPY2 and LAPY3 routines

### DIFF
--- a/SRC/cgelqt3.f
+++ b/SRC/cgelqt3.f
@@ -157,7 +157,7 @@
 *
       IF( M.EQ.1 ) THEN
 *
-*        Compute Householder transform when N=1
+*        Compute Householder transform when M=1
 *
          CALL CLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
          T(1,1)=CONJG(T(1,1))

--- a/SRC/dgelqt3.f
+++ b/SRC/dgelqt3.f
@@ -171,7 +171,7 @@
 *
       IF( M.EQ.1 ) THEN
 *
-*        Compute Householder transform when N=1
+*        Compute Householder transform when M=1
 *
          CALL DLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
 *

--- a/SRC/dlapy2.f
+++ b/SRC/dlapy2.f
@@ -31,7 +31,7 @@
 *> \verbatim
 *>
 *> DLAPY2 returns sqrt(x**2+y**2), taking care not to cause unnecessary
-*> overflow.
+*> overflow and unnecessary underflow.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/dlapy3.f
+++ b/SRC/dlapy3.f
@@ -31,7 +31,7 @@
 *> \verbatim
 *>
 *> DLAPY3 returns sqrt(x**2+y**2+z**2), taking care not to cause
-*> unnecessary overflow.
+*> unnecessary overflow and unnecessary underflow.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/sgelqt3.f
+++ b/SRC/sgelqt3.f
@@ -156,7 +156,7 @@
 *
       IF( M.EQ.1 ) THEN
 *
-*        Compute Householder transform when N=1
+*        Compute Householder transform when M=1
 *
          CALL SLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
 *

--- a/SRC/slapy2.f
+++ b/SRC/slapy2.f
@@ -31,7 +31,7 @@
 *> \verbatim
 *>
 *> SLAPY2 returns sqrt(x**2+y**2), taking care not to cause unnecessary
-*> overflow.
+*> overflow and unnecessary underflow.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/slapy3.f
+++ b/SRC/slapy3.f
@@ -31,7 +31,7 @@
 *> \verbatim
 *>
 *> SLAPY3 returns sqrt(x**2+y**2+z**2), taking care not to cause
-*> unnecessary overflow.
+*> unnecessary overflow and unnecessary underflow.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/zgelqt3.f
+++ b/SRC/zgelqt3.f
@@ -172,7 +172,7 @@
 *
       IF( M.EQ.1 ) THEN
 *
-*        Compute Householder transform when N=1
+*        Compute Householder transform when M=1
 *
          CALL ZLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
          T(1,1)=CONJG(T(1,1))


### PR DESCRIPTION
**Description**
Adds the text
"taking care not to cause unnecessary overflow __or unnecessary underflow.__"
to better describe the algorithms LAPY2 and LAPY3.

__[edited]__
Also, fixes comments in GELQT3.
Closes #574