### PR TITLE
make.inc.gfortran: define a default value for DOCSDIR

### DIFF
--- a/INSTALL/make.inc.gfortran
+++ b/INSTALL/make.inc.gfortran
@@ -79,3 +79,8 @@ CBLASLIB     = $(TOPSRCDIR)/libcblas.a
 LAPACKLIB    = $(TOPSRCDIR)/liblapack.a
 TMGLIB       = $(TOPSRCDIR)/libtmglib.a
 LAPACKELIB   = $(TOPSRCDIR)/liblapacke.a
+
+#  DOCUMENTATION DIRECTORY
+# If you generate html pages (make html), documentation will be placed in $(DOCSDIR)/explore-html
+# If you generate man pages (make man), documentation will be placed in $(DOCSDIR)/man
+DOCSDIR       = $(TOPSRCDIR)/DOCS


### PR DESCRIPTION
The same has already be done in `make.inc.nagfor`.

Actually it could make sense to define `DOCSDIR` in all the `make.inc.*`, for consistency.