### PR TITLE
Fix the number of matrices to test in TESTING/{s,c,d,z}ed.in (6->7)

### DIFF
--- a/TESTING/EIG/ddrvst2stg.f
+++ b/TESTING/EIG/ddrvst2stg.f
@@ -2793,7 +2793,7 @@ c           LIWEDC = 12
                      RESULT( NTEST ) = ULPINV
                      RESULT( NTEST+1 ) = ULPINV
                      RESULT( NTEST+2 ) = ULPINV
-                     GO TO 700
+                     GO TO 1720
                   END IF
                END IF
 *
@@ -2820,13 +2820,13 @@ c           LIWEDC = 12
                      RETURN
                   ELSE
                      RESULT( NTEST ) = ULPINV
-                     GO TO 700
+                     GO TO 1720
                   END IF
                END IF
 *
                IF( M3.EQ.0 .AND. N.GT.0 ) THEN
                   RESULT( NTEST ) = ULPINV
-                  GO TO 700
+                  GO TO 1720
                END IF
 *
 *              Do test 78 (or +54)

--- a/TESTING/ced.in
+++ b/TESTING/ced.in
@@ -1,5 +1,5 @@
 CES               Data for the Complex Nonsymmetric Schur Form Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -8,7 +8,7 @@ T
 2518 3899 995 397 Seed for random number generator
 CES 21            Use all matrix types
 CEV               Data for the Complex Nonsymmetric Eigenvalue Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -17,7 +17,7 @@ T
 2518 3899 995 397 Seed for random number generator
 CEV 21            Use all matrix types
 CSX               Data for the Complex Nonsymmetric Schur Form Expert Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios

--- a/TESTING/ded.in
+++ b/TESTING/ded.in
@@ -1,5 +1,5 @@
 DEV               Data file for Real Nonsymmetric Eigenvalue Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -8,7 +8,7 @@ T
 2518 3899 995 397 Seed for random number generator
 DEV 21            Use all matrix types
 DES               Data file for Real Nonsymmetric Schur Form Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -17,7 +17,7 @@ T
 2518 3899 995 397 Seed for random number generator
 DES 21            Use all matrix types
 DVX               Data file for Real Nonsymmetric Eigenvalue Expert Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios

--- a/TESTING/sed.in
+++ b/TESTING/sed.in
@@ -1,5 +1,5 @@
 SEV               Data file for the Real Nonsymmetric Eigenvalue Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -8,7 +8,7 @@ T
 2518 3899 995 397 Seed for random number generator
 SEV 21            Use all matrix types
 SES               Data file for the Real Nonsymmetric Schur Form Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -17,7 +17,7 @@ T
 2518 3899 995 397 Seed for random number generator
 SES 21            Use all matrix types
 SVX               Data file for the Real Nonsymmetric Eigenvalue Expert Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios

--- a/TESTING/zed.in
+++ b/TESTING/zed.in
@@ -1,5 +1,5 @@
 ZES               Data for the Complex Nonsymmetric Schur Form Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -8,7 +8,7 @@ T
 2518 3899 995 397 Seed for random number generator
 ZES 21            Use all matrix types
 ZEV               Data for the Complex Nonsymmetric Eigenvalue Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios
@@ -17,7 +17,7 @@ T
 2518 3899 995 397 Seed for random number generator
 ZEV 21            Use all matrix types
 ZSX               Data for the Complex Nonsymmetric Schur Form Expert Driver
-6                 Number of matrix dimensions
+7                 Number of matrix dimensions
 0 1 2 3 5 10 20   Matrix dimensions
 3 3 1 11 4 8 2 0  Parameters NB, NBMIN, NXOVER, INMIN, INWIN, INIBL, ISHFTS, IACC22
 20.0              Threshold for test ratios


### PR DESCRIPTION
The number of matrices to test in TESTING/{s,c,d,z}ed.in look wrong. 
7 seems correct but 6 looks wrong.