### PR TITLE
Try improve convergence dlaed4

### DIFF
--- a/SRC/dlaed4.f
+++ b/SRC/dlaed4.f
@@ -328,9 +328,12 @@
          IF( C.LT.ZERO )
      $      C = ABS( C )
          IF( C.EQ.ZERO ) THEN
-*          ETA = B/A
+*           ETA = B/A
 *           ETA = RHO - TAU
-            ETA = DLTUB - TAU
+*           ETA = DLTUB - TAU
+*
+*           Update proposed by Li, Ren-Cang:
+            ETA = -W / ( DPSI+DPHI )
          ELSE IF( A.GE.ZERO ) THEN
             ETA = ( A+SQRT( ABS( A*A-FOUR*B*C ) ) ) / ( TWO*C )
          ELSE

--- a/SRC/slaed4.f
+++ b/SRC/slaed4.f
@@ -328,9 +328,12 @@
          IF( C.LT.ZERO )
      $      C = ABS( C )
          IF( C.EQ.ZERO ) THEN
-*          ETA = B/A
+*           ETA = B/A
 *           ETA = RHO - TAU
-            ETA = DLTUB - TAU
+*           ETA = DLTUB - TAU
+*
+*           Update proposed by Li, Ren-Cang:
+            ETA = -W / ( DPSI+DPHI )
          ELSE IF( A.GE.ZERO ) THEN
             ETA = ( A+SQRT( ABS( A*A-FOUR*B*C ) ) ) / ( TWO*C )
          ELSE


### PR DESCRIPTION
**Description, and suggested fix from Professor Ren-Cang Li, University of Texas at Arlington**

Consider the case of computing the last updated eigenvalue using `DLAED4`. If `C=0`, `ETA` is currently set to 

    DLTUB (upper bound) - TAU
        
Chances exist that `TAU` is close to the desired value `DLAM - D(N)`. In such a case, the current initial guess for `ETA` would be very close to the upper bound (either `RHO` or `RHO/2`). As a result, it may take a lot more iterations to get to `DLAM - D(N)` eventually.

One idea is to use a Newton step instead, i.e.,

    ETA = -W / ( DPSI+DPHI )
    
This is the same initial step adopted when `W*ETA.GT.ZERO`.