### PR TITLE
Update conda version used in Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda clean --packages
+  - conda clean --yes --packages
   - conda update --yes -n base conda
   - conda config --add channels conda-forge --force
   - conda install --yes --quiet flang jom

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ install:
   - conda config --add channels conda-forge --force
   - conda clean --all --yes
 #  - conda install --yes conda=4.3.8 --force
-#  - conda install --yes charset-normalizer --force  
+  - conda install --yes -c conda-forge charset-normalizer=2.0.5 --force  
 #  - conda update --yes -n base conda
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
     CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 install:
-  - call %CONDA_INSTALL_LOCN%\conda update --yes conda
+  - call %CONDA_INSTALL_LOCN%\Scripts\conda update --yes conda
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
 #  - conda install --yes conda=4.3.8 --force

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ install:
 #  - conda update --yes -n base conda
 #  - conda config --add channels conda-forge --force
 #  - conda clean --all --yes
-  - conda install -c conda-forge --yes --quiet flang
+  - %CONDA_INSTALL_LOCN%\conda install -c conda-forge --yes --quiet flang
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,9 +23,9 @@ install:
 #  - conda config --set auto_update_conda false
 #  - conda install --yes conda=4.3.8 --force
 #  - conda install --yes -c conda-forge charset-normalizer=2.0.5 --force  
-  - conda update --yes -n base conda
+#  - conda update --yes -n base conda
   - conda config --add channels conda-forge --force
-  - conda clean --all --yes
+#  - conda clean --all --yes
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,10 +16,10 @@ cache:
 
 environment:
   global:
-    CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+    CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
 
 install:
-  - call %CONDA_INSTALL_LOCN%\Scripts\conda update --yes conda
+#  - call %CONDA_INSTALL_LOCN%\Scripts\conda update --yes conda
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
 #  - conda install --yes conda=4.3.8 --force
@@ -27,7 +27,7 @@ install:
 #  - conda update --yes -n base conda
 #  - conda config --add channels conda-forge --force
 #  - conda clean --all --yes
-  - conda install -c conda-forge --yes --quiet flang
+  - conda install -c conda-forge --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,8 +21,8 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda clean --yes --packages
   - conda config --add channels conda-forge --force
+  - conda install --yes charset-normalizer --force  
   - conda update --yes -n base conda
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ install:
 #  - conda install --yes conda=4.3.8 --force
 #  - conda install --yes -c conda-forge charset-normalizer=2.0.5 --force  
 #  - conda update --yes -n base conda
-  - conda config --add channels conda-forge --force
+#  - conda config --add channels conda-forge --force
 #  - conda clean --all --yes
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
 #  - conda update --yes -n base conda
 #  - conda config --add channels conda-forge --force
 #  - conda clean --all --yes
-  - conda install --yes --quiet flang jom
+  - conda install -c conda-forge --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
+  - conda clean --packages
   - conda update --yes -n base conda
   - conda config --add channels conda-forge --force
   - conda install --yes --quiet flang jom

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,22 +11,13 @@ skip_commits:
 # Add [av skip] to commit messages
   message: /\[av skip\]/
 
-#cache:
-#  - '%APPVEYOR_BUILD_FOLDER%\build'
-
 environment:
   global:
     CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
 
 install:
-#  - call %CONDA_INSTALL_LOCN%\Scripts\conda update --yes conda
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-#  - conda install --yes conda=4.3.8 --force
-#  - conda install --yes -c conda-forge charset-normalizer=2.0.5 --force  
-#  - conda update --yes -n base conda
-#  - conda config --add channels conda-forge --force
-#  - conda clean --all --yes
   - conda install -c conda-forge --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - conda config --set auto_update_conda false
   - conda config --add channels conda-forge --force
-  - conda install --yes conda=4.10.3 --force
+  - conda install --yes conda=4.3.8 --force
   - conda install --yes charset-normalizer --force  
   - conda update --yes -n base conda
   - conda install --yes --quiet flang jom

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,7 @@ environment:
     CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 install:
+  - conda update --yes conda
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
 #  - conda install --yes conda=4.3.8 --force

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
 #  - conda update --yes -n base conda
 #  - conda config --add channels conda-forge --force
 #  - conda clean --all --yes
