### PR TITLE
Fixes the documentation of [cz]ROTG

### DIFF
--- a/BLAS/SRC/crotg.f90
+++ b/BLAS/SRC/crotg.f90
@@ -58,7 +58,7 @@
 !>
 !> \param[out] S
 !> \verbatim
-!>          S is REAL
+!>          S is COMPLEX
 !>          The scalar s.
 !> \endverbatim
 !

--- a/BLAS/SRC/zrotg.f90
+++ b/BLAS/SRC/zrotg.f90
@@ -58,7 +58,7 @@
 !>
 !> \param[out] S
 !> \verbatim
-!>          S is DOUBLE PRECISION
+!>          S is DOUBLE COMPLEX
 !>          The scalar s.
 !> \endverbatim
 !


### PR DESCRIPTION
Fix a small typo in the documentation of [cz]ROTG.
Thanks to @mgates3.