### PR TITLE
fix a typo, thanks to Jim Demmel for letting me know

### DIFF
--- a/BLAS/SRC/crotg.f90
+++ b/BLAS/SRC/crotg.f90
@@ -11,7 +11,7 @@
 !  CROTG constructs a plane rotation
 !     [  c         s ] [ a ] = [ r ]
 !     [ -conjg(s)  c ] [ b ]   [ 0 ]
-!  where c is real, s ic complex, and c**2 + conjg(s)*s = 1.
+!  where c is real, s is complex, and c**2 + conjg(s)*s = 1.
 !
 !> \par Purpose:
 !  =============

--- a/BLAS/SRC/zrotg.f90
+++ b/BLAS/SRC/zrotg.f90
@@ -11,7 +11,7 @@
 !  ZROTG constructs a plane rotation
 !     [  c         s ] [ a ] = [ r ]
 !     [ -conjg(s)  c ] [ b ]   [ 0 ]
-!  where c is real, s ic complex, and c**2 + conjg(s)*s = 1.
+!  where c is real, s is complex, and c**2 + conjg(s)*s = 1.
 !
 !> \par Purpose:
 !  =============


### PR DESCRIPTION
From Jim Demmel

The comment

   !  where c is real, s ic complex, and c**2 + conjg(s)*s = 1.

should be

   !  where c is real, s is complex, and c**2 + conjg(s)*s = 1.

Thanks, Jim