### PR TITLE
Standardized documentation

### DIFF
--- a/SRC/cgbrfsx.f
+++ b/SRC/cgbrfsx.f
@@ -350,7 +350,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/cgbsvxx.f
+++ b/SRC/cgbsvxx.f
@@ -473,7 +473,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/cgelq.f
+++ b/SRC/cgelq.f
@@ -53,7 +53,7 @@
 *>          On exit, the elements on and below the diagonal of the array
 *>          contain the M-by-min(M,N) lower trapezoidal matrix L
 *>          (L is lower triangular if M <= N);
-*>          the elements above the diagonal are used to store part of the 
+*>          the elements above the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -66,10 +66,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is COMPLEX array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -81,15 +81,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -105,7 +106,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -130,15 +131,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any LQ factorization algorithm they wish. The triangular 
+*> creating any LQ factorization algorithm they wish. The triangular
 *> (trapezoidal) L has to be stored in the lower part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -148,7 +149,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/cgemlq.f
+++ b/SRC/cgemlq.f
@@ -110,7 +110,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK
@@ -119,7 +120,7 @@
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -143,7 +144,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.
@@ -159,7 +160,7 @@
 *>  block sizes MB and NB returned by ILAENV, CGELQ will use either
 *>  CLASWLQ (if the matrix is wide-and-short) or CGELQT to compute
 *>  the LQ factorization.
-*>  This version of CGEMLQ will use either CLAMSWLQ or CGEMLQT to 
+*>  This version of CGEMLQ will use either CLAMSWLQ or CGEMLQT to
 *>  multiply matrix Q by another matrix.
 *>  Further Details in CLAMSWLQ or CGEMLQT.
 *> \endverbatim

--- a/SRC/cgemqr.f
+++ b/SRC/cgemqr.f
@@ -111,7 +111,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK
@@ -120,7 +121,7 @@
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -144,7 +145,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/cgeqr.f
+++ b/SRC/cgeqr.f
@@ -54,7 +54,7 @@
 *>          On exit, the elements on and above the diagonal of the array
 *>          contain the min(M,N)-by-N upper trapezoidal matrix R
 *>          (R is upper triangular if M >= N);
-*>          the elements below the diagonal are used to store part of the 
+*>          the elements below the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -67,10 +67,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is COMPLEX array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -82,15 +82,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -106,7 +107,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -131,15 +132,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any QR factorization algorithm they wish. The triangular 
+*> creating any QR factorization algorithm they wish. The triangular
 *> (trapezoidal) R has to be stored in the upper part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -149,7 +150,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/cgerfsx.f
+++ b/SRC/cgerfsx.f
@@ -325,7 +325,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/cgesc2.f
+++ b/SRC/cgesc2.f
@@ -68,7 +68,7 @@
 *>
 *> \param[in,out] RHS
 *> \verbatim
-*>          RHS is COMPLEX array, dimension N.
+*>          RHS is COMPLEX array, dimension (N)
 *>          On entry, the right hand side vector b.
 *>          On exit, the solution vector X.
 *> \endverbatim

--- a/SRC/cgesvdq.f
+++ b/SRC/cgesvdq.f
@@ -148,7 +148,7 @@
 *>
 *> \param[in] LDA
 *> \verbatim
-*>          LDA is INTEGER.
+*>          LDA is INTEGER
 *>          The leading dimension of the array A.  LDA >= max(1,M).
 *> \endverbatim
 *>
@@ -173,7 +173,7 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER.
+*>          LDU is INTEGER
 *>          The leading dimension of the array U.
 *>          If JOBU = 'A', 'S', 'U', 'R',  LDU >= max(1,M).
 *>          If JOBU = 'F',                 LDU >= max(1,N).
@@ -325,7 +325,7 @@
 *>
 *> \param[in] LRWORK
 *> \verbatim
-*>          LRWORK is INTEGER.
+*>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>          If JOBP ='P', then LRWORK >= MAX(2, M, 5*N);
 *>          Otherwise, LRWORK >= MAX(2, 5*N).

--- a/SRC/cgesvdq.f
+++ b/SRC/cgesvdq.f
@@ -154,7 +154,7 @@
 *>
 *> \param[out] S
 *> \verbatim
-*>          S is REAL array of dimension N.
+*>          S is REAL array of dimension (N)
 *>          The singular values of A, ordered so that S(i) >= S(i+1).
 *> \endverbatim
 *>

--- a/SRC/cgesvj.f
+++ b/SRC/cgesvj.f
@@ -215,7 +215,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
-*>          LWORK is INTEGER.
+*>          LWORK is INTEGER
 *>          Length of CWORK, LWORK >= M+N.
 *> \endverbatim
 *>

--- a/SRC/cgesvxx.f
+++ b/SRC/cgesvxx.f
@@ -453,7 +453,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/cgetsls.f
+++ b/SRC/cgetsls.f
@@ -118,7 +118,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -131,7 +132,7 @@
 *>          If LWORK = -1 or -2, then a workspace query is assumed.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>

--- a/SRC/cgetsqrhrt.f
+++ b/SRC/cgetsqrhrt.f
@@ -131,6 +131,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= MAX( LWT + LW1, MAX( LWT+N*N+LW2, LWT+N*N+N ) ),
 *>          where

--- a/SRC/cgetsqrhrt.f
+++ b/SRC/cgetsqrhrt.f
@@ -124,7 +124,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/chbev_2stage.f
+++ b/SRC/chbev_2stage.f
@@ -124,7 +124,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX array, dimension LWORK
+*>          WORK is COMPLEX array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/cherfsx.f
+++ b/SRC/cherfsx.f
@@ -312,7 +312,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/chesvxx.f
+++ b/SRC/chesvxx.f
@@ -420,7 +420,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/clalsa.f
+++ b/SRC/clalsa.f
@@ -122,7 +122,8 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER, LDU = > N.
+*>         LDU is INTEGER
+*>         LDU = > N.
 *>         The leading dimension of arrays U, VT, DIFL, DIFR,
 *>         POLES, GIVNUM, and Z.
 *> \endverbatim
