### PR TITLE
Fixes a bug in the Blue's scaling constants of nrm2

### DIFF
--- a/BLAS/SRC/dnrm2.f90
+++ b/BLAS/SRC/dnrm2.f90
@@ -99,15 +99,15 @@ function DNRM2( n, x, incx )
    real(wp), parameter :: one  = 1.0_wp
    real(wp), parameter :: maxN = huge(0.0_wp)
 !  ..
-!  .. Blue's ccaling constants ..
+!  .. Blue's scaling constants ..
    real(wp), parameter :: tsml = real(radix(0._wp), wp)**ceiling( &
        (minexponent(0._wp) - 1) * 0.5_wp)
    real(wp), parameter :: tbig = real(radix(0._wp), wp)**floor( &
        (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp)
    real(wp), parameter :: ssml = real(radix(0._wp), wp)**( - floor( &
-       (minexponent(0._wp) - 1) * 0.5_wp))
+       (minexponent(0._wp) - digits(0._wp)) * 0.5_wp))
    real(wp), parameter :: sbig = real(radix(0._wp), wp)**( - ceiling( &
-       (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp))
+       (maxexponent(0._wp) + digits(0._wp) - 1) * 0.5_wp))
 !  ..
 !  .. Scalar Arguments ..
    integer :: incx, n

--- a/BLAS/SRC/dznrm2.f90
+++ b/BLAS/SRC/dznrm2.f90
@@ -100,15 +100,15 @@ function DZNRM2( n, x, incx )
    real(wp), parameter :: one  = 1.0_wp
    real(wp), parameter :: maxN = huge(0.0_wp)
 !  ..
-!  .. Blue's ccaling constants ..
+!  .. Blue's scaling constants ..
    real(wp), parameter :: tsml = real(radix(0._wp), wp)**ceiling( &
        (minexponent(0._wp) - 1) * 0.5_wp)
    real(wp), parameter :: tbig = real(radix(0._wp), wp)**floor( &
        (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp)
    real(wp), parameter :: ssml = real(radix(0._wp), wp)**( - floor( &
-       (minexponent(0._wp) - 1) * 0.5_wp))
+       (minexponent(0._wp) - digits(0._wp)) * 0.5_wp))
    real(wp), parameter :: sbig = real(radix(0._wp), wp)**( - ceiling( &
-       (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp))
+       (maxexponent(0._wp) + digits(0._wp) - 1) * 0.5_wp))
 !  ..
 !  .. Scalar Arguments ..
    integer :: incx, n

--- a/BLAS/SRC/scnrm2.f90
+++ b/BLAS/SRC/scnrm2.f90
@@ -100,15 +100,15 @@ function SCNRM2( n, x, incx )
    real(wp), parameter :: one  = 1.0_wp
    real(wp), parameter :: maxN = huge(0.0_wp)
 !  ..
-!  .. Blue's ccaling constants ..
+!  .. Blue's scaling constants ..
    real(wp), parameter :: tsml = real(radix(0._wp), wp)**ceiling( &
        (minexponent(0._wp) - 1) * 0.5_wp)
    real(wp), parameter :: tbig = real(radix(0._wp), wp)**floor( &
        (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp)
    real(wp), parameter :: ssml = real(radix(0._wp), wp)**( - floor( &
-       (minexponent(0._wp) - 1) * 0.5_wp))
+       (minexponent(0._wp) - digits(0._wp)) * 0.5_wp))
    real(wp), parameter :: sbig = real(radix(0._wp), wp)**( - ceiling( &
-       (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp))
+       (maxexponent(0._wp) + digits(0._wp) - 1) * 0.5_wp))
 !  ..
 !  .. Scalar Arguments ..
    integer :: incx, n

--- a/BLAS/SRC/snrm2.f90
+++ b/BLAS/SRC/snrm2.f90
@@ -99,15 +99,15 @@ function SNRM2( n, x, incx )
    real(wp), parameter :: one  = 1.0_wp
    real(wp), parameter :: maxN = huge(0.0_wp)
 !  ..
-!  .. Blue's ccaling constants ..
+!  .. Blue's scaling constants ..
    real(wp), parameter :: tsml = real(radix(0._wp), wp)**ceiling( &
        (minexponent(0._wp) - 1) * 0.5_wp)
    real(wp), parameter :: tbig = real(radix(0._wp), wp)**floor( &
        (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp)
    real(wp), parameter :: ssml = real(radix(0._wp), wp)**( - floor( &
-       (minexponent(0._wp) - 1) * 0.5_wp))
+       (minexponent(0._wp) - digits(0._wp)) * 0.5_wp))
    real(wp), parameter :: sbig = real(radix(0._wp), wp)**( - ceiling( &
-       (maxexponent(0._wp) - digits(0._wp) + 1) * 0.5_wp))
+       (maxexponent(0._wp) + digits(0._wp) - 1) * 0.5_wp))
 !  ..
 !  .. Scalar Arguments ..
    integer :: incx, n


### PR DESCRIPTION
Fixes a bug in the Blue's scaling constants of nrm2 thanks to Arm Performance Libraries!
This is the same bug fixed on #559 for la_constants.f90.