### PR TITLE
Fix workspace size returned by getsls

### DIFF
--- a/SRC/cgetsls.f
+++ b/SRC/cgetsls.f
@@ -183,17 +183,16 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, TRAN
-      INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
-     $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
+      INTEGER            I, IASCL, IBSCL, J, MAXMN, BROW,
+     $                   SCLLEN, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
       REAL               ANRM, BIGNUM, BNRM, SMLNUM, DUM( 1 )
       COMPLEX            TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      INTEGER            ILAENV
       REAL               SLAMCH, CLANGE
-      EXTERNAL           LSAME, ILAENV, SLABAD, SLAMCH, CLANGE
+      EXTERNAL           LSAME, SLABAD, SLAMCH, CLANGE
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CGEQR, CGEMQR, CLASCL, CLASET,
@@ -207,9 +206,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      MINMN = MIN( M, N )
       MAXMN = MAX( M, N )
-      MNK   = MAX( MINMN, NRHS )
       TRAN  = LSAME( TRANS, 'C' )
 *
       LQUERY = ( LWORK.EQ.-1 .OR. LWORK.EQ.-2 )
@@ -230,7 +227,7 @@
 *
       IF( INFO.EQ.0 ) THEN
 *
-*     Determine the block size and minimum LWORK
+*     Determine the optimum and minimum LWORK
 *
        IF( M.GE.N ) THEN
          CALL CGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
@@ -268,15 +265,15 @@
           INFO = -10
        END IF
 *
+       WORK( 1 ) = REAL( WSIZEO )
+*
       END IF
 *
       IF( INFO.NE.0 ) THEN
         CALL XERBLA( 'CGETSLS', -INFO )
-        WORK( 1 ) = REAL( WSIZEO )
         RETURN
       END IF
       IF( LQUERY ) THEN
-        IF( LWORK.EQ.-1 ) WORK( 1 ) = REAL( WSIZEO )
         IF( LWORK.EQ.-2 ) WORK( 1 ) = REAL( WSIZEM )
         RETURN
       END IF

--- a/SRC/dgetsls.f
+++ b/SRC/dgetsls.f
@@ -181,16 +181,15 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, TRAN
-      INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
-     $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
+      INTEGER            I, IASCL, IBSCL, J, MAXMN, BROW,
+     $                   SCLLEN, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
       DOUBLE PRECISION   ANRM, BIGNUM, BNRM, SMLNUM, TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      INTEGER            ILAENV
       DOUBLE PRECISION   DLAMCH, DLANGE
-      EXTERNAL           LSAME, ILAENV, DLABAD, DLAMCH, DLANGE
+      EXTERNAL           LSAME, DLABAD, DLAMCH, DLANGE
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DGEQR, DGEMQR, DLASCL, DLASET,
@@ -204,9 +203,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      MINMN = MIN( M, N )
       MAXMN = MAX( M, N )
-      MNK   = MAX( MINMN, NRHS )
       TRAN  = LSAME( TRANS, 'T' )
 *
       LQUERY = ( LWORK.EQ.-1 .OR. LWORK.EQ.-2 )
@@ -227,7 +224,7 @@
 *
       IF( INFO.EQ.0 ) THEN
 *
-*     Determine the block size and minimum LWORK
+*     Determine the optimum and minimum LWORK
 *
        IF( M.GE.N ) THEN
          CALL DGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
@@ -265,16 +262,16 @@
           INFO = -10
        END IF
 *
+       WORK( 1 ) = DBLE( WSIZEO )
+*
       END IF
 *
       IF( INFO.NE.0 ) THEN
         CALL XERBLA( 'DGETSLS', -INFO )
-        WORK( 1 ) = DBLE( WSIZEO )
         RETURN
       END IF
       IF( LQUERY ) THEN
-        IF( LWORK.EQ.-1 ) WORK( 1 ) = REAL( WSIZEO )
-        IF( LWORK.EQ.-2 ) WORK( 1 ) = REAL( WSIZEM )
+        IF( LWORK.EQ.-2 ) WORK( 1 ) = DBLE( WSIZEM )
         RETURN
       END IF
       IF( LWORK.LT.WSIZEO ) THEN

--- a/SRC/sgetsls.f
+++ b/SRC/sgetsls.f
@@ -181,16 +181,15 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, TRAN
-      INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
-     $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
+      INTEGER            I, IASCL, IBSCL, J, MAXMN, BROW,
+     $                   SCLLEN, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
       REAL               ANRM, BIGNUM, BNRM, SMLNUM, TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      INTEGER            ILAENV
       REAL               SLAMCH, SLANGE