@@ -189,7 +190,8 @@
 *>
 *> \param[in] LDGCOL
 *> \verbatim
-*>          LDGCOL is INTEGER, LDGCOL = > N.
+*>         LDGCOL is INTEGER
+*>         LDGCOL = > N.
 *>         The leading dimension of arrays GIVCOL and PERM.
 *> \endverbatim
 *>

--- a/SRC/clamswlq.f
+++ b/SRC/clamswlq.f
@@ -129,7 +129,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK

--- a/SRC/clamtsqr.f
+++ b/SRC/clamtsqr.f
@@ -129,8 +129,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX array, dimension (MAX(1,LWORK))
-*>
+*>         WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/claqr0.f
+++ b/SRC/claqr0.f
@@ -150,7 +150,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX array, dimension LWORK
+*>          WORK is COMPLEX array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/claqr4.f
+++ b/SRC/claqr4.f
@@ -158,7 +158,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX array, dimension LWORK
+*>          WORK is COMPLEX array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/claswlq.f
+++ b/SRC/claswlq.f
@@ -104,6 +104,7 @@
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= MB*M.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/claswlq.f
+++ b/SRC/claswlq.f
@@ -99,8 +99,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX array, dimension (MAX(1,LWORK))
-*>
+*>         WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/clatsqr.f
+++ b/SRC/clatsqr.f
@@ -107,6 +107,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= NB*N.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/clatsqr.f
+++ b/SRC/clatsqr.f
@@ -101,7 +101,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK

--- a/SRC/cporfsx.f
+++ b/SRC/cporfsx.f
@@ -304,7 +304,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/cposvxx.f
+++ b/SRC/cposvxx.f
@@ -407,7 +407,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/csyrfsx.f
+++ b/SRC/csyrfsx.f
@@ -313,7 +313,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/csysvxx.f
+++ b/SRC/csysvxx.f
@@ -420,7 +420,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/cungtsqr.f
+++ b/SRC/cungtsqr.f
@@ -134,6 +134,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= (M+NB)*N.
 *>          If LWORK = -1, then a workspace query is assumed.
 *>          The routine only calculates the optimal size of the WORK

