### PR TITLE
Fix out of bounds read in slarrv

### DIFF
--- a/SRC/clarrv.f
+++ b/SRC/clarrv.f
@@ -348,7 +348,7 @@
 *
 *     Quick return if possible
 *
-      IF( N.LE.0 ) THEN
+      IF( (N.LE.0).OR.(M.LE.0) ) THEN
          RETURN
       END IF
 *

--- a/SRC/dlarrv.f
+++ b/SRC/dlarrv.f
@@ -350,7 +350,7 @@
 *
 *     Quick return if possible
 *
-      IF( N.LE.0 ) THEN
+      IF( (N.LE.0).OR.(M.LE.0) ) THEN
          RETURN
       END IF
 *

--- a/SRC/slarrv.f
+++ b/SRC/slarrv.f
@@ -350,7 +350,7 @@
 *
 *     Quick return if possible
 *
-      IF( N.LE.0 ) THEN
+      IF( (N.LE.0).OR.(M.LE.0) ) THEN
          RETURN
       END IF
 *

--- a/SRC/zlarrv.f
+++ b/SRC/zlarrv.f
@@ -348,7 +348,7 @@
 *
 *     Quick return if possible
 *
-      IF( N.LE.0 ) THEN
+      IF( (N.LE.0).OR.(M.LE.0) ) THEN
          RETURN
       END IF
 *


### PR DESCRIPTION
This was originally reported as https://github.com/JuliaLang/julia/issues/42415.
I've tracked this down to an out of bounds read on the following line:

https://github.com/Reference-LAPACK/lapack/blob/44ecb6a5ff821b1cbb39f8cc2166cb098e060b4d/SRC/slarrv.f#L423

In the crashing example, `M` is `0`, causing `slarrv` to read uninitialized
memory from the work array. I believe the `0` for `M` is correct and indeed,
the documentation above supports that `M` may be zero:

https://github.com/Reference-LAPACK/lapack/blob/44ecb6a5ff821b1cbb39f8cc2166cb098e060b4d/SRC/slarrv.f#L113-L116

I believe it may be sufficient to early-out this function as suggested
in this PR. However, I have limited context for the full routine here,
so I would appreciate a sanity check.