### PR TITLE
Fixed format warnings in 64 bit integer builds.

### DIFF
--- a/CBLAS/examples/cblas_example1.c
+++ b/CBLAS/examples/cblas_example1.c
@@ -61,7 +61,7 @@ int main ( )
                 y, incy );
    /* Print y */
    for( i = 0; i < n; i++ )
-      printf(" y%d = %f\n", i, y[i]);
+      printf(" y%" CBLAS_IFMT " = %f\n", i, y[i]);
    free(a);
    free(x);
    free(y);

--- a/CBLAS/include/cblas.h
+++ b/CBLAS/include/cblas.h
@@ -2,6 +2,7 @@
 #define CBLAS_H
 #include <stddef.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 
 #ifdef __cplusplus
@@ -21,6 +22,17 @@ extern "C" {            /* Assume C declarations for C++ */
    #define CBLAS_INT int64_t
 #else
    #define CBLAS_INT int32_t
+#endif
+#endif
+
+/*
+ * Integer format string
+ */
+#ifndef CBLAS_IFMT
+#ifdef WeirdNEC
+   #define CBLAS_IFMT PRId64
+#else
+   #define CBLAS_IFMT PRId32
 #endif
 #endif
 

--- a/CBLAS/src/cblas_xerbla.c
+++ b/CBLAS/src/cblas_xerbla.c
@@ -63,7 +63,7 @@ cblas_xerbla(CBLAS_INT info, const char *rout, const char *form, ...)
       }
    }
    if (info)
-      fprintf(stderr, "Parameter %d to routine %s was incorrect\n", info, rout);
+      fprintf(stderr, "Parameter %" CBLAS_IFMT " to routine %s was incorrect\n", info, rout);
    vfprintf(stderr, form, argptr);
    va_end(argptr);
    if (info && !info)

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -78,7 +78,7 @@ void cblas_xerbla(CBLAS_INT info, const char *rout, const char *form, ...)
    }
 
    if (info != cblas_info){
-      printf("***** XERBLA WAS CALLED WITH INFO = %d INSTEAD OF %d in %s *******\n",info, cblas_info, rout);
+      printf("***** XERBLA WAS CALLED WITH INFO = %" CBLAS_IFMT " INSTEAD OF %d in %s *******\n",info, cblas_info, rout);
       cblas_lerr = PASSED;
       cblas_ok = FALSE;
    } else cblas_lerr = FAILED;

--- a/LAPACKE/example/example_DGESV_colmajor.c
+++ b/LAPACKE/example/example_DGESV_colmajor.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         /* Check for the exact singularity */
         if( info > 0 ) {
                 printf( "The diagonal element of the triangular factor of A,\n" );
-                printf( "U(%i,%i) is zero, so that A is singular;\n", info, info );
+                printf( "U(%" LAPACK_IFMT ",%" LAPACK_IFMT ") is zero, so that A is singular;\n", info, info );
                 printf( "the solution could not be computed.\n" );
                 exit( 1 );
         }

--- a/LAPACKE/example/example_DGESV_rowmajor.c
+++ b/LAPACKE/example/example_DGESV_rowmajor.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
         /* Check for the exact singularity */
         if( info > 0 ) {
                 printf( "The diagonal element of the triangular factor of A,\n" );
-                printf( "U(%i,%i) is zero, so that A is singular;\n", info, info );
+                printf( "U(%" LAPACK_IFMT ",%" LAPACK_IFMT ") is zero, so that A is singular;\n", info, info );
                 printf( "the solution could not be computed.\n" );
                 exit( 1 );
         }