--- a/SRC/cungtsqr.f
+++ b/SRC/cungtsqr.f
@@ -127,7 +127,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX array, dimension (MAX(2,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(2,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/cungtsqr_row.f
+++ b/SRC/cungtsqr_row.f
@@ -145,6 +145,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= NBLOCAL * MAX(NBLOCAL,(N-NBLOCAL)),
 *>          where NBLOCAL=MIN(NB,N).

--- a/SRC/cungtsqr_row.f
+++ b/SRC/cungtsqr_row.f
@@ -138,7 +138,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/cunm22.f
+++ b/SRC/cunm22.f
@@ -82,11 +82,18 @@
 *> \endverbatim
 *>
 *> \param[in] N1
+*> \verbatim
+*>          N1 is INTEGER
+*>          The dimension of Q12. N1 >= 0.
+*>          The following requirement must be satisfied:
+*>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
+*> \endverbatim
+*>
 *> \param[in] N2
 *> \verbatim
 *>          N1 is INTEGER
 *>          N2 is INTEGER
-*>          The dimension of Q12 and Q21, respectively. N1, N2 >= 0.
+*>          The dimension of Q21. N2 >= 0.
 *>          The following requirement must be satisfied:
 *>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
 *> \endverbatim

--- a/SRC/dgelq.f
+++ b/SRC/dgelq.f
@@ -53,7 +53,7 @@
 *>          On exit, the elements on and below the diagonal of the array
 *>          contain the M-by-min(M,N) lower trapezoidal matrix L
 *>          (L is lower triangular if M <= N);
-*>          the elements above the diagonal are used to store part of the 
+*>          the elements above the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -66,10 +66,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is DOUBLE PRECISION array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -81,15 +81,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -105,7 +106,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -130,15 +131,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any LQ factorization algorithm they wish. The triangular 
+*> creating any LQ factorization algorithm they wish. The triangular
 *> (trapezoidal) L has to be stored in the lower part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -148,7 +149,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/dgemlq.f
+++ b/SRC/dgemlq.f
@@ -111,7 +111,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK
@@ -120,7 +121,7 @@
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -144,7 +145,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.
@@ -160,7 +161,7 @@
 *>  block sizes MB and NB returned by ILAENV, DGELQ will use either
 *>  DLASWLQ (if the matrix is wide-and-short) or DGELQT to compute
 *>  the LQ factorization.
-*>  This version of DGEMLQ will use either DLAMSWLQ or DGEMLQT to 
+*>  This version of DGEMLQ will use either DLAMSWLQ or DGEMLQT to
 *>  multiply matrix Q by another matrix.
 *>  Further Details in DLAMSWLQ or DGEMLQT.
 *> \endverbatim

--- a/SRC/dgemqr.f
+++ b/SRC/dgemqr.f
@@ -111,7 +111,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK
@@ -120,7 +121,7 @@
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -144,7 +145,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.
@@ -160,7 +161,7 @@
 *>  block sizes MB and NB returned by ILAENV, DGEQR will use either
 *>  DLATSQR (if the matrix is tall-and-skinny) or DGEQRT to compute
 *>  the QR factorization.
-*>  This version of DGEMQR will use either DLAMTSQR or DGEMQRT to 
+*>  This version of DGEMQR will use either DLAMTSQR or DGEMQRT to
 *>  multiply matrix Q by another matrix.
 *>  Further Details in DLATMSQR or DGEMQRT.
 *>

--- a/SRC/dgeqr.f
+++ b/SRC/dgeqr.f
@@ -54,7 +54,7 @@
 *>          On exit, the elements on and above the diagonal of the array
 *>          contain the min(M,N)-by-N upper trapezoidal matrix R
 *>          (R is upper triangular if M >= N);
-*>          the elements below the diagonal are used to store part of the 
+*>          the elements below the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -67,10 +67,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is DOUBLE PRECISION array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -82,15 +82,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -106,7 +107,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -131,15 +132,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any QR factorization algorithm they wish. The triangular 
+*> creating any QR factorization algorithm they wish. The triangular
 *> (trapezoidal) R has to be stored in the upper part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -149,7 +150,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/dgesvdq.f
+++ b/SRC/dgesvdq.f
@@ -148,7 +148,7 @@
 *>
 *> \param[in] LDA
 *> \verbatim
-*>          LDA is INTEGER.
+*>          LDA is INTEGER
 *>          The leading dimension of the array A.  LDA >= max(1,M).
 *> \endverbatim
 *>
@@ -173,7 +173,7 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER.
+*>          LDU is INTEGER
 *>          The leading dimension of the array U.
 *>          If JOBU = 'A', 'S', 'U', 'R',  LDU >= max(1,M).
 *>          If JOBU = 'F',                 LDU >= max(1,N).
@@ -327,7 +327,7 @@
 *>
 *> \param[in] LRWORK
 *> \verbatim
-*>          LRWORK is INTEGER.
+*>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>          If JOBP ='P', then LRWORK >= MAX(2, M).
 *>          Otherwise, LRWORK >= 2

--- a/SRC/dgesvdq.f
+++ b/SRC/dgesvdq.f
@@ -154,7 +154,7 @@
 *>
 *> \param[out] S
 *> \verbatim
-*>          S is DOUBLE PRECISION array of dimension N.
+*>          S is DOUBLE PRECISION array of dimension (N)
 *>          The singular values of A, ordered so that S(i) >= S(i+1).
 *> \endverbatim
 *>

--- a/SRC/dgetsls.f
+++ b/SRC/dgetsls.f
@@ -118,7 +118,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -131,7 +132,7 @@
 *>          If LWORK = -1 or -2, then a workspace query is assumed.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>

--- a/SRC/dgetsqrhrt.f
+++ b/SRC/dgetsqrhrt.f
@@ -124,7 +124,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/dgetsqrhrt.f
+++ b/SRC/dgetsqrhrt.f
@@ -131,6 +131,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= MAX( LWT + LW1, MAX( LWT+N*N+LW2, LWT+N*N+N ) ),
 *>          where

--- a/SRC/dlalsa.f
+++ b/SRC/dlalsa.f
@@ -123,7 +123,8 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER, LDU = > N.
+*>         LDU is INTEGER
+*>         LDU = > N.
 *>         The leading dimension of arrays U, VT, DIFL, DIFR,
 *>         POLES, GIVNUM, and Z.
 *> \endverbatim
@@ -190,7 +191,8 @@
 *>
 *> \param[in] LDGCOL
 *> \verbatim
-*>          LDGCOL is INTEGER, LDGCOL = > N.
+*>         LDGCOL is INTEGER
+*>         LDGCOL = > N.
 *>         The leading dimension of arrays GIVCOL and PERM.
 *> \endverbatim
 *>

--- a/SRC/dlamswlq.f
+++ b/SRC/dlamswlq.f
@@ -129,7 +129,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK

--- a/SRC/dlamtsqr.f
+++ b/SRC/dlamtsqr.f
@@ -129,8 +129,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
-*>
+*>         WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/dlaqr0.f
+++ b/SRC/dlaqr0.f
@@ -166,7 +166,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is DOUBLE PRECISION array, dimension LWORK
+*>          WORK is DOUBLE PRECISION array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/dlaqr4.f
+++ b/SRC/dlaqr4.f
@@ -173,7 +173,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is DOUBLE PRECISION array, dimension LWORK
+*>          WORK is DOUBLE PRECISION array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/dlasda.f
+++ b/SRC/dlasda.f
@@ -111,7 +111,8 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER, LDU = > N.
+*>         LDU is INTEGER
+*>         LDU => N.
 *>         The leading dimension of arrays U, VT, DIFL, DIFR, POLES,
 *>         GIVNUM, and Z.
 *> \endverbatim
@@ -191,7 +192,8 @@
 *>
 *> \param[in] LDGCOL
 *> \verbatim
-*>          LDGCOL is INTEGER, LDGCOL = > N.
+*>         LDGCOL is INTEGER
+*>         LDGCOL = > N.
 *>         The leading dimension of arrays GIVCOL and PERM.
 *> \endverbatim
 *>

--- a/SRC/dlaswlq.f
+++ b/SRC/dlaswlq.f
@@ -104,6 +104,7 @@
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= MB*M.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/dlaswlq.f
+++ b/SRC/dlaswlq.f
@@ -99,8 +99,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
-*>
+*>         WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/dlatsqr.f
+++ b/SRC/dlatsqr.f
@@ -101,7 +101,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK

--- a/SRC/dlatsqr.f
+++ b/SRC/dlatsqr.f
@@ -107,6 +107,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= NB*N.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/dorgtsqr.f
+++ b/SRC/dorgtsqr.f
@@ -134,6 +134,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= (M+NB)*N.
 *>          If LWORK = -1, then a workspace query is assumed.
 *>          The routine only calculates the optimal size of the WORK

--- a/SRC/dorgtsqr.f
+++ b/SRC/dorgtsqr.f
@@ -127,7 +127,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) DOUBLE PRECISION array, dimension (MAX(2,LWORK))
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(2,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/dorgtsqr_row.f
+++ b/SRC/dorgtsqr_row.f
@@ -145,6 +145,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= NBLOCAL * MAX(NBLOCAL,(N-NBLOCAL)),
 *>          where NBLOCAL=MIN(NB,N).

--- a/SRC/dorgtsqr_row.f
+++ b/SRC/dorgtsqr_row.f
@@ -138,7 +138,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/dorm22.f
+++ b/SRC/dorm22.f
@@ -83,11 +83,17 @@
 *> \endverbatim
 *>
 *> \param[in] N1
+*> \verbatim
+*>          N1 is INTEGER
+*>          The dimension of Q12. N1 >= 0.
+*>          The following requirement must be satisfied:
+*>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
+*> \endverbatim
+*>
 *> \param[in] N2
 *> \verbatim
 *>          N1 is INTEGER
-*>          N2 is INTEGER
-*>          The dimension of Q12 and Q21, respectively. N1, N2 >= 0.
+*>          The dimension of Q21. N2 >= 0.
 *>          The following requirement must be satisfied:
 *>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
 *> \endverbatim

--- a/SRC/dposvxx.f
+++ b/SRC/dposvxx.f
@@ -408,7 +408,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/dsbev_2stage.f
+++ b/SRC/dsbev_2stage.f
@@ -123,7 +123,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is DOUBLE PRECISION array, dimension LWORK
+*>          WORK is DOUBLE PRECISION array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/dsbevd_2stage.f
+++ b/SRC/dsbevd_2stage.f
@@ -132,7 +132,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is DOUBLE PRECISION array, dimension LWORK
+*>          WORK is DOUBLE PRECISION array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/dsyev_2stage.f
+++ b/SRC/dsyev_2stage.f
@@ -97,7 +97,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is DOUBLE PRECISION array, dimension LWORK
+*>          WORK is DOUBLE PRECISION array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/dtgex2.f
+++ b/SRC/dtgex2.f
@@ -77,7 +77,7 @@
 *>
 *> \param[in,out] A
 *> \verbatim
-*>          A is DOUBLE PRECISION array, dimensions (LDA,N)
+*>          A is DOUBLE PRECISION array, dimension (LDA,N)
 *>          On entry, the matrix A in the pair (A, B).
 *>          On exit, the updated matrix A.
 *> \endverbatim
@@ -90,7 +90,7 @@
 *>
 *> \param[in,out] B
 *> \verbatim
-*>          B is DOUBLE PRECISION array, dimensions (LDB,N)
+*>          B is DOUBLE PRECISION array, dimension (LDB,N)
 *>          On entry, the matrix B in the pair (A, B).
 *>          On exit, the updated matrix B.
 *> \endverbatim

--- a/SRC/sgbrfsx.f
+++ b/SRC/sgbrfsx.f
@@ -350,7 +350,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/sgbsvxx.f
+++ b/SRC/sgbsvxx.f
@@ -473,7 +473,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/sgelq.f
+++ b/SRC/sgelq.f
@@ -53,7 +53,7 @@
 *>          On exit, the elements on and below the diagonal of the array
 *>          contain the M-by-min(M,N) lower trapezoidal matrix L
 *>          (L is lower triangular if M <= N);
-*>          the elements above the diagonal are used to store part of the 
+*>          the elements above the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -66,10 +66,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is REAL array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -81,15 +81,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) REAL array, dimension (MAX(1,LWORK))
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -105,7 +106,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -130,15 +131,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any LQ factorization algorithm they wish. The triangular 
+*> creating any LQ factorization algorithm they wish. The triangular
 *> (trapezoidal) L has to be stored in the lower part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -148,7 +149,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/sgemlq.f
+++ b/SRC/sgemlq.f
@@ -110,7 +110,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) REAL array, dimension (MAX(1,LWORK))
+*>         WORK is REAL array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK
@@ -119,7 +120,7 @@
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -143,7 +144,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.
@@ -159,7 +160,7 @@
 *>  block sizes MB and NB returned by ILAENV, SGELQ will use either
 *>  SLASWLQ (if the matrix is wide-and-short) or SGELQT to compute
 *>  the LQ factorization.
-*>  This version of SGEMLQ will use either SLAMSWLQ or SGEMLQT to 
+*>  This version of SGEMLQ will use either SLAMSWLQ or SGEMLQT to
 *>  multiply matrix Q by another matrix.
 *>  Further Details in SLAMSWLQ or SGEMLQT.
 *> \endverbatim

--- a/SRC/sgemqr.f
+++ b/SRC/sgemqr.f
@@ -111,7 +111,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) REAL array, dimension (MAX(1,LWORK))
+*>         WORK is REAL array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK
@@ -120,7 +121,7 @@
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -144,7 +145,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.
@@ -160,7 +161,7 @@
 *>  block sizes MB and NB returned by ILAENV, SGEQR will use either
 *>  SLATSQR (if the matrix is tall-and-skinny) or SGEQRT to compute
 *>  the QR factorization.
