### PR TITLE
Adds __attribute__((const)) to LAPACKE_lsame

### DIFF
--- a/LAPACKE/include/lapacke_utils.h
+++ b/LAPACKE/include/lapacke_utils.h
@@ -66,7 +66,11 @@ extern "C" {
 void LAPACKE_xerbla( const char *name, lapack_int info );
 
 /* Compare two chars (case-insensitive) */
-lapack_logical LAPACKE_lsame( char ca,  char cb );
+lapack_logical LAPACKE_lsame( char ca,  char cb )
+#if defined __GNUC__
+  __attribute__((const))
+#endif
+	;
 
 /* Functions to convert column-major to row-major 2d arrays and vice versa. */
 void LAPACKE_cgb_trans( int matrix_layout, lapack_int m, lapack_int n,


### PR DESCRIPTION
Adds __attribute__((const)) to LAPACKE_lsame. This change allows for optimizations on GCC. This solution was proposed by @martin-frbg on https://github.com/xianyi/OpenBLAS/pull/3549.

Fixes #652.