### PR TITLE
Fix typo in lapack.h

### DIFF
--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -216,9 +216,9 @@ void LAPACK_sbbcsd_base(
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    #define LAPACK_sbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)
+    #define LAPACK_sbbcsd(...) LAPACK_sbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)
 #else
-    #define LAPACK_sbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__)
+    #define LAPACK_sbbcsd(...) LAPACK_sbbcsd_base(__VA_ARGS__)
 #endif
 
 #define LAPACK_zbbcsd_base LAPACK_GLOBAL(zbbcsd,ZBBCSD)


### PR DESCRIPTION
Fixed typos on lines 219 and 221 in lapack.h

**Description**
Line 219 currently reads:
    `#define LAPACK_sbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)`

It should be changed to: 
`    #define LAPACK_sbbcsd(...) LAPACK_sbbcsd_base(__VA_ARGS__, 1, 1, 1, 1, 1)
`

Line 221 currently reads:
`    #define LAPACK_sbbcsd(...) LAPACK_dbbcsd_base(__VA_ARGS__)
`
It should be changed to:
`    #define LAPACK_sbbcsd(...) LAPACK_sbbcsd_base(__VA_ARGS__)
`
**Checklist**

- [x ] The documententation has been updated
- [ x] If the PR solves a specific issue, it is set to be closed on merge.