### PR TITLE
Fixed the test dependencies of the test summary

### DIFF
--- a/TESTING/CMakeLists.txt
+++ b/TESTING/CMakeLists.txt
@@ -10,7 +10,7 @@ add_subdirectory(EIG)
 
 # Only run this test if python 3 is found
 if(PYTHON_EXECUTABLE)
-  message(STATUS "Running Summary")
+  message(STATUS "Enabling LAPACK test summary (see TESTING/testing_results.txt)")
   file(COPY ${LAPACK_SOURCE_DIR}/lapack_testing.py DESTINATION ${LAPACK_BINARY_DIR})
   add_test(
     NAME LAPACK_Test_Summary
@@ -32,7 +32,7 @@ function(add_lapack_test output input target)
       -DINTDIR=${CMAKE_CFG_INTDIR}
       -P "${LAPACK_SOURCE_DIR}/TESTING/runtest.cmake")
 
-    if(PYTHONINTERP_FOUND)
+    if(PYTHON_EXECUTABLE)
       set_property(
         TEST LAPACK_Test_Summary
         APPEND PROPERTY DEPENDS LAPACK-${testName}


### PR DESCRIPTION
**Description**

A small fix of the test dependencies. The `if(PYTHONINTERP_FOUND)` was from the time we used `find_package(PythonInterp 2.7 QUIET)` instead of the `find_program(PYTHON_EXECUTABLE python3)` (see a51f8ba).

I also changed the comment since it sounded like the test summary would run during the configuring stage.

**Checklist**

- [x] The documentation has been updated. (N/A)
- [x] If the PR solves a specific issue, it is set to be closed on merge. (N/A)