### PR TITLE
New algorithms for computing Givens rotations

### DIFF
--- a/BLAS/SRC/crotg.f90
+++ b/BLAS/SRC/crotg.f90
@@ -69,7 +69,7 @@
 !
 !> \date December 2021
 !
-!> \ingroup OTHERauxiliary
+!> \ingroup single_blas_level1
 !
 !> \par Further Details:
 !  =====================
@@ -136,24 +136,38 @@ subroutine CROTG( a, b, c, s )
       r = f
    else if( f == czero ) then
       c = zero
-      g1 = max( abs(real(g)), abs(aimag(g)) )
-      rtmax = sqrt( safmax/2 )
-      if( g1 > rtmin .and. g1 < rtmax ) then
+      if( real(g) == zero ) then
+         r = abs(aimag(g))
+         s = conjg( g ) / r
+      elseif( aimag(g) == zero ) then
+         r = abs(real(g))
+         s = conjg( g ) / r
+      else
+         g1 = max( abs(real(g)), abs(aimag(g)) )
+         rtmax = sqrt( safmax/2 )
+         if( g1 > rtmin .and. g1 < rtmax ) then
 !
 !        Use unscaled algorithm
 !
-         d = abs( g )
-         s = conjg( g ) / d
-         r = d
-      else
+!           The following two lines can be replaced by `d = abs( g )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( g )
+            d = sqrt( g2 )
+            s = conjg( g ) / d
+            r = d
+         else
 !
 !        Use scaled algorithm
 !
-         u = min( safmax, max( safmin, g1 ) )
-         gs = g / u
-         d = abs( gs )
-         s = conjg( gs ) / d
-         r = d*u
+            u = min( safmax, max( safmin, g1 ) )
+            gs = g / u
+!           The following two lines can be replaced by `d = abs( gs )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( gs )
+            d = sqrt( g2 )
+            s = conjg( gs ) / d
+            r = d*u
+         end if
       end if
    else
       f1 = max( abs(real(f)), abs(aimag(f)) )
@@ -192,7 +206,7 @@ subroutine CROTG( a, b, c, s )
                r = f / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = f * ( h2 / d )
             end if
             s = conjg( g ) * ( f / d )
@@ -248,7 +262,7 @@ subroutine CROTG( a, b, c, s )
                r = fs / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = fs * ( h2 / d )
             end if
             s = conjg( gs ) * ( fs / d )

--- a/BLAS/SRC/zrotg.f90
+++ b/BLAS/SRC/zrotg.f90
@@ -69,7 +69,7 @@
 !
 !> \date December 2021
 !
-!> \ingroup OTHERauxiliary
+!> \ingroup single_blas_level1
 !
 !> \par Further Details:
 !  =====================
@@ -136,24 +136,38 @@ subroutine ZROTG( a, b, c, s )
       r = f
    else if( f == czero ) then
       c = zero
-      g1 = max( abs(real(g)), abs(aimag(g)) )
-      rtmax = sqrt( safmax/2 )
-      if( g1 > rtmin .and. g1 < rtmax ) then
+      if( real(g) == zero ) then
+         r = abs(aimag(g))
+         s = conjg( g ) / r
+      elseif( aimag(g) == zero ) then
+         r = abs(real(g))
+         s = conjg( g ) / r
+      else
+         g1 = max( abs(real(g)), abs(aimag(g)) )
+         rtmax = sqrt( safmax/2 )
+         if( g1 > rtmin .and. g1 < rtmax ) then
 !
 !        Use unscaled algorithm
 !
-         d = abs( g )
-         s = conjg( g ) / d
-         r = d
-      else
+!           The following two lines can be replaced by `d = abs( g )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( g )
+            d = sqrt( g2 )
+            s = conjg( g ) / d
+            r = d
+         else
 !
 !        Use scaled algorithm
 !
-         u = min( safmax, max( safmin, g1 ) )
-         gs = g / u
-         d = abs( gs )
-         s = conjg( gs ) / d
-         r = d*u
+            u = min( safmax, max( safmin, g1 ) )
+            gs = g / u
+!           The following two lines can be replaced by `d = abs( gs )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( gs )
+            d = sqrt( g2 )
+            s = conjg( gs ) / d
+            r = d*u
+         end if
       end if
    else
       f1 = max( abs(real(f)), abs(aimag(f)) )
@@ -192,7 +206,7 @@ subroutine ZROTG( a, b, c, s )
                r = f / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = f * ( h2 / d )
             end if
             s = conjg( g ) * ( f / d )
@@ -248,7 +262,7 @@ subroutine ZROTG( a, b, c, s )
                r = fs / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = fs * ( h2 / d )
             end if
             s = conjg( gs ) * ( fs / d )

--- a/BLAS/SRC/zrotg.f90
+++ b/BLAS/SRC/zrotg.f90
@@ -1,4 +1,4 @@
-!> \brief \b ZROTG
+!> \brief \b ZROTG  generates a Givens rotation with real cosine and complex sine.
 !
 !  =========== DOCUMENTATION ===========
 !
