### PR TITLE
Use flags -mfpmath=sse (x86-64) -msse2 (x86) in cmake.yml

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,8 +34,8 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-Wall -pedantic"
-  FFLAGS: "-fimplicit-none -frecursive -fcheck=all"
+  CFLAGS: "-Wall -pedantic -mfpmath=sse -msse2"
+  FFLAGS: "-fimplicit-none -frecursive -fcheck=all -mfpmath=sse -msse2"
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
 
 defaults:


### PR DESCRIPTION
The flags enable the use of scalar floating-point instructions present in the SSE instruction set for the GCC. Based on the discussion in #575. See also https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html

- I let `makefile.yml` without those flags so as to continue testing the default options for GCC.

- Should we add other flags to improve the compatibility of LAPACK with a larger class of compilers?