### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,15 @@ CBLAS, a C interface to the BLAS, and (5) LAPACKE, a C interface to LAPACK.
    cmake -DCMAKE_INSTALL_LIBDIR=$HOME/.local/lapack ..
    cmake --build . -j --target install
    ```
-
+ - LAPACK can be built and installed using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+   ```sh
+   git clone https://github.com/Microsoft/vcpkg.git
+   cd vcpkg
+   ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+   ./vcpkg integrate install
+   ./vcpkg install lapack
+   ```
+   The lapack port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## User Support
 


### PR DESCRIPTION
Lapack is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for lapack and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build lapack, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/lapack/portfile.cmake). We try to keep the library maintained as close as possible to the original library.