### PR TITLE
Fix type precision in dorbdb6 and zunbdb6

### DIFF
--- a/SRC/dorbdb6.f
+++ b/SRC/dorbdb6.f
@@ -181,7 +181,7 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IX
-      REAL               EPS, NORM, NORM_NEW, SCL, SSQ
+      DOUBLE PRECISION   EPS, NORM, NORM_NEW, SCL, SSQ
 *     ..
 *     .. External Functions ..
       DOUBLE PRECISION   DLAMCH

--- a/SRC/zunbdb6.f
+++ b/SRC/zunbdb6.f
@@ -185,7 +185,7 @@
       DOUBLE PRECISION   EPS, NORM, NORM_NEW, SCL, SSQ
 *     ..
 *     .. External Functions ..
-      REAL               DLAMCH
+      DOUBLE PRECISION   DLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           ZGEMV, ZLASSQ, XERBLA


### PR DESCRIPTION
**Description**

Building shared libraries on current master https://github.com/Reference-LAPACK/lapack/commit/984dcc059ca82e33a4d1c5326f7cf3a8f07dfaf0 with `-flto -Wlto-type-mismatch` generates the warnings
```
lapack/SRC/dorbdb6.f:252: warning: type of ‘dlassq’ does not match original declaration [-Wlto-type-mismatch]
  252 |       CALL DLASSQ( M1, X1, INCX1, SCL, SSQ )
      | 
lapack/SRC/dlassq.f90:136: note: ‘dlassq’ was previously declared here
  136 | subroutine DLASSQ( n, x, incx, scl, sumsq )
      | 
lapack/SRC/dlassq.f90:136: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
```
and
```
lapack/SRC/zunbdb6.f:224: warning: type of ‘dlamch’ does not match original declaration [-Wlto-type-mismatch]
  224 |       EPS = DLAMCH( 'Precision' )
      | 
lapack/INSTALL/dlamch.f:68: note: return value type mismatch
   68 |       DOUBLE PRECISION FUNCTION DLAMCH( CMACH )
      | 
lapack/INSTALL/dlamch.f:68: note: type ‘double’ should match type ‘float’
lapack/INSTALL/dlamch.f:68: note: ‘dlamch’ was previously declared here
lapack/INSTALL/dlamch.f:68: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
```
showing that these calls to `DLASSQ` and `DLAMCH` are not correct; they are using wrong argument and return types respectively.

To me it looks like a simple oversight of not replacing `REAL` with `DOUBLE PRECISION` in two places. And that indeed gets rid of the type mismatches. Hence this pull request.

If the choice of `REAL` is intentional in these places, then I believe the calls should still be fixed, but in a different way. Perhaps casting to `DOUBLE PRECISION` before passing to `DLASSQ` and using `SLAMCH` instead of `DLAMCH`?

**Checklist**

- [N/A] The documentation has been updated.
- [N/A] If the PR solves a specific issue, it is set to be closed on merge.