### PR TITLE
Test OpenMP

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,8 +34,7 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-Wall -pedantic -fopenmp"
-  FFLAGS: "-fimplicit-none -frecursive -fopenmp -fcheck=all"
+  CFLAGS: "-Wall -pedantic"
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
 
 defaults:
@@ -55,11 +54,15 @@ jobs:
 
     env:
       BUILD_TYPE: Release
+      FFLAGS: ${{ matrix.fflags }}
 
     strategy:
       fail-fast: true
       matrix:
         os: [ macos-latest, ubuntu-latest ]
+        fflags: [
+          "-fimplicit-none -frecursive -fcheck=all",
+          "-fimplicit-none -frecursive -fcheck=all -fopenmp" ]
     
     steps:
     
@@ -111,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest 
     env:
       BUILD_TYPE: Coverage
+      FFLAGS: "-fopenmp"
     steps:     
     
     - name: Checkout LAPACK

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,8 +34,8 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-Wall -pedantic"
-  FFLAGS: "-fimplicit-none -frecursive -fcheck=all"
+  CFLAGS: "-Wall -pedantic -fopenmp"
+  FFLAGS: "-fimplicit-none -frecursive -fopenmp -fcheck=all"
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
 
 defaults:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -32,8 +32,8 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-Wall -pedantic"
-  FFLAGS: "-fimplicit-none -frecursive -fcheck=all"
+  CFLAGS: "-Wall -pedantic -fopenmp"
+  FFLAGS: "-fimplicit-none -frecursive -fopenmp -fcheck=all"
 
 defaults:
   run:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -32,7 +32,7 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-Wall -pedantic -fopenmp"
+  CFLAGS: "-Wall -pedantic"
   FFLAGS: "-fimplicit-none -frecursive -fopenmp -fcheck=all"
 
 defaults:


### PR DESCRIPTION
Some few routines use OpenMP parallelism and this is not under being tested. It should be, right?
This PR adds "-fopenmp" to the Fortran compilation flags to the Github workflows for test.