### PR TITLE
Fix (s,d)LASET calls in CCHKST2STG and ZCHKST2STG

### DIFF
--- a/TESTING/EIG/cchkst2stg.f
+++ b/TESTING/EIG/cchkst2stg.f
@@ -687,7 +687,7 @@
      $                   XERBLA, CCOPY, CHET21, CHETRD, CHPT21, CHPTRD,
      $                   CLACPY, CLASET, CLATMR, CLATMS, CPTEQR, CSTEDC,
      $                   CSTEMR, CSTEIN, CSTEQR, CSTT21, CSTT22, CUNGTR,
-     $                   CUPGTR, CHETRD_2STAGE
+     $                   CUPGTR, CHETRD_2STAGE, SLASET
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, REAL, CONJG, INT, LOG, MAX, MIN, SQRT
@@ -1011,8 +1011,8 @@
 *           the one from above. Compare it with D1 computed 
 *           using the 1-stage.
 *
-            CALL DLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
-            CALL DLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
+            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
+            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
             CALL CLACPY( 'U', N, N, A, LDA, V, LDU )
             LH = MAX(1, 4*N)
             LW = LWORK - LH
@@ -1045,8 +1045,8 @@
 *           the one from above. Compare it with D1 computed 
 *           using the 1-stage. 
 *
-            CALL DLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
-            CALL DLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
+            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
+            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
             CALL CLACPY( 'L', N, N, A, LDA, V, LDU )
             CALL CHETRD_2STAGE( 'N', "L", N, V, LDU, SD, SE, TAU, 
      $                   WORK, LH, WORK( LH+1 ), LW, IINFO )

--- a/TESTING/EIG/zchkst2stg.f
+++ b/TESTING/EIG/zchkst2stg.f
@@ -687,7 +687,7 @@
      $                   XERBLA, ZCOPY, ZHET21, ZHETRD, ZHPT21, ZHPTRD,
      $                   ZLACPY, ZLASET, ZLATMR, ZLATMS, ZPTEQR, ZSTEDC,
      $                   ZSTEMR, ZSTEIN, ZSTEQR, ZSTT21, ZSTT22, ZUNGTR,
-     $                   ZUPGTR, ZHETRD_2STAGE
+     $                   ZUPGTR, ZHETRD_2STAGE, DLASET
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, DBLE, DCONJG, INT, LOG, MAX, MIN, SQRT


### PR DESCRIPTION
This PR declares the operations (s,d)LASET explicitly in (c,z)CHKST2STG respectively.
Alos, it fixes the calls in CCHKST2STG, from DLASET to SLASET.