-*>  This version of SGEMQR will use either SLAMTSQR or SGEMQRT to 
+*>  This version of SGEMQR will use either SLAMTSQR or SGEMQRT to
 *>  multiply matrix Q by another matrix.
 *>  Further Details in SLAMTSQR or SGEMQRT.
 *>

--- a/SRC/sgeqr.f
+++ b/SRC/sgeqr.f
@@ -54,7 +54,7 @@
 *>          On exit, the elements on and above the diagonal of the array
 *>          contain the min(M,N)-by-N upper trapezoidal matrix R
 *>          (R is upper triangular if M >= N);
-*>          the elements below the diagonal are used to store part of the 
+*>          the elements below the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -67,10 +67,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is REAL array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -82,15 +82,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) REAL array, dimension (MAX(1,LWORK))
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -106,7 +107,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -131,15 +132,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any QR factorization algorithm they wish. The triangular 
+*> creating any QR factorization algorithm they wish. The triangular
 *> (trapezoidal) R has to be stored in the upper part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -149,7 +150,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/sgerfsx.f
+++ b/SRC/sgerfsx.f
@@ -325,7 +325,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/sgesvdq.f
+++ b/SRC/sgesvdq.f
@@ -148,7 +148,7 @@
 *>
 *> \param[in] LDA
 *> \verbatim
-*>          LDA is INTEGER.
+*>          LDA is INTEGER
 *>          The leading dimension of the array A.  LDA >= max(1,M).
 *> \endverbatim
 *>
@@ -173,7 +173,7 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER.
+*>          LDU is INTEGER
 *>          The leading dimension of the array U.
 *>          If JOBU = 'A', 'S', 'U', 'R',  LDU >= max(1,M).
 *>          If JOBU = 'F',                 LDU >= max(1,N).
@@ -327,7 +327,7 @@
 *>
 *> \param[in] LRWORK
 *> \verbatim
-*>          LRWORK is INTEGER.
+*>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>          If JOBP ='P', then LRWORK >= MAX(2, M).
 *>          Otherwise, LRWORK >= 2

