### PR TITLE
Define conversions explicitly, and use more rigorous flags in the CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,7 +34,7 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-Wall -pedantic"
+  CFLAGS: "-flto -Wall -pedantic-errors"
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
 
 defaults:
@@ -61,8 +61,8 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
         fflags: [
-          "-fimplicit-none -frecursive -fcheck=all",
-          "-fimplicit-none -frecursive -fcheck=all -fopenmp" ]
+          "-flto -Wall -fimplicit-none -frecursive -fcheck=all",
+          "-flto -Wall -fimplicit-none -frecursive -fcheck=all -fopenmp" ]
     
     steps:
     

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -61,8 +61,8 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
         fflags: [
-          "-flto -Wall -fimplicit-none -frecursive -fcheck=all",
-          "-flto -Wall -fimplicit-none -frecursive -fcheck=all -fopenmp" ]
+          "-flto -Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all",
+          "-flto -Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all -fopenmp" ]
     
     steps:
     

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,7 +34,7 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-flto -Wall -pedantic-errors"
+  CFLAGS: "-Wall -pedantic"
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
 
 defaults:
@@ -61,8 +61,8 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
         fflags: [
-          "-flto -Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all",
-          "-flto -Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all -fopenmp" ]
+          "-Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all",
+          "-Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all -fopenmp" ]
     
     steps:
     

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -32,8 +32,15 @@ on:
     - '!**md'
 
 env:
-  CFLAGS: "-Wall -pedantic"
-  FFLAGS: "-fimplicit-none -frecursive -fopenmp -fcheck=all"
+  CC: "gcc"
+  FC: "gfortran"
+  CFLAGS: "-O3 -flto -Wall -pedantic-errors"
+  FFLAGS: "-O2 -flto -Wall -fimplicit-none -frecursive -fopenmp -fcheck=all"
+  FFLAGS_NOOPT: "-O0 -flto -Wall -fimplicit-none -frecursive -fopenmp -fcheck=all"
+  LDFLAGS: ""
+  AR: "ar"
+  ARFLAGS: "cr"
+  RANLIB: "ranlib"
 
 defaults:
   run:
@@ -46,9 +53,19 @@ jobs:
     steps:
     - name: Checkout LAPACK
       uses: actions/checkout@v2
+    - name: Set configurations
+      run: |
+        echo "SHELL = /bin/sh" >> make.inc
+        echo "FFLAGS_DRV = ${{env.FFLAGS}}" >> make.inc
+        echo "TIMER = INT_ETIME" >> make.inc
+        echo "BLASLIB = ${{github.workspace}}/librefblas.a" >> make.inc
+        echo "CBLASLIB = ${{github.workspace}}/libcblas.a" >> make.inc
+        echo "LAPACKLIB = ${{github.workspace}}/liblapack.a" >> make.inc
+        echo "TMGLIB = ${{github.workspace}}/libtmglib.a" >> make.inc
+        echo "LAPACKELIB = ${{github.workspace}}/liblapacke.a" >> make.inc
+        echo "DOCSDIR = ${{github.workspace}}/DOCS" >> make.inc
     - name: Install
       run: |
-        cp make.inc.example make.inc
         make -s -j2 all
         make -j2 lapack_install
 
@@ -57,12 +74,22 @@ jobs:
     steps:
     - name: Checkout LAPACK
       uses: actions/checkout@v2
+    - name: Set configurations
+      run: |
+        echo "SHELL = /bin/sh" >> make.inc
+        echo "FFLAGS_DRV = ${{env.FFLAGS}}" >> make.inc
+        echo "TIMER = INT_ETIME" >> make.inc
+        echo "BLASLIB = ${{github.workspace}}/librefblas.a" >> make.inc
+        echo "CBLASLIB = ${{github.workspace}}/libcblas.a" >> make.inc
+        echo "LAPACKLIB = ${{github.workspace}}/liblapack.a" >> make.inc
+        echo "TMGLIB = ${{github.workspace}}/libtmglib.a" >> make.inc
+        echo "LAPACKELIB = ${{github.workspace}}/liblapacke.a" >> make.inc
+        echo "DOCSDIR = ${{github.workspace}}/DOCS" >> make.inc
     - name: Alias for GCC compilers
       run: |
         sudo ln -s $(which gcc-11) /usr/local/bin/gcc
         sudo ln -s $(which gfortran-11) /usr/local/bin/gfortran
     - name: Install
       run: |
-        cp make.inc.example make.inc
         make -s -j2 all
         make -j2 lapack_install

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -35,7 +35,7 @@ env:
   CC: "gcc"
   FC: "gfortran"
   CFLAGS: "-O3 -flto -Wall -pedantic-errors"
-  FFLAGS: "-O2 -flto -Wall -fimplicit-none -frecursive -fopenmp -fcheck=all"
+  FFLAGS: "-O2 -flto -Wall -Werror=conversion -pedantic -fimplicit-none -frecursive -fopenmp -fcheck=all"
   FFLAGS_NOOPT: "-O0 -flto -Wall -fimplicit-none -frecursive -fopenmp -fcheck=all"
   LDFLAGS: ""
   AR: "ar"

--- a/BLAS/SRC/cherk.f
+++ b/BLAS/SRC/cherk.f
@@ -352,7 +352,7 @@
   200             CONTINUE
                   RTEMP = ZERO
                   DO 210 L = 1,K
-                      RTEMP = RTEMP + CONJG(A(L,J))*A(L,J)
+                      RTEMP = RTEMP + REAL(CONJG(A(L,J))*A(L,J))
   210             CONTINUE
                   IF (BETA.EQ.ZERO) THEN
                       C(J,J) = ALPHA*RTEMP
@@ -364,7 +364,7 @@
               DO 260 J = 1,N
                   RTEMP = ZERO
                   DO 230 L = 1,K
-                      RTEMP = RTEMP + CONJG(A(L,J))*A(L,J)
+                      RTEMP = RTEMP + REAL(CONJG(A(L,J))*A(L,J))
   230             CONTINUE
                   IF (BETA.EQ.ZERO) THEN
                       C(J,J) = ALPHA*RTEMP

--- a/BLAS/SRC/sdsdot.f
+++ b/BLAS/SRC/sdsdot.f
@@ -130,7 +130,7 @@
 *     ..
       DSDOT = SB
       IF (N.LE.0) THEN
-         SDSDOT = DSDOT
+         SDSDOT = REAL(DSDOT)
          RETURN
       END IF
       IF (INCX.EQ.INCY .AND. INCX.GT.0) THEN
@@ -155,7 +155,7 @@
             KY = KY + INCY
          END DO
       END IF
-      SDSDOT = DSDOT
+      SDSDOT = REAL(DSDOT)
       RETURN
 *
 *     End of SDSDOT

--- a/BLAS/SRC/zherk.f
+++ b/BLAS/SRC/zherk.f
@@ -352,7 +352,7 @@
   200             CONTINUE
                   RTEMP = ZERO
                   DO 210 L = 1,K
-                      RTEMP = RTEMP + DCONJG(A(L,J))*A(L,J)
+                      RTEMP = RTEMP + DBLE(DCONJG(A(L,J))*A(L,J))
   210             CONTINUE
                   IF (BETA.EQ.ZERO) THEN
                       C(J,J) = ALPHA*RTEMP
@@ -364,7 +364,7 @@
               DO 260 J = 1,N
                   RTEMP = ZERO
                   DO 230 L = 1,K
-                      RTEMP = RTEMP + DCONJG(A(L,J))*A(L,J)
+                      RTEMP = RTEMP + DBLE(DCONJG(A(L,J))*A(L,J))
   230             CONTINUE
                   IF (BETA.EQ.ZERO) THEN
                       C(J,J) = ALPHA*RTEMP

