### PR TITLE
Fix accuracy issues in the Givens rotations

### DIFF
--- a/BLAS/SRC/crotg.f90
+++ b/BLAS/SRC/crotg.f90
@@ -122,7 +122,7 @@ subroutine CROTG( a, b, c, s )
    complex(wp) :: a, b, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, f2, g1, g2, h2, p, u, uu, v, vv, w
+   real(wp) :: d, f1, f2, g1, g2, h2, w2, u, uu, v, vv, w
    complex(wp) :: f, fs, g, gs, r, t
 !  ..
 !  .. Intrinsic Functions ..
@@ -149,8 +149,7 @@ subroutine CROTG( a, b, c, s )
 !
 !        Use unscaled algorithm
 !
-         g2 = ABSSQ( g )
-         d = sqrt( g2 )
+         d = abs( g )
          s = conjg( g ) / d
          r = d
       else
@@ -160,8 +159,7 @@ subroutine CROTG( a, b, c, s )
          u = min( safmax, max( safmin, g1 ) )
          uu = one / u
          gs = g*uu
-         g2 = ABSSQ( gs )
-         d = sqrt( g2 )
+         d = abs( g2 )
          s = conjg( gs ) / d
          r = d*u
       end if
@@ -176,15 +174,10 @@ subroutine CROTG( a, b, c, s )
          f2 = ABSSQ( f )
          g2 = ABSSQ( g )
          h2 = f2 + g2
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = f2*p
-         s = conjg( g )*( f*p )
-         r = f*( h2*p )
+         d = sqrt( one + ( g2/f2 ) )
+         r = f*d
+         c = one / d
+         s = conjg( g )*( r / h2 )
       else
 !
 !        Use scaled algorithm
@@ -201,27 +194,25 @@ subroutine CROTG( a, b, c, s )
             v = min( safmax, max( safmin, f1 ) )
             vv = one / v
             w = v * uu
+            w2 = w**2
             fs = f*vv
             f2 = ABSSQ( fs )
-            h2 = f2*w**2 + g2
+            h2 = f2*w2 + g2
          else
 !
 !           Otherwise use the same scaling for f and g.
 !
             w = one
+            w2 = one
             fs = f*uu
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = ( f2*p )*w
-         s = conjg( gs )*( fs*p )
-         r = ( fs*( h2*p ) )*u
+         d = sqrt( w2 + ( g2/f2 ) )
+         c = w / d
+         r = fs*d
+         s = conjg( gs )*( r / h2 )
+         r = r*u
       end if
    end if
    a = r

--- a/BLAS/SRC/zrotg.f90
+++ b/BLAS/SRC/zrotg.f90
@@ -122,7 +122,7 @@ subroutine ZROTG( a, b, c, s )
    complex(wp) :: a, b, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, f2, g1, g2, h2, p, u, uu, v, vv, w
+   real(wp) :: d, f1, f2, g1, g2, h2, w2, u, uu, v, vv, w
    complex(wp) :: f, fs, g, gs, r, t
 !  ..
 !  .. Intrinsic Functions ..
@@ -149,8 +149,7 @@ subroutine ZROTG( a, b, c, s )
 !
 !        Use unscaled algorithm
 !
-         g2 = ABSSQ( g )
-         d = sqrt( g2 )
+         d = abs( g )
          s = conjg( g ) / d
          r = d
       else
@@ -160,8 +159,7 @@ subroutine ZROTG( a, b, c, s )
          u = min( safmax, max( safmin, g1 ) )
          uu = one / u
          gs = g*uu
-         g2 = ABSSQ( gs )
-         d = sqrt( g2 )
+         d = abs( g2 )
          s = conjg( gs ) / d
          r = d*u
       end if
@@ -176,15 +174,10 @@ subroutine ZROTG( a, b, c, s )
          f2 = ABSSQ( f )
          g2 = ABSSQ( g )
          h2 = f2 + g2
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = f2*p
-         s = conjg( g )*( f*p )
-         r = f*( h2*p )
+         d = sqrt( one + ( g2/f2 ) )
+         r = f*d
+         c = one / d
+         s = conjg( g )*( r / h2 )
       else
 !
 !        Use scaled algorithm
@@ -201,27 +194,25 @@ subroutine ZROTG( a, b, c, s )
             v = min( safmax, max( safmin, f1 ) )
             vv = one / v
             w = v * uu
+            w2 = w**2
             fs = f*vv
             f2 = ABSSQ( fs )
-            h2 = f2*w**2 + g2
+            h2 = f2*w2 + g2
          else
 !
 !           Otherwise use the same scaling for f and g.
 !
             w = one
+            w2 = one
             fs = f*uu
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = ( f2*p )*w
-         s = conjg( gs )*( fs*p )
-         r = ( fs*( h2*p ) )*u
+         d = sqrt( w2 + ( g2/f2 ) )
+         c = w / d
+         r = fs*d
+         s = conjg( gs )*( r / h2 )
+         r = r*u
       end if
    end if
    a = r

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -129,7 +129,7 @@ subroutine CLARTG( f, g, c, s, r )
    complex(wp)        f, g, r, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, f2, g1, g2, h2, p, u, uu, v, vv, w
+   real(wp) :: d, f1, f2, g1, g2, h2, w2, u, uu, v, vv, w
    complex(wp) :: fs, gs, t
 !  ..
 !  .. Intrinsic Functions ..
@@ -199,19 +199,21 @@ subroutine CLARTG( f, g, c, s, r )
             v = min( safmax, max( safmin, f1 ) )
             vv = one / v
             w = v * uu
+            w2 = w**2
             fs = f*vv
             f2 = ABSSQ( fs )