--- a/SRC/sgesvdq.f
+++ b/SRC/sgesvdq.f
@@ -154,7 +154,7 @@
 *>
 *> \param[out] S
 *> \verbatim
-*>          S is REAL array of dimension N.
+*>          S is REAL array of dimension (N)
 *>          The singular values of A, ordered so that S(i) >= S(i+1).
 *> \endverbatim
 *>

--- a/SRC/sgesvxx.f
+++ b/SRC/sgesvxx.f
@@ -453,7 +453,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/sgetsls.f
+++ b/SRC/sgetsls.f
@@ -118,7 +118,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) REAL array, dimension (MAX(1,LWORK))
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -131,7 +132,7 @@
 *>          If LWORK = -1 or -2, then a workspace query is assumed.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>

--- a/SRC/sgetsqrhrt.f
+++ b/SRC/sgetsqrhrt.f
@@ -124,7 +124,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) REAL array, dimension (MAX(1,LWORK))
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/sgetsqrhrt.f
+++ b/SRC/sgetsqrhrt.f
@@ -131,6 +131,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= MAX( LWT + LW1, MAX( LWT+N*N+LW2, LWT+N*N+N ) ),
 *>          where

--- a/SRC/slalsa.f
+++ b/SRC/slalsa.f
@@ -123,7 +123,8 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER, LDU = > N.
+*>         LDU is INTEGER
+*>         LDU = > N.
 *>         The leading dimension of arrays U, VT, DIFL, DIFR,
 *>         POLES, GIVNUM, and Z.
 *> \endverbatim
@@ -190,7 +191,8 @@
 *>
 *> \param[in] LDGCOL
 *> \verbatim
-*>          LDGCOL is INTEGER, LDGCOL = > N.
+*>         LDGCOL is INTEGER
+*>         LDGCOL = > N.
 *>         The leading dimension of arrays GIVCOL and PERM.
 *> \endverbatim
 *>

--- a/SRC/slamswlq.f
+++ b/SRC/slamswlq.f
@@ -129,7 +129,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) REAL array, dimension (MAX(1,LWORK))
+*>         WORK is REAL array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK

--- a/SRC/slamtsqr.f
+++ b/SRC/slamtsqr.f
@@ -129,8 +129,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) REAL array, dimension (MAX(1,LWORK))
-*>
+*>         WORK is REAL array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/slaqr0.f
+++ b/SRC/slaqr0.f
@@ -166,7 +166,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension LWORK
+*>          WORK is REAL array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/slaqr4.f
+++ b/SRC/slaqr4.f
@@ -173,7 +173,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension LWORK
+*>          WORK is REAL array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/slasda.f
+++ b/SRC/slasda.f
@@ -111,7 +111,8 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER, LDU = > N.
+*>         LDU is INTEGER
+*>         LDU = > N.
 *>         The leading dimension of arrays U, VT, DIFL, DIFR, POLES,
 *>         GIVNUM, and Z.
 *> \endverbatim
@@ -191,7 +192,8 @@
 *>
 *> \param[in] LDGCOL
 *> \verbatim
-*>          LDGCOL is INTEGER, LDGCOL = > N.
+*>         LDGCOL is INTEGER
+*>         LDGCOL = > N.
 *>         The leading dimension of arrays GIVCOL and PERM.
 *> \endverbatim
 *>

--- a/SRC/slaswlq.f
+++ b/SRC/slaswlq.f
@@ -104,6 +104,7 @@
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= MB * M.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/slaswlq.f
+++ b/SRC/slaswlq.f
@@ -99,8 +99,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) REAL array, dimension (MAX(1,LWORK))
-*>
+*>         WORK is REAL array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/slatdf.f
+++ b/SRC/slatdf.f
@@ -82,7 +82,7 @@
 *>
 *> \param[in,out] RHS
 *> \verbatim
-*>          RHS is REAL array, dimension N.
+*>          RHS is REAL array, dimension (N)
 *>          On entry, RHS contains contributions from other subsystems.
 *>          On exit, RHS contains the solution of the subsystem with
 *>          entries according to the value of IJOB (see above).

--- a/SRC/slatsqr.f
+++ b/SRC/slatsqr.f
@@ -101,7 +101,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) REAL array, dimension (MAX(1,LWORK))
+*>         WORK is REAL array, dimension (MAX(1,LWORK))
+*>         workspace
 *> \endverbatim
 *>
 *> \param[in] LWORK

--- a/SRC/slatsqr.f
+++ b/SRC/slatsqr.f
@@ -107,6 +107,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= NB*N.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/sorgtsqr.f
+++ b/SRC/sorgtsqr.f
@@ -134,6 +134,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= (M+NB)*N.
 *>          If LWORK = -1, then a workspace query is assumed.
 *>          The routine only calculates the optimal size of the WORK

