### PR TITLE
Link C libraries against build include folder

### DIFF
--- a/CBLAS/src/CMakeLists.txt
+++ b/CBLAS/src/CMakeLists.txt
@@ -124,7 +124,7 @@ if(HAS_ATTRIBUTE_WEAK_SUPPORT)
   target_compile_definitions(${CBLASLIB} PRIVATE HAS_ATTRIBUTE_WEAK_SUPPORT)
 endif()
 target_include_directories(${CBLASLIB} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  $<BUILD_INTERFACE:${LAPACK_BINARY_DIR}/../include>
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(${CBLASLIB} PRIVATE ${BLAS_LIBRARIES})

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -80,7 +80,7 @@ set_target_properties(
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
 target_include_directories(${LAPACKELIB} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${LAPACK_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
 if(WIN32 AND NOT UNIX)


### PR DESCRIPTION
**Description**
This PR fixes a bug in the build system. The `lapacke` and `cblas` targets include the source include folder instead of the build include folder. This means that any target downstream target that links against these using `target_link_libraries` won't get the correct include folder, which critically is missing the auto-generated `xxx_mangling.h` headers. This PR changes the build interface so that these targets now correctly use the `${LAPACK_BINARY_DIR}/include` directory.

This arose from issue #614, which I was trying to build the lapack library after downloading it via `FetchContent`, which is useful for bundling lapack together with source code rather than relying on a system installation.

I'm not sure where/how to update the documentation for this change, but am happy to do so with some input from the maintainers.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.