-            h2 = f2*w**2 + g2
+            h2 = f2*w2 + g2
          else
 !
 !           Otherwise use the same scaling for f and g.
 !
             w = one
+            w2 = one
             fs = f*uu
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
-         d = sqrt( w**2 + ( g2/f2 ) )
+         d = sqrt( w2 + ( g2/f2 ) )
          c = w / d
          r = fs*d
          s = conjg( gs )*( r / h2 )

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -154,8 +154,7 @@ subroutine CLARTG( f, g, c, s, r )
 !
 !        Use unscaled algorithm
 !
-         g2 = ABSSQ( g )
-         d = sqrt( g2 )
+         d = abs( g )
          s = conjg( g ) / d
          r = d
       else
@@ -165,8 +164,7 @@ subroutine CLARTG( f, g, c, s, r )
          u = min( safmax, max( safmin, g1 ) )
          uu = one / u
          gs = g*uu
-         g2 = ABSSQ( gs )
-         d = sqrt( g2 )
+         d = abs( g2 )
          s = conjg( gs ) / d
          r = d*u
       end if
@@ -181,15 +179,10 @@ subroutine CLARTG( f, g, c, s, r )
          f2 = ABSSQ( f )
          g2 = ABSSQ( g )
          h2 = f2 + g2
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = f2*p
-         s = conjg( g )*( f*p )
-         r = f*( h2*p )
+         d = sqrt( one + ( g2/f2 ) )
+         r = f*d
+         c = one / d
+         s = conjg( g )*( r / h2 )
       else
 !
 !        Use scaled algorithm
@@ -218,15 +211,11 @@ subroutine CLARTG( f, g, c, s, r )
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = ( f2*p )*w
-         s = conjg( gs )*( fs*p )
-         r = ( fs*( h2*p ) )*u
+         d = sqrt( w**2 + ( g2/f2 ) )
+         c = w / d
+         r = fs*d
+         s = conjg( gs )*( r / h2 )
+         r = r*u
       end if
    end if
    return

--- a/SRC/zlartg.f90
+++ b/SRC/zlartg.f90
@@ -129,7 +129,7 @@ subroutine ZLARTG( f, g, c, s, r )
    complex(wp)        f, g, r, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, f2, g1, g2, h2, p, u, uu, v, vv, w
+   real(wp) :: d, f1, f2, g1, g2, h2, w2, u, uu, v, vv, w
    complex(wp) :: fs, gs, t
 !  ..
 !  .. Intrinsic Functions ..
@@ -154,8 +154,7 @@ subroutine ZLARTG( f, g, c, s, r )
 !
 !        Use unscaled algorithm
 !
-         g2 = ABSSQ( g )
-         d = sqrt( g2 )
+         d = abs( g )
          s = conjg( g ) / d
          r = d
       else
@@ -165,8 +164,7 @@ subroutine ZLARTG( f, g, c, s, r )
          u = min( safmax, max( safmin, g1 ) )
          uu = one / u
          gs = g*uu
-         g2 = ABSSQ( gs )
-         d = sqrt( g2 )
+         d = abs( g2 )
          s = conjg( gs ) / d
          r = d*u
       end if
@@ -181,15 +179,10 @@ subroutine ZLARTG( f, g, c, s, r )
          f2 = ABSSQ( f )
          g2 = ABSSQ( g )
          h2 = f2 + g2
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = f2*p
-         s = conjg( g )*( f*p )
-         r = f*( h2*p )
+         d = sqrt( one + ( g2/f2 ) )
+         r = f*d
+         c = one / d
+         s = conjg( g )*( r / h2 )
       else
 !
 !        Use scaled algorithm
@@ -206,27 +199,25 @@ subroutine ZLARTG( f, g, c, s, r )
             v = min( safmax, max( safmin, f1 ) )
             vv = one / v
             w = v * uu
+            w2 = w**2
             fs = f*vv
             f2 = ABSSQ( fs )
-            h2 = f2*w**2 + g2
+            h2 = f2*w2 + g2
          else
 !
 !           Otherwise use the same scaling for f and g.
 !
             w = one
+            w2 = one
             fs = f*uu
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
-         else
-            d = sqrt( f2 )*sqrt( h2 )
-         end if
-         p = 1 / d
-         c = ( f2*p )*w
-         s = conjg( gs )*( fs*p )
-         r = ( fs*( h2*p ) )*u
+         d = sqrt( w2 + ( g2/f2 ) )
+         c = w / d
+         r = fs*d
+         s = conjg( gs )*( r / h2 )
+         r = r*u
       end if
    end if
    return


### PR DESCRIPTION
Solves #629

**Description**

@sergey-v-kuznetsov highlighted in #629 that the new Givens rotations operations may have lower accuracy than the ones that were in LAPACK up to release 3.9. In fact, I noticed that | c^2 + s^2 - 1 | (which should be 0) is 3x larger with 3.10 than with 3.9, and so this means that the norm of the 2x2 matrix is 3x further away from 1 with 3.10 than with 3.9. This answers the results @sergey-v-kuznetsov obtained with his [test](https://github.com/Reference-LAPACK/lapack/files/7325814/test.zip).

I kept overall the 3.10 code and changed a few lines to recover the behavior LAPACK 3.9 had. Main changes:
- `g2 = ABSSQ( g ); d = sqrt( g2 )` changed to `d = abs( g )`
- `sqrt( one + ( g2/f2 ) )` instead of `sqrt( f2 * h2 )` or `sqrt( f2 )*sqrt( h2 )`

Here is my modified version of @sergey-v-kuznetsov's test: [test.zip](https://github.com/Reference-LAPACK/lapack/files/7331975/test.zip)

**Checklist**

- [ ] The documentation has been updated.
- [ ] Improve the tests related to the precision of | c^2 + s^2 - 1 |