--- a/SRC/sorgtsqr.f
+++ b/SRC/sorgtsqr.f
@@ -127,7 +127,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) REAL array, dimension (MAX(2,LWORK))
+*>          WORK is REAL array, dimension (MAX(2,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/sorgtsqr_row.f
+++ b/SRC/sorgtsqr_row.f
@@ -145,6 +145,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= NBLOCAL * MAX(NBLOCAL,(N-NBLOCAL)),
 *>          where NBLOCAL=MIN(NB,N).

--- a/SRC/sorgtsqr_row.f
+++ b/SRC/sorgtsqr_row.f
@@ -138,7 +138,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) REAL array, dimension (MAX(1,LWORK))
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/sorm22.f
+++ b/SRC/sorm22.f
@@ -83,11 +83,17 @@
 *> \endverbatim
 *>
 *> \param[in] N1
-*> \param[in] N2
 *> \verbatim
 *>          N1 is INTEGER
+*>          The dimension of Q12. N1 >= 0.
+*>          The following requirement must be satisfied:
+*>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
+*> \endverbatim
+*>
+*> \param[in] N2
+*> \verbatim
 *>          N2 is INTEGER
-*>          The dimension of Q12 and Q21, respectively. N1, N2 >= 0.
+*>          The dimension of Q21. N2 >= 0.
 *>          The following requirement must be satisfied:
 *>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
 *> \endverbatim

--- a/SRC/sporfsx.f
+++ b/SRC/sporfsx.f
@@ -305,7 +305,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/sposvxx.f
+++ b/SRC/sposvxx.f
@@ -408,7 +408,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/ssbev_2stage.f
+++ b/SRC/ssbev_2stage.f
@@ -123,7 +123,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension LWORK
+*>          WORK is REAL array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/ssbevd_2stage.f
+++ b/SRC/ssbevd_2stage.f
@@ -132,7 +132,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension LWORK
+*>          WORK is REAL array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/ssyev_2stage.f
+++ b/SRC/ssyev_2stage.f
@@ -97,7 +97,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension LWORK
+*>          WORK is REAL array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/ssyrfsx.f
+++ b/SRC/ssyrfsx.f
@@ -313,7 +313,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/ssysvxx.f
+++ b/SRC/ssysvxx.f
@@ -419,7 +419,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is REAL array, dimension NPARAMS
+*>          PARAMS is REAL array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zgbrfsx.f
+++ b/SRC/zgbrfsx.f
@@ -350,7 +350,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zgbsvxx.f
+++ b/SRC/zgbsvxx.f
@@ -473,7 +473,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zgelq.f
+++ b/SRC/zgelq.f
@@ -53,7 +53,7 @@
 *>          On exit, the elements on and below the diagonal of the array
 *>          contain the M-by-min(M,N) lower trapezoidal matrix L
 *>          (L is lower triangular if M <= N);
-*>          the elements above the diagonal are used to store part of the 
+*>          the elements above the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -66,10 +66,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is COMPLEX*16 array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -81,15 +81,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -105,7 +106,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -130,15 +131,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any LQ factorization algorithm they wish. The triangular 
+*> creating any LQ factorization algorithm they wish. The triangular
 *> (trapezoidal) L has to be stored in the lower part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -148,7 +149,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/zgemlq.f
+++ b/SRC/zgemlq.f
@@ -109,16 +109,16 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
-*> \endverbatim
-*>
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
+*> \endverbatim*>
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -142,7 +142,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.
@@ -158,7 +158,7 @@
 *>  block sizes MB and NB returned by ILAENV, ZGELQ will use either
 *>  ZLASWLQ (if the matrix is wide-and-short) or ZGELQT to compute
 *>  the LQ factorization.
-*>  This version of ZGEMLQ will use either ZLAMSWLQ or ZGEMLQT to 
+*>  This version of ZGEMLQ will use either ZLAMSWLQ or ZGEMLQT to
 *>  multiply matrix Q by another matrix.
 *>  Further Details in ZLAMSWLQ or ZGEMLQT.
 *> \endverbatim

--- a/SRC/zgemqr.f
+++ b/SRC/zgemqr.f
@@ -111,16 +111,16 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
-*> \endverbatim
-*>
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
+*> \endverbatim*>
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          If LWORK = -1, then a workspace query is assumed. The routine
 *>          only calculates the size of the WORK array, returns this
-*>          value as WORK(1), and no error message related to WORK 
+*>          value as WORK(1), and no error message related to WORK
 *>          is issued by XERBLA.
 *> \endverbatim
 *>
@@ -144,7 +144,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/zgeqr.f
+++ b/SRC/zgeqr.f
@@ -54,7 +54,7 @@
 *>          On exit, the elements on and above the diagonal of the array
 *>          contain the min(M,N)-by-N upper trapezoidal matrix R
 *>          (R is upper triangular if M >= N);
-*>          the elements below the diagonal are used to store part of the 
+*>          the elements below the diagonal are used to store part of the
 *>          data structure to represent Q.
 *> \endverbatim
 *>
@@ -67,10 +67,10 @@
 *> \param[out] T
 *> \verbatim
 *>          T is COMPLEX*16 array, dimension (MAX(5,TSIZE))
-*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal 
+*>          On exit, if INFO = 0, T(1) returns optimal (or either minimal
 *>          or optimal, if query is assumed) TSIZE. See TSIZE for details.
 *>          Remaining T contains part of the data structure used to represent Q.
-*>          If one wants to apply or construct Q, then one needs to keep T 
+*>          If one wants to apply or construct Q, then one needs to keep T
 *>          (in addition to A) and pass it to further subroutines.
 *> \endverbatim
 *>
@@ -82,15 +82,16 @@
 *>          only calculates the sizes of the T and WORK arrays, returns these
 *>          values as the first entries of the T and WORK arrays, and no error
 *>          message related to T or WORK is issued by XERBLA.
-*>          If TSIZE = -1, the routine calculates optimal size of T for the 
+*>          If TSIZE = -1, the routine calculates optimal size of T for the
 *>          optimum performance and returns this value in T(1).
-*>          If TSIZE = -2, the routine calculates minimal size of T and 
+*>          If TSIZE = -2, the routine calculates minimal size of T and
 *>          returns this value in T(1).
 *> \endverbatim
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -106,7 +107,7 @@
 *>          message related to T or WORK is issued by XERBLA.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>
@@ -131,15 +132,15 @@
 *> \verbatim
 *>
 *> The goal of the interface is to give maximum freedom to the developers for
-*> creating any QR factorization algorithm they wish. The triangular 
+*> creating any QR factorization algorithm they wish. The triangular
 *> (trapezoidal) R has to be stored in the upper part of A. The lower part of A
 *> and the array T can be used to store any relevant information for applying or
 *> constructing the Q factor. The WORK array can safely be discarded after exit.
 *>
-*> Caution: One should not expect the sizes of T and WORK to be the same from one 
+*> Caution: One should not expect the sizes of T and WORK to be the same from one
 *> LAPACK implementation to the other, or even from one execution to the other.
-*> A workspace query (for T and WORK) is needed at each execution. However, 
-*> for a given execution, the size of T and WORK are fixed and will not change 
+*> A workspace query (for T and WORK) is needed at each execution. However,
+*> for a given execution, the size of T and WORK are fixed and will not change
 *> from one query to the next.
 *>
 *> \endverbatim
@@ -149,7 +150,7 @@
 *>
 *> \verbatim
 *>
-*> These details are particular for this LAPACK implementation. Users should not 
+*> These details are particular for this LAPACK implementation. Users should not
 *> take them for granted. These details may change in the future, and are not likely
 *> true for another LAPACK implementation. These details are relevant if one wants
 *> to try to understand the code. They are not part of the interface.

--- a/SRC/zgerfsx.f
+++ b/SRC/zgerfsx.f
@@ -325,7 +325,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zgesc2.f
+++ b/SRC/zgesc2.f
@@ -68,7 +68,7 @@
 *>
 *> \param[in,out] RHS
 *> \verbatim
-*>          RHS is COMPLEX*16 array, dimension N.
+*>          RHS is COMPLEX*16 array, dimension (N)
 *>          On entry, the right hand side vector b.
 *>          On exit, the solution vector X.
 *> \endverbatim

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -51,8 +51,8 @@
 *> left and the right singular vectors of A, respectively.
 *> \endverbatim
 *
-*  Arguments
-*  =========
+*  Arguments:
+*  ==========
 *
 *> \param[in] JOBA
 *> \verbatim

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -238,7 +238,7 @@
 *>
 *> \param[out] CWORK
 *> \verbatim
-*>          CWORK is COMPLEX*12 array, dimension (max(2, LCWORK)), used as a workspace.
+*>          CWORK is COMPLEX*16 array, dimension (max(2, LCWORK)), used as a workspace.
 *>          On exit, if, on entry, LCWORK.NE.-1, CWORK(1:N) contains parameters
 *>          needed to recover the Q factor from the QR factorization computed by
 *>          ZGEQP3.

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -148,7 +148,7 @@
 *>
 *> \param[in] LDA
 *> \verbatim
-*>          LDA is INTEGER.
+*>          LDA is INTEGER
 *>          The leading dimension of the array A.  LDA >= max(1,M).
 *> \endverbatim
 *>
@@ -173,7 +173,7 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER.
+*>          LDU is INTEGER
 *>          The leading dimension of the array U.
 *>          If JOBU = 'A', 'S', 'U', 'R',  LDU >= max(1,M).
 *>          If JOBU = 'F',                 LDU >= max(1,N).
@@ -325,7 +325,7 @@
 *>
 *> \param[in] LRWORK
 *> \verbatim
-*>          LRWORK is INTEGER.
+*>          LRWORK is INTEGER
 *>          The dimension of the array RWORK.
 *>          If JOBP ='P', then LRWORK >= MAX(2, M, 5*N);
 *>          Otherwise, LRWORK >= MAX(2, 5*N).

--- a/SRC/zgesvdq.f
+++ b/SRC/zgesvdq.f
@@ -154,7 +154,7 @@
 *>
 *> \param[out] S
 *> \verbatim
-*>          S is DOUBLE PRECISION array of dimension N.
+*>          S is DOUBLE PRECISION array of dimension (N)
 *>          The singular values of A, ordered so that S(i) >= S(i+1).
 *> \endverbatim
 *>

--- a/SRC/zgesvj.f
+++ b/SRC/zgesvj.f
@@ -215,7 +215,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
-*>          LWORK is INTEGER.
+*>          LWORK is INTEGER
 *>          Length of CWORK, LWORK >= M+N.
 *> \endverbatim
 *>

--- a/SRC/zgesvxx.f
+++ b/SRC/zgesvxx.f
@@ -453,7 +453,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zgetsls.f
+++ b/SRC/zgetsls.f
@@ -118,7 +118,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) contains optimal (or either minimal
 *>          or optimal, if query was assumed) LWORK.
 *>          See LWORK for details.
