### PR TITLE
Adding NAG Fortran compiler (nagfor) support in the CMake build system.

### DIFF
--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -22,6 +22,12 @@ if ( FORTRAN_ILP )
         else ()
             set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -integer-size 64")
         endif()
+    elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "NAG" )
+        if ( WIN32 )
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /i8")
+        else ()
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i8")
+        endif()
     else()
         set(CPE_ENV $ENV{PE_ENV})
         if(CPE_ENV STREQUAL "CRAY")
@@ -85,6 +91,48 @@ elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "HP" )
        CACHE STRING "Flags used by the compiler during release builds" FORCE )
   set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO} +O2 -g"
        CACHE STRING "Flags used by the compiler during release with debug info builds" FORCE )
+
+# NAG Fortran
+elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "NAG" )
+  if( "${CMAKE_Fortran_FLAGS}" MATCHES "[-/]ieee=(stop|nonstd)" )
+    set( FPE_EXIT TRUE )
+  endif()
+
+  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]ieee=full") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ieee=full")
+  endif()
+
+  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]dcfuns") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -dcfuns")
+  endif()
+
+  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]thread_safe") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -thread_safe")
+  endif()
+
+  # Disable warnings
+  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]w=obs") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w=obs")
+  endif()
+
+  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]w=x77") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w=x77")
+  endif()
+
+  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]w=ques") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w=ques")
+  endif()
+
+  if( NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]w=unused") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w=unused")
+  endif()
+
+  # Suppress compiler banner and summary
+  check_fortran_compiler_flag("-quiet" _quiet)
+  if( _quiet AND NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]quiet") )
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -quiet")
+  endif()
+
 else()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
   check_fortran_compiler_flag("-recursive" _recursiveFlag)
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL XL)
   check_fortran_compiler_flag("-qrecur" _qrecurFlag)
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL NAG)
+  check_fortran_compiler_flag("-recursive" _recursiveFlag)
 else()
   message(WARNING "Fortran local arrays should be allocated on the stack."
     " Please use a compiler which guarantees that feature."

--- a/TESTING/EIG/cchkhb2stg.f
+++ b/TESTING/EIG/cchkhb2stg.f
@@ -852,8 +852,9 @@
       CALL SLASUM( 'CHB', NOUNIT, NERRS, NTESTT )
       RETURN
 *
- 9999 FORMAT( ' CCHKHB2STG: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
-     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9999 FORMAT( ' CCHKHB2STG: ', A, ' returned INFO=', I6, '.', / 9X,
+     $      'N=', I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5,
+     $      ')' )
  9998 FORMAT( / 1X, A3,
      $     ' -- Complex Hermitian Banded Tridiagonal Reduction Routines'
      $       )

--- a/TESTING/EIG/dchksb2stg.f
+++ b/TESTING/EIG/dchksb2stg.f
@@ -840,8 +840,9 @@
       CALL DLASUM( 'DSB', NOUNIT, NERRS, NTESTT )
       RETURN
 *
- 9999 FORMAT( ' DCHKSB2STG: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
-     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9999 FORMAT( ' DCHKSB2STG: ', A, ' returned INFO=', I6, '.', / 9X,
+     $      'N=', I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5,
+     $      ')' )
 *
  9998 FORMAT( / 1X, A3,
      $      ' -- Real Symmetric Banded Tridiagonal Reduction Routines' )

--- a/TESTING/EIG/schksb2stg.f
+++ b/TESTING/EIG/schksb2stg.f
@@ -840,8 +840,9 @@
       CALL SLASUM( 'SSB', NOUNIT, NERRS, NTESTT )
       RETURN
 *
- 9999 FORMAT( ' SCHKSB2STG: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
-     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9999 FORMAT( ' SCHKSB2STG: ', A, ' returned INFO=', I6, '.', / 9X,
+     $      'N=', I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5,
+     $      ')' )
 *
  9998 FORMAT( / 1X, A3,
      $      ' -- Real Symmetric Banded Tridiagonal Reduction Routines' )

--- a/TESTING/EIG/zchkhb2stg.f
+++ b/TESTING/EIG/zchkhb2stg.f
@@ -849,8 +849,9 @@
       CALL DLASUM( 'ZHB', NOUNIT, NERRS, NTESTT )
       RETURN
 *
- 9999 FORMAT( ' ZCHKHB2STG: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
-     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9999 FORMAT( ' ZCHKHB2STG: ', A, ' returned INFO=', I6, '.', / 9X,
+     $      'N=', I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5,
+     $      ')' )
  9998 FORMAT( / 1X, A3,
      $     ' -- Complex Hermitian Banded Tridiagonal Reduction Routines'
      $       )


### PR DESCRIPTION
**Description**

The changes in this pull request add the necessary compiler flags for the NAG Fortran compiler in the CMake files. The following flags were added in places where they are necessary:
- ```-recursive``` (available since nagfor 7.0)
- ```-i8``` (64bit integers)
- ```-ieee=full``` (no FPE traps)
- ```-dcfuns``` (non-standard double precision complex intrinsic functions: CDABS, DCMPLX, DCONJG, DIMAG, DREAL)
- ```-thread_safe``` (enable thread safety)
- ```-quiet``` (Suppress compiler banner and summary)

Disabled warnings:
- ```-w=obs``` (obsolescent features)
- ```-w=x77``` (F77 extensions)
- ```-w=ques``` (questionable usage)
- ```-w=unused``` (unused variables, imports, procedures, etc.)

Miscellaneous changes:

The nagfor compiler detected a few lines in the test files that had line lengths of 73. I refactored those to less or equal 72 characters.

**Checklist**

- [x] The documentation has been updated. (**not applicable**)
- [x] If the PR solves a specific issue, it is set to be closed on merge. (**not applicable**)