### PR TITLE
Fix workspace query for *syevd and *heevd routines

### DIFF
--- a/SRC/cheevd.f
+++ b/SRC/cheevd.f
@@ -284,7 +284,7 @@
                LIWMIN = 1
             END IF
             LOPT = MAX( LWMIN, N +
-     $                  ILAENV( 1, 'CHETRD', UPLO, N, -1, -1, -1 ) )
+     $                  N*ILAENV( 1, 'CHETRD', UPLO, N, -1, -1, -1 ) )
             LROPT = LRWMIN
             LIOPT = LIWMIN
          END IF

--- a/SRC/dsyevd.f
+++ b/SRC/dsyevd.f
@@ -257,7 +257,7 @@
                LWMIN = 2*N + 1
             END IF
             LOPT = MAX( LWMIN, 2*N +
-     $                  ILAENV( 1, 'DSYTRD', UPLO, N, -1, -1, -1 ) )
+     $                  N*ILAENV( 1, 'DSYTRD', UPLO, N, -1, -1, -1 ) )
             LIOPT = LIWMIN
          END IF
          WORK( 1 ) = LOPT

--- a/SRC/ssyevd.f
+++ b/SRC/ssyevd.f
@@ -255,7 +255,7 @@
                LWMIN = 2*N + 1
             END IF
             LOPT = MAX( LWMIN, 2*N +
-     $                  ILAENV( 1, 'SSYTRD', UPLO, N, -1, -1, -1 ) )
+     $                  N*ILAENV( 1, 'SSYTRD', UPLO, N, -1, -1, -1 ) )
             LIOPT = LIWMIN
          END IF
          WORK( 1 ) = LOPT

--- a/SRC/zheevd.f
+++ b/SRC/zheevd.f
@@ -284,7 +284,7 @@
                LIWMIN = 1
             END IF
             LOPT = MAX( LWMIN, N +
-     $                  ILAENV( 1, 'ZHETRD', UPLO, N, -1, -1, -1 ) )
+     $                  N*ILAENV( 1, 'ZHETRD', UPLO, N, -1, -1, -1 ) )
             LROPT = LRWMIN
             LIOPT = LIWMIN
          END IF


### PR DESCRIPTION
**Description**

The optimal workspace for `dsytrd` is `n*nb` where `nb` is the blocksize provided by `ilaenv`.  However, when `dsyevd` is called with `lwork=-1`, the requested workspace size is only `2*n + nb` (`2*n` is needed to hold the tridiagonal matrix).
So, `dsyevd` will use the unblocked `dsytrd` unless the user knows to provide extra workspace, regardless of how well `ilaenv` is tuned.

The issue is also present in `ssyevd`, `cheevd`, and `zheevd`.

This PR corrects `dsyevd` et al. to request enough workspace to use a blocked tridiagonal reduction.

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.