@@ -131,7 +132,7 @@
 *>          If LWORK = -1 or -2, then a workspace query is assumed.
 *>          If LWORK = -1, the routine calculates optimal size of WORK for the
 *>          optimal performance and returns this value in WORK(1).
-*>          If LWORK = -2, the routine calculates minimal size of WORK and 
+*>          If LWORK = -2, the routine calculates minimal size of WORK and
 *>          returns this value in WORK(1).
 *> \endverbatim
 *>

--- a/SRC/zgetsqrhrt.f
+++ b/SRC/zgetsqrhrt.f
@@ -124,7 +124,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/zgetsqrhrt.f
+++ b/SRC/zgetsqrhrt.f
@@ -131,6 +131,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= MAX( LWT + LW1, MAX( LWT+N*N+LW2, LWT+N*N+N ) ),
 *>          where

--- a/SRC/zhbev_2stage.f
+++ b/SRC/zhbev_2stage.f
@@ -124,7 +124,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX*16 array, dimension LWORK
+*>          WORK is COMPLEX*16 array, dimension (LWORK)
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/zherfsx.f
+++ b/SRC/zherfsx.f
@@ -312,7 +312,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zhesvxx.f
+++ b/SRC/zhesvxx.f
@@ -420,7 +420,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zlalsa.f
+++ b/SRC/zlalsa.f
@@ -122,7 +122,8 @@
 *>
 *> \param[in] LDU
 *> \verbatim
-*>          LDU is INTEGER, LDU = > N.
+*>         LDU is INTEGER
+*>         LDU = > N.
 *>         The leading dimension of arrays U, VT, DIFL, DIFR,
 *>         POLES, GIVNUM, and Z.
 *> \endverbatim
@@ -189,7 +190,8 @@
 *>
 *> \param[in] LDGCOL
 *> \verbatim
-*>          LDGCOL is INTEGER, LDGCOL = > N.
+*>         LDGCOL is INTEGER
+*>         LDGCOL = > N.
 *>         The leading dimension of arrays GIVCOL and PERM.
 *> \endverbatim
 *>

--- a/SRC/zlamswlq.f
+++ b/SRC/zlamswlq.f
@@ -129,9 +129,9 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
-*> \endverbatim
-*>
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
+*> \endverbatim*>
 *> \param[in] LWORK
 *> \verbatim
 *>          LWORK is INTEGER

