### PR TITLE
Fix type mismatches in function calls of testing code

### DIFF
--- a/TESTING/EIG/cerrst.f
+++ b/TESTING/EIG/cerrst.f
@@ -628,56 +628,56 @@
          SRNAMT = 'CHEEVX_2STAGE'
          INFOT = 1
          CALL CHEEVX_2STAGE( '/', 'A', 'U', 0, A, 1,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 1, W, 1, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 1
          CALL CHEEVX_2STAGE( 'V', 'A', 'U', 0, A, 1,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 1, W, 1, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 2
          CALL CHEEVX_2STAGE( 'N', '/', 'U', 0, A, 1,
-     $                0.0D0, 1.0D0, 1, 0, 0.0D0,
+     $                0.0, 1.0, 1, 0, 0.0,
      $                M, X, Z, 1, W, 1, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 3
          CALL CHEEVX_2STAGE( 'N', 'A', '/', 0, A, 1,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 1, W, 1, RW, IW, I3, INFO )
          INFOT = 4
          CALL CHEEVX_2STAGE( 'N', 'A', 'U', -1, A, 1,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 1, W, 1, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 6
          CALL CHEEVX_2STAGE( 'N', 'A', 'U', 2, A, 1,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 2, W, 3, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 8
          CALL CHEEVX_2STAGE( 'N', 'V', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 1, W, 1, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 9
          CALL CHEEVX_2STAGE( 'N', 'I', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 1, W, 1, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 10
          CALL CHEEVX_2STAGE( 'N', 'I', 'U', 2, A, 2,
-     $                0.0D0, 0.0D0, 2, 1, 0.0D0,
+     $                0.0, 0.0, 2, 1, 0.0,
      $                M, X, Z, 2, W, 3, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 15
          CALL CHEEVX_2STAGE( 'N', 'A', 'U', 2, A, 2,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 0, W, 3, RW, IW, I3, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 17
          CALL CHEEVX_2STAGE( 'N', 'A', 'U', 2, A, 2,
-     $                0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                0.0, 0.0, 0, 0, 0.0,
      $                M, X, Z, 2, W, 0, RW, IW, I1, INFO )
          CALL CHKXER( 'CHEEVX_2STAGE', INFOT, NOUT, LERR, OK )
          NT = NT + 11
@@ -755,79 +755,79 @@
          N = 1
          INFOT = 1
          CALL CHEEVR_2STAGE( '/', 'A', 'U', 0, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 1
          CALL CHEEVR_2STAGE( 'V', 'A', 'U', 0, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 2
          CALL CHEEVR_2STAGE( 'N', '/', 'U', 0, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 3
          CALL CHEEVR_2STAGE( 'N', 'A', '/', -1, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N,
      $                IW( 2*N+1 ), 10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 4
          CALL CHEEVR_2STAGE( 'N', 'A', 'U', -1, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N,
      $                IW( 2*N+1 ), 10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 6
          CALL CHEEVR_2STAGE( 'N', 'A', 'U', 2, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 8
          CALL CHEEVR_2STAGE( 'N', 'V', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 9
          CALL CHEEVR_2STAGE( 'N', 'I', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 0, 1, 0.0D0,
+     $                0.0, 0.0, 0, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 10
          CALL CHEEVR_2STAGE( 'N', 'I', 'U', 2, A, 2,
-     $                0.0D0, 0.0D0, 2, 1, 0.0D0,
+     $                0.0, 0.0, 2, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 15
          CALL CHEEVR_2STAGE( 'N', 'I', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 0, IW, Q, 2*N, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 18
          CALL CHEEVR_2STAGE( 'N', 'I', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 2*N-1, RW, 24*N, IW( 2*N+1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 20
          CALL CHEEVR_2STAGE( 'N', 'I', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 26*N, RW, 24*N-1, IW( 2*N-1 ),
      $                10*N, INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 22
          CALL CHEEVR_2STAGE( 'N', 'I', 'U', 1, A, 1,
-     $                0.0D0, 0.0D0, 1, 1, 0.0D0,
+     $                0.0, 0.0, 1, 1, 0.0,
      $                M, R, Z, 1, IW, Q, 26*N, RW, 24*N, IW, 10*N-1,
      $                INFO )
          CALL CHKXER( 'CHEEVR_2STAGE', INFOT, NOUT, LERR, OK )
@@ -1259,65 +1259,65 @@
          SRNAMT = 'CHBEVX_2STAGE'
          INFOT = 1
          CALL CHBEVX_2STAGE( '/', 'A', 'U', 0, 0, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          INFOT = 1
          CALL CHBEVX_2STAGE( 'V', 'A', 'U', 0, 0, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 2
          CALL CHBEVX_2STAGE( 'N', '/', 'U', 0, 0, A, 1, Q, 1,
-     $                       0.0D0, 1.0D0, 1, 0, 0.0D0,
+     $                       0.0, 1.0, 1, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 3
          CALL CHBEVX_2STAGE( 'N', 'A', '/', 0, 0, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          INFOT = 4
          CALL CHBEVX_2STAGE( 'N', 'A', 'U', -1, 0, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 5
          CALL CHBEVX_2STAGE( 'N', 'A', 'U', 0, -1, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 7
          CALL CHBEVX_2STAGE( 'N', 'A', 'U', 2, 1, A, 1, Q, 2,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 2, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
 *         INFOT = 9
 *         CALL CHBEVX_2STAGE( 'V', 'A', 'U', 2, 0, A, 1, Q, 1,
-*     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+*     $                       0.0, 0.0, 0, 0, 0.0,
 *     $                       M, X, Z, 2, W, 0, RW, IW, I3, INFO )
 *         CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 11
          CALL CHBEVX_2STAGE( 'N', 'V', 'U', 1, 0, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 12
          CALL CHBEVX_2STAGE( 'N', 'I', 'U', 1, 0, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 13
          CALL CHBEVX_2STAGE( 'N', 'I', 'U', 1, 0, A, 1, Q, 1,
-     $                       0.0D0, 0.0D0, 1, 2, 0.0D0,
+     $                       0.0, 0.0, 1, 2, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 18
          CALL CHBEVX_2STAGE( 'N', 'A', 'U', 2, 0, A, 1, Q, 2,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 0, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          INFOT = 20
          CALL CHBEVX_2STAGE( 'N', 'A', 'U', 2, 0, A, 1, Q, 2,
-     $                       0.0D0, 0.0D0, 0, 0, 0.0D0,
+     $                       0.0, 0.0, 0, 0, 0.0,
      $                       M, X, Z, 1, W, 0, RW, IW, I3, INFO )
          CALL CHKXER( 'CHBEVX_2STAGE', INFOT, NOUT, LERR, OK )
          NT = NT + 12

--- a/TESTING/LIN/cerrrfp.f
+++ b/TESTING/LIN/cerrrfp.f
@@ -63,7 +63,8 @@
 *     ..
 *     .. Local Scalars ..
       INTEGER            INFO
-      COMPLEX            ALPHA, BETA
+      COMPLEX            ALPHACMPLX
+      REAL               ALPHA, BETA
 *     ..
 *     .. Local Arrays ..
       COMPLEX            A( 1, 1), B( 1, 1)
@@ -91,8 +92,9 @@
       OK = .TRUE.
       A( 1, 1 ) = CMPLX( 1.0 , 1.0 )
       B( 1, 1 ) = CMPLX( 1.0 , 1.0  )
-      ALPHA     = CMPLX( 1.0 , 1.0  )
-      BETA      = CMPLX( 1.0 , 1.0  )
+      ALPHACMPLX = CMPLX( 1.0 , 1.0  )
+      ALPHA = 1.0
+      BETA = 1.0
 *
       SRNAMT = 'CPFTRF'
       INFOT = 1
@@ -135,28 +137,28 @@
 *
       SRNAMT = 'CTFSM '
       INFOT = 1
-      CALL CTFSM( '/', 'L', 'U', 'C', 'U', 0, 0, ALPHA, A, B, 1 )
+      CALL CTFSM( '/', 'L', 'U', 'C', 'U', 0, 0, ALPHACMPLX, A, B, 1 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
       INFOT = 2
-      CALL CTFSM( 'N', '/', 'U', 'C', 'U', 0, 0, ALPHA, A, B, 1 )
+      CALL CTFSM( 'N', '/', 'U', 'C', 'U', 0, 0, ALPHACMPLX, A, B, 1 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
       INFOT = 3
-      CALL CTFSM( 'N', 'L', '/', 'C', 'U', 0, 0, ALPHA, A, B, 1 )
+      CALL CTFSM( 'N', 'L', '/', 'C', 'U', 0, 0, ALPHACMPLX, A, B, 1 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
       INFOT = 4
-      CALL CTFSM( 'N', 'L', 'U', '/', 'U', 0, 0, ALPHA, A, B, 1 )
+      CALL CTFSM( 'N', 'L', 'U', '/', 'U', 0, 0, ALPHACMPLX, A, B, 1 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
       INFOT = 5
-      CALL CTFSM( 'N', 'L', 'U', 'C', '/', 0, 0, ALPHA, A, B, 1 )
+      CALL CTFSM( 'N', 'L', 'U', 'C', '/', 0, 0, ALPHACMPLX, A, B, 1 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
       INFOT = 6
-      CALL CTFSM( 'N', 'L', 'U', 'C', 'U', -1, 0, ALPHA, A, B, 1 )
+      CALL CTFSM( 'N', 'L', 'U', 'C', 'U', -1, 0, ALPHACMPLX, A, B, 1 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
       INFOT = 7
-      CALL CTFSM( 'N', 'L', 'U', 'C', 'U', 0, -1, ALPHA, A, B, 1 )
+      CALL CTFSM( 'N', 'L', 'U', 'C', 'U', 0, -1, ALPHACMPLX, A, B, 1 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
       INFOT = 11
-      CALL CTFSM( 'N', 'L', 'U', 'C', 'U', 0, 0, ALPHA, A, B, 0 )
+      CALL CTFSM( 'N', 'L', 'U', 'C', 'U', 0, 0, ALPHACMPLX, A, B, 0 )
       CALL CHKXER( 'CTFSM ', INFOT, NOUT, LERR, OK )
 *
       SRNAMT = 'CTFTRI'

--- a/TESTING/LIN/clqt04.f
+++ b/TESTING/LIN/clqt04.f
@@ -86,8 +86,9 @@
 *     ..
 *     .. Local allocatable arrays
       COMPLEX, ALLOCATABLE :: AF(:,:), Q(:,:),
-     $  L(:,:), RWORK(:), WORK( : ), T(:,:),
+     $  L(:,:), WORK( : ), T(:,:),
      $  CF(:,:), DF(:,:), A(:,:), C(:,:), D(:,:)
+      REAL, ALLOCATABLE :: RWORK(:)
 *
 *     .. Parameters ..
       REAL       ZERO

--- a/TESTING/LIN/clqt05.f
+++ b/TESTING/LIN/clqt05.f
@@ -93,8 +93,9 @@
 *     ..
 *     .. Local allocatable arrays
       COMPLEX, ALLOCATABLE :: AF(:,:), Q(:,:),
-     $  R(:,:), RWORK(:), WORK( : ), T(:,:),
+     $  R(:,:), WORK( : ), T(:,:),
      $  CF(:,:), DF(:,:), A(:,:), C(:,:), D(:,:)
+      REAL, ALLOCATABLE :: RWORK(:)
 *
 *     .. Parameters ..
       REAL ZERO

--- a/TESTING/LIN/ctsqr01.f
+++ b/TESTING/LIN/ctsqr01.f
@@ -96,8 +96,9 @@
 *     ..
 *     .. Local allocatable arrays
       COMPLEX, ALLOCATABLE :: AF(:,:), Q(:,:),
-     $  R(:,:), RWORK(:), WORK( : ), T(:),
+     $  R(:,:), WORK( : ), T(:),
      $  CF(:,:), DF(:,:), A(:,:), C(:,:), D(:,:), LQ(:,:)
+      REAL, ALLOCATABLE :: RWORK(:)
 *
 *     .. Parameters ..
       REAL ZERO

--- a/TESTING/LIN/cunhr_col01.f
+++ b/TESTING/LIN/cunhr_col01.f
@@ -311,7 +311,7 @@
 *     Compute |I - (Q**H)*Q| / ( eps * m ) and store in RESULT(2)
 *
       CALL CLASET( 'Full', M, M, CZERO, CONE, R, M )
-      CALL CHERK( 'U', 'C', M, M, -CONE, Q, M, CONE, R, M )
+      CALL CHERK( 'U', 'C', M, M, REAL(-CONE), Q, M, REAL(CONE), R, M )
       RESID = CLANSY( '1', 'Upper', M, R, M, RWORK )
       RESULT( 2 ) = RESID / ( EPS * MAX( 1, M ) )
 *

--- a/TESTING/LIN/cunhr_col02.f
+++ b/TESTING/LIN/cunhr_col02.f
@@ -273,7 +273,7 @@
 *     Compute |I - (Q**T)*Q| / ( eps * m ) and store in RESULT(2)
 *
       CALL CLASET( 'Full', M, M, CZERO, CONE, R, M )
-      CALL CHERK( 'U', 'C', M, M, -CONE, Q, M, CONE, R, M )
+      CALL CHERK( 'U', 'C', M, M, REAL(-CONE), Q, M, REAL(CONE), R, M )
       RESID = CLANSY( '1', 'Upper', M, R, M, RWORK )
       RESULT( 2 ) = RESID / ( EPS * MAX( 1, M ) )
 *

--- a/TESTING/LIN/zchkhe_aa_2stage.f
+++ b/TESTING/LIN/zchkhe_aa_2stage.f
@@ -185,7 +185,8 @@
       LOGICAL            DOTYPE( * )
       INTEGER            IWORK( * ), NBVAL( * ), NSVAL( * ), NVAL( * )
       COMPLEX*16         A( * ), AFAC( * ), AINV( * ), B( * ),
-     $                   RWORK( * ), WORK( * ), X( * ), XACT( * )
+     $                   WORK( * ), X( * ), XACT( * )
+      DOUBLE PRECISION   RWORK( * )
 *     ..
 *
 *  =====================================================================

--- a/TESTING/LIN/zlqt04.f
+++ b/TESTING/LIN/zlqt04.f
@@ -86,8 +86,9 @@
 *     ..
 *     .. Local allocatable arrays
       COMPLEX*16, ALLOCATABLE :: AF(:,:), Q(:,:),
-     $  L(:,:), RWORK(:), WORK( : ), T(:,:),
+     $  L(:,:), WORK( : ), T(:,:),
      $  CF(:,:), DF(:,:), A(:,:), C(:,:), D(:,:)
+      DOUBLE PRECISION, ALLOCATABLE :: RWORK(:)
 *
 *     .. Parameters ..
       DOUBLE PRECISION ZERO

--- a/TESTING/LIN/zlqt05.f
+++ b/TESTING/LIN/zlqt05.f
@@ -93,8 +93,9 @@
 *     ..
 *     .. Local allocatable arrays
       COMPLEX*16, ALLOCATABLE :: AF(:,:), Q(:,:),
-     $  R(:,:), RWORK(:), WORK( : ), T(:,:),
+     $  R(:,:), WORK( : ), T(:,:),
      $  CF(:,:), DF(:,:), A(:,:), C(:,:), D(:,:)
+      DOUBLE PRECISION, ALLOCATABLE :: RWORK(:)
 *
 *     .. Parameters ..
       DOUBLE PRECISION ZERO

--- a/TESTING/LIN/ztsqr01.f
+++ b/TESTING/LIN/ztsqr01.f
@@ -96,8 +96,9 @@
 *     ..
 *     .. Local allocatable arrays
       COMPLEX*16, ALLOCATABLE :: AF(:,:), Q(:,:),
-     $  R(:,:), RWORK(:), WORK( : ), T(:),
+     $  R(:,:), WORK( : ), T(:),
      $  CF(:,:), DF(:,:), A(:,:), C(:,:), D(:,:), LQ(:,:)
+      DOUBLE PRECISION, ALLOCATABLE :: RWORK(:)
 *
 *     .. Parameters ..
       DOUBLE PRECISION ZERO

--- a/TESTING/LIN/zunhr_col01.f
+++ b/TESTING/LIN/zunhr_col01.f
@@ -311,7 +311,7 @@
 *     Compute |I - (Q**H)*Q| / ( eps * m ) and store in RESULT(2)
 *
       CALL ZLASET( 'Full', M, M, CZERO, CONE, R, M )
-      CALL ZHERK( 'U', 'C', M, M, -CONE, Q, M, CONE, R, M )
+      CALL ZHERK( 'U', 'C', M, M, REAL(-CONE), Q, M, REAL(CONE), R, M )
       RESID = ZLANSY( '1', 'Upper', M, R, M, RWORK )
       RESULT( 2 ) = RESID / ( EPS * MAX( 1, M ) )
 *

--- a/TESTING/LIN/zunhr_col02.f
+++ b/TESTING/LIN/zunhr_col02.f
@@ -273,7 +273,7 @@
 *     Compute |I - (Q**T)*Q| / ( eps * m ) and store in RESULT(2)
 *
       CALL ZLASET( 'Full', M, M, CZERO, CONE, R, M )
-      CALL ZHERK( 'U', 'C', M, M, -CONE, Q, M, CONE, R, M )
+      CALL ZHERK( 'U', 'C', M, M, REAL(-CONE), Q, M, REAL(CONE), R, M )
       RESID = ZLANSY( '1', 'Upper', M, R, M, RWORK )
       RESULT( 2 ) = RESID / ( EPS * MAX( 1, M ) )
 *


### PR DESCRIPTION
**Description**

Follow up on #702 which missed the type mismatch errors when compiling with `-flto -Wlto-type-mismatch` in the test code.

**Checklist**

- [N/A ] The documentation has been updated.
- [N/A] If the PR solves a specific issue, it is set to be closed on merge.