### PR TITLE
Address issues with IBM XL builds

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -11,9 +11,7 @@ FortranCInterface_HEADER(${LAPACK_BINARY_DIR}/include/cblas_mangling.h
                          MACRO_NAMESPACE "F77_"
                          SYMBOL_NAMESPACE "F77_")
 if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
-  message(WARNING "Reverting to pre-defined include/lapacke_mangling.h")
-    configure_file(include/lapacke_mangling_with_flags.h.in
-                  ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h)
+  message(WARNING "Reverting to pre-defined include/cblas_mangling.h")
     configure_file(include/cblas_mangling_with_flags.h.in
                  ${LAPACK_BINARY_DIR}/include/cblas_mangling.h)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,28 +91,40 @@ include(PreventInBuildInstalls)
 
 # Check if recursive flag exists
 include(CheckFortranCompilerFlag)
-check_fortran_compiler_flag("-recursive" _recursiveFlag)
-check_fortran_compiler_flag("-frecursive" _frecursiveFlag)
-check_fortran_compiler_flag("-Mrecursive" _MrecursiveFlag)
+if(CMAKE_Fortran_COMPILER_ID STREQUAL Flang)
+  check_fortran_compiler_flag("-Mrecursive" _MrecursiveFlag)
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
+  check_fortran_compiler_flag("-frecursive" _frecursiveFlag)
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
+  check_fortran_compiler_flag("-recursive" _recursiveFlag)
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
+  check_fortran_compiler_flag("-qrecur" _qrecurFlag)
+endif()
 
 # Add recursive flag
-if(_recursiveFlag)
-  string(REGEX MATCH "-recursive" output_test <string> "${CMAKE_Fortran_FLAGS}")
+if(_MrecursiveFlag)
+  string(REGEX MATCH "-Mrecursive" output_test <string> "${CMAKE_Fortran_FLAGS}")
   if(NOT output_test)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -recursive"
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mrecursive"
       CACHE STRING "Recursive flag must be set" FORCE)
   endif()
 elseif(_frecursiveFlag)
   string(REGEX MATCH "-frecursive" output_test <string> "${CMAKE_Fortran_FLAGS}")
   if(NOT output_test)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -frecursive"
-    CACHE STRING "Recursive flag must be set" FORCE)
+      CACHE STRING "Recursive flag must be set" FORCE)
   endif()
-elseif(_MrecursiveFlag)
-  string(REGEX MATCH "-Mrecursive" output_test <string> "${CMAKE_Fortran_FLAGS}")
+elseif(_recursiveFlag)
+  string(REGEX MATCH "-recursive" output_test <string> "${CMAKE_Fortran_FLAGS}")
   if(NOT output_test)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mrecursive"
-    CACHE STRING "Recursive flag must be set" FORCE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -recursive"
+      CACHE STRING "Recursive flag must be set" FORCE)
+  endif()
+elseif(_qrecurFlag)
+  string(REGEX MATCH "-qrecur" output_test <string> "${CMAKE_Fortran_FLAGS}")
+  if(NOT output_test)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qrecur"
+      CACHE STRING "Recursive flag must be set" FORCE)
   endif()
 endif()
 
@@ -121,7 +133,7 @@ if(UNIX)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model strict")
   endif()
   if(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict=none")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qnosave -qstrict")
   endif()
 # Delete libmtsk in linking sequence for Sun/Oracle Fortran Compiler.
 # This library is not present in the Sun package SolarisStudio12.3-linux-x86-bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,10 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
   check_fortran_compiler_flag("-recursive" _recursiveFlag)
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
   check_fortran_compiler_flag("-qrecur" _qrecurFlag)
+else()
+  message(WARNING "Fortran local arrays should be allocated on the stack."
+    " Please use a compiler which guarantees that feature."
+    " See https://github.com/Reference-LAPACK/lapack/pull/188 and references therein.")
 endif()
 
 # Add recursive flag

--- a/INSTALL/make.inc.XLF
+++ b/INSTALL/make.inc.XLF
@@ -14,10 +14,10 @@ CFLAGS = -O3 -qnosave
 #  the compiler options desired when NO OPTIMIZATION is selected.
 #
 FC = xlf
-FFLAGS = -O3 -qfixed -qnosave
+FFLAGS = -O3 -qfixed -qnosave -qrecur
 # For -O2, add -qstrict=none
 FFLAGS_DRV = $(FFLAGS)
-FFLAGS_NOOPT = -O0 -qfixed -qnosave
+FFLAGS_NOOPT = -O0 -qfixed -qnosave -qrecur
 
 #  Define LDFLAGS to the desired linker options for your machine.
 #


### PR DESCRIPTION
**Description**
This PR addresses #606, by adding correct detection for the IBM XL Fortran (`xlf`) recursive option (`-qrecur`). 

Note that the current logic will test ALL possible recursive flags against a target compiler; in the case of `xlf` this unexpectedly "succeeds" when the Intel-specific flag `-recursive` is passed in. Actually it doesn't really succeed, but `xlf` does not correctly report failure, so `cmake CheckFortranCompilerFlag` ends up tacking `-recursive` onto `CMAKE_Fortran_FLAGS`. The resulting attempt to compile with this bogus flag fails.

You can see the errant compiler behavior with a simple example "Hello World" program:
```
$ xlf_r -recursive -o hello-dumb hello.f90
** helloworld   === End of Compilation 1 ===
1501-510  Compilation successful for file hello.f90.
ld: cannot find -lgcc_s
ld: cannot find -lgcc_s

$ ls
hello.f90  hello.o

$ file hello.o
hello.o: ELF 64-bit LSB relocatable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), not stripped
```
The `xlf` compiler produces an intermediate object code that will not link.

P.S. I've sent this patch to the [Spack project](https://github.com/spack/spack/pull/25793). They've accepted it but of course it would be best to implement the fixes upstream.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.