--- a/SRC/zlamtsqr.f
+++ b/SRC/zlamtsqr.f
@@ -129,8 +129,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
-*>
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/zlaqr0.f
+++ b/SRC/zlaqr0.f
@@ -151,7 +151,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX*16 array, dimension LWORK
+*>          WORK is COMPLEX*16 array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/zlaqr4.f
+++ b/SRC/zlaqr4.f
@@ -157,7 +157,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX*16 array, dimension LWORK
+*>          WORK is COMPLEX*16 array, dimension (LWORK)
 *>           On exit, if LWORK = -1, WORK(1) returns an estimate of
 *>           the optimal value for LWORK.
 *> \endverbatim

--- a/SRC/zlaswlq.f
+++ b/SRC/zlaswlq.f
@@ -104,6 +104,7 @@
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= MB*M.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/zlaswlq.f
+++ b/SRC/zlaswlq.f
@@ -99,8 +99,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
-*>
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
 *> \endverbatim
 *> \param[in] LWORK
 *> \verbatim

--- a/SRC/zlatsqr.f
+++ b/SRC/zlatsqr.f
@@ -106,6 +106,7 @@
 *> \endverbatim*>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= NB*N.
 *>          If LWORK = -1, then a workspace query is assumed; the routine
 *>          only calculates the optimal size of the WORK array, returns

--- a/SRC/zlatsqr.f
+++ b/SRC/zlatsqr.f
@@ -101,9 +101,9 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>         (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
-*> \endverbatim
-*>
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
+*> \endverbatim*>
 *> \param[in] LWORK
 *> \verbatim
 *>          The dimension of the array WORK.  LWORK >= NB*N.

--- a/SRC/zporfsx.f
+++ b/SRC/zporfsx.f
@@ -304,7 +304,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zposvxx.f
+++ b/SRC/zposvxx.f
@@ -407,7 +407,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zsyrfsx.f
+++ b/SRC/zsyrfsx.f
@@ -313,7 +313,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/zsysvxx.f
+++ b/SRC/zsysvxx.f
@@ -420,7 +420,7 @@
 *>
 *> \param[in,out] PARAMS
 *> \verbatim
-*>          PARAMS is DOUBLE PRECISION array, dimension NPARAMS
+*>          PARAMS is DOUBLE PRECISION array, dimension (NPARAMS)
 *>     Specifies algorithm parameters.  If an entry is < 0.0, then
 *>     that entry will be filled with default value used for that
 *>     parameter.  Only positions up to NPARAMS are accessed; defaults

--- a/SRC/ztgex2.f
+++ b/SRC/ztgex2.f
@@ -76,7 +76,7 @@
 *>
 *> \param[in,out] A
 *> \verbatim
-*>          A is COMPLEX*16 array, dimensions (LDA,N)
+*>          A is COMPLEX*16 array, dimension (LDA,N)
 *>          On entry, the matrix A in the pair (A, B).
 *>          On exit, the updated matrix A.
 *> \endverbatim
@@ -89,7 +89,7 @@
 *>
 *> \param[in,out] B
 *> \verbatim
-*>          B is COMPLEX*16 array, dimensions (LDB,N)
+*>          B is COMPLEX*16 array, dimension (LDB,N)
 *>          On entry, the matrix B in the pair (A, B).
 *>          On exit, the updated matrix B.
 *> \endverbatim

--- a/SRC/zungtsqr.f
+++ b/SRC/zungtsqr.f
@@ -134,6 +134,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.  LWORK >= (M+NB)*N.
 *>          If LWORK = -1, then a workspace query is assumed.
 *>          The routine only calculates the optimal size of the WORK

--- a/SRC/zungtsqr.f
+++ b/SRC/zungtsqr.f
@@ -127,7 +127,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX*16 array, dimension (MAX(2,LWORK))
+*>          WORK is COMPLEX*16 array, dimension (MAX(2,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/zungtsqr_row.f
+++ b/SRC/zungtsqr_row.f
@@ -145,6 +145,7 @@
 *>
 *> \param[in] LWORK
 *> \verbatim
+*>          LWORK is INTEGER
 *>          The dimension of the array WORK.
 *>          LWORK >= NBLOCAL * MAX(NBLOCAL,(N-NBLOCAL)),
 *>          where NBLOCAL=MIN(NB,N).

--- a/SRC/zungtsqr_row.f
+++ b/SRC/zungtsqr_row.f
@@ -138,7 +138,8 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          (workspace) COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          workspace
 *>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
 *> \endverbatim
 *>

--- a/SRC/zunm22.f
+++ b/SRC/zunm22.f
@@ -82,11 +82,17 @@
 *> \endverbatim
 *>
 *> \param[in] N1
-*> \param[in] N2
 *> \verbatim
 *>          N1 is INTEGER
+*>          The dimension of Q12. N1 >= 0.
+*>          The following requirement must be satisfied:
+*>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
+*> \endverbatim
+*>
+*> \param[in] N2
+*> \verbatim
 *>          N2 is INTEGER
-*>          The dimension of Q12 and Q21, respectively. N1, N2 >= 0.
+*>          The dimension of Q21. N2 >= 0.
 *>          The following requirement must be satisfied:
 *>          N1 + N2 = M if SIDE = 'L' and N1 + N2 = N if SIDE = 'R'.
 *> \endverbatim


### PR DESCRIPTION
**Description**
This PR updates only the documentation, more specifically the `PARAMS` section. In all cases, I tried to standardize the comment style, i.e. follow the majority. Changes include
```
- dimensions (X)
+ dimension (X)

- dimension X
+ dimension (X)
```
the aim of these changes is to simplify the creation of Fortran interfaces for type checking during compilation. With the current changes, it is possible to create interfaces based on the documentation for approx 1700/2000 routines.


The script and the interfaces are attached below (with obfuscated file extension)
[create_interface_py.txt](https://github.com/Reference-LAPACK/lapack/files/7793303/create_interface_py.txt)

[lapack_f90.txt](https://github.com/Reference-LAPACK/lapack/files/7793304/lapack_f90.txt)


**Checklist**

- [x] The documentation has been updated.
