### PR TITLE
Solve build issues with ibm xlf

### DIFF
--- a/BLAS/SRC/xerbla_array.f
+++ b/BLAS/SRC/xerbla_array.f
@@ -105,7 +105,7 @@
       EXTERNAL XERBLA
 *     ..
 *     .. Executable Statements ..
-      SRNAME = ''
+      SRNAME = ' '
       DO I = 1, MIN( SRNAME_LEN, LEN( SRNAME ) )
          SRNAME( I:I ) = SRNAME_ARRAY( I )
       END DO

--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -22,6 +22,9 @@ if ( FORTRAN_ILP )
         else ()
             set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -integer-size 64")
         endif()
+    elseif( (CMAKE_Fortran_COMPILER_ID STREQUAL "VisualAge" ) OR  # CMake 2.6
+            (CMAKE_Fortran_COMPILER_ID STREQUAL "XL" ) )          # CMake 2.8
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qintsize=8")
     else()
         set(CPE_ENV $ENV{PE_ENV})
         if(CPE_ENV STREQUAL "CRAY")

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(NOT LAPACKE)
+    return()
+endif()
+
+
 # Create a header file lapacke_mangling.h for the routines called in my C programs
 include(FortranCInterface)
 ## Ensure that the fortran compiler and c compiler specified are compatible
@@ -12,11 +17,6 @@ if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
 endif()
 
 add_subdirectory(include)
-
-
-if(NOT LAPACKE)
-    return()
-endif()
 
 
 message(STATUS "LAPACKE enabled")

--- a/SRC/dsytrd_sy2sb.f
+++ b/SRC/dsytrd_sy2sb.f
@@ -293,7 +293,7 @@
       INFO   = 0
       UPPER  = LSAME( UPLO, 'U' )
       LQUERY = ( LWORK.EQ.-1 )
-      LWMIN  = ILAENV2STAGE( 4, 'DSYTRD_SY2SB', '', N, KD, -1, -1 )
+      LWMIN  = ILAENV2STAGE( 4, 'DSYTRD_SY2SB', ' ', N, KD, -1, -1 )
       
       IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
          INFO = -1

--- a/SRC/xerbla_array.f
+++ b/SRC/xerbla_array.f
@@ -115,7 +115,7 @@
       EXTERNAL XERBLA
 *     ..
 *     .. Executable Statements ..
-      SRNAME = ''
+      SRNAME = ' '
       DO I = 1, MIN( SRNAME_LEN, LEN( SRNAME ) )
          SRNAME( I:I ) = SRNAME_ARRAY( I )
       END DO

--- a/SRC/zhetrd_he2hb.f
+++ b/SRC/zhetrd_he2hb.f
@@ -293,7 +293,7 @@
       INFO   = 0
       UPPER  = LSAME( UPLO, 'U' )
       LQUERY = ( LWORK.EQ.-1 )
-      LWMIN  = ILAENV2STAGE( 4, 'ZHETRD_HE2HB', '', N, KD, -1, -1 )
+      LWMIN  = ILAENV2STAGE( 4, 'ZHETRD_HE2HB', ' ', N, KD, -1, -1 )
       
       IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
          INFO = -1


### PR DESCRIPTION
**Description**

I configure  lapack-3.10.1 with the following options:

```
cmake -H. -Bobjdir -DCMAKE_C_COMPILER=gcc -DCMAKE_Fortran_COMPILER=xlf -DCMAKE_INSTALL_PREFIX=/run_dir/3rd-party -DBUILD_INDEX64=ON -DBUILD_SINGLE=OFF -DBUILD_COMPLEX=OFF -DCBLAS=OFF -DLAPACKE=OFF
```

cmake then fails with the following message:

```
-- Detecting Fortran/C Interface
-- Detecting Fortran/C Interface - Failed to compile
-- Verifying Fortran/C Compiler Compatibility
CMake Warning (dev) at /usr/share/cmake-3.16/Modules/FortranCInterface.cmake:309 (message):
  No FortranCInterface mangling known for VerifyFortran
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FortranCInterface/Verify/CMakeLists.txt:16 (FortranCInterface_HEADER)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Verifying Fortran/C Compiler Compatibility - Failed
...
    [100%] Linking C executable VerifyFortranC
    /usr/bin/cmake -E cmake_link_script CMakeFiles/VerifyFortranC.dir/link.txt --verbose=1
    /usr/bin/gcc  -DWeirdNEC -DLAPACK_ILP64 -DHAVE_LAPACK_CONFIG_H -O3 -DNDEBUG   CMakeFiles/VerifyFortranC.dir/main.c.o CMakeFiles/VerifyFortranC.dir/VerifyC.c.o  -o VerifyFortranC   -L/opt/ibm/xlsmp/5.1.1/lib  -L/opt/ibm/xlmass/9.1.1/lib  -L/opt/ibm/xlf/16.1.1/lib  libVerifyFortran.a -lxlf90 -lxlopt -lxlomp_ser -lxl -lxlfmath -ldl -lrt -lpthread -lm 
    /usr/bin/ld: CMakeFiles/VerifyFortranC.dir/main.c.o: in function `main':
    main.c:(.text.startup+0x1c): undefined reference to `VerifyFortran'
...
Call Stack (most recent call first):
  LAPACKE/CMakeLists.txt:4 (FortranCInterface_VERIFY)
```

Here I have:
```
# cmake --version
cmake version 3.16.3
...
# gcc --version
gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
...
# xlf -qversion
IBM XL Fortran for Linux, V16.1.1 (Community Edition)
Version: 16.01.0001.0003
...
```

You will notice that I do not want to build LAPACKE, but it still breaks the build. This is addressed by commit 8d3ae005a3587e3e271cf80871d708d6b38c7fff. I can now get a bit further with the build.

```
cd objdir && /usr/bin/make VERBOSE=1
```

yields

```
[  1%] Building Fortran object BLAS/SRC/CMakeFiles/blas64.dir/xerbla_array.f.o
cd /run_dir/3rd-party/lapack/objdir/BLAS/SRC && /opt/ibm/xlf/16.1.1/bin/xlf   -qthreaded -qhalt=e -qrecur -qnosave -qstrict -fdefault-integer-8 -O   -c /run_dir/3rd-party/lapack/BLAS/SRC/xerbla_array.f -o CMakeFiles/blas64.dir/xerbla_array.f.o
COMMAND LINE  1520-065 (W) The XLF77(PERSISTENT) option stores entities in static storage.  This may affect the thread safety of your code.
"/run_dir/3rd-party/lapack/BLAS/SRC/xerbla_array.f", line 108.16: 1515-009 (E) Null literal string is not permitted.  A single blank is assumed.
** xerbla_array   === End of Compilation 1 ===
1501-511  Compilation failed for file xerbla_array.f.
```

The failed compilations is addressed by commit 7939cb1b4d977da37a90c3b515f4ce4c3fe82435. Now the build completes successfully.

**Checklist**

- [ ] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.