### PR TITLE
Revert "Do not check the FortranCInterface if LAPACKE is not built."

### DIFF
--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -1,8 +1,3 @@
-if(NOT LAPACKE)
-    return()
-endif()
-
-
 # Create a header file lapacke_mangling.h for the routines called in my C programs
 include(FortranCInterface)
 ## Ensure that the fortran compiler and c compiler specified are compatible
@@ -17,6 +12,11 @@ if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
 endif()
 
 add_subdirectory(include)
+
+
+if(NOT LAPACKE)
+    return()
+endif()
 
 
 message(STATUS "LAPACKE enabled")


### PR DESCRIPTION
**Description**

Fixes #692.

**Checklist**

- [ ] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.