--- a/LAPACKE/example/example_DGELS_rowmajor.c
+++ b/LAPACKE/example/example_DGELS_rowmajor.c
@@ -64,8 +64,8 @@
 int main (int argc, const char * argv[])
 {
    /* Locals */
-   double A[5][3] = {1,1,1,2,3,4,3,5,2,4,2,5,5,4,3};
-   double b[5][2] = {-10,-3,12,14,14,12,16,16,18,16};
+   double A[5][3] = {{1,1,1},{2,3,4},{3,5,2},{4,2,5},{5,4,3}};
+   double b[5][2] = {{-10,-3},{12,14},{14,12},{16,16},{18,16}};
    lapack_int info,m,n,lda,ldb,nrhs;
 
    /* Initialization */

--- a/LAPACKE/src/lapacke_cgesvdq.c
+++ b/LAPACKE/src/lapacke_cgesvdq.c
@@ -48,7 +48,6 @@ lapack_int LAPACKE_cgesvdq( int matrix_layout, char joba, char jobp,
     lapack_int lrwork = -1;
     float* rwork = NULL;
     float rwork_query;
-    lapack_int i;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_cgesvdq", -1 );
         return -1;

--- a/LAPACKE/src/lapacke_dgesvdq.c
+++ b/LAPACKE/src/lapacke_dgesvdq.c
@@ -48,7 +48,6 @@ lapack_int LAPACKE_dgesvdq( int matrix_layout, char joba, char jobp,
     lapack_int lrwork = -1;
     double* rwork = NULL;
     double rwork_query;
-    lapack_int i;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_dgesvdq", -1 );
         return -1;

--- a/LAPACKE/src/lapacke_sgesvdq.c
+++ b/LAPACKE/src/lapacke_sgesvdq.c
@@ -48,7 +48,6 @@ lapack_int LAPACKE_sgesvdq( int matrix_layout, char joba, char jobp,
     lapack_int lrwork = -1;
     float* rwork = NULL;
     float rwork_query;
-    lapack_int i;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_sgesvdq", -1 );
         return -1;

--- a/LAPACKE/src/lapacke_zgesvdq.c
+++ b/LAPACKE/src/lapacke_zgesvdq.c
@@ -48,7 +48,6 @@ lapack_int LAPACKE_zgesvdq( int matrix_layout, char joba, char jobp,
     lapack_int lrwork = -1;
     double* rwork = NULL;
     double rwork_query;
-    lapack_int i;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_zgesvdq", -1 );
         return -1;

--- a/SRC/cgebak.f
+++ b/SRC/cgebak.f
@@ -238,7 +238,7 @@
      $            GO TO 40
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 40
                CALL CSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -252,7 +252,7 @@
      $            GO TO 50
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 50
                CALL CSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )

--- a/SRC/cgees.f
+++ b/SRC/cgees.f
@@ -282,7 +282,7 @@
 *
             CALL CHSEQR( 'S', JOBVS, N, 1, N, A, LDA, W, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = REAL( WORK( 1 ) )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, HSWORK )

--- a/SRC/cgeesx.f
+++ b/SRC/cgeesx.f
@@ -337,7 +337,7 @@
 *
             CALL CHSEQR( 'S', JOBVS, N, 1, N, A, LDA, W, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = REAL( WORK( 1 ) )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, HSWORK )

--- a/SRC/cgejsv.f
+++ b/SRC/cgejsv.f
@@ -704,11 +704,11 @@
           IF ( LQUERY ) THEN 
               CALL CGEQP3( M, N, A, LDA, IWORK, CDUMMY, CDUMMY, -1, 
      $             RDUMMY, IERR )
-              LWRK_CGEQP3 = REAL( CDUMMY(1) )
+              LWRK_CGEQP3 = INT( CDUMMY(1) )
               CALL CGEQRF( N, N, A, LDA, CDUMMY, CDUMMY,-1, IERR )
-              LWRK_CGEQRF = REAL( CDUMMY(1) )
+              LWRK_CGEQRF = INT( CDUMMY(1) )
               CALL CGELQF( N, N, A, LDA, CDUMMY, CDUMMY,-1, IERR )
-              LWRK_CGELQF = REAL( CDUMMY(1) )
+              LWRK_CGELQF = INT( CDUMMY(1) )
           END IF
           MINWRK  = 2
           OPTWRK  = 2
@@ -724,7 +724,7 @@
               IF ( LQUERY ) THEN 
                   CALL CGESVJ( 'L', 'N', 'N', N, N, A, LDA, SVA, N, V, 
      $                 LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                  LWRK_CGESVJ = REAL( CDUMMY(1) )
+                  LWRK_CGESVJ = INT( CDUMMY(1) )
                   IF ( ERREST ) THEN 
                       OPTWRK = MAX( N+LWRK_CGEQP3, N**2+LWCON, 
      $                              N+LWRK_CGEQRF, LWRK_CGESVJ )
@@ -760,10 +760,10 @@
              IF ( LQUERY ) THEN
                  CALL CGESVJ( 'L', 'U', 'N', N,N, U, LDU, SVA, N, A,
      $                LDA, CDUMMY, -1, RDUMMY, -1, IERR )
-                 LWRK_CGESVJ = REAL( CDUMMY(1) )
+                 LWRK_CGESVJ = INT( CDUMMY(1) )
                  CALL CUNMLQ( 'L', 'C', N, N, N, A, LDA, CDUMMY,
      $                V, LDV, CDUMMY, -1, IERR )
-                 LWRK_CUNMLQ = REAL( CDUMMY(1) )
+                 LWRK_CUNMLQ = INT( CDUMMY(1) )
                  IF ( ERREST ) THEN 
                  OPTWRK = MAX( N+LWRK_CGEQP3, LWCON, LWRK_CGESVJ, 
      $                         N+LWRK_CGELQF, 2*N+LWRK_CGEQRF,
@@ -799,10 +799,10 @@
              IF ( LQUERY ) THEN
                  CALL CGESVJ( 'L', 'U', 'N', N,N, U, LDU, SVA, N, A,
      $                LDA, CDUMMY, -1, RDUMMY, -1, IERR )
-                 LWRK_CGESVJ = REAL( CDUMMY(1) )
+                 LWRK_CGESVJ = INT( CDUMMY(1) )
                  CALL CUNMQR( 'L', 'N', M, N, N, A, LDA, CDUMMY, U,
      $               LDU, CDUMMY, -1, IERR )
-                 LWRK_CUNMQRM = REAL( CDUMMY(1) )
+                 LWRK_CUNMQRM = INT( CDUMMY(1) )
                  IF ( ERREST ) THEN
                  OPTWRK = N + MAX( LWRK_CGEQP3, LWCON, N+LWRK_CGEQRF,
      $                             LWRK_CGESVJ, LWRK_CUNMQRM )
@@ -861,26 +861,26 @@
              IF ( LQUERY ) THEN
                  CALL CUNMQR( 'L', 'N', M, N, N, A, LDA, CDUMMY, U,
      $                LDU, CDUMMY, -1, IERR )
-                 LWRK_CUNMQRM = REAL( CDUMMY(1) )
+                 LWRK_CUNMQRM = INT( CDUMMY(1) )
                  CALL CUNMQR( 'L', 'N', N, N, N, A, LDA, CDUMMY, U,
      $                LDU, CDUMMY, -1, IERR )
-                 LWRK_CUNMQR = REAL( CDUMMY(1) )
+                 LWRK_CUNMQR = INT( CDUMMY(1) )
                  IF ( .NOT. JRACC ) THEN
                      CALL CGEQP3( N,N, A, LDA, IWORK, CDUMMY,CDUMMY, -1,
      $                    RDUMMY, IERR )
-                     LWRK_CGEQP3N = REAL( CDUMMY(1) )
+                     LWRK_CGEQP3N = INT( CDUMMY(1) )
                      CALL CGESVJ( 'L', 'U', 'N', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_CGESVJ = REAL( CDUMMY(1) )
+                     LWRK_CGESVJ = INT( CDUMMY(1) )
                      CALL CGESVJ( 'U', 'U', 'N', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_CGESVJU = REAL( CDUMMY(1) )
+                     LWRK_CGESVJU = INT( CDUMMY(1) )
                      CALL CGESVJ( 'L', 'U', 'V', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_CGESVJV = REAL( CDUMMY(1) )
+                     LWRK_CGESVJV = INT( CDUMMY(1) )
                      CALL CUNMLQ( 'L', 'C', N, N, N, A, LDA, CDUMMY,
      $                    V, LDV, CDUMMY, -1, IERR )
-                     LWRK_CUNMLQ = REAL( CDUMMY(1) )
+                     LWRK_CUNMLQ = INT( CDUMMY(1) )
                      IF ( ERREST ) THEN 
                        OPTWRK = MAX( N+LWRK_CGEQP3, N+LWCON, 
      $                          2*N+N**2+LWCON, 2*N+LWRK_CGEQRF, 
@@ -909,13 +909,13 @@
                  ELSE
                      CALL CGESVJ( 'L', 'U', 'V', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_CGESVJV = REAL( CDUMMY(1) )
+                     LWRK_CGESVJV = INT( CDUMMY(1) )
                      CALL CUNMQR( 'L', 'N', N, N, N, CDUMMY, N, CDUMMY,
      $                    V, LDV, CDUMMY, -1, IERR )
-                     LWRK_CUNMQR = REAL( CDUMMY(1) )
+                     LWRK_CUNMQR = INT( CDUMMY(1) )
                      CALL CUNMQR( 'L', 'N', M, N, N, A, LDA, CDUMMY, U,
      $                    LDU, CDUMMY, -1, IERR )
-                     LWRK_CUNMQRM = REAL( CDUMMY(1) )
+                     LWRK_CUNMQRM = INT( CDUMMY(1) )
                      IF ( ERREST ) THEN 
                         OPTWRK = MAX( N+LWRK_CGEQP3, N+LWCON,   
      $                           2*N+LWRK_CGEQRF, 2*N+N**2,  

--- a/SRC/cggbak.f
+++ b/SRC/cggbak.f
@@ -253,7 +253,7 @@
             IF( ILO.EQ.1 )
      $         GO TO 50
             DO 40 I = ILO - 1, 1, -1
-               K = RSCALE( I )
+               K = INT( RSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 40
                CALL CSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -263,7 +263,7 @@
             IF( IHI.EQ.N )
      $         GO TO 70
             DO 60 I = IHI + 1, N
-               K = RSCALE( I )
+               K = INT( RSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 60
                CALL CSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -277,7 +277,7 @@
             IF( ILO.EQ.1 )
      $         GO TO 90
             DO 80 I = ILO - 1, 1, -1
-               K = LSCALE( I )
+               K = INT( LSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 80
                CALL CSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -287,7 +287,7 @@
             IF( IHI.EQ.N )
      $         GO TO 110
             DO 100 I = IHI + 1, N
-               K = LSCALE( I )
+               K = INT( LSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 100
                CALL CSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )

--- a/SRC/cggbal.f
+++ b/SRC/cggbal.f
@@ -535,7 +535,7 @@
          IRAB = ICAMAX( N-ILO+1, B( I, ILO ), LDB )
          RAB = MAX( RAB, ABS( B( I, IRAB+ILO-1 ) ) )
          LRAB = INT( LOG10( RAB+SFMIN ) / BASL+ONE )
-         IR = LSCALE( I ) + SIGN( HALF, LSCALE( I ) )
+         IR = INT( LSCALE( I ) + SIGN( HALF, LSCALE( I ) ) )
          IR = MIN( MAX( IR, LSFMIN ), LSFMAX, LSFMAX-LRAB )
          LSCALE( I ) = SCLFAC**IR
          ICAB = ICAMAX( IHI, A( 1, I ), 1 )
@@ -543,7 +543,7 @@
          ICAB = ICAMAX( IHI, B( 1, I ), 1 )
          CAB = MAX( CAB, ABS( B( ICAB, I ) ) )
          LCAB = INT( LOG10( CAB+SFMIN ) / BASL+ONE )
-         JC = RSCALE( I ) + SIGN( HALF, RSCALE( I ) )
+         JC = INT( RSCALE( I ) + SIGN( HALF, RSCALE( I ) ) )
          JC = MIN( MAX( JC, LSFMIN ), LSFMAX, LSFMAX-LCAB )
          RSCALE( I ) = SCLFAC**JC
   360 CONTINUE

--- a/SRC/cggglm.f
+++ b/SRC/cggglm.f
@@ -289,7 +289,7 @@
 *
       CALL CGGQRF( N, M, P, A, LDA, WORK, B, LDB, WORK( M+1 ),
      $             WORK( M+NP+1 ), LWORK-M-NP, INFO )
-      LOPT = REAL( WORK( M+NP+1 ) )
+      LOPT = INT( WORK( M+NP+1 ) )
 *
 *     Update left-hand-side vector d = Q**H*d = ( d1 ) M
 *                                               ( d2 ) N-M

--- a/SRC/cgghd3.f
+++ b/SRC/cgghd3.f
@@ -511,7 +511,7 @@
 *
                IF( JJ.GT.0 ) THEN
                   DO I = JJ, 1, -1
-                     C = DBLE( A( J+1+I, J ) )
+                     C = REAL( A( J+1+I, J ) )
                      CALL CROT( IHI-TOP, A( TOP+1, J+I+1 ), 1,
      $                          A( TOP+1, J+I ), 1, C,
      $                          -CONJG( B( J+1+I, J ) ) )

--- a/SRC/cgglse.f
+++ b/SRC/cgglse.f
@@ -276,7 +276,7 @@
 *
       CALL CGGRQF( P, M, N, B, LDB, WORK, A, LDA, WORK( P+1 ),
      $             WORK( P+MN+1 ), LWORK-P-MN, INFO )
-      LOPT = REAL( WORK( P+MN+1 ) )
+      LOPT = INT( WORK( P+MN+1 ) )
 *
 *     Update c = Z**H *c = ( c1 ) N-P
 *                       ( c2 ) M+P-N

--- a/SRC/cggqrf.f
+++ b/SRC/cggqrf.f
@@ -276,7 +276,7 @@
 *     QR factorization of N-by-M matrix A: A = Q*R
 *
       CALL CGEQRF( N, M, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = REAL( WORK( 1 ) )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := Q**H*B.
 *

--- a/SRC/cggrqf.f
+++ b/SRC/cggrqf.f
@@ -275,7 +275,7 @@
 *     RQ factorization of M-by-N matrix A: A = R*Q
 *
       CALL CGERQF( M, N, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = REAL( WORK( 1 ) )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := B*Q**H
 *

--- a/SRC/chegvd.f
+++ b/SRC/chegvd.f
@@ -360,9 +360,9 @@
       CALL CHEGST( ITYPE, UPLO, N, A, LDA, B, LDB, INFO )
       CALL CHEEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, RWORK, LRWORK,
      $             IWORK, LIWORK, INFO )
-      LOPT = MAX( REAL( LOPT ), REAL( WORK( 1 ) ) )
-      LROPT = MAX( REAL( LROPT ), REAL( RWORK( 1 ) ) )
-      LIOPT = MAX( REAL( LIOPT ), REAL( IWORK( 1 ) ) )
+      LOPT = INT( MAX( REAL( LOPT ), REAL( WORK( 1 ) ) ) )
+      LROPT = INT( MAX( REAL( LROPT ), REAL( RWORK( 1 ) ) ) )
+      LIOPT = INT( MAX( REAL( LIOPT ), REAL( IWORK( 1 ) ) ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *

--- a/SRC/chesv_rk.f
+++ b/SRC/chesv_rk.f
@@ -280,7 +280,7 @@
             LWKOPT = 1
          ELSE
             CALL CHETRF_RK( UPLO, N, A, LDA, E, IPIV, WORK, -1, INFO )
-            LWKOPT = REAL( WORK(1) )
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/chpgvd.f
+++ b/SRC/chpgvd.f
@@ -335,9 +335,9 @@
       CALL CHPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL CHPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, RWORK,
      $             LRWORK, IWORK, LIWORK, INFO )
-      LWMIN = MAX( REAL( LWMIN ), REAL( WORK( 1 ) ) )
-      LRWMIN = MAX( REAL( LRWMIN ), REAL( RWORK( 1 ) ) )
-      LIWMIN = MAX( REAL( LIWMIN ), REAL( IWORK( 1 ) ) )
+      LWMIN = INT( MAX( REAL( LWMIN ), REAL( WORK( 1 ) ) ) )
+      LRWMIN = INT( MAX( REAL( LRWMIN ), REAL( RWORK( 1 ) ) ) )
+      LIWMIN = INT( MAX( REAL( LIWMIN ), REAL( IWORK( 1 ) ) ) )
 *
       IF( WANTZ ) THEN
 *

--- a/SRC/csysv.f
+++ b/SRC/csysv.f
@@ -223,7 +223,7 @@
             LWKOPT = 1
          ELSE
             CALL CSYTRF( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = REAL( WORK(1) )
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/csysv_rk.f
+++ b/SRC/csysv_rk.f
@@ -280,7 +280,7 @@
             LWKOPT = 1
          ELSE
             CALL CSYTRF_RK( UPLO, N, A, LDA, E, IPIV, WORK, -1, INFO )
-            LWKOPT = REAL( WORK(1) )
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/csysv_rook.f
+++ b/SRC/csysv_rook.f
@@ -256,7 +256,7 @@
             LWKOPT = 1
          ELSE
             CALL CSYTRF_ROOK( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = REAL( WORK(1) )
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/cungbr.f
+++ b/SRC/cungbr.f
@@ -233,7 +233,7 @@
                END IF
             END IF
          END IF
-         LWKOPT = REAL( WORK( 1 ) )
+         LWKOPT = INT( WORK( 1 ) )
          LWKOPT = MAX (LWKOPT, MN)
       END IF
 *

--- a/SRC/dgebak.f
+++ b/SRC/dgebak.f
@@ -236,7 +236,7 @@
      $            GO TO 40
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 40
                CALL DSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -250,7 +250,7 @@
      $            GO TO 50
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 50
                CALL DSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )

--- a/SRC/dgees.f
+++ b/SRC/dgees.f
@@ -302,7 +302,7 @@
 *
             CALL DHSEQR( 'S', JOBVS, N, 1, N, A, LDA, WR, WI, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = WORK( 1 )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, N + HSWORK )

--- a/SRC/dgeesx.f
+++ b/SRC/dgeesx.f
@@ -382,7 +382,7 @@
 *
             CALL DHSEQR( 'S', JOBVS, N, 1, N, A, LDA, WR, WI, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = WORK( 1 )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, N + HSWORK )

--- a/SRC/dgelss.f
+++ b/SRC/dgelss.f
@@ -305,7 +305,7 @@
 *                 Compute space needed for DGELQF
                   CALL DGELQF( M, N, A, LDA, DUM(1), DUM(1),
      $                -1, INFO )
-                  LWORK_DGELQF=DUM(1)
+                  LWORK_DGELQF = INT( DUM(1) )
 *                 Compute space needed for DGEBRD
                   CALL DGEBRD( M, M, A, LDA, S, DUM(1), DUM(1),
      $                      DUM(1), DUM(1), -1, INFO )

--- a/SRC/dggglm.f
+++ b/SRC/dggglm.f
@@ -288,7 +288,7 @@
 *
       CALL DGGQRF( N, M, P, A, LDA, WORK, B, LDB, WORK( M+1 ),
      $             WORK( M+NP+1 ), LWORK-M-NP, INFO )
-      LOPT = WORK( M+NP+1 )
+      LOPT = INT( WORK( M+NP+1 ) )
 *
 *     Update left-hand-side vector d = Q**T*d = ( d1 ) M
 *                                               ( d2 ) N-M

--- a/SRC/dgglse.f
+++ b/SRC/dgglse.f
@@ -276,7 +276,7 @@
 *
       CALL DGGRQF( P, M, N, B, LDB, WORK, A, LDA, WORK( P+1 ),
      $             WORK( P+MN+1 ), LWORK-P-MN, INFO )
-      LOPT = WORK( P+MN+1 )
+      LOPT = INT( WORK( P+MN+1 ) )
 *
 *     Update c = Z**T *c = ( c1 ) N-P
 *                          ( c2 ) M+P-N

--- a/SRC/dggqrf.f
+++ b/SRC/dggqrf.f
@@ -276,7 +276,7 @@
 *     QR factorization of N-by-M matrix A: A = Q*R
 *
       CALL DGEQRF( N, M, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = WORK( 1 )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := Q**T*B.
 *

--- a/SRC/dggrqf.f
+++ b/SRC/dggrqf.f
@@ -275,7 +275,7 @@
 *     RQ factorization of M-by-N matrix A: A = R*Q
 *
       CALL DGERQF( M, N, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = WORK( 1 )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := B*Q**T
 *

--- a/SRC/dlag2s.f
+++ b/SRC/dlag2s.f
@@ -34,8 +34,8 @@
 *>
 *> \verbatim
 *>
-*> DLAG2S converts a DOUBLE PRECISION matrix, SA, to a SINGLE
-*> PRECISION matrix, A.
+*> DLAG2S converts a DOUBLE PRECISION matrix, A, to a SINGLE
+*> PRECISION matrix, SA.
 *>
 *> RMAX is the overflow for the SINGLE PRECISION arithmetic
 *> DLAG2S checks that all the entries of A are between -RMAX and
@@ -128,6 +128,9 @@
       REAL               SLAMCH
       EXTERNAL           SLAMCH
 *     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          REAL
+*     ..
 *     .. Executable Statements ..
 *
       RMAX = SLAMCH( 'O' )
@@ -137,7 +140,7 @@
                INFO = 1
                GO TO 30
             END IF
-            SA( I, J ) = A( I, J )
+            SA( I, J ) = REAL( A( I, J ) )
    10    CONTINUE
    20 CONTINUE
       INFO = 0

--- a/SRC/dlat2s.f
+++ b/SRC/dlat2s.f
@@ -134,6 +134,9 @@
       LOGICAL            LSAME
       EXTERNAL           SLAMCH, LSAME
 *     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          REAL
+*     ..
 *     .. Executable Statements ..
 *
       RMAX = SLAMCH( 'O' )
@@ -146,7 +149,7 @@
                   INFO = 1
                   GO TO 50
                END IF
-               SA( I, J ) = A( I, J )
+               SA( I, J ) = REAL( A( I, J ) )
    10       CONTINUE
    20    CONTINUE
       ELSE
@@ -157,7 +160,7 @@
                   INFO = 1
                   GO TO 50
                END IF
-               SA( I, J ) = A( I, J )
+               SA( I, J ) = REAL( A( I, J ) )
    30       CONTINUE
    40    CONTINUE
       END IF

--- a/SRC/dorgbr.f
+++ b/SRC/dorgbr.f
@@ -232,7 +232,7 @@
                END IF
             END IF
          END IF
-         LWKOPT = WORK( 1 )
+         LWKOPT = INT( WORK( 1 ) )
          LWKOPT = MAX (LWKOPT, MN)
       END IF
 *

--- a/SRC/dspgvd.f
+++ b/SRC/dspgvd.f
@@ -307,8 +307,8 @@
       CALL DSPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL DSPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, IWORK,
      $             LIWORK, INFO )
-      LWMIN = MAX( DBLE( LWMIN ), DBLE( WORK( 1 ) ) )
-      LIWMIN = MAX( DBLE( LIWMIN ), DBLE( IWORK( 1 ) ) )
+      LWMIN = INT( MAX( DBLE( LWMIN ), DBLE( WORK( 1 ) ) ) )
+      LIWMIN = INT( MAX( DBLE( LIWMIN ), DBLE( IWORK( 1 ) ) ) )
 *
       IF( WANTZ ) THEN
 *

--- a/SRC/dsygvd.f
+++ b/SRC/dsygvd.f
@@ -330,8 +330,8 @@
       CALL DSYGST( ITYPE, UPLO, N, A, LDA, B, LDB, INFO )
       CALL DSYEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, IWORK, LIWORK,
      $             INFO )
-      LOPT = MAX( DBLE( LOPT ), DBLE( WORK( 1 ) ) )
-      LIOPT = MAX( DBLE( LIOPT ), DBLE( IWORK( 1 ) ) )
+      LOPT = INT( MAX( DBLE( LOPT ), DBLE( WORK( 1 ) ) ) )
+      LIOPT = INT( MAX( DBLE( LIOPT ), DBLE( IWORK( 1 ) ) ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *

--- a/SRC/dsysv.f
+++ b/SRC/dsysv.f
@@ -223,7 +223,7 @@
             LWKOPT = 1
          ELSE
             CALL DSYTRF( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = WORK(1)
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/dsysv_rk.f
+++ b/SRC/dsysv_rk.f
@@ -280,7 +280,7 @@
             LWKOPT = 1
          ELSE
             CALL DSYTRF_RK( UPLO, N, A, LDA, E, IPIV, WORK, -1, INFO )
-            LWKOPT = WORK(1)
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/dsysv_rook.f
+++ b/SRC/dsysv_rook.f
@@ -256,7 +256,7 @@
             LWKOPT = 1
          ELSE
             CALL DSYTRF_ROOK( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = WORK(1)
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/sgebak.f
+++ b/SRC/sgebak.f
@@ -236,7 +236,7 @@
      $            GO TO 40
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 40
                CALL SSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -250,7 +250,7 @@
      $            GO TO 50
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 50
                CALL SSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )

--- a/SRC/sgees.f
+++ b/SRC/sgees.f
@@ -302,7 +302,7 @@
 *
             CALL SHSEQR( 'S', JOBVS, N, 1, N, A, LDA, WR, WI, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = WORK( 1 )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, N + HSWORK )

--- a/SRC/sgeesx.f
+++ b/SRC/sgeesx.f
@@ -382,7 +382,7 @@
 *
             CALL SHSEQR( 'S', JOBVS, N, 1, N, A, LDA, WR, WI, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = WORK( 1 )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, N + HSWORK )

--- a/SRC/sggbak.f
+++ b/SRC/sggbak.f
@@ -252,7 +252,7 @@
      $         GO TO 50
 *
             DO 40 I = ILO - 1, 1, -1
-               K = RSCALE( I )
+               K = INT( RSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 40
                CALL SSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -262,7 +262,7 @@
             IF( IHI.EQ.N )
      $         GO TO 70
             DO 60 I = IHI + 1, N
-               K = RSCALE( I )
+               K = INT( RSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 60
                CALL SSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -276,7 +276,7 @@
             IF( ILO.EQ.1 )
      $         GO TO 90
             DO 80 I = ILO - 1, 1, -1
-               K = LSCALE( I )
+               K = INT( LSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 80
                CALL SSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -286,7 +286,7 @@
             IF( IHI.EQ.N )
      $         GO TO 110
             DO 100 I = IHI + 1, N
-               K = LSCALE( I )
+               K = INT( LSCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 100
                CALL SSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )

--- a/SRC/sggbal.f
+++ b/SRC/sggbal.f
@@ -522,7 +522,7 @@
          IRAB = ISAMAX( N-ILO+1, B( I, ILO ), LDB )
          RAB = MAX( RAB, ABS( B( I, IRAB+ILO-1 ) ) )
          LRAB = INT( LOG10( RAB+SFMIN ) / BASL+ONE )
-         IR = LSCALE( I ) + SIGN( HALF, LSCALE( I ) )
+         IR = INT( LSCALE( I ) + SIGN( HALF, LSCALE( I ) ) )
          IR = MIN( MAX( IR, LSFMIN ), LSFMAX, LSFMAX-LRAB )
          LSCALE( I ) = SCLFAC**IR
          ICAB = ISAMAX( IHI, A( 1, I ), 1 )
@@ -530,7 +530,7 @@
          ICAB = ISAMAX( IHI, B( 1, I ), 1 )
          CAB = MAX( CAB, ABS( B( ICAB, I ) ) )
          LCAB = INT( LOG10( CAB+SFMIN ) / BASL+ONE )
-         JC = RSCALE( I ) + SIGN( HALF, RSCALE( I ) )
+         JC = INT( RSCALE( I ) + SIGN( HALF, RSCALE( I ) ) )
          JC = MIN( MAX( JC, LSFMIN ), LSFMAX, LSFMAX-LCAB )
          RSCALE( I ) = SCLFAC**JC
   360 CONTINUE

--- a/SRC/sggglm.f
+++ b/SRC/sggglm.f
@@ -288,7 +288,7 @@
 *
       CALL SGGQRF( N, M, P, A, LDA, WORK, B, LDB, WORK( M+1 ),
      $             WORK( M+NP+1 ), LWORK-M-NP, INFO )
-      LOPT = WORK( M+NP+1 )
+      LOPT = INT( WORK( M+NP+1 ) )
 *
 *     Update left-hand-side vector d = Q**T*d = ( d1 ) M
 *                                               ( d2 ) N-M

--- a/SRC/sgglse.f
+++ b/SRC/sgglse.f
@@ -276,7 +276,7 @@
 *
       CALL SGGRQF( P, M, N, B, LDB, WORK, A, LDA, WORK( P+1 ),
      $             WORK( P+MN+1 ), LWORK-P-MN, INFO )
-      LOPT = WORK( P+MN+1 )
+      LOPT = INT( WORK( P+MN+1 ) )
 *
 *     Update c = Z**T *c = ( c1 ) N-P
 *                          ( c2 ) M+P-N

--- a/SRC/sggqrf.f
+++ b/SRC/sggqrf.f
@@ -276,7 +276,7 @@
 *     QR factorization of N-by-M matrix A: A = Q*R
 *
       CALL SGEQRF( N, M, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = WORK( 1 )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := Q**T*B.
 *

--- a/SRC/sggrqf.f
+++ b/SRC/sggrqf.f
@@ -275,7 +275,7 @@
 *     RQ factorization of M-by-N matrix A: A = R*Q
 *
       CALL SGERQF( M, N, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = WORK( 1 )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := B*Q**T
 *

--- a/SRC/sorgbr.f
+++ b/SRC/sorgbr.f
@@ -232,7 +232,7 @@
                END IF
             END IF
          END IF
-         LWKOPT = WORK( 1 )
+         LWKOPT = INT( WORK( 1 ) )
          LWKOPT = MAX (LWKOPT, MN)
       END IF
 *

--- a/SRC/sspgvd.f
+++ b/SRC/sspgvd.f
@@ -307,8 +307,8 @@
       CALL SSPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL SSPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, IWORK,
      $             LIWORK, INFO )
-      LWMIN = MAX( REAL( LWMIN ), REAL( WORK( 1 ) ) )
-      LIWMIN = MAX( REAL( LIWMIN ), REAL( IWORK( 1 ) ) )
+      LWMIN = INT( MAX( REAL( LWMIN ), REAL( WORK( 1 ) ) ) )
+      LIWMIN = INT( MAX( REAL( LIWMIN ), REAL( IWORK( 1 ) ) ) )
 *
       IF( WANTZ ) THEN
 *

--- a/SRC/ssygvd.f
+++ b/SRC/ssygvd.f
@@ -330,8 +330,8 @@
       CALL SSYGST( ITYPE, UPLO, N, A, LDA, B, LDB, INFO )
       CALL SSYEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, IWORK, LIWORK,
      $             INFO )
-      LOPT = MAX( REAL( LOPT ), REAL( WORK( 1 ) ) )
-      LIOPT = MAX( REAL( LIOPT ), REAL( IWORK( 1 ) ) )
+      LOPT = INT( MAX( REAL( LOPT ), REAL( WORK( 1 ) ) ) )
+      LIOPT = INT( MAX( REAL( LIOPT ), REAL( IWORK( 1 ) ) ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *

--- a/SRC/ssysv.f
+++ b/SRC/ssysv.f
@@ -223,7 +223,7 @@
             LWKOPT = 1
          ELSE
             CALL SSYTRF( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = WORK(1)
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/ssysv_rk.f
+++ b/SRC/ssysv_rk.f
@@ -280,7 +280,7 @@
             LWKOPT = 1
          ELSE
             CALL SSYTRF_RK( UPLO, N, A, LDA, E, IPIV, WORK, -1, INFO )
-            LWKOPT = WORK(1)
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/ssysv_rook.f
+++ b/SRC/ssysv_rook.f
@@ -256,7 +256,7 @@
             LWKOPT = 1
          ELSE
             CALL SSYTRF_ROOK( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = WORK(1)
+            LWKOPT = INT( WORK( 1 ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/zgebak.f
+++ b/SRC/zgebak.f
@@ -238,7 +238,7 @@
      $            GO TO 40
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 40
                CALL ZSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )
@@ -252,7 +252,7 @@
      $            GO TO 50
                IF( I.LT.ILO )
      $            I = ILO - II
-               K = SCALE( I )
+               K = INT( SCALE( I ) )
                IF( K.EQ.I )
      $            GO TO 50
                CALL ZSWAP( M, V( I, 1 ), LDV, V( K, 1 ), LDV )

--- a/SRC/zgees.f
+++ b/SRC/zgees.f
@@ -282,7 +282,7 @@
 *
             CALL ZHSEQR( 'S', JOBVS, N, 1, N, A, LDA, W, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = DBLE( WORK( 1 ) )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, HSWORK )

--- a/SRC/zgeesx.f
+++ b/SRC/zgeesx.f
@@ -337,7 +337,7 @@
 *
             CALL ZHSEQR( 'S', JOBVS, N, 1, N, A, LDA, W, VS, LDVS,
      $             WORK, -1, IEVAL )
-            HSWORK = DBLE( WORK( 1 ) )
+            HSWORK = INT( WORK( 1 ) )
 *
             IF( .NOT.WANTVS ) THEN
                MAXWRK = MAX( MAXWRK, HSWORK )

--- a/SRC/zgejsv.f
+++ b/SRC/zgejsv.f
@@ -707,11 +707,11 @@
           IF ( LQUERY ) THEN 
               CALL ZGEQP3( M, N, A, LDA, IWORK, CDUMMY, CDUMMY, -1, 
      $             RDUMMY, IERR )
-              LWRK_ZGEQP3 = DBLE( CDUMMY(1) )
+              LWRK_ZGEQP3 = INT( CDUMMY(1) )
               CALL ZGEQRF( N, N, A, LDA, CDUMMY, CDUMMY,-1, IERR )
-              LWRK_ZGEQRF = DBLE( CDUMMY(1) )
+              LWRK_ZGEQRF = INT( CDUMMY(1) )
               CALL ZGELQF( N, N, A, LDA, CDUMMY, CDUMMY,-1, IERR )
-              LWRK_ZGELQF = DBLE( CDUMMY(1) )
+              LWRK_ZGELQF = INT( CDUMMY(1) )
           END IF
           MINWRK  = 2
           OPTWRK  = 2
@@ -727,7 +727,7 @@
               IF ( LQUERY ) THEN 
                   CALL ZGESVJ( 'L', 'N', 'N', N, N, A, LDA, SVA, N, V, 
      $                 LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                  LWRK_ZGESVJ = DBLE( CDUMMY(1) )
+                  LWRK_ZGESVJ = INT( CDUMMY(1) )
                   IF ( ERREST ) THEN 
                       OPTWRK = MAX( N+LWRK_ZGEQP3, N**2+LWCON, 
      $                              N+LWRK_ZGEQRF, LWRK_ZGESVJ )
@@ -763,10 +763,10 @@
              IF ( LQUERY ) THEN
                  CALL ZGESVJ( 'L', 'U', 'N', N,N, U, LDU, SVA, N, A,
      $                LDA, CDUMMY, -1, RDUMMY, -1, IERR )
-                 LWRK_ZGESVJ = DBLE( CDUMMY(1) )
+                 LWRK_ZGESVJ = INT( CDUMMY(1) )
                  CALL ZUNMLQ( 'L', 'C', N, N, N, A, LDA, CDUMMY,
      $                V, LDV, CDUMMY, -1, IERR )
-                 LWRK_ZUNMLQ = DBLE( CDUMMY(1) )
+                 LWRK_ZUNMLQ = INT( CDUMMY(1) )
                  IF ( ERREST ) THEN 
                  OPTWRK = MAX( N+LWRK_ZGEQP3, LWCON, LWRK_ZGESVJ, 
      $                         N+LWRK_ZGELQF, 2*N+LWRK_ZGEQRF,
@@ -802,10 +802,10 @@
              IF ( LQUERY ) THEN
                  CALL ZGESVJ( 'L', 'U', 'N', N,N, U, LDU, SVA, N, A,
      $                LDA, CDUMMY, -1, RDUMMY, -1, IERR )
-                 LWRK_ZGESVJ = DBLE( CDUMMY(1) )
+                 LWRK_ZGESVJ = INT( CDUMMY(1) )
                  CALL ZUNMQR( 'L', 'N', M, N, N, A, LDA, CDUMMY, U,
      $               LDU, CDUMMY, -1, IERR )
-                 LWRK_ZUNMQRM = DBLE( CDUMMY(1) )
+                 LWRK_ZUNMQRM = INT( CDUMMY(1) )
                  IF ( ERREST ) THEN
                  OPTWRK = N + MAX( LWRK_ZGEQP3, LWCON, N+LWRK_ZGEQRF,
      $                             LWRK_ZGESVJ, LWRK_ZUNMQRM )
@@ -864,26 +864,26 @@
              IF ( LQUERY ) THEN
                  CALL ZUNMQR( 'L', 'N', M, N, N, A, LDA, CDUMMY, U,
      $                LDU, CDUMMY, -1, IERR )
-                 LWRK_ZUNMQRM = DBLE( CDUMMY(1) )
+                 LWRK_ZUNMQRM = INT( CDUMMY(1) )
                  CALL ZUNMQR( 'L', 'N', N, N, N, A, LDA, CDUMMY, U,
      $                LDU, CDUMMY, -1, IERR )
-                 LWRK_ZUNMQR = DBLE( CDUMMY(1) )
+                 LWRK_ZUNMQR = INT( CDUMMY(1) )
                  IF ( .NOT. JRACC ) THEN
                      CALL ZGEQP3( N,N, A, LDA, IWORK, CDUMMY,CDUMMY, -1,
      $                    RDUMMY, IERR )
-                     LWRK_ZGEQP3N = DBLE( CDUMMY(1) )
+                     LWRK_ZGEQP3N = INT( CDUMMY(1) )
                      CALL ZGESVJ( 'L', 'U', 'N', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_ZGESVJ = DBLE( CDUMMY(1) )
+                     LWRK_ZGESVJ = INT( CDUMMY(1) )
                      CALL ZGESVJ( 'U', 'U', 'N', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_ZGESVJU = DBLE( CDUMMY(1) )
+                     LWRK_ZGESVJU = INT( CDUMMY(1) )
                      CALL ZGESVJ( 'L', 'U', 'V', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_ZGESVJV = DBLE( CDUMMY(1) )
+                     LWRK_ZGESVJV = INT( CDUMMY(1) )
                      CALL ZUNMLQ( 'L', 'C', N, N, N, A, LDA, CDUMMY,
      $                    V, LDV, CDUMMY, -1, IERR )
-                     LWRK_ZUNMLQ = DBLE( CDUMMY(1) )
+                     LWRK_ZUNMLQ = INT( CDUMMY(1) )
                      IF ( ERREST ) THEN 
                        OPTWRK = MAX( N+LWRK_ZGEQP3, N+LWCON, 
      $                          2*N+N**2+LWCON, 2*N+LWRK_ZGEQRF, 
@@ -912,13 +912,13 @@
                  ELSE
                      CALL ZGESVJ( 'L', 'U', 'V', N, N, U, LDU, SVA,
      $                    N, V, LDV, CDUMMY, -1, RDUMMY, -1, IERR )
-                     LWRK_ZGESVJV = DBLE( CDUMMY(1) )
+                     LWRK_ZGESVJV = INT( CDUMMY(1) )
                      CALL ZUNMQR( 'L', 'N', N, N, N, CDUMMY, N, CDUMMY,
      $                    V, LDV, CDUMMY, -1, IERR )
-                     LWRK_ZUNMQR = DBLE( CDUMMY(1) )
+                     LWRK_ZUNMQR = INT( CDUMMY(1) )
                      CALL ZUNMQR( 'L', 'N', M, N, N, A, LDA, CDUMMY, U,
      $                    LDU, CDUMMY, -1, IERR )
-                     LWRK_ZUNMQRM = DBLE( CDUMMY(1) )
+                     LWRK_ZUNMQRM = INT( CDUMMY(1) )
                      IF ( ERREST ) THEN 
                         OPTWRK = MAX( N+LWRK_ZGEQP3, N+LWCON,   
      $                           2*N+LWRK_ZGEQRF, 2*N+N**2,  

--- a/SRC/zggglm.f
+++ b/SRC/zggglm.f
@@ -289,7 +289,7 @@
 *
       CALL ZGGQRF( N, M, P, A, LDA, WORK, B, LDB, WORK( M+1 ),
      $             WORK( M+NP+1 ), LWORK-M-NP, INFO )
-      LOPT = DBLE( WORK( M+NP+1 ) )
+      LOPT = INT( WORK( M+NP+1 ) )
 *
 *     Update left-hand-side vector d = Q**H*d = ( d1 ) M
 *                                               ( d2 ) N-M

--- a/SRC/zgglse.f
+++ b/SRC/zgglse.f
@@ -276,7 +276,7 @@
 *
       CALL ZGGRQF( P, M, N, B, LDB, WORK, A, LDA, WORK( P+1 ),
      $             WORK( P+MN+1 ), LWORK-P-MN, INFO )
-      LOPT = DBLE( WORK( P+MN+1 ) )
+      LOPT = INT( WORK( P+MN+1 ) )
 *
 *     Update c = Z**H *c = ( c1 ) N-P
 *                       ( c2 ) M+P-N

--- a/SRC/zggqrf.f
+++ b/SRC/zggqrf.f
@@ -276,7 +276,7 @@
 *     QR factorization of N-by-M matrix A: A = Q*R
 *
       CALL ZGEQRF( N, M, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = DBLE( WORK( 1 ) )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := Q**H*B.
 *

--- a/SRC/zggrqf.f
+++ b/SRC/zggrqf.f
@@ -275,7 +275,7 @@
 *     RQ factorization of M-by-N matrix A: A = R*Q
 *
       CALL ZGERQF( M, N, A, LDA, TAUA, WORK, LWORK, INFO )
-      LOPT = DBLE( WORK( 1 ) )
+      LOPT = INT( WORK( 1 ) )
 *
 *     Update B := B*Q**H
 *

--- a/SRC/zhegvd.f
+++ b/SRC/zhegvd.f
@@ -360,9 +360,9 @@
       CALL ZHEGST( ITYPE, UPLO, N, A, LDA, B, LDB, INFO )
       CALL ZHEEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, RWORK, LRWORK,
      $             IWORK, LIWORK, INFO )
-      LOPT = MAX( DBLE( LOPT ), DBLE( WORK( 1 ) ) )
-      LROPT = MAX( DBLE( LROPT ), DBLE( RWORK( 1 ) ) )
-      LIOPT = MAX( DBLE( LIOPT ), DBLE( IWORK( 1 ) ) )
+      LOPT = INT( MAX( DBLE( LOPT ), DBLE( WORK( 1 ) ) ) )
+      LROPT = INT( MAX( DBLE( LROPT ), DBLE( RWORK( 1 ) ) ) )
+      LIOPT = INT( MAX( DBLE( LIOPT ), DBLE( IWORK( 1 ) ) ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *

--- a/SRC/zhesv_rk.f
+++ b/SRC/zhesv_rk.f
@@ -280,7 +280,7 @@
             LWKOPT = 1
          ELSE
             CALL ZHETRF_RK( UPLO, N, A, LDA, E, IPIV, WORK, -1, INFO )
-            LWKOPT = DBLE( WORK(1) )
+            LWKOPT = INT( DBLE( WORK( 1 ) ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/zhpgvd.f
+++ b/SRC/zhpgvd.f
@@ -335,9 +335,9 @@
       CALL ZHPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL ZHPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, RWORK,
      $             LRWORK, IWORK, LIWORK, INFO )
-      LWMIN = MAX( DBLE( LWMIN ), DBLE( WORK( 1 ) ) )
-      LRWMIN = MAX( DBLE( LRWMIN ), DBLE( RWORK( 1 ) ) )
-      LIWMIN = MAX( DBLE( LIWMIN ), DBLE( IWORK( 1 ) ) )
+      LWMIN = INT( MAX( DBLE( LWMIN ), DBLE( WORK( 1 ) ) ) )
+      LRWMIN = INT( MAX( DBLE( LRWMIN ), DBLE( RWORK( 1 ) ) ) )
+      LIWMIN = INT( MAX( DBLE( LIWMIN ), DBLE( IWORK( 1 ) ) ) )
 *
       IF( WANTZ ) THEN
 *

--- a/SRC/zlag2c.f
+++ b/SRC/zlag2c.f
@@ -124,7 +124,7 @@
       DOUBLE PRECISION   RMAX
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          DBLE, DIMAG
+      INTRINSIC          DBLE, DIMAG, CMPLX
 *     ..
 *     .. External Functions ..
       REAL               SLAMCH
@@ -142,7 +142,7 @@
                INFO = 1
                GO TO 30
             END IF
-            SA( I, J ) = A( I, J )
+            SA( I, J ) = CMPLX( A( I, J ) )
    10    CONTINUE
    20 CONTINUE
       INFO = 0

--- a/SRC/zlaic1.f
+++ b/SRC/zlaic1.f
@@ -348,9 +348,9 @@
                B = ( ZETA2*ZETA2+ZETA1*ZETA1-ONE )*HALF
                C = ZETA1*ZETA1
                IF( B.GE.ZERO ) THEN
-                  T = -C / ( B+SQRT( B*B+C ) )
+                  T = DBLE( -C / ( B+SQRT( B*B+C ) ) )
                ELSE
-                  T = B - SQRT( B*B+C )
+                  T = DBLE( B - SQRT( B*B+C ) )
                END IF
                SINE = -( ALPHA / ABSEST ) / T
                COSINE = -( GAMMA / ABSEST ) / ( ONE+T )

--- a/SRC/zlat2c.f
+++ b/SRC/zlat2c.f
@@ -130,7 +130,7 @@
       LOGICAL            UPPER
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          DBLE, DIMAG
+      INTRINSIC          DBLE, DIMAG, CMPLX
 *     ..
 *     .. External Functions ..
       REAL               SLAMCH
@@ -151,7 +151,7 @@
                   INFO = 1
                   GO TO 50
                END IF
-               SA( I, J ) = A( I, J )
+               SA( I, J ) = CMPLX( A( I, J ) )
    10       CONTINUE
    20    CONTINUE
       ELSE
@@ -164,7 +164,7 @@
                   INFO = 1
                   GO TO 50
                END IF
-               SA( I, J ) = A( I, J )
+               SA( I, J ) = CMPLX( A( I, J ) )
    30       CONTINUE
    40    CONTINUE
       END IF

--- a/SRC/zsysv.f
+++ b/SRC/zsysv.f
@@ -223,7 +223,7 @@
             LWKOPT = 1
          ELSE
             CALL ZSYTRF( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = DBLE( WORK(1) )
+            LWKOPT = INT( DBLE( WORK( 1 ) ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/zsysv_rk.f
+++ b/SRC/zsysv_rk.f
@@ -280,7 +280,7 @@
             LWKOPT = 1
          ELSE
             CALL ZSYTRF_RK( UPLO, N, A, LDA, E, IPIV, WORK, -1, INFO )
-            LWKOPT = DBLE( WORK(1) )
+            LWKOPT = INT( DBLE( WORK( 1 ) ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/zsysv_rook.f
+++ b/SRC/zsysv_rook.f
@@ -256,7 +256,7 @@
             LWKOPT = 1
          ELSE
             CALL ZSYTRF_ROOK( UPLO, N, A, LDA, IPIV, WORK, -1, INFO )
-            LWKOPT = DBLE( WORK(1) )
+            LWKOPT = INT( DBLE( WORK( 1 ) ) )
          END IF
          WORK( 1 ) = LWKOPT
       END IF

--- a/SRC/zungbr.f
+++ b/SRC/zungbr.f
@@ -233,7 +233,7 @@
                END IF
             END IF
          END IF
-         LWKOPT = DBLE( WORK( 1 ) )
+         LWKOPT = INT( DBLE( WORK( 1 ) ) )
          LWKOPT = MAX (LWKOPT, MN)
       END IF
 *

--- a/TESTING/EIG/cdrvsg.f
+++ b/TESTING/EIG/cdrvsg.f
@@ -663,8 +663,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*SLARND( 1, ISEED2 )
-               IU = 1 + ( N-1 )*SLARND( 1, ISEED2 )
+               IL = 1 + INT( ( N-1 )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/cget37.f
+++ b/TESTING/EIG/cget37.f
@@ -265,7 +265,7 @@
   100       CONTINUE
             WSRT( KMIN ) = WSRT( I )
             WSRT( I ) = VMIN
-            VCMIN = WTMP( I )
+            VCMIN = REAL( WTMP( I ) )
             WTMP( I ) = W( KMIN )
             WTMP( KMIN ) = VCMIN
             VMIN = STMP( KMIN )

--- a/TESTING/EIG/ddrvsg.f
+++ b/TESTING/EIG/ddrvsg.f
@@ -645,8 +645,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*DLARND( 1, ISEED2 )
-               IU = 1 + ( N-1 )*DLARND( 1, ISEED2 )
+               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/sdrvsg.f
+++ b/TESTING/EIG/sdrvsg.f
@@ -645,8 +645,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*SLARND( 1, ISEED2 )
-               IU = 1 + ( N-1 )*SLARND( 1, ISEED2 )
+               IL = 1 + INT( ( N-1 )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/zdrvsg.f
+++ b/TESTING/EIG/zdrvsg.f
@@ -663,8 +663,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*DLARND( 1, ISEED2 )
-               IU = 1 + ( N-1 )*DLARND( 1, ISEED2 )
+               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/zget37.f
+++ b/TESTING/EIG/zget37.f
@@ -265,7 +265,7 @@
   100       CONTINUE
             WSRT( KMIN ) = WSRT( I )
             WSRT( I ) = VMIN
-            VCMIN = WTMP( I )
+            VCMIN = DBLE( WTMP( I ) )
             WTMP( I ) = W( KMIN )
             WTMP( KMIN ) = VCMIN
             VMIN = STMP( KMIN )

--- a/TESTING/LIN/cchkpt.f
+++ b/TESTING/LIN/cchkpt.f
@@ -319,15 +319,15 @@
 *                 elements.
 *
                   IF( IZERO.EQ.1 ) THEN
-                     D( 1 ) = Z( 2 )
+                     D( 1 ) = REAL( Z( 2 ) )
                      IF( N.GT.1 )
      $                  E( 1 ) = Z( 3 )
                   ELSE IF( IZERO.EQ.N ) THEN
                      E( N-1 ) = Z( 1 )
-                     D( N ) = Z( 2 )
+                     D( N ) = REAL( Z( 2 ) )
                   ELSE
                      E( IZERO-1 ) = Z( 1 )
-                     D( IZERO ) = Z( 2 )
+                     D( IZERO ) = REAL( Z( 2 ) )
                      E( IZERO ) = Z( 3 )
                   END IF
                END IF

--- a/TESTING/LIN/cchktr.f
+++ b/TESTING/LIN/cchktr.f
@@ -380,7 +380,7 @@
 *                       This line is needed on a Sun SPARCstation.
 *
                         IF( N.GT.0 )
-     $                     DUMMY = A( 1 )
+     $                     DUMMY = REAL( A( 1 ) )
 *
                         CALL CTRT02( UPLO, TRANS, DIAG, N, NRHS, A, LDA,
      $                               X, LDA, B, LDA, WORK, RWORK,

--- a/TESTING/LIN/cdrvgt.f
+++ b/TESTING/LIN/cdrvgt.f
@@ -307,16 +307,16 @@
                   IZERO = 0
                ELSE IF( IMAT.EQ.8 ) THEN
                   IZERO = 1
-                  Z( 2 ) = A( N )
+                  Z( 2 ) = REAL( A( N ) )
                   A( N ) = ZERO
                   IF( N.GT.1 ) THEN
-                     Z( 3 ) = A( 1 )
+                     Z( 3 ) = REAL( A( 1 ) )
                      A( 1 ) = ZERO
                   END IF
                ELSE IF( IMAT.EQ.9 ) THEN
                   IZERO = N
-                  Z( 1 ) = A( 3*N-2 )
-                  Z( 2 ) = A( 2*N-1 )
+                  Z( 1 ) = REAL( A( 3*N-2 ) )
+                  Z( 2 ) = REAL( A( 2*N-1 ) )
                   A( 3*N-2 ) = ZERO
                   A( 2*N-1 ) = ZERO
                ELSE

--- a/TESTING/LIN/cdrvpt.f
+++ b/TESTING/LIN/cdrvpt.f
@@ -266,12 +266,12 @@
 *
                IA = 1
                DO 20 I = 1, N - 1
-                  D( I ) = A( IA )
+                  D( I ) = REAL( A( IA ) )
                   E( I ) = A( IA+1 )
                   IA = IA + 2
    20          CONTINUE
                IF( N.GT.0 )
-     $            D( N ) = A( IA )
+     $            D( N ) = REAL( A( IA ) )
             ELSE
 *
 *              Type 7-12:  generate a diagonally dominant matrix with
@@ -333,13 +333,13 @@
                   Z( 2 ) = D( 1 )
                   D( 1 ) = ZERO
                   IF( N.GT.1 ) THEN
-                     Z( 3 ) = E( 1 )
+                     Z( 3 ) = REAL( E( 1 ) )
                      E( 1 ) = ZERO
                   END IF
                ELSE IF( IMAT.EQ.9 ) THEN
                   IZERO = N
                   IF( N.GT.1 ) THEN
-                     Z( 1 ) = E( N-1 )
+                     Z( 1 ) = REAL( E( N-1 ) )
                      E( N-1 ) = ZERO
                   END IF
                   Z( 2 ) = D( N )
@@ -347,9 +347,9 @@
                ELSE IF( IMAT.EQ.10 ) THEN
                   IZERO = ( N+1 ) / 2
                   IF( IZERO.GT.1 ) THEN
-                     Z( 1 ) = E( IZERO-1 )
+                     Z( 1 ) = REAL( E( IZERO-1 ) )
                      E( IZERO-1 ) = ZERO
-                     Z( 3 ) = E( IZERO )
+                     Z( 3 ) = REAL( E( IZERO ) )
                      E( IZERO ) = ZERO
                   END IF
                   Z( 2 ) = D( IZERO )

--- a/TESTING/LIN/clattp.f
+++ b/TESTING/LIN/clattp.f
@@ -336,7 +336,7 @@
                WORK( J+1 ) = PLUS2
                WORK( N+J+1 ) = ZERO
                PLUS1 = STAR1 / PLUS2
-               REXP = CLARND( 2, ISEED )
+               REXP = REAL( CLARND( 2, ISEED ) )
                IF( REXP.LT.ZERO ) THEN
                   STAR1 = -SFAC**( ONE-REXP )*CLARND( 5, ISEED )
                ELSE
@@ -790,7 +790,7 @@
             DO 460 J = 1, N / 2
                JL = JJ
                DO 450 I = J, N - J
-                  T = AP( JR-I+J )
+                  T = REAL( AP( JR-I+J ) )
                   AP( JR-I+J ) = AP( JL )
                   AP( JL ) = T
                   JL = JL + I
@@ -804,7 +804,7 @@
             DO 480 J = 1, N / 2
                JR = JJ
                DO 470 I = J, N - J
-                  T = AP( JL+I-J )
+                  T = REAL( AP( JL+I-J ) )
                   AP( JL+I-J ) = AP( JR )
                   AP( JR ) = T
                   JR = JR - I

--- a/TESTING/LIN/cpbt01.f
+++ b/TESTING/LIN/cpbt01.f
@@ -201,7 +201,8 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            AKK = CDOTC( KLEN+1, AFAC( KC, K ), 1, AFAC( KC, K ), 1 )
+            AKK = REAL(
+     $         CDOTC( KLEN+1, AFAC( KC, K ), 1, AFAC( KC, K ), 1 ) )
             AFAC( KD+1, K ) = AKK
 *
 *           Compute the rest of column K.
@@ -228,7 +229,7 @@
 *
 *           Scale column K by the diagonal element.
 *
-            AKK = AFAC( 1, K )
+            AKK = REAL( AFAC( 1, K ) )
             CALL CSSCAL( KLEN+1, AKK, AFAC( 1, K ), 1 )
 *
    40    CONTINUE

--- a/TESTING/LIN/cpot01.f
+++ b/TESTING/LIN/cpot01.f
@@ -176,7 +176,7 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            TR = CDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 )
+            TR = REAL( CDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 ) )
             AFAC( K, K ) = TR
 *
 *           Compute the rest of column K.

--- a/TESTING/LIN/cppt01.f
+++ b/TESTING/LIN/cppt01.f
@@ -178,7 +178,7 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            TR = CDOTC( K, AFAC( KC ), 1, AFAC( KC ), 1 )
+            TR = REAL( CDOTC( K, AFAC( KC ), 1, AFAC( KC ), 1 ) )
             AFAC( KC+K-1 ) = TR
 *
 *           Compute the rest of column K.

--- a/TESTING/LIN/cpst01.f
+++ b/TESTING/LIN/cpst01.f
@@ -219,7 +219,7 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            TR = CDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 )
+            TR = REAL( CDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 ) )
             AFAC( K, K ) = TR
 *
 *           Compute the rest of column K.

--- a/TESTING/LIN/zchkpt.f
+++ b/TESTING/LIN/zchkpt.f
@@ -319,15 +319,15 @@
 *                 elements.
 *
                   IF( IZERO.EQ.1 ) THEN
-                     D( 1 ) = Z( 2 )
+                     D( 1 ) = DBLE( Z( 2 ) )
                      IF( N.GT.1 )
      $                  E( 1 ) = Z( 3 )
                   ELSE IF( IZERO.EQ.N ) THEN
                      E( N-1 ) = Z( 1 )
-                     D( N ) = Z( 2 )
+                     D( N ) = DBLE( Z( 2 ) )
                   ELSE
                      E( IZERO-1 ) = Z( 1 )
-                     D( IZERO ) = Z( 2 )
+                     D( IZERO ) = DBLE( Z( 2 ) )
                      E( IZERO ) = Z( 3 )
                   END IF
                END IF

--- a/TESTING/LIN/zchktr.f
+++ b/TESTING/LIN/zchktr.f
@@ -380,7 +380,7 @@
 *                       This line is needed on a Sun SPARCstation.
 *
                         IF( N.GT.0 )
-     $                     DUMMY = A( 1 )
+     $                     DUMMY = DBLE( A( 1 ) )
 *
                         CALL ZTRT02( UPLO, TRANS, DIAG, N, NRHS, A, LDA,
      $                               X, LDA, B, LDA, WORK, RWORK,

--- a/TESTING/LIN/zdrvgt.f
+++ b/TESTING/LIN/zdrvgt.f
@@ -307,16 +307,16 @@
                   IZERO = 0
                ELSE IF( IMAT.EQ.8 ) THEN
                   IZERO = 1
-                  Z( 2 ) = A( N )
+                  Z( 2 ) = DBLE( A( N ) )
                   A( N ) = ZERO
                   IF( N.GT.1 ) THEN
-                     Z( 3 ) = A( 1 )
+                     Z( 3 ) = DBLE( A( 1 ) )
                      A( 1 ) = ZERO
                   END IF
                ELSE IF( IMAT.EQ.9 ) THEN
                   IZERO = N
-                  Z( 1 ) = A( 3*N-2 )
-                  Z( 2 ) = A( 2*N-1 )
+                  Z( 1 ) = DBLE( A( 3*N-2 ) )
+                  Z( 2 ) = DBLE( A( 2*N-1 ) )
                   A( 3*N-2 ) = ZERO
                   A( 2*N-1 ) = ZERO
                ELSE

--- a/TESTING/LIN/zdrvpt.f
+++ b/TESTING/LIN/zdrvpt.f
@@ -266,12 +266,12 @@
 *
                IA = 1
                DO 20 I = 1, N - 1
-                  D( I ) = A( IA )
+                  D( I ) = DBLE( A( IA ) )
                   E( I ) = A( IA+1 )
                   IA = IA + 2
    20          CONTINUE
                IF( N.GT.0 )
-     $            D( N ) = A( IA )
+     $            D( N ) = DBLE( A( IA ) )
             ELSE
 *
 *              Type 7-12:  generate a diagonally dominant matrix with
@@ -333,13 +333,13 @@
                   Z( 2 ) = D( 1 )
                   D( 1 ) = ZERO
                   IF( N.GT.1 ) THEN
-                     Z( 3 ) = E( 1 )
+                     Z( 3 ) = DBLE( E( 1 ) )
                      E( 1 ) = ZERO
                   END IF
                ELSE IF( IMAT.EQ.9 ) THEN
                   IZERO = N
                   IF( N.GT.1 ) THEN
-                     Z( 1 ) = E( N-1 )
+                     Z( 1 ) = DBLE( E( N-1 ) )
                      E( N-1 ) = ZERO
                   END IF
                   Z( 2 ) = D( N )
@@ -347,9 +347,9 @@
                ELSE IF( IMAT.EQ.10 ) THEN
                   IZERO = ( N+1 ) / 2
                   IF( IZERO.GT.1 ) THEN
-                     Z( 1 ) = E( IZERO-1 )
+                     Z( 1 ) = DBLE( E( IZERO-1 ) )
                      E( IZERO-1 ) = ZERO
-                     Z( 3 ) = E( IZERO )
+                     Z( 3 ) = DBLE( E( IZERO ) )
                      E( IZERO ) = ZERO
                   END IF
                   Z( 2 ) = D( IZERO )

--- a/TESTING/LIN/zlattp.f
+++ b/TESTING/LIN/zlattp.f
@@ -336,7 +336,7 @@
                WORK( J+1 ) = PLUS2
                WORK( N+J+1 ) = ZERO
                PLUS1 = STAR1 / PLUS2
-               REXP = ZLARND( 2, ISEED )
+               REXP = DBLE( ZLARND( 2, ISEED ) )
                IF( REXP.LT.ZERO ) THEN
                   STAR1 = -SFAC**( ONE-REXP )*ZLARND( 5, ISEED )
                ELSE
@@ -790,7 +790,7 @@
             DO 460 J = 1, N / 2
                JL = JJ
                DO 450 I = J, N - J
-                  T = AP( JR-I+J )
+                  T = DBLE( AP( JR-I+J ) )
                   AP( JR-I+J ) = AP( JL )
                   AP( JL ) = T
                   JL = JL + I
@@ -804,7 +804,7 @@
             DO 480 J = 1, N / 2
                JR = JJ
                DO 470 I = J, N - J
-                  T = AP( JL+I-J )
+                  T = DBLE( AP( JL+I-J ) )
                   AP( JL+I-J ) = AP( JR )
                   AP( JR ) = T
                   JR = JR - I

--- a/TESTING/LIN/zpbt01.f
+++ b/TESTING/LIN/zpbt01.f
@@ -201,7 +201,8 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            AKK = ZDOTC( KLEN+1, AFAC( KC, K ), 1, AFAC( KC, K ), 1 )
+            AKK = DBLE(
+     $         ZDOTC( KLEN+1, AFAC( KC, K ), 1, AFAC( KC, K ), 1 ) )
             AFAC( KD+1, K ) = AKK
 *
 *           Compute the rest of column K.
@@ -228,7 +229,7 @@
 *
 *           Scale column K by the diagonal element.
 *
-            AKK = AFAC( 1, K )
+            AKK = DBLE( AFAC( 1, K ) )
             CALL ZDSCAL( KLEN+1, AKK, AFAC( 1, K ), 1 )
 *
    40    CONTINUE

--- a/TESTING/LIN/zpot01.f
+++ b/TESTING/LIN/zpot01.f
@@ -176,7 +176,7 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            TR = ZDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 )
+            TR = DBLE( ZDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 ) )
             AFAC( K, K ) = TR
 *
 *           Compute the rest of column K.

--- a/TESTING/LIN/zppt01.f
+++ b/TESTING/LIN/zppt01.f
@@ -178,7 +178,7 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            TR = ZDOTC( K, AFAC( KC ), 1, AFAC( KC ), 1 )
+            TR = DBLE( ZDOTC( K, AFAC( KC ), 1, AFAC( KC ), 1 ) )
             AFAC( KC+K-1 ) = TR
 *
 *           Compute the rest of column K.

--- a/TESTING/LIN/zpst01.f
+++ b/TESTING/LIN/zpst01.f
@@ -219,7 +219,7 @@
 *
 *           Compute the (K,K) element of the result.
 *
-            TR = ZDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 )
+            TR = DBLE( ZDOTC( K, AFAC( 1, K ), 1, AFAC( 1, K ), 1 ) )
             AFAC( K, K ) = TR
 *
 *           Compute the rest of column K.


### PR DESCRIPTION
PR #702 fixed a problem that could be avoided by using more strict flags in the CI. This PR:

- Applies explicit type casts all over the library (not including tests for now).
- Use more strict flags in the CI.

I still couldn't use `-Werror=lto-type-mismatch`, as suggested in https://github.com/Reference-LAPACK/lapack/pull/702#issuecomment-1210683461, because the tests still have type mismatch and/or implicit type casts.