--- a/LAPACKE/example/lapacke_example_aux.c
+++ b/LAPACKE/example/lapacke_example_aux.c
@@ -28,6 +28,6 @@ void print_matrix_colmajor( char* desc, lapack_int m, lapack_int n, double* mat,
 void print_vector( char* desc, lapack_int n, lapack_int* vec ) {
         lapack_int j;
         printf( "\n %s\n", desc );
-        for( j = 0; j < n; j++ ) printf( " %6i", vec[j] );
+        for( j = 0; j < n; j++ ) printf( " %6" LAPACK_IFMT, vec[j] );
         printf( "\n" );
 }

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -84,7 +84,9 @@ extern "C" {
 #define lapack_int     int32_t
 #endif
 
+#ifndef LAPACK_IFMT
 #define LAPACK_IFMT    PRId32
+#endif
 
 #ifndef lapack_logical
 #define lapack_logical lapack_int

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -81,15 +81,26 @@ extern "C" {
 
 /*----------------------------------------------------------------------------*/
 #ifndef lapack_int
-#define lapack_int     int32_t
+#if defined(LAPACK_ILP64)
+#define lapack_int        int64_t
+#else
+#define lapack_int        int32_t
+#endif
 #endif
 
+/*
+ * Integer format string
+ */
 #ifndef LAPACK_IFMT
-#define LAPACK_IFMT    PRId32
+#if defined(LAPACK_ILP64)
+#define LAPACK_IFMT       PRId64
+#else
+#define LAPACK_IFMT       PRId32
+#endif
 #endif
 
 #ifndef lapack_logical
-#define lapack_logical lapack_int
+#define lapack_logical    lapack_int
 #endif
 
 /* f2c, hence clapack and MacOS Accelerate, returns double instead of float

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -12,6 +12,7 @@
 
 #include <stdlib.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 /* It seems all current Fortran compilers put strlen at end.
 *  Some historical compilers put strlen after the str argument
@@ -80,8 +81,10 @@ extern "C" {
 
 /*----------------------------------------------------------------------------*/
 #ifndef lapack_int
-#define lapack_int     int
+#define lapack_int     int32_t
 #endif
+
+#define LAPACK_IFMT    PRId32
 
 #ifndef lapack_logical
 #define lapack_logical lapack_int

--- a/LAPACKE/include/lapacke_config.h
+++ b/LAPACKE/include/lapacke_config.h
@@ -46,9 +46,9 @@ extern "C" {
 
 #ifndef lapack_int
 #if defined(LAPACK_ILP64)
-#define lapack_int              int64_t
+#define lapack_int        int64_t
 #else
-#define lapack_int              int32_t
+#define lapack_int        int32_t
 #endif
 #endif
 
@@ -57,14 +57,14 @@ extern "C" {
  */
 #ifndef LAPACK_IFMT
 #if defined(LAPACK_ILP64)
-   #define LAPACK_IFMT PRId64
+#define LAPACK_IFMT       PRId64
 #else
-   #define LAPACK_IFMT PRId32
+#define LAPACK_IFMT       PRId32
 #endif
 #endif
 
 #ifndef lapack_logical
-#define lapack_logical          lapack_int
+#define lapack_logical    lapack_int
 #endif
 
 #ifndef LAPACK_COMPLEX_CUSTOM

--- a/LAPACKE/include/lapacke_config.h
+++ b/LAPACKE/include/lapacke_config.h
@@ -42,12 +42,24 @@ extern "C" {
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #ifndef lapack_int
 #if defined(LAPACK_ILP64)
 #define lapack_int              int64_t
 #else
 #define lapack_int              int32_t
+#endif
+#endif
+
+/*
+ * Integer format string
+ */
+#ifndef LAPACK_IFMT
+#if defined(LAPACK_ILP64)
+   #define LAPACK_IFMT PRId64
+#else
+   #define LAPACK_IFMT PRId32
 #endif
 #endif
 


### PR DESCRIPTION
**Description**

There were print format warnings when 64-bit integers are enabled. The `fprintf` statements were using "%d" or "%i" as integer conversion specifiers which are the ones for 32-bit integers. 64-bit are "%lld" (MacOS) or "%ld" (Linux):

```shell
/Users/simonm/git/lapack/CBLAS/src/cblas_xerbla.c:66:69: warning: format specifies type 'int' but the argument has type 'int64_t' (aka 'long long') [-Wformat]
      fprintf(stderr, "Parameter %d to routine %s was incorrect\n", info, rout);
                                 ~~                                 ^~~~
                                 %lld
1 warning generated.
```

I added the preprocessor defines CBLAS_IFMT and LAPACK_IFMT which use the correct specifier (platform independent via "inttypes.h"). We could also put `#ifdefs` around each `fprintf` statement which is a bit tedious IMHO.

**Checklist**

- [N/A] The documentation has been updated.
- [N/A] If the PR solves a specific issue, it is set to be closed on merge.