### PR TITLE
fixed comments: specify which norm is used (no.1 from PR #562)

### DIFF
--- a/TESTING/EIG/dget02.f
+++ b/TESTING/EIG/dget02.f
@@ -32,6 +32,7 @@
 *>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
 *> where op(A) = A or A**T, depending on TRANS, and EPS is the
 *> machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/EIG/sget02.f
+++ b/TESTING/EIG/sget02.f
@@ -32,6 +32,7 @@
 *>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
 *> where op(A) = A or A**T, depending on TRANS, and EPS is the
 *> machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/cqrt17.f
+++ b/TESTING/LIN/cqrt17.f
@@ -35,6 +35,8 @@
 *>
 *>    alpha = norm(B) if IRESID = 1 (zero-residual problem)
 *>    alpha = norm(R) if IRESID = 2 (otherwise).
+*>
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/dgbt02.f
+++ b/TESTING/LIN/dgbt02.f
@@ -32,6 +32,7 @@
 *>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
 *> where op(A) = A or A**T, depending on TRANS, and EPS is the
 *> machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/dget02.f
+++ b/TESTING/LIN/dget02.f
@@ -32,6 +32,7 @@
 *>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
 *> where op(A) = A or A**T, depending on TRANS, and EPS is the
 *> machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/dgtt02.f
+++ b/TESTING/LIN/dgtt02.f
@@ -31,6 +31,7 @@
 *> system of equations:
 *>    RESID = norm(B - op(A)*X) / (norm(op(A)) * norm(X) * EPS),
 *> where EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/dqrt17.f
+++ b/TESTING/LIN/dqrt17.f
@@ -35,6 +35,8 @@
 *>
 *>    alpha = norm(B) if IRESID = 1 (zero-residual problem)
 *>    alpha = norm(R) if IRESID = 2 (otherwise).
+*>
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/dtbt02.f
+++ b/TESTING/LIN/dtbt02.f
@@ -34,6 +34,7 @@
 *> the number of right hand sides of
 *>    norm(b - op(A)*x) / ( norm(op(A)) * norm(x) * EPS ),
 *> where op(A) denotes A or A' and EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/dtpt02.f
+++ b/TESTING/LIN/dtpt02.f
@@ -33,6 +33,7 @@
 *> the maximum over the number of right hand sides of
 *>    norm(b - op(A)*x) / ( norm(op(A)) * norm(x) * EPS ),
 *> where op(A) denotes A or A' and EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/dtrt02.f
+++ b/TESTING/LIN/dtrt02.f
@@ -34,6 +34,7 @@
 *> number of right hand sides of
 *>    norm(b - op(A)*x) / ( norm(op(A)) * norm(x) * EPS ),
 *> where op(A) denotes A or A' and EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/sgbt02.f
+++ b/TESTING/LIN/sgbt02.f
@@ -32,6 +32,7 @@
 *>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
 *> where op(A) = A or A**T, depending on TRANS, and EPS is the
 *> machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/sget02.f
+++ b/TESTING/LIN/sget02.f
@@ -32,6 +32,7 @@
 *>    RESID = norm(B - op(A)*X) / ( norm(op(A)) * norm(X) * EPS ),
 *> where op(A) = A or A**T, depending on TRANS, and EPS is the
 *> machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/sgtt02.f
+++ b/TESTING/LIN/sgtt02.f
@@ -31,6 +31,7 @@
 *> system of equations:
 *>    RESID = norm(B - op(A)*X) / (norm(op(A)) * norm(X) * EPS),
 *> where EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/sqrt17.f
+++ b/TESTING/LIN/sqrt17.f
@@ -35,6 +35,8 @@
 *>
 *>    alpha = norm(B) if IRESID = 1 (zero-residual problem)
 *>    alpha = norm(R) if IRESID = 2 (otherwise).
+*>
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/stbt02.f
+++ b/TESTING/LIN/stbt02.f
@@ -33,6 +33,7 @@
 *> number of right hand sides of
 *>    norm(b - op(A)*x) / ( norm(op(A)) * norm(x) * EPS ),
 *> where op(A) denotes A or A' and EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/stpt02.f
+++ b/TESTING/LIN/stpt02.f
@@ -33,6 +33,7 @@
 *> the maximum over the number of right hand sides of
 *>    norm(b - op(A)*x) / ( norm(op(A)) * norm(x) * EPS ),
 *> where op(A) denotes A or A' and EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/strt02.f
+++ b/TESTING/LIN/strt02.f
@@ -34,6 +34,7 @@
 *> number of right hand sides of
 *>    norm(b - op(A)*x) / ( norm(op(A)) * norm(x) * EPS ),
 *> where op(A) denotes A or A' and EPS is the machine epsilon.
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:

--- a/TESTING/LIN/zqrt17.f
+++ b/TESTING/LIN/zqrt17.f
@@ -35,6 +35,8 @@
 *>
 *>    alpha = norm(B) if IRESID = 1 (zero-residual problem)
 *>    alpha = norm(R) if IRESID = 2 (otherwise).
+*>
+*> The norm used is the 1-norm.
 *> \endverbatim
 *
 *  Arguments:


### PR DESCRIPTION
Despite the recommendation, no change has been made in xGBT02, xGET02, xGTT02, xTBT02, xTPT02, and xTRT02 for C,Z datatypes yet: as it was noted afterwards in PR #571, those routines are using mixed types of norm: 1-norm for op(A) and taxicab-based norm |Re(z)|+|Im(z)| for residual.
