### PR TITLE
se2.in causes an infinite loop when dsyevr_2stage or dsyevr failed.

### DIFF
--- a/TESTING/EIG/ddrvst2stg.f
+++ b/TESTING/EIG/ddrvst2stg.f
@@ -2793,7 +2793,7 @@ c           LIWEDC = 12
                      RESULT( NTEST ) = ULPINV
                      RESULT( NTEST+1 ) = ULPINV
                      RESULT( NTEST+2 ) = ULPINV
-                     GO TO 700
+                     GO TO 1720
                   END IF
                END IF
 *
@@ -2820,13 +2820,13 @@ c           LIWEDC = 12
                      RETURN
                   ELSE
                      RESULT( NTEST ) = ULPINV
-                     GO TO 700
+                     GO TO 1720
                   END IF
                END IF
 *
                IF( M3.EQ.0 .AND. N.GT.0 ) THEN
                   RESULT( NTEST ) = ULPINV
-                  GO TO 700
+                  GO TO 1720
                END IF
 *
 *              Do test 78 (or +54)


### PR DESCRIPTION
ddrvst2stg.f  tests symmetric eigenvalue problem drivers using se2.in
when dsyevr_2stage or dsyevr failed, it jumps to label 700. This causes
an infinite loop. Usually, this issue is unnoticed these routines do not fail. 

As I looked into the source code, when dsyevr_2stage or dsyevr failed,
we should jump to label 1720 instead.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.