### PR TITLE
Make lapy and nrm2 consistent

### DIFF
--- a/SRC/dlapy2.f
+++ b/SRC/dlapy2.f
@@ -78,12 +78,15 @@
       PARAMETER          ( ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
-      DOUBLE PRECISION   W, XABS, YABS, Z
+      DOUBLE PRECISION   W, XABS, YABS, Z, HUGEVAL
       LOGICAL            X_IS_NAN, Y_IS_NAN
 *     ..
 *     .. External Functions ..
       LOGICAL            DISNAN
       EXTERNAL           DISNAN
+*     ..
+*     .. External Subroutines ..
+      DOUBLE PRECISION   DLAMCH
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX, MIN, SQRT
@@ -94,13 +97,14 @@
       Y_IS_NAN = DISNAN( Y )
       IF ( X_IS_NAN ) DLAPY2 = X
       IF ( Y_IS_NAN ) DLAPY2 = Y
+      HUGEVAL = DLAMCH( 'Overflow' )
 *
       IF ( .NOT.( X_IS_NAN.OR.Y_IS_NAN ) ) THEN
          XABS = ABS( X )
          YABS = ABS( Y )
          W = MAX( XABS, YABS )
          Z = MIN( XABS, YABS )
-         IF( Z.EQ.ZERO ) THEN
+         IF( Z.EQ.ZERO .OR. W.GT.HUGEVAL ) THEN
             DLAPY2 = W
          ELSE
             DLAPY2 = W*SQRT( ONE+( Z / W )**2 )

--- a/SRC/dlapy3.f
+++ b/SRC/dlapy3.f
@@ -81,18 +81,22 @@
       PARAMETER          ( ZERO = 0.0D0 )
 *     ..
 *     .. Local Scalars ..
-      DOUBLE PRECISION   W, XABS, YABS, ZABS
+      DOUBLE PRECISION   W, XABS, YABS, ZABS, HUGEVAL
+*     ..
+*     .. External Subroutines ..
+      DOUBLE PRECISION   DLAMCH
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX, SQRT
 *     ..
 *     .. Executable Statements ..
 *
+      HUGEVAL = DLAMCH( 'Overflow' )
       XABS = ABS( X )
       YABS = ABS( Y )
       ZABS = ABS( Z )
       W = MAX( XABS, YABS, ZABS )
-      IF( W.EQ.ZERO ) THEN
+      IF( W.EQ.ZERO .OR. W.GT.HUGEVAL ) THEN
 *     W can be zero for max(0,nan,0)
 *     adding all three entries together will make sure
 *     NaN will not disappear.

--- a/SRC/slapy2.f
+++ b/SRC/slapy2.f
@@ -78,18 +78,18 @@
       PARAMETER          ( ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
-      REAL               W, XABS, YABS, Z
+      REAL               W, XABS, YABS, Z, HUGEVAL
       LOGICAL            X_IS_NAN, Y_IS_NAN
 *     ..
 *     .. External Functions ..
       LOGICAL            SISNAN
       EXTERNAL           SISNAN
 *     ..
+*     .. External Subroutines ..
+      REAL               SLAMCH
+*     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX, MIN, SQRT
-*     ..
-*     .. Executable Statements ..
-*
 *     ..
 *     .. Executable Statements ..
 *
@@ -97,13 +97,14 @@
       Y_IS_NAN = SISNAN( Y )
       IF ( X_IS_NAN ) SLAPY2 = X
       IF ( Y_IS_NAN ) SLAPY2 = Y
+      HUGEVAL = SLAMCH( 'Overflow' )
 *
       IF ( .NOT.( X_IS_NAN.OR.Y_IS_NAN ) ) THEN
          XABS = ABS( X )
          YABS = ABS( Y )
          W = MAX( XABS, YABS )
          Z = MIN( XABS, YABS )
-         IF( Z.EQ.ZERO ) THEN
+         IF( Z.EQ.ZERO .OR. W.GT.HUGEVAL ) THEN
             SLAPY2 = W
          ELSE
             SLAPY2 = W*SQRT( ONE+( Z / W )**2 )

--- a/SRC/slapy3.f
+++ b/SRC/slapy3.f
@@ -81,18 +81,22 @@
       PARAMETER          ( ZERO = 0.0E0 )
 *     ..
 *     .. Local Scalars ..
-      REAL               W, XABS, YABS, ZABS
+      REAL               W, XABS, YABS, ZABS, HUGEVAL
+*     ..
+*     .. External Subroutines ..
+      REAL               SLAMCH
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX, SQRT
 *     ..
 *     .. Executable Statements ..
 *
+      HUGEVAL = SLAMCH( 'Overflow' )
       XABS = ABS( X )
       YABS = ABS( Y )
       ZABS = ABS( Z )
       W = MAX( XABS, YABS, ZABS )
-      IF( W.EQ.ZERO ) THEN
+      IF( W.EQ.ZERO .OR. W.GT.HUGEVAL ) THEN
 *     W can be zero for max(0,nan,0)
 *     adding all three entries together will make sure
 *     NaN will not disappear.


### PR DESCRIPTION
**Description**

If some of the inputs are `inf`, `{s,d}lapy{2,3}` and the new` {s,d}nrm2` routines return inconsistent results, `NaN` in contrast to `inf`.

- lapy2 if both inputs are `inf`
- lapy3 if at least one of the 3 inputs is `inf`

This commit adds a check to avoid the divisions `inf / inf` that introduce `NaN`.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.