@@ -24,12 +24,12 @@
 !>           = 1        if x  = 0
 !>    c = |a| / sqrt(|a|**2 + |b|**2)
 !>    s = sgn(a) * conjg(b) / sqrt(|a|**2 + |b|**2)
-!> When a and b are real and r /= 0, the formulas simplify to
 !>    r = sgn(a)*sqrt(|a|**2 + |b|**2)
+!> When a and b are real and r /= 0, the formulas simplify to
 !>    c = a / r
 !>    s = b / r
-!> the same as in ZROTG when |a| > |b|.  When |b| >= |a|, the
-!> sign of c and s will be different from those computed by ZROTG
+!> the same as in DROTG when |a| > |b|.  When |b| >= |a|, the
+!> sign of c and s will be different from those computed by DROTG
 !> if the signs of a and b are not the same.
 !>
 !> \endverbatim
@@ -65,19 +65,18 @@
 !  Authors:
 !  ========
 !
-!> \author Edward Anderson, Lockheed Martin
+!> \author Weslley Pereira, University of Colorado Denver, USA
 !
-!> \par Contributors:
-!  ==================
-!>
-!> Weslley Pereira, University of Colorado Denver, USA
+!> \date December 2021
 !
-!> \ingroup single_blas_level1
+!> \ingroup OTHERauxiliary
 !
 !> \par Further Details:
 !  =====================
 !>
 !> \verbatim
+!>
+!> Based on the algorithm from
 !>
 !>  Anderson E. (2017)
 !>  Algorithm 978: Safe Scaling in the Level 1 BLAS
@@ -108,21 +107,14 @@ subroutine ZROTG( a, b, c, s )
       1-minexponent(0._wp), &
       maxexponent(0._wp)-1 &
    )
-   real(wp), parameter :: rtmin = sqrt( real(radix(0._wp),wp)**max( &
-      minexponent(0._wp)-1, &
-      1-maxexponent(0._wp) &
-   ) / epsilon(0._wp) )
-   real(wp), parameter :: rtmax = sqrt( real(radix(0._wp),wp)**max( &
-      1-minexponent(0._wp), &
-      maxexponent(0._wp)-1 &
-   ) * epsilon(0._wp) )
+   real(wp), parameter :: rtmin = sqrt( safmin )
 !  ..
 !  .. Scalar Arguments ..
    real(wp) :: c
    complex(wp) :: a, b, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, f2, g1, g2, h2, u, v, w
+   real(wp) :: d, f1, f2, g1, g2, h2, u, v, w, rtmax
    complex(wp) :: f, fs, g, gs, r, t
 !  ..
 !  .. Intrinsic Functions ..
@@ -145,6 +137,7 @@ subroutine ZROTG( a, b, c, s )
    else if( f == czero ) then
       c = zero
       g1 = max( abs(real(g)), abs(aimag(g)) )
+      rtmax = sqrt( safmax/2 )
       if( g1 > rtmin .and. g1 < rtmax ) then
 !
 !        Use unscaled algorithm
@@ -165,6 +158,7 @@ subroutine ZROTG( a, b, c, s )
    else
       f1 = max( abs(real(f)), abs(aimag(f)) )
       g1 = max( abs(real(g)), abs(aimag(g)) )
+      rtmax = sqrt( safmax/4 )
       if( f1 > rtmin .and. f1 < rtmax .and. &
           g1 > rtmin .and. g1 < rtmax ) then
 !
@@ -173,14 +167,36 @@ subroutine ZROTG( a, b, c, s )
          f2 = ABSSQ( f )
          g2 = ABSSQ( g )
          h2 = f2 + g2
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
+         ! safmin <= f2 <= h2 <= safmax 
+         if( f2 >= h2 * safmin ) then
+            ! safmin <= f2/h2 <= 1, and h2/f2 is finite
+            c = sqrt( f2 / h2 )
+            r = f / c
+            rtmax = rtmax * 2
+            if( f2 > rtmin .and. h2 < rtmax ) then
+               ! safmin <= sqrt( f2*h2 ) <= safmax
+               s = conjg( g ) * ( f / sqrt( f2*h2 ) )
+            else
+               s = conjg( g ) * ( r / h2 )
+            end if
          else
-            d = sqrt( f2 )*sqrt( h2 )
+            ! f2/h2 <= safmin may be subnormal, and h2/f2 may overflow.
+            ! Moreover,
+            !  safmin <= f2*f2 * safmax < f2 * h2 < h2*h2 * safmin <= safmax,
+            !  sqrt(safmin) <= sqrt(f2 * h2) <= sqrt(safmax).
+            ! Also,
+            !  g2 >> f2, which means that h2 = g2.
+            d = sqrt( f2 * h2 )
+            c = f2 / d
+            if( c >= safmin ) then
+               r = f / c
+            else
+               ! f2 / sqrt(f2 * h2) < safmin, then
+               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               r = f * ( h2 / d )
+            end if
+            s = conjg( g ) * ( f / d )
          end if
-         c = f2 / d
-         s = conjg( g )*( f / d )
-         r = f*( h2 / d )
       else
 !
 !        Use scaled algorithm