-  - conda install -c conda-forge --yes --quiet flang jom
+  - conda install -c conda-forge --yes --quiet flang
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,8 +22,8 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda clean --yes --packages
-  - conda update --yes -n base conda
   - conda config --add channels conda-forge --force
+  - conda update --yes -n base conda
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
     CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 install:
-  - conda update --yes conda
+  - call %CONDA_INSTALL_LOCN%\conda update --yes conda
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
 #  - conda install --yes conda=4.3.8 --force
@@ -27,7 +27,7 @@ install:
 #  - conda update --yes -n base conda
 #  - conda config --add channels conda-forge --force
 #  - conda clean --all --yes
-  - %CONDA_INSTALL_LOCN%\conda install -c conda-forge --yes --quiet flang
+  - conda install -c conda-forge --yes --quiet flang
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,8 @@ environment:
 
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - conda config --set auto_update_conda false
+#  - conda config --set auto_update_conda false
+  - conda update --yes -n base conda
   - conda config --add channels conda-forge --force
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ environment:
 
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-#  - conda config --set auto_update_conda false
+  - conda config --set auto_update_conda false
   - conda config --add channels conda-forge --force
   - conda install --yes charset-normalizer --force  
   - conda update --yes -n base conda

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - conda config --set auto_update_conda false
   - conda config --add channels conda-forge --force
-  - conda install conda=4.10.3
+  - conda install --yes conda=4.10.3 --force
   - conda install --yes charset-normalizer --force  
   - conda update --yes -n base conda
   - conda install --yes --quiet flang jom

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,8 +24,8 @@ install:
   - conda config --add channels conda-forge --force
   - conda clean --all --yes
 #  - conda install --yes conda=4.3.8 --force
-  - conda install --yes -c conda-forge charset-normalizer=2.0.5 --force  
-#  - conda update --yes -n base conda
+#  - conda install --yes -c conda-forge charset-normalizer=2.0.5 --force  
+  - conda update --yes -n base conda
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,8 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - conda config --set auto_update_conda false
   - conda config --add channels conda-forge --force
-  - conda install --yes conda-forge/win-64::charset-normalizer --force  
+  - conda install conda=4.10.3
+  - conda install --yes charset-normalizer --force  
   - conda update --yes -n base conda
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,11 +20,11 @@ environment:
 
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - conda config --set auto_update_conda false
+#  - conda config --set auto_update_conda false
   - conda config --add channels conda-forge --force
-  - conda install --yes conda=4.3.8 --force
-  - conda install --yes charset-normalizer --force  
-  - conda update --yes -n base conda
+#  - conda install --yes conda=4.3.8 --force
+#  - conda install --yes charset-normalizer --force  
+#  - conda update --yes -n base conda
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,8 @@ skip_commits:
 # Add [av skip] to commit messages
   message: /\[av skip\]/
 
-cache:
-  - '%APPVEYOR_BUILD_FOLDER%\build'
+#cache:
+#  - '%APPVEYOR_BUILD_FOLDER%\build'
 
 environment:
   global:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,11 +21,11 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda config --add channels conda-forge --force
-  - conda clean --all --yes
 #  - conda install --yes conda=4.3.8 --force
 #  - conda install --yes -c conda-forge charset-normalizer=2.0.5 --force  
   - conda update --yes -n base conda
+  - conda config --add channels conda-forge --force
+  - conda clean --all --yes
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,7 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda config --add channels conda-forge --force
+  - conda clean --all --yes
 #  - conda install --yes conda=4.3.8 --force
 #  - conda install --yes charset-normalizer --force  
 #  - conda update --yes -n base conda

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - conda config --set auto_update_conda false
   - conda config --add channels conda-forge --force
-  - conda install --yes charset-normalizer --force  
+  - conda install --yes conda-forge/win-64::charset-normalizer --force  
   - conda update --yes -n base conda
   - conda install --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64


### PR DESCRIPTION
**Description**
fixes recent CI failures with internal conda errors like  "InvalidVersionSpecError: Invalid version spec =2.7" (see also conda/conda issue 10618) and inability to install the "charset-normalizer" package
**Checklist**
N/A