-      EXTERNAL           LSAME, ILAENV, SLABAD, SLAMCH, SLANGE
+      EXTERNAL           LSAME, SLABAD, SLAMCH, SLANGE
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SGEQR, SGEMQR, SLASCL, SLASET,
@@ -204,9 +203,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      MINMN = MIN( M, N )
       MAXMN = MAX( M, N )
-      MNK   = MAX( MINMN, NRHS )
       TRAN  = LSAME( TRANS, 'T' )
 *
       LQUERY = ( LWORK.EQ.-1 .OR. LWORK.EQ.-2 )
@@ -227,7 +224,7 @@
 *
       IF( INFO.EQ.0 ) THEN
 *
-*     Determine the block size and minimum LWORK
+*     Determine the optimum and minimum LWORK
 *
        IF( M.GE.N ) THEN
          CALL SGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
@@ -265,15 +262,15 @@
           INFO = -10
        END IF
 *
+       WORK( 1 ) = REAL( WSIZEO )
+*
       END IF
 *
       IF( INFO.NE.0 ) THEN
         CALL XERBLA( 'SGETSLS', -INFO )
-        WORK( 1 ) = REAL( WSIZEO )
         RETURN
       END IF
       IF( LQUERY ) THEN
-        IF( LWORK.EQ.-1 ) WORK( 1 ) = REAL( WSIZEO )
         IF( LWORK.EQ.-2 ) WORK( 1 ) = REAL( WSIZEM )
         RETURN
       END IF

--- a/SRC/zgetsls.f
+++ b/SRC/zgetsls.f
@@ -183,17 +183,16 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            LQUERY, TRAN
-      INTEGER            I, IASCL, IBSCL, J, MINMN, MAXMN, BROW,
-     $                   SCLLEN, MNK, TSZO, TSZM, LWO, LWM, LW1, LW2,
+      INTEGER            I, IASCL, IBSCL, J, MAXMN, BROW,
+     $                   SCLLEN, TSZO, TSZM, LWO, LWM, LW1, LW2,
      $                   WSIZEO, WSIZEM, INFO2
       DOUBLE PRECISION   ANRM, BIGNUM, BNRM, SMLNUM, DUM( 1 )
       COMPLEX*16         TQ( 5 ), WORKQ( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      INTEGER            ILAENV
       DOUBLE PRECISION   DLAMCH, ZLANGE
-      EXTERNAL           LSAME, ILAENV, DLABAD, DLAMCH, ZLANGE
+      EXTERNAL           LSAME, DLABAD, DLAMCH, ZLANGE
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           ZGEQR, ZGEMQR, ZLASCL, ZLASET,
@@ -207,9 +206,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      MINMN = MIN( M, N )
       MAXMN = MAX( M, N )
-      MNK   = MAX( MINMN, NRHS )
       TRAN  = LSAME( TRANS, 'C' )
 *
       LQUERY = ( LWORK.EQ.-1 .OR. LWORK.EQ.-2 )
@@ -230,7 +227,7 @@
 *
       IF( INFO.EQ.0 ) THEN
 *
-*     Determine the block size and minimum LWORK
+*     Determine the optimum and minimum LWORK
 *
        IF( M.GE.N ) THEN
          CALL ZGEQR( M, N, A, LDA, TQ, -1, WORKQ, -1, INFO2 )
@@ -268,16 +265,16 @@
           INFO = -10
        END IF
 *
+       WORK( 1 ) = DBLE( WSIZEO )
+*
       END IF
 *
       IF( INFO.NE.0 ) THEN
         CALL XERBLA( 'ZGETSLS', -INFO )
-        WORK( 1 ) = DBLE( WSIZEO )
         RETURN
       END IF
       IF( LQUERY ) THEN
-        IF( LWORK.EQ.-1 ) WORK( 1 ) = REAL( WSIZEO )
-        IF( LWORK.EQ.-2 ) WORK( 1 ) = REAL( WSIZEM )
+        IF( LWORK.EQ.-2 ) WORK( 1 ) = DBLE( WSIZEM )
         RETURN
       END IF
       IF( LWORK.LT.WSIZEO ) THEN


### PR DESCRIPTION
**Description**
Make least squares solver getsls work as a drop-in replacement of gels
- [dz]getsls: cast workspace size with dble, not real
- Move workspace write to precede xerbla. Follow the documentation and return the optimal workspace in work(1) even on quick return

Clean up unused variables.

**Checklist**

- [X] The documentation has been updated.
- [X] If the PR solves a specific issue, it is set to be closed on merge.