@@ -207,14 +223,39 @@ subroutine ZROTG( a, b, c, s )
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
+         ! safmin <= f2 <= h2 <= safmax 
+         if( f2 >= h2 * safmin ) then
+            ! safmin <= f2/h2 <= 1, and h2/f2 is finite
+            c = sqrt( f2 / h2 )
+            r = fs / c
+            rtmax = rtmax * 2
+            if( f2 > rtmin .and. h2 < rtmax ) then
+               ! safmin <= sqrt( f2*h2 ) <= safmax
+               s = conjg( gs ) * ( fs / sqrt( f2*h2 ) )
+            else
+               s = conjg( gs ) * ( r / h2 )
+            end if
          else
-            d = sqrt( f2 )*sqrt( h2 )
+            ! f2/h2 <= safmin may be subnormal, and h2/f2 may overflow.
+            ! Moreover,
+            !  safmin <= f2*f2 * safmax < f2 * h2 < h2*h2 * safmin <= safmax,
+            !  sqrt(safmin) <= sqrt(f2 * h2) <= sqrt(safmax).
+            ! Also,
+            !  g2 >> f2, which means that h2 = g2.
+            d = sqrt( f2 * h2 )
+            c = f2 / d
+            if( c >= safmin ) then
+               r = fs / c
+            else
+               ! f2 / sqrt(f2 * h2) < safmin, then
+               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               r = fs * ( h2 / d )
+            end if
+            s = conjg( gs ) * ( fs / d )
          end if
-         c = ( f2 / d )*w
-         s = conjg( gs )*( fs / d )
-         r = ( fs*( h2 / d ) )*u
+         ! Rescale c and r
+         c = c * w
+         r = r * u
       end if
    end if
    a = r

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -224,7 +224,6 @@ subroutine CLARTG( f, g, c, s, r )
             h2 = f2 + g2
          end if
          if( f2 > safmin * g2 ) then
-            ! Use a precise algorithm
             d = sqrt( w**2 + g2/f2 )
             c = w / d
             if( f2 > rtmin .and. h2 < rtmax ) then

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -233,7 +233,6 @@ subroutine CLARTG( f, g, c, s, r )
          else
             c = ( f2*p )*w
          end if
-         c = ( f2*p )*w
          s = conjg( gs )*( fs*p )
          r = ( fs*( h2*p ) )*u
       end if

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -187,7 +187,11 @@ subroutine CLARTG( f, g, c, s, r )
             d = sqrt( f2 )*sqrt( h2 )
          end if
          p = 1 / d
-         c = f2*p
+         if( f2 > safmin * g2 ) then
+            c = 1 / sqrt( one + g2/f2 )
+         else
+            c = f2*p
+         end if
          s = conjg( g )*( f*p )
          r = f*( h2*p )
       else
@@ -224,6 +228,11 @@ subroutine CLARTG( f, g, c, s, r )
             d = sqrt( f2 )*sqrt( h2 )
          end if
          p = 1 / d
+         if( f2 > safmin * g2 ) then
+            c = (1 / sqrt( one + g2/f2 )) * w
+         else
+            c = ( f2*p )*w
+         end if
          c = ( f2*p )*w
          s = conjg( gs )*( fs*p )
          r = ( fs*( h2*p ) )*u

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -30,7 +30,7 @@
 !> The mathematical formulas used for C and S are
 !>
 !>    sgn(x) = {  x / |x|,   x != 0
-!>             {  1,         x = 0
+!>             {  1,         x  = 0
 !>
 !>    R = sgn(F) * sqrt(|F|**2 + |G|**2)
 !>
@@ -38,19 +38,20 @@
 !>
 !>    S = sgn(F) * conjg(G) / sqrt(|F|**2 + |G|**2)
 !>
+!> Special conditions:
+!>    If G=0, then C=1 and S=0.
+!>    If F=0, then C=0 and S is chosen so that R is real.
+!>
 !> When F and G are real, the formulas simplify to C = F/R and
 !> S = G/R, and the returned values of C, S, and R should be
-!> identical to those returned by CLARTG.
+!> identical to those returned by SLARTG.
 !>
 !> The algorithm used to compute these quantities incorporates scaling
 !> to avoid overflow or underflow in computing the square root of the
 !> sum of squares.
 !>
-!> This is a faster version of the BLAS1 routine CROTG, except for
-!> the following differences:
-!>    F and G are unchanged on return.
-!>    If G=0, then C=1 and S=0.
-!>    If F=0, then C=0 and S is chosen so that R is real.
+!> This is the same routine CROTG fom BLAS1, except that
+!> F and G are unchanged on return.
 !>
 !> Below, wp=>sp stands for single precision from LA_CONSTANTS module.
 !> \endverbatim
@@ -91,21 +92,18 @@
 !  Authors:
 !  ========
 !
-!> \author Edward Anderson, Lockheed Martin
+!> \author Weslley Pereira, University of Colorado Denver, USA
 !
-!> \date August 2016
+!> \date December 2021
 !
 !> \ingroup OTHERauxiliary
-!
-!> \par Contributors:
-!  ==================
-!>
-!> Weslley Pereira, University of Colorado Denver, USA
 !
 !> \par Further Details:
 !  =====================
 !>
 !> \verbatim
+!>
+!> Based on the algorithm from
 !>
 !>  Anderson E. (2017)
 !>  Algorithm 978: Safe Scaling in the Level 1 BLAS

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -150,24 +150,38 @@ subroutine CLARTG( f, g, c, s, r )
       r = f
    else if( f == czero ) then
       c = zero
-      g1 = max( abs(real(g)), abs(aimag(g)) )
-      rtmax = sqrt( safmax/2 )
-      if( g1 > rtmin .and. g1 < rtmax ) then
+      if( real(g) == zero ) then
+         r = abs(aimag(g))
+         s = conjg( g ) / r
+      elseif( aimag(g) == zero ) then
+         r = abs(real(g))
+         s = conjg( g ) / r
+      else
+         g1 = max( abs(real(g)), abs(aimag(g)) )
+         rtmax = sqrt( safmax/2 )
+         if( g1 > rtmin .and. g1 < rtmax ) then
 !
 !        Use unscaled algorithm
 !
-         d = abs( g )
-         s = conjg( g ) / d
-         r = d
-      else
+!           The following two lines can be replaced by `d = abs( g )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( g )
+            d = sqrt( g2 )
+            s = conjg( g ) / d
+            r = d
+         else
 !
 !        Use scaled algorithm
 !
-         u = min( safmax, max( safmin, g1 ) )
-         gs = g / u
-         d = abs( gs )
-         s = conjg( gs ) / d
-         r = d*u
+            u = min( safmax, max( safmin, g1 ) )
+            gs = g / u
+!           The following two lines can be replaced by `d = abs( gs )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( gs )
+            d = sqrt( g2 )
+            s = conjg( gs ) / d
+            r = d*u
+         end if
       end if
    else
       f1 = max( abs(real(f)), abs(aimag(f)) )
@@ -206,7 +220,7 @@ subroutine CLARTG( f, g, c, s, r )
                r = f / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = f * ( h2 / d )
             end if
             s = conjg( g ) * ( f / d )
@@ -262,7 +276,7 @@ subroutine CLARTG( f, g, c, s, r )
                r = fs / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = fs * ( h2 / d )
             end if
             s = conjg( gs ) * ( fs / d )

--- a/SRC/dlartg.f90
+++ b/SRC/dlartg.f90
@@ -11,7 +11,7 @@
 !       SUBROUTINE DLARTG( F, G, C, S, R )
 !
 !       .. Scalar Arguments ..
-!       REAL(wp)      C, F, G, R, S
+!       REAL(wp)          C, F, G, R, S
 !       ..
 !
 !> \par Purpose:
@@ -37,15 +37,13 @@
 !> This version is discontinuous in R at F = 0 but it returns the same
 !> C and S as ZLARTG for complex inputs (F,0) and (G,0).
 !>
-!> This is a more accurate version of the BLAS1 routine DROTG,
+!> This is a more accurate version of the BLAS1 routine SROTG,
 !> with the following other differences:
 !>    F and G are unchanged on return.
 !>    If G=0, then C=1 and S=0.
 !>    If F=0 and (G .ne. 0), then C=0 and S=sign(1,G) without doing any
 !>       floating point operations (saves work in DBDSQR when
 !>       there are zeros on the diagonal).
-!>
-!> If F exceeds G in magnitude, C will be positive.
 !>
 !> Below, wp=>dp stands for double precision from LA_CONSTANTS module.
 !> \endverbatim
@@ -112,7 +110,7 @@
 subroutine DLARTG( f, g, c, s, r )
    use LA_CONSTANTS, &
    only: wp=>dp, zero=>dzero, half=>dhalf, one=>done, &
-         rtmin=>drtmin, rtmax=>drtmax, safmin=>dsafmin, safmax=>dsafmax
+         safmin=>dsafmin, safmax=>dsafmax
 !
 !  -- LAPACK auxiliary routine (version 3.10.0) --
 !  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -123,10 +121,14 @@ subroutine DLARTG( f, g, c, s, r )
    real(wp) :: c, f, g, r, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, fs, g1, gs, u
+   real(wp) :: d, f1, fs, g1, gs, u, rtmin, rtmax
 !  ..
 !  .. Intrinsic Functions ..
    intrinsic :: abs, sign, sqrt
+!  ..
+!  .. Constants ..
+   rtmin = sqrt( safmin )
+   rtmax = sqrt( safmax/2 )
 !  ..
 !  .. Executable Statements ..
 !
@@ -154,7 +156,7 @@ subroutine DLARTG( f, g, c, s, r )
       c = abs( fs ) / d
       r = sign( d, f )
       s = gs / r
-      r = r * u
+      r = r*u
    end if
    return
 end subroutine

--- a/SRC/dlartg.f90
+++ b/SRC/dlartg.f90
@@ -37,7 +37,7 @@
 !> This version is discontinuous in R at F = 0 but it returns the same
 !> C and S as ZLARTG for complex inputs (F,0) and (G,0).
 !>
-!> This is a more accurate version of the BLAS1 routine SROTG,
+!> This is a more accurate version of the BLAS1 routine DROTG,
 !> with the following other differences:
 !>    F and G are unchanged on return.
 !>    If G=0, then C=1 and S=0.

--- a/SRC/slartg.f90
+++ b/SRC/slartg.f90
@@ -35,7 +35,7 @@
 !> square root of the sum of squares.
 !>
 !> This version is discontinuous in R at F = 0 but it returns the same
-!> C and S as SLARTG for complex inputs (F,0) and (G,0).
+!> C and S as CLARTG for complex inputs (F,0) and (G,0).
 !>
 !> This is a more accurate version of the BLAS1 routine SROTG,
 !> with the following other differences:
@@ -44,8 +44,6 @@
 !>    If F=0 and (G .ne. 0), then C=0 and S=sign(1,G) without doing any
 !>       floating point operations (saves work in SBDSQR when
 !>       there are zeros on the diagonal).
-!>
-!> If F exceeds G in magnitude, C will be positive.
 !>
 !> Below, wp=>sp stands for single precision from LA_CONSTANTS module.
 !> \endverbatim
@@ -112,7 +110,7 @@
 subroutine SLARTG( f, g, c, s, r )
    use LA_CONSTANTS, &
    only: wp=>sp, zero=>szero, half=>shalf, one=>sone, &
-         rtmin=>srtmin, rtmax=>srtmax, safmin=>ssafmin, safmax=>ssafmax
+         safmin=>ssafmin, safmax=>ssafmax
 !
 !  -- LAPACK auxiliary routine (version 3.10.0) --
 !  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -123,10 +121,14 @@ subroutine SLARTG( f, g, c, s, r )
    real(wp) :: c, f, g, r, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, fs, g1, gs, u
+   real(wp) :: d, f1, fs, g1, gs, u, rtmin, rtmax
 !  ..
 !  .. Intrinsic Functions ..
    intrinsic :: abs, sign, sqrt
+!  ..
+!  .. Constants ..
+   rtmin = sqrt( safmin )
+   rtmax = sqrt( safmax/2 )
 !  ..
 !  .. Executable Statements ..
 !

--- a/SRC/zlartg.f90
+++ b/SRC/zlartg.f90
@@ -150,24 +150,38 @@ subroutine ZLARTG( f, g, c, s, r )
       r = f
    else if( f == czero ) then
       c = zero
-      g1 = max( abs(real(g)), abs(aimag(g)) )
-      rtmax = sqrt( safmax/2 )
-      if( g1 > rtmin .and. g1 < rtmax ) then
+      if( real(g) == zero ) then
+         r = abs(aimag(g))
+         s = conjg( g ) / r
+      elseif( aimag(g) == zero ) then
+         r = abs(real(g))
+         s = conjg( g ) / r
+      else
+         g1 = max( abs(real(g)), abs(aimag(g)) )
+         rtmax = sqrt( safmax/2 )
+         if( g1 > rtmin .and. g1 < rtmax ) then
 !
 !        Use unscaled algorithm
 !
-         d = abs( g )
-         s = conjg( g ) / d
-         r = d
-      else
+!           The following two lines can be replaced by `d = abs( g )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( g )
+            d = sqrt( g2 )
+            s = conjg( g ) / d
+            r = d
+         else
 !
 !        Use scaled algorithm
 !
-         u = min( safmax, max( safmin, g1 ) )
-         gs = g / u
-         d = abs( gs )
-         s = conjg( gs ) / d
-         r = d*u
+            u = min( safmax, max( safmin, g1 ) )
+            gs = g / u
+!           The following two lines can be replaced by `d = abs( gs )`.
+!           This algorithm do not use the intrinsic complex abs.
+            g2 = ABSSQ( gs )
+            d = sqrt( g2 )
+            s = conjg( gs ) / d
+            r = d*u
+         end if
       end if
    else
       f1 = max( abs(real(f)), abs(aimag(f)) )
@@ -206,7 +220,7 @@ subroutine ZLARTG( f, g, c, s, r )
                r = f / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = f * ( h2 / d )
             end if
             s = conjg( g ) * ( f / d )
@@ -262,7 +276,7 @@ subroutine ZLARTG( f, g, c, s, r )
                r = fs / c
             else
                ! f2 / sqrt(f2 * h2) < safmin, then
-               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = fs * ( h2 / d )
             end if
             s = conjg( gs ) * ( fs / d )

--- a/SRC/zlartg.f90
+++ b/SRC/zlartg.f90
@@ -11,8 +11,8 @@
 !       SUBROUTINE ZLARTG( F, G, C, S, R )
 !
 !       .. Scalar Arguments ..
-!       REAL(wp)           C
-!       COMPLEX(wp)        F, G, R, S
+!       REAL(wp)              C
+!       COMPLEX(wp)           F, G, R, S
 !       ..
 !
 !> \par Purpose:
@@ -30,13 +30,17 @@
 !> The mathematical formulas used for C and S are
 !>
 !>    sgn(x) = {  x / |x|,   x != 0
-!>             {  1,         x = 0
+!>             {  1,         x  = 0
 !>
 !>    R = sgn(F) * sqrt(|F|**2 + |G|**2)
 !>
 !>    C = |F| / sqrt(|F|**2 + |G|**2)
 !>
 !>    S = sgn(F) * conjg(G) / sqrt(|F|**2 + |G|**2)
+!>
+!> Special conditions:
+!>    If G=0, then C=1 and S=0.
+!>    If F=0, then C=0 and S is chosen so that R is real.
 !>
 !> When F and G are real, the formulas simplify to C = F/R and
 !> S = G/R, and the returned values of C, S, and R should be
@@ -46,11 +50,8 @@
 !> to avoid overflow or underflow in computing the square root of the
 !> sum of squares.
 !>
-!> This is a faster version of the BLAS1 routine ZROTG, except for
-!> the following differences:
-!>    F and G are unchanged on return.
-!>    If G=0, then C=1 and S=0.
-!>    If F=0, then C=0 and S is chosen so that R is real.
+!> This is the same routine CROTG fom BLAS1, except that
+!> F and G are unchanged on return.
 !>
 !> Below, wp=>dp stands for double precision from LA_CONSTANTS module.
 !> \endverbatim
@@ -91,21 +92,18 @@
 !  Authors:
 !  ========
 !
-!> \author Edward Anderson, Lockheed Martin
+!> \author Weslley Pereira, University of Colorado Denver, USA
 !
-!> \date August 2016
+!> \date December 2021
 !
 !> \ingroup OTHERauxiliary
-!
-!> \par Contributors:
-!  ==================
-!>
-!> Weslley Pereira, University of Colorado Denver, USA
 !
 !> \par Further Details:
 !  =====================
 !>
 !> \verbatim
+!>
+!> Based on the algorithm from
 !>
 !>  Anderson E. (2017)
 !>  Algorithm 978: Safe Scaling in the Level 1 BLAS
@@ -117,7 +115,7 @@
 subroutine ZLARTG( f, g, c, s, r )
    use LA_CONSTANTS, &
    only: wp=>dp, zero=>dzero, one=>done, two=>dtwo, czero=>zzero, &
-         rtmin=>drtmin, rtmax=>drtmax, safmin=>dsafmin, safmax=>dsafmax
+         safmin=>dsafmin, safmax=>dsafmax
 !
 !  -- LAPACK auxiliary routine (version 3.10.0) --
 !  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -129,7 +127,7 @@ subroutine ZLARTG( f, g, c, s, r )
    complex(wp)        f, g, r, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, f2, g1, g2, h2, u, v, w
+   real(wp) :: d, f1, f2, g1, g2, h2, u, v, w, rtmin, rtmax
    complex(wp) :: fs, gs, t
 !  ..
 !  .. Intrinsic Functions ..
@@ -141,6 +139,9 @@ subroutine ZLARTG( f, g, c, s, r )
 !  .. Statement Function definitions ..
    ABSSQ( t ) = real( t )**2 + aimag( t )**2
 !  ..
+!  .. Constants ..
+   rtmin = sqrt( safmin )
+!  ..
 !  .. Executable Statements ..
 !
    if( g == czero ) then
@@ -150,6 +151,7 @@ subroutine ZLARTG( f, g, c, s, r )
    else if( f == czero ) then
       c = zero
       g1 = max( abs(real(g)), abs(aimag(g)) )
+      rtmax = sqrt( safmax/2 )
       if( g1 > rtmin .and. g1 < rtmax ) then
 !
 !        Use unscaled algorithm
@@ -170,6 +172,7 @@ subroutine ZLARTG( f, g, c, s, r )
    else
       f1 = max( abs(real(f)), abs(aimag(f)) )
       g1 = max( abs(real(g)), abs(aimag(g)) )
+      rtmax = sqrt( safmax/4 )
       if( f1 > rtmin .and. f1 < rtmax .and. &
           g1 > rtmin .and. g1 < rtmax ) then
 !
@@ -178,14 +181,36 @@ subroutine ZLARTG( f, g, c, s, r )
          f2 = ABSSQ( f )
          g2 = ABSSQ( g )
          h2 = f2 + g2
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
+         ! safmin <= f2 <= h2 <= safmax 
+         if( f2 >= h2 * safmin ) then
+            ! safmin <= f2/h2 <= 1, and h2/f2 is finite
+            c = sqrt( f2 / h2 )
+            r = f / c
+            rtmax = rtmax * 2
+            if( f2 > rtmin .and. h2 < rtmax ) then
+               ! safmin <= sqrt( f2*h2 ) <= safmax
+               s = conjg( g ) * ( f / sqrt( f2*h2 ) )
+            else
+               s = conjg( g ) * ( r / h2 )
+            end if
          else
-            d = sqrt( f2 )*sqrt( h2 )
+            ! f2/h2 <= safmin may be subnormal, and h2/f2 may overflow.
+            ! Moreover,
+            !  safmin <= f2*f2 * safmax < f2 * h2 < h2*h2 * safmin <= safmax,
+            !  sqrt(safmin) <= sqrt(f2 * h2) <= sqrt(safmax).
+            ! Also,
+            !  g2 >> f2, which means that h2 = g2.
+            d = sqrt( f2 * h2 )
+            c = f2 / d
+            if( c >= safmin ) then
+               r = f / c
+            else
+               ! f2 / sqrt(f2 * h2) < safmin, then
+               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               r = f * ( h2 / d )
+            end if
+            s = conjg( g ) * ( f / d )
          end if
-         c = f2 / d
-         s = conjg( g )*( f / d )
-         r = f*( h2 / d )
       else
 !
 !        Use scaled algorithm
@@ -212,14 +237,39 @@ subroutine ZLARTG( f, g, c, s, r )
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
-         if( f2 > rtmin .and. h2 < rtmax ) then
-            d = sqrt( f2*h2 )
+         ! safmin <= f2 <= h2 <= safmax 
+         if( f2 >= h2 * safmin ) then
+            ! safmin <= f2/h2 <= 1, and h2/f2 is finite
+            c = sqrt( f2 / h2 )
+            r = fs / c
+            rtmax = rtmax * 2
+            if( f2 > rtmin .and. h2 < rtmax ) then
+               ! safmin <= sqrt( f2*h2 ) <= safmax
+               s = conjg( gs ) * ( fs / sqrt( f2*h2 ) )
+            else
+               s = conjg( gs ) * ( r / h2 )
+            end if
          else
-            d = sqrt( f2 )*sqrt( h2 )
+            ! f2/h2 <= safmin may be subnormal, and h2/f2 may overflow.
+            ! Moreover,
+            !  safmin <= f2*f2 * safmax < f2 * h2 < h2*h2 * safmin <= safmax,
+            !  sqrt(safmin) <= sqrt(f2 * h2) <= sqrt(safmax).
+            ! Also,
+            !  g2 >> f2, which means that h2 = g2.
+            d = sqrt( f2 * h2 )
+            c = f2 / d
+            if( c >= safmin ) then
+               r = fs / c
+            else
+               ! f2 / sqrt(f2 * h2) < safmin, then
+               !  h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
+               r = fs * ( h2 / d )
+            end if
+            s = conjg( gs ) * ( fs / d )
          end if
-         c = ( f2 / d )*w
-         s = conjg( gs )*( fs / d )
-         r = ( fs*( h2 / d ) )*u
+         ! Rescale c and r
+         c = c * w
+         r = r * u
       end if
    end if
    return

--- a/SRC/zlartg.f90
+++ b/SRC/zlartg.f90
@@ -129,7 +129,7 @@ subroutine ZLARTG( f, g, c, s, r )
    complex(wp)        f, g, r, s
 !  ..
 !  .. Local Scalars ..
-   real(wp) :: d, f1, f2, g1, g2, h2, p, u, uu, v, vv, w
+   real(wp) :: d, f1, f2, g1, g2, h2, u, v, w
    complex(wp) :: fs, gs, t
 !  ..
 !  .. Intrinsic Functions ..
@@ -154,8 +154,7 @@ subroutine ZLARTG( f, g, c, s, r )
 !
 !        Use unscaled algorithm
 !
-         g2 = ABSSQ( g )
-         d = sqrt( g2 )
+         d = abs( g )
          s = conjg( g ) / d
          r = d
       else
@@ -163,10 +162,8 @@ subroutine ZLARTG( f, g, c, s, r )
 !        Use scaled algorithm
 !
          u = min( safmax, max( safmin, g1 ) )
-         uu = one / u
-         gs = g*uu
-         g2 = ABSSQ( gs )
-         d = sqrt( g2 )
+         gs = g / u
+         d = abs( gs )
          s = conjg( gs ) / d
          r = d*u
       end if
@@ -186,27 +183,24 @@ subroutine ZLARTG( f, g, c, s, r )
          else
             d = sqrt( f2 )*sqrt( h2 )
          end if
-         p = 1 / d
-         c = f2*p
-         s = conjg( g )*( f*p )
-         r = f*( h2*p )
+         c = f2 / d
+         s = conjg( g )*( f / d )
+         r = f*( h2 / d )
       else
 !
 !        Use scaled algorithm
 !
          u = min( safmax, max( safmin, f1, g1 ) )
-         uu = one / u
-         gs = g*uu
+         gs = g / u
          g2 = ABSSQ( gs )
-         if( f1*uu < rtmin ) then
+         if( f1 < rtmin*u ) then
 !
 !           f is not well-scaled when scaled by g1.
 !           Use a different scaling for f.
 !
             v = min( safmax, max( safmin, f1 ) )
-            vv = one / v
-            w = v * uu
-            fs = f*vv
+            w = v / u
+            fs = f / v
             f2 = ABSSQ( fs )
             h2 = f2*w**2 + g2
          else
@@ -214,7 +208,7 @@ subroutine ZLARTG( f, g, c, s, r )
 !           Otherwise use the same scaling for f and g.
 !
             w = one
-            fs = f*uu
+            fs = f / u
             f2 = ABSSQ( fs )
             h2 = f2 + g2
          end if
@@ -223,10 +217,9 @@ subroutine ZLARTG( f, g, c, s, r )
          else
             d = sqrt( f2 )*sqrt( h2 )
          end if
-         p = 1 / d
-         c = ( f2*p )*w
-         s = conjg( gs )*( fs*p )
-         r = ( fs*( h2*p ) )*u
+         c = ( f2 / d )*w
+         s = conjg( gs )*( fs / d )
+         r = ( fs*( h2 / d ) )*u
       end if
    end if
    return

--- a/SRC/zlartg.f90
+++ b/SRC/zlartg.f90
@@ -50,7 +50,7 @@
 !> to avoid overflow or underflow in computing the square root of the
 !> sum of squares.
 !>
-!> This is the same routine CROTG fom BLAS1, except that
+!> This is the same routine ZROTG fom BLAS1, except that
 !> F and G are unchanged on return.
 !>
 !> Below, wp=>dp stands for double precision from LA_CONSTANTS module.


### PR DESCRIPTION
Closes #629

New algorithms for computing Givens rotations
---------------------------------------------

@sergey-v-kuznetsov highlighted in #629 that the new Givens rotations operations may have lower accuracy than the ones that were in LAPACK up to release 3.9. This was verified after applying several rotations to a initial unitary matrix. This PR proposes:

1. A new algorithm for computing complex Givens rotations.
2. A slight modification in the algorithms for computing real-valued Givens rotations.

Both modifications target the improvement of the output's accuracy.

@langou and I are preparing a report with the numerical analysis and experiments comparing the different algorithms for computing Givens rotations. We will share the document here when it is ready to review. 

**Minor modifications**

1. Use `rtmin = sqrt( safmin )` instead of `rtmin = sqrt( safmin / epsilon )`. The first condition is sufficient to guarantee all real variables used in the intermediate steps of the new algorithm belong to the interval `[safmin,safmax]`.
2. Set `rtmax` to either `sqrt( safmin/4 )`, `sqrt( safmin/2 )` or `sqrt( safmin )`. This variable depends on where it is in the algorithm. The value is the maximum possible in order that all real variables used in the intermediate steps of the new algorithm belong to the interval `[safmin,safmax]`.
3. Eliminate the intermediate computations like `p = one / d`, `uu = one / u` and `vv = one / v`. These operations reduce the number of divisions in the code at the cost of possibly increasing the accumulation error. I am trying to improve accuracy, so I remove the intermediate operations at the cost of having additional floating-point divisions.
4. When `f = 0`, check if `real(g) == 0` or `aimag(g) == 0` to avoid unnecessary `ABSSQ( g ); sqrt( g2 )`. This change reduces the accumulation error when `real(g) == 0` (analogously `aimag(g) == 0`) and `aimag(g)**2` (analogously `real(g)**2`) cannot be stored in the respective finite precision. We choose not to use the intrinsic complex `abs` because its implementation is compiler-dependent.

**Major changes**

The algorithm for computing complex Givens rotations was revisited. This is the new code in `(c,z)ROTG` and `(c,z)LARTG` for the unscaled part:

```f90
f2 = ABSSQ( f )
g2 = ABSSQ( g )
h2 = f2 + g2
! safmin <= f2 <= h2 <= safmax 
if( f2 >= h2 * safmin ) then
    ! safmin <= f2/h2 <= 1, and h2/f2 is finite
    c = sqrt( f2 / h2 )
    r = f / c
    rtmax = rtmax * 2
    if( f2 > rtmin .and. h2 < rtmax ) then
        ! safmin <= sqrt( f2*h2 ) <= safmax
        s = conjg( g ) * ( f / sqrt( f2*h2 ) )
    else
        s = conjg( g ) * ( r / h2 )
    end if
else
    ! f2/h2 <= safmin may be subnormal, and h2/f2 may overflow.
    ! Moreover,
    !  safmin <= f2*f2 * safmax < f2 * h2 < h2*h2 * safmin <= safmax,
    !  sqrt(safmin) <= sqrt(f2 * h2) <= sqrt(safmax).
    ! Also,
    !  g2 >> f2, which means that h2 = g2.
    d = sqrt( f2 * h2 )
    c = f2 / d
    if( c >= safmin ) then
        r = f / c
    else
        ! f2 / sqrt(f2 * h2) < safmin, then
        !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
        r = f * ( h2 / d )
    end if
    s = conjg( g ) * ( f / d )
end if
```

- The worst-case scenario analysis shows this algorithm is more accurate than both the algorithms from 3.9.1 and 3.10.0.
- All real variables used in intermediate computations belong to the interval `[safmin,safmax]`.

**Acknowledgements**

Thanks to people that contributed in the discussions about this code:
- @sergey-v-kuznetsov, @ecanesc, @alilotfi90 and @langou,
- People from @BallisticLA team, especially prof. Jim Demmel.

**Checklist**

- [x] The documentation has been updated.
- [ ] Time measurements.