### PR TITLE
Implemented a LAPACKE_?langb interface

### DIFF
--- a/LAPACKE/include/lapacke.h
+++ b/LAPACKE/include/lapacke.h
@@ -2313,6 +2313,19 @@ lapack_int LAPACKE_zlagge( int matrix_layout, lapack_int m, lapack_int n,
 float LAPACKE_slamch( char cmach );
 double LAPACKE_dlamch( char cmach );
 
+float LAPACKE_slangb( int matrix_layout, char norm, lapack_int n,
+                      lapack_int kl, lapack_int ku, const float* ab,
+                      lapack_int ldab );
+double LAPACKE_dlangb( int matrix_layout, char norm, lapack_int n,
+                       lapack_int kl, lapack_int ku, const double* ab,
+                       lapack_int ldab );
+float LAPACKE_clangb( int matrix_layout, char norm, lapack_int n,
+                      lapack_int kl, lapack_int ku,
+                      const lapack_complex_float* ab, lapack_int ldab );
+double LAPACKE_zlangb( int matrix_layout, char norm, lapack_int n,
+                       lapack_int kl, lapack_int ku,
+                       const lapack_complex_double* ab, lapack_int ldab );
+
 float LAPACKE_slange( int matrix_layout, char norm, lapack_int m,
                            lapack_int n, const float* a, lapack_int lda );
 double LAPACKE_dlange( int matrix_layout, char norm, lapack_int m,
@@ -7575,6 +7588,21 @@ double LAPACKE_dlapy3_work( double x, double y, double z );
 
 float LAPACKE_slamch_work( char cmach );
 double LAPACKE_dlamch_work( char cmach );
+
+float LAPACKE_slangb_work( int matrix_layout, char norm, lapack_int n,
+                           lapack_int kl, lapack_int ku, const float* ab,
+                           lapack_int ldab, float* work );
+double LAPACKE_dlangb_work( int matrix_layout, char norm, lapack_int n,
+                            lapack_int kl, lapack_int ku, const double* ab,
+                            lapack_int ldab, double* work );
+float LAPACKE_clangb_work( int matrix_layout, char norm, lapack_int n,
+                           lapack_int kl, lapack_int ku,
+                           const lapack_complex_float* ab, lapack_int ldab,
+                           float* work );
+double LAPACKE_zlangb_work( int matrix_layout, char norm, lapack_int n,
+                            lapack_int kl, lapack_int ku,
+                            const lapack_complex_double* ab, lapack_int ldab,
+                            double* work );
 
 float LAPACKE_slange_work( int matrix_layout, char norm, lapack_int m,
                                 lapack_int n, const float* a, lapack_int lda,

--- a/LAPACKE/src/CMakeLists.txt
+++ b/LAPACKE/src/CMakeLists.txt
@@ -309,6 +309,8 @@ lapacke_clacrm.c
 lapacke_clacrm_work.c
 lapacke_clag2z.c
 lapacke_clag2z_work.c
+lapacke_clangb.c
+lapacke_clangb_work.c
 lapacke_clange.c
 lapacke_clange_work.c
 lapacke_clanhe.c
@@ -791,6 +793,8 @@ lapacke_dlag2s.c
 lapacke_dlag2s_work.c
 lapacke_dlamch.c
 lapacke_dlamch_work.c
+lapacke_dlangb.c
+lapacke_dlangb_work.c
 lapacke_dlange.c
 lapacke_dlange_work.c
 lapacke_dlansy.c
@@ -1366,6 +1370,8 @@ lapacke_slag2d.c
 lapacke_slag2d_work.c
 lapacke_slamch.c
 lapacke_slamch_work.c
+lapacke_slangb.c
+lapacke_slangb_work.c
 lapacke_slange.c
 lapacke_slange_work.c
 lapacke_slansy.c
@@ -2066,6 +2072,8 @@ lapacke_zlacrm.c
 lapacke_zlacrm_work.c
 lapacke_zlag2c.c
 lapacke_zlag2c_work.c
+lapacke_zlangb.c
+lapacke_zlangb_work.c
 lapacke_zlange.c
 lapacke_zlange_work.c
 lapacke_zlanhe.c

--- a/LAPACKE/src/lapacke_clangb.c
+++ b/LAPACKE/src/lapacke_clangb.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_clangb.c
+++ b/LAPACKE/src/lapacke_clangb.c
@@ -1,0 +1,73 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native high-level C interface to LAPACK function clangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+float LAPACKE_clangb( int matrix_layout, char norm, lapack_int n,
+                      lapack_int kl, lapack_int ku,
+                      const lapack_complex_float* ab, lapack_int ldab )
+{
+    lapack_int info = 0;
+    float res = 0.;
+    float* work = NULL;
+    if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
+        LAPACKE_xerbla( "LAPACKE_clangb", -1 );
+        return -1;
+    }
+#ifndef LAPACK_DISABLE_NAN_CHECK
+    if( LAPACKE_get_nancheck() ) {
+        /* Optionally check input matrices for NaNs */
+        if( LAPACKE_cgb_nancheck( matrix_layout, n, n, kl, ku, ab, ldab ) ) {
+            return -6;
+        }
+    }
+#endif
+    /* Allocate memory for working array(s) */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        work = (float*)LAPACKE_malloc( sizeof(float) * MAX(1,n) );
+        if( work == NULL ) {
+            info = LAPACK_WORK_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+    }
+    /* Call middle-level interface */
+    res = LAPACKE_clangb_work( matrix_layout, norm, n, kl, ku, ab, ldab, work );
+    /* Release memory and exit */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        LAPACKE_free( work );
+    }
+exit_level_0:
+    if( info == LAPACK_WORK_MEMORY_ERROR ) {
+        LAPACKE_xerbla( "LAPACKE_clangb", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_clangb.c
+++ b/LAPACKE/src/lapacke_clangb.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native high-level C interface to LAPACK function clangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_clangb_work.c
+++ b/LAPACKE/src/lapacke_clangb_work.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_clangb_work.c
+++ b/LAPACKE/src/lapacke_clangb_work.c
@@ -1,0 +1,77 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native middle-level C interface to LAPACK function clangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+float LAPACKE_clangb_work( int matrix_layout, char norm, lapack_int n,
+                           lapack_int kl, lapack_int ku,
+                           const lapack_complex_float* ab, lapack_int ldab,
+                           float* work )
+{
+    lapack_int info = 0;
+    float res = 0.;
+    if( matrix_layout == LAPACK_COL_MAJOR ) {
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_clangb( &norm, &n, &kl, &ku, ab, &ldab, work );
+    } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
+        lapack_int ldab_t = MAX(1,kl+ku+1);
+        lapack_complex_float* ab_t = NULL;
+        /* Check leading dimension(s) */
+        if( ldab < kl+ku+1 ) {
+            info = -7;
+            LAPACKE_xerbla( "LAPACKE_clangb_work", info );
+            return info;
+        }
+        /* Allocate memory for temporary array(s) */
+        ab_t = (lapack_complex_float*)
+            LAPACKE_malloc( sizeof(lapack_complex_float) * ldab_t * MAX(1,n) );
+        if( ab_t == NULL ) {
+            info = LAPACK_TRANSPOSE_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+        /* Transpose input matrices */
+        LAPACKE_cgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_clangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
+        info = 0;  /* LAPACK call is ok! */
+        /* Release memory and exit */
+        LAPACKE_free( ab_t );
+exit_level_0:
+        if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {
+            LAPACKE_xerbla( "LAPACKE_clangb_work", info );
+        }
+    } else {
+        info = -1;
+        LAPACKE_xerbla( "LAPACKE_clangb_work", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_clangb_work.c
+++ b/LAPACKE/src/lapacke_clangb_work.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native middle-level C interface to LAPACK function clangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_clangb_work.c
+++ b/LAPACKE/src/lapacke_clangb_work.c
@@ -62,7 +62,6 @@ float LAPACKE_clangb_work( int matrix_layout, char norm, lapack_int n,
         LAPACKE_cgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_clangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         LAPACKE_free( ab_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_clangb_work.c
+++ b/LAPACKE/src/lapacke_clangb_work.c
@@ -43,27 +43,35 @@ float LAPACKE_clangb_work( int matrix_layout, char norm, lapack_int n,
         /* Call LAPACK function and adjust info */
         res = LAPACK_clangb( &norm, &n, &kl, &ku, ab, &ldab, work );
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ldab_t = MAX(1,kl+ku+1);
-        lapack_complex_float* ab_t = NULL;
+        char norm_lapack;
+        float* work_lapack = NULL;
         /* Check leading dimension(s) */
         if( ldab < kl+ku+1 ) {
             info = -7;
             LAPACKE_xerbla( "LAPACKE_clangb_work", info );
             return info;
         }
-        /* Allocate memory for temporary array(s) */
-        ab_t = (lapack_complex_float*)
-            LAPACKE_malloc( sizeof(lapack_complex_float) * ldab_t * MAX(1,n) );
-        if( ab_t == NULL ) {
-            info = LAPACK_TRANSPOSE_MEMORY_ERROR;
-            goto exit_level_0;
+        if( LAPACKE_lsame( norm, '1' ) || LAPACKE_lsame( norm, 'o' ) ) {
+            norm_lapack = 'i';
+        } else if( LAPACKE_lsame( norm, 'i' ) ) {
+            norm_lapack = '1';
+        } else {
+            norm_lapack = norm;
         }
-        /* Transpose input matrices */
-        LAPACKE_cgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
-        /* Call LAPACK function and adjust info */
-        res = LAPACK_clangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
+        /* Allocate memory for work array(s) */
+        if( LAPACKE_lsame( norm_lapack, 'i' ) ) {
+            work_lapack = (float*)LAPACKE_malloc( sizeof(float) * MAX(1,n) );
+            if( work_lapack == NULL ) {
+                info = LAPACK_WORK_MEMORY_ERROR;
+                goto exit_level_0;
+            }
+        }
+        /* Call LAPACK function */
+        res = LAPACK_clangb( &norm, &n, &ku, &kl, ab, &ldab, work );
         /* Release memory and exit */
-        LAPACKE_free( ab_t );
+        if( work_lapack ) {
+            LAPACKE_free( work_lapack );
+        }
 exit_level_0:
         if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {
             LAPACKE_xerbla( "LAPACKE_clangb_work", info );

--- a/LAPACKE/src/lapacke_dlangb.c
+++ b/LAPACKE/src/lapacke_dlangb.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_dlangb.c
+++ b/LAPACKE/src/lapacke_dlangb.c
@@ -1,0 +1,73 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native high-level C interface to LAPACK function dlangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+double LAPACKE_dlangb( int matrix_layout, char norm, lapack_int n,
+                       lapack_int kl, lapack_int ku, const double* ab,
+                       lapack_int ldab )
+{
+    lapack_int info = 0;
+    double res = 0.;
+    double* work = NULL;
+    if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
+        LAPACKE_xerbla( "LAPACKE_dlangb", -1 );
+        return -1;
+    }
+#ifndef LAPACK_DISABLE_NAN_CHECK
+    if( LAPACKE_get_nancheck() ) {
+        /* Optionally check input matrices for NaNs */
+        if( LAPACKE_dgb_nancheck( matrix_layout, n, n, kl, ku, ab, ldab ) ) {
+            return -6;
+        }
+    }
+#endif
+    /* Allocate memory for working array(s) */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        work = (double*)LAPACKE_malloc( sizeof(double) * MAX(1,n) );
+        if( work == NULL ) {
+            info = LAPACK_WORK_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+    }
+    /* Call middle-level interface */
+    res = LAPACKE_dlangb_work( matrix_layout, norm, n, kl, ku, ab, ldab, work );
+    /* Release memory and exit */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        LAPACKE_free( work );
+    }
+exit_level_0:
+    if( info == LAPACK_WORK_MEMORY_ERROR ) {
+        LAPACKE_xerbla( "LAPACKE_dlangb", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_dlangb.c
+++ b/LAPACKE/src/lapacke_dlangb.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native high-level C interface to LAPACK function dlangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_dlangb_work.c
+++ b/LAPACKE/src/lapacke_dlangb_work.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_dlangb_work.c
+++ b/LAPACKE/src/lapacke_dlangb_work.c
@@ -1,0 +1,75 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native middle-level C interface to LAPACK function dlangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+double LAPACKE_dlangb_work( int matrix_layout, char norm, lapack_int n,
+                            lapack_int kl, lapack_int ku, const double* ab,
+                            lapack_int ldab, double* work )
+{
+    lapack_int info = 0;
+    double res = 0.;
+    if( matrix_layout == LAPACK_COL_MAJOR ) {
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_dlangb( &norm, &n, &kl, &ku, ab, &ldab, work );
+    } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
+        lapack_int ldab_t = MAX(1,kl+ku+1);
+        double* ab_t = NULL;
+        /* Check leading dimension(s) */
+        if( ldab < kl+ku+1 ) {
+            info = -7;
+            LAPACKE_xerbla( "LAPACKE_dlangb_work", info );
+            return info;
+        }
+        /* Allocate memory for temporary array(s) */
+        ab_t = (double*)LAPACKE_malloc( sizeof(double) * ldab_t * MAX(1,n) );
+        if( ab_t == NULL ) {
+            info = LAPACK_TRANSPOSE_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+        /* Transpose input matrices */
+        LAPACKE_dgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_dlangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
+        info = 0;  /* LAPACK call is ok! */
+        /* Release memory and exit */
+        LAPACKE_free( ab_t );
+exit_level_0:
+        if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {
+            LAPACKE_xerbla( "LAPACKE_dlangb_work", info );
+        }
+    } else {
+        info = -1;
+        LAPACKE_xerbla( "LAPACKE_dlangb_work", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_dlangb_work.c
+++ b/LAPACKE/src/lapacke_dlangb_work.c
@@ -60,7 +60,6 @@ double LAPACKE_dlangb_work( int matrix_layout, char norm, lapack_int n,
         LAPACKE_dgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_dlangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         LAPACKE_free( ab_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_dlangb_work.c
+++ b/LAPACKE/src/lapacke_dlangb_work.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native middle-level C interface to LAPACK function dlangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_dlangb_work.c
+++ b/LAPACKE/src/lapacke_dlangb_work.c
@@ -42,26 +42,35 @@ double LAPACKE_dlangb_work( int matrix_layout, char norm, lapack_int n,
         /* Call LAPACK function and adjust info */
         res = LAPACK_dlangb( &norm, &n, &kl, &ku, ab, &ldab, work );
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ldab_t = MAX(1,kl+ku+1);
-        double* ab_t = NULL;
+        char norm_lapack;
+        double* work_lapack = NULL;
         /* Check leading dimension(s) */
         if( ldab < kl+ku+1 ) {
             info = -7;
             LAPACKE_xerbla( "LAPACKE_dlangb_work", info );
             return info;
         }
-        /* Allocate memory for temporary array(s) */
-        ab_t = (double*)LAPACKE_malloc( sizeof(double) * ldab_t * MAX(1,n) );
-        if( ab_t == NULL ) {
-            info = LAPACK_TRANSPOSE_MEMORY_ERROR;
-            goto exit_level_0;
+        if( LAPACKE_lsame( norm, '1' ) || LAPACKE_lsame( norm, 'o' ) ) {
+            norm_lapack = 'i';
+        } else if( LAPACKE_lsame( norm, 'i' ) ) {
+            norm_lapack = '1';
+        } else {
+            norm_lapack = norm;
         }
-        /* Transpose input matrices */
-        LAPACKE_dgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
-        /* Call LAPACK function and adjust info */
-        res = LAPACK_dlangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
+        /* Allocate memory for work array(s) */
+        if( LAPACKE_lsame( norm_lapack, 'i' ) ) {
+            work_lapack = (double*)LAPACKE_malloc( sizeof(double) * MAX(1,n) );
+            if( work_lapack == NULL ) {
+                info = LAPACK_WORK_MEMORY_ERROR;
+                goto exit_level_0;
+            }
+        }
+        /* Call LAPACK function */
+        res = LAPACK_dlangb( &norm, &n, &ku, &kl, ab, &ldab, work );
         /* Release memory and exit */
-        LAPACKE_free( ab_t );
+        if( work_lapack ) {
+            LAPACKE_free( work_lapack );
+        }
 exit_level_0:
         if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {
             LAPACKE_xerbla( "LAPACKE_dlangb_work", info );

--- a/LAPACKE/src/lapacke_slangb.c
+++ b/LAPACKE/src/lapacke_slangb.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_slangb.c
+++ b/LAPACKE/src/lapacke_slangb.c
@@ -1,0 +1,73 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native high-level C interface to LAPACK function slangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+float LAPACKE_slangb( int matrix_layout, char norm, lapack_int n,
+                      lapack_int kl, lapack_int ku, const float* ab,
+                      lapack_int ldab )
+{
+    lapack_int info = 0;
+    float res = 0.;
+    float* work = NULL;
+    if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
+        LAPACKE_xerbla( "LAPACKE_slangb", -1 );
+        return -1;
+    }
+#ifndef LAPACK_DISABLE_NAN_CHECK
+    if( LAPACKE_get_nancheck() ) {
+        /* Optionally check input matrices for NaNs */
+        if( LAPACKE_sgb_nancheck( matrix_layout, n, n, kl, ku, ab, ldab ) ) {
+            return -6;
+        }
+    }
+#endif
+    /* Allocate memory for working array(s) */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        work = (float*)LAPACKE_malloc( sizeof(float) * MAX(1,n) );
+        if( work == NULL ) {
+            info = LAPACK_WORK_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+    }
+    /* Call middle-level interface */
+    res = LAPACKE_slangb_work( matrix_layout, norm, n, kl, ku, ab, ldab, work );
+    /* Release memory and exit */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        LAPACKE_free( work );
+    }
+exit_level_0:
+    if( info == LAPACK_WORK_MEMORY_ERROR ) {
+        LAPACKE_xerbla( "LAPACKE_slangb", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_slangb.c
+++ b/LAPACKE/src/lapacke_slangb.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native high-level C interface to LAPACK function slangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_slangb_work.c
+++ b/LAPACKE/src/lapacke_slangb_work.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_slangb_work.c
+++ b/LAPACKE/src/lapacke_slangb_work.c
@@ -1,0 +1,75 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native middle-level C interface to LAPACK function slangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+float LAPACKE_slangb_work( int matrix_layout, char norm, lapack_int n,
+                           lapack_int kl, lapack_int ku, const float* ab,
+                           lapack_int ldab, float* work )
+{
+    lapack_int info = 0;
+    float res = 0.;
+    if( matrix_layout == LAPACK_COL_MAJOR ) {
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_slangb( &norm, &n, &kl, &ku, ab, &ldab, work );
+    } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
+        lapack_int ldab_t = MAX(1,kl+ku+1);
+        float* ab_t = NULL;
+        /* Check leading dimension(s) */
+        if( ldab < kl+ku+1 ) {
+            info = -7;
+            LAPACKE_xerbla( "LAPACKE_slangb_work", info );
+            return info;
+        }
+        /* Allocate memory for temporary array(s) */
+        ab_t = (float*)LAPACKE_malloc( sizeof(float) * ldab_t * MAX(1,n) );
+        if( ab_t == NULL ) {
+            info = LAPACK_TRANSPOSE_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+        /* Transpose input matrices */
+        LAPACKE_sgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_slangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
+        info = 0;  /* LAPACK call is ok! */
+        /* Release memory and exit */
+        LAPACKE_free( ab_t );
+exit_level_0:
+        if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {
+            LAPACKE_xerbla( "LAPACKE_slangb_work", info );
+        }
+    } else {
+        info = -1;
+        LAPACKE_xerbla( "LAPACKE_slangb_work", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_slangb_work.c
+++ b/LAPACKE/src/lapacke_slangb_work.c
@@ -60,7 +60,6 @@ float LAPACKE_slangb_work( int matrix_layout, char norm, lapack_int n,
         LAPACKE_sgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_slangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         LAPACKE_free( ab_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_slangb_work.c
+++ b/LAPACKE/src/lapacke_slangb_work.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native middle-level C interface to LAPACK function slangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_zlangb.c
+++ b/LAPACKE/src/lapacke_zlangb.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_zlangb.c
+++ b/LAPACKE/src/lapacke_zlangb.c
@@ -1,0 +1,73 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native high-level C interface to LAPACK function zlangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+double LAPACKE_zlangb( int matrix_layout, char norm, lapack_int n,
+                       lapack_int kl, lapack_int ku,
+                       const lapack_complex_double* ab, lapack_int ldab )
+{
+    lapack_int info = 0;
+    double res = 0.;
+    double* work = NULL;
+    if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
+        LAPACKE_xerbla( "LAPACKE_zlangb", -1 );
+        return -1;
+    }
+#ifndef LAPACK_DISABLE_NAN_CHECK
+    if( LAPACKE_get_nancheck() ) {
+        /* Optionally check input matrices for NaNs */
+        if( LAPACKE_zgb_nancheck( matrix_layout, n, n, kl, ku, ab, ldab ) ) {
+            return -6;
+        }
+    }
+#endif
+    /* Allocate memory for working array(s) */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        work = (double*)LAPACKE_malloc( sizeof(double) * MAX(1,n) );
+        if( work == NULL ) {
+            info = LAPACK_WORK_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+    }
+    /* Call middle-level interface */
+    res = LAPACKE_zlangb_work( matrix_layout, norm, n, kl, ku, ab, ldab, work );
+    /* Release memory and exit */
+    if( LAPACKE_lsame( norm, 'i' ) ) {
+        LAPACKE_free( work );
+    }
+exit_level_0:
+    if( info == LAPACK_WORK_MEMORY_ERROR ) {
+        LAPACKE_xerbla( "LAPACKE_zlangb", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_zlangb.c
+++ b/LAPACKE/src/lapacke_zlangb.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native high-level C interface to LAPACK function zlangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_zlangb_work.c
+++ b/LAPACKE/src/lapacke_zlangb_work.c
@@ -27,7 +27,7 @@
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
 * Contents: Native middle-level C interface to LAPACK function zlangb
-* Author: Intel Corporation
+* Author: Simon Märtens
 *****************************************************************************/
 
 #include "lapacke_utils.h"

--- a/LAPACKE/src/lapacke_zlangb_work.c
+++ b/LAPACKE/src/lapacke_zlangb_work.c
@@ -1,0 +1,77 @@
+/*****************************************************************************
+  Copyright (c) 2014, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native middle-level C interface to LAPACK function zlangb
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+double LAPACKE_zlangb_work( int matrix_layout, char norm, lapack_int n,
+                            lapack_int kl, lapack_int ku,
+                            const lapack_complex_double* ab, lapack_int ldab,
+                            double* work )
+{
+    lapack_int info = 0;
+    double res = 0.;
+    if( matrix_layout == LAPACK_COL_MAJOR ) {
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_zlangb( &norm, &n, &kl, &ku, ab, &ldab, work );
+    } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
+        lapack_int ldab_t = MAX(1,kl+ku+1);
+        lapack_complex_double* ab_t = NULL;
+        /* Check leading dimension(s) */
+        if( ldab < kl+ku+1 ) {
+            info = -7;
+            LAPACKE_xerbla( "LAPACKE_zlangb_work", info );
+            return info;
+        }
+        /* Allocate memory for temporary array(s) */
+        ab_t = (lapack_complex_double*)
+            LAPACKE_malloc( sizeof(lapack_complex_double) * ldab_t * MAX(1,n) );
+        if( ab_t == NULL ) {
+            info = LAPACK_TRANSPOSE_MEMORY_ERROR;
+            goto exit_level_0;
+        }
+        /* Transpose input matrices */
+        LAPACKE_zgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
+        /* Call LAPACK function and adjust info */
+        res = LAPACK_zlangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
+        info = 0;  /* LAPACK call is ok! */
+        /* Release memory and exit */
+        LAPACKE_free( ab_t );
+exit_level_0:
+        if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {
+            LAPACKE_xerbla( "LAPACKE_zlangb_work", info );
+        }
+    } else {
+        info = -1;
+        LAPACKE_xerbla( "LAPACKE_zlangb_work", info );
+    }
+    return res;
+}

--- a/LAPACKE/src/lapacke_zlangb_work.c
+++ b/LAPACKE/src/lapacke_zlangb_work.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-  Copyright (c) 2014, Intel Corp.
+  Copyright (c) 2022, Intel Corp.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/LAPACKE/src/lapacke_zlangb_work.c
+++ b/LAPACKE/src/lapacke_zlangb_work.c
@@ -62,7 +62,6 @@ double LAPACKE_zlangb_work( int matrix_layout, char norm, lapack_int n,
         LAPACKE_zgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
         /* Call LAPACK function and adjust info */
         res = LAPACK_zlangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
-        info = 0;  /* LAPACK call is ok! */
         /* Release memory and exit */
         LAPACKE_free( ab_t );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zlangb_work.c
+++ b/LAPACKE/src/lapacke_zlangb_work.c
@@ -43,27 +43,35 @@ double LAPACKE_zlangb_work( int matrix_layout, char norm, lapack_int n,
         /* Call LAPACK function and adjust info */
         res = LAPACK_zlangb( &norm, &n, &kl, &ku, ab, &ldab, work );
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
-        lapack_int ldab_t = MAX(1,kl+ku+1);
-        lapack_complex_double* ab_t = NULL;
+        char norm_lapack;
+        double* work_lapack = NULL;
         /* Check leading dimension(s) */
         if( ldab < kl+ku+1 ) {
             info = -7;
             LAPACKE_xerbla( "LAPACKE_zlangb_work", info );
             return info;
         }
-        /* Allocate memory for temporary array(s) */
-        ab_t = (lapack_complex_double*)
-            LAPACKE_malloc( sizeof(lapack_complex_double) * ldab_t * MAX(1,n) );
-        if( ab_t == NULL ) {
-            info = LAPACK_TRANSPOSE_MEMORY_ERROR;
-            goto exit_level_0;
+        if( LAPACKE_lsame( norm, '1' ) || LAPACKE_lsame( norm, 'o' ) ) {
+            norm_lapack = 'i';
+        } else if( LAPACKE_lsame( norm, 'i' ) ) {
+            norm_lapack = '1';
+        } else {
+            norm_lapack = norm;
         }
-        /* Transpose input matrices */
-        LAPACKE_zgb_trans( matrix_layout, n, n, kl, ku, ab, ldab, ab_t, ldab_t );
-        /* Call LAPACK function and adjust info */
-        res = LAPACK_zlangb( &norm, &n, &kl, &ku, ab_t, &ldab_t, work );
+        /* Allocate memory for work array(s) */
+        if( LAPACKE_lsame( norm_lapack, 'i' ) ) {
+            work_lapack = (double*)LAPACKE_malloc( sizeof(double) * MAX(1,n) );
+            if( work_lapack == NULL ) {
+                info = LAPACK_WORK_MEMORY_ERROR;
+                goto exit_level_0;
+            }
+        }
+        /* Call LAPACK function */
+        res = LAPACK_zlangb( &norm, &n, &ku, &kl, ab, &ldab, work );
         /* Release memory and exit */
-        LAPACKE_free( ab_t );
+        if( work_lapack ) {
+            LAPACKE_free( work_lapack );
+        }
 exit_level_0:
         if( info == LAPACK_TRANSPOSE_MEMORY_ERROR ) {
             LAPACKE_xerbla( "LAPACKE_zlangb_work", info );


### PR DESCRIPTION
**Description**

Following up on #722, I've implemented the  `LAPACKE_?langb` interfaces. I've used the same trick as in `LAPACKE_?lange` where you interpret the matrix as transposed in row-major layout. Although the matrix is in band layout here, it works because it is a square matrix (correct me if I'm wrong). `kl` and `ku` are swapped in the row-major case due to the implicit transposition.

Does the documentation update itself via oxygen?

Closes #722 

**Checklist**

- [ ] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.