### PR TITLE
NaN check for trapezoidal routines.

### DIFF
--- a/LAPACKE/include/lapacke_utils.h
+++ b/LAPACKE/include/lapacke_utils.h
@@ -376,6 +376,10 @@ lapack_logical LAPACKE_ctr_nancheck( int matrix_layout, char uplo, char diag,
                                       lapack_int n,
                                       const lapack_complex_float *a,
                                       lapack_int lda );
+lapack_logical LAPACKE_ctz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const lapack_complex_float *a,
+                                     lapack_int lda );
 
 lapack_logical LAPACKE_dgb_nancheck( int matrix_layout, lapack_int m,
                                       lapack_int n, lapack_int kl,
@@ -440,6 +444,9 @@ lapack_logical LAPACKE_dtr_nancheck( int matrix_layout, char uplo, char diag,
                                       lapack_int n,
                                       const double *a,
                                       lapack_int lda );
+lapack_logical LAPACKE_dtz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const double *a, lapack_int lda );
 
 lapack_logical LAPACKE_sgb_nancheck( int matrix_layout, lapack_int m,
                                       lapack_int n, lapack_int kl,
@@ -504,6 +511,9 @@ lapack_logical LAPACKE_str_nancheck( int matrix_layout, char uplo, char diag,
                                       lapack_int n,
                                       const float *a,
                                       lapack_int lda );
+lapack_logical LAPACKE_stz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const float *a, lapack_int lda );
 
 lapack_logical LAPACKE_zgb_nancheck( int matrix_layout, lapack_int m,
                                       lapack_int n, lapack_int kl,
@@ -574,6 +584,10 @@ lapack_logical LAPACKE_ztr_nancheck( int matrix_layout, char uplo, char diag,
                                       lapack_int n,
                                       const lapack_complex_double *a,
                                       lapack_int lda );
+lapack_logical LAPACKE_ztz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const lapack_complex_double *a,
+                                     lapack_int lda );
 
 #ifdef __cplusplus
 }

--- a/LAPACKE/src/Makefile
+++ b/LAPACKE/src/Makefile
@@ -356,6 +356,8 @@ lapacke_clacrm.o \
 lapacke_clacrm_work.o \
 lapacke_clag2z.o \
 lapacke_clag2z_work.o \
+lapacke_clangb.o \
+lapacke_clangb_work.o \
 lapacke_clange.o \
 lapacke_clange_work.o \
 lapacke_clanhe.o \
@@ -840,6 +842,8 @@ lapacke_dlag2s.o \
 lapacke_dlag2s_work.o \
 lapacke_dlamch.o \
 lapacke_dlamch_work.o \
+lapacke_dlangb.o \
+lapacke_dlangb_work.o \
 lapacke_dlange.o \
 lapacke_dlange_work.o \
 lapacke_dlansy.o \
@@ -1412,6 +1416,8 @@ lapacke_slag2d.o \
 lapacke_slag2d_work.o \
 lapacke_slamch.o \
 lapacke_slamch_work.o \
+lapacke_slangb.o \
+lapacke_slangb_work.o \
 lapacke_slange.o \
 lapacke_slange_work.o \
 lapacke_slansy.o \
@@ -2114,6 +2120,8 @@ lapacke_zlacrm.o \
 lapacke_zlacrm_work.o \
 lapacke_zlag2c.o \
 lapacke_zlag2c_work.o \
+lapacke_zlangb.o \
+lapacke_zlangb_work.o \
 lapacke_zlange.o \
 lapacke_zlange_work.o \
 lapacke_zlanhe.o \

--- a/LAPACKE/src/lapacke_clantr.c
+++ b/LAPACKE/src/lapacke_clantr.c
@@ -33,8 +33,8 @@
 #include "lapacke_utils.h"
 
 float LAPACKE_clantr( int matrix_layout, char norm, char uplo, char diag,
-                           lapack_int m, lapack_int n, const lapack_complex_float* a,
-                           lapack_int lda )
+                      lapack_int m, lapack_int n, const lapack_complex_float* a,
+                      lapack_int lda )
 {
     lapack_int info = 0;
     float res = 0.;
@@ -46,7 +46,7 @@ float LAPACKE_clantr( int matrix_layout, char norm, char uplo, char diag,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        if( LAPACKE_ctr_nancheck( matrix_layout, uplo, diag, MIN(m,n), a, lda ) ) {
+        if( LAPACKE_ctz_nancheck( matrix_layout, 'f', uplo, diag, m, n, a, lda ) ) {
             return -7;
         }
     }

--- a/LAPACKE/src/lapacke_dlantr.c
+++ b/LAPACKE/src/lapacke_dlantr.c
@@ -46,7 +46,7 @@ double LAPACKE_dlantr( int matrix_layout, char norm, char uplo, char diag,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        if( LAPACKE_dtr_nancheck( matrix_layout, uplo, diag, MIN(m,n), a, lda ) ) {
+        if( LAPACKE_dtz_nancheck( matrix_layout, 'f', uplo, diag, m, n, a, lda ) ) {
             return -7;
         }
     }

--- a/LAPACKE/src/lapacke_slantr.c
+++ b/LAPACKE/src/lapacke_slantr.c
@@ -46,7 +46,7 @@ float LAPACKE_slantr( int matrix_layout, char norm, char uplo, char diag,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        if( LAPACKE_str_nancheck( matrix_layout, uplo, diag, MIN(m,n), a, lda ) ) {
+        if( LAPACKE_stz_nancheck( matrix_layout, 'f', uplo, diag, m, n, a, lda ) ) {
             return -7;
         }
     }

--- a/LAPACKE/src/lapacke_zlantr.c
+++ b/LAPACKE/src/lapacke_zlantr.c
@@ -46,7 +46,7 @@ double LAPACKE_zlantr( int matrix_layout, char norm, char uplo, char diag,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        if( LAPACKE_ztr_nancheck( matrix_layout, uplo, diag, MIN(m,n), a, lda ) ) {
+        if( LAPACKE_ztz_nancheck( matrix_layout, 'f', uplo, diag, m, n, a, lda ) ) {
             return -7;
         }
     }

--- a/LAPACKE/utils/CMakeLists.txt
+++ b/LAPACKE/utils/CMakeLists.txt
@@ -43,11 +43,3 @@ lapacke_make_complex_float.c                                                    
 lapacke_lsame.c
 lapacke_xerbla.c
 )
-
-
-
-
-
-
-
-

--- a/LAPACKE/utils/CMakeLists.txt
+++ b/LAPACKE/utils/CMakeLists.txt
@@ -1,39 +1,53 @@
 set(UTILS
-lapacke_c_nancheck.c            lapacke_ctr_trans.c             lapacke_make_complex_float.c    lapacke_zgb_nancheck.c
-lapacke_cgb_nancheck.c          lapacke_d_nancheck.c            lapacke_s_nancheck.c            lapacke_zgb_trans.c
-lapacke_cgb_trans.c             lapacke_dgb_nancheck.c          lapacke_sgb_nancheck.c          lapacke_zge_nancheck.c
-lapacke_cge_nancheck.c          lapacke_dgb_trans.c             lapacke_sgb_trans.c             lapacke_zge_trans.c
-lapacke_cge_trans.c             lapacke_dge_nancheck.c          lapacke_sge_nancheck.c          lapacke_zgg_nancheck.c
-lapacke_cgg_nancheck.c          lapacke_dge_trans.c             lapacke_sge_trans.c             lapacke_zgg_trans.c
-lapacke_cgg_trans.c             lapacke_dgg_nancheck.c          lapacke_sgg_nancheck.c          lapacke_zgt_nancheck.c
-lapacke_cgt_nancheck.c          lapacke_dgg_trans.c             lapacke_sgg_trans.c             lapacke_zhb_nancheck.c
-lapacke_chb_nancheck.c          lapacke_dgt_nancheck.c          lapacke_sgt_nancheck.c          lapacke_zhb_trans.c
-lapacke_chb_trans.c             lapacke_dhs_nancheck.c          lapacke_shs_nancheck.c          lapacke_zhe_nancheck.c
-lapacke_che_nancheck.c          lapacke_dhs_trans.c             lapacke_shs_trans.c             lapacke_zhe_trans.c
-lapacke_che_trans.c             lapacke_dpb_nancheck.c          lapacke_spb_nancheck.c          lapacke_zhp_nancheck.c
-lapacke_chp_nancheck.c          lapacke_dpb_trans.c             lapacke_spb_trans.c             lapacke_zhp_trans.c
-lapacke_chp_trans.c             lapacke_dpf_nancheck.c          lapacke_spf_nancheck.c          lapacke_zhs_nancheck.c
-lapacke_chs_nancheck.c          lapacke_dpf_trans.c             lapacke_spf_trans.c             lapacke_zhs_trans.c
-lapacke_chs_trans.c             lapacke_dpo_nancheck.c          lapacke_spo_nancheck.c          lapacke_zpb_nancheck.c
-lapacke_cpb_nancheck.c          lapacke_dpo_trans.c             lapacke_spo_trans.c             lapacke_zpb_trans.c
-lapacke_cpb_trans.c             lapacke_dpp_nancheck.c          lapacke_spp_nancheck.c          lapacke_zpf_nancheck.c
-lapacke_cpf_nancheck.c          lapacke_dpp_trans.c             lapacke_spp_trans.c             lapacke_zpf_trans.c
-lapacke_cpf_trans.c             lapacke_dpt_nancheck.c          lapacke_spt_nancheck.c          lapacke_zpo_nancheck.c
-lapacke_cpo_nancheck.c          lapacke_dsb_nancheck.c          lapacke_ssb_nancheck.c          lapacke_zpo_trans.c
-lapacke_cpo_trans.c             lapacke_dsb_trans.c             lapacke_ssb_trans.c             lapacke_zpp_nancheck.c
-lapacke_cpp_nancheck.c          lapacke_dsp_nancheck.c          lapacke_ssp_nancheck.c          lapacke_zpp_trans.c
-lapacke_cpp_trans.c             lapacke_dsp_trans.c             lapacke_ssp_trans.c             lapacke_zpt_nancheck.c
-lapacke_cpt_nancheck.c          lapacke_dst_nancheck.c          lapacke_sst_nancheck.c          lapacke_zsp_nancheck.c
-lapacke_csp_nancheck.c          lapacke_dsy_nancheck.c          lapacke_ssy_nancheck.c          lapacke_zsp_trans.c
-lapacke_csp_trans.c             lapacke_dsy_trans.c             lapacke_ssy_trans.c             lapacke_zst_nancheck.c
-lapacke_cst_nancheck.c          lapacke_dtb_nancheck.c          lapacke_stb_nancheck.c          lapacke_zsy_nancheck.c
-lapacke_csy_nancheck.c          lapacke_dtb_trans.c             lapacke_stb_trans.c             lapacke_zsy_trans.c
-lapacke_csy_trans.c             lapacke_dtf_nancheck.c          lapacke_stf_nancheck.c          lapacke_ztb_nancheck.c
-lapacke_ctb_nancheck.c          lapacke_dtf_trans.c             lapacke_stf_trans.c             lapacke_ztb_trans.c
-lapacke_ctb_trans.c             lapacke_dtp_nancheck.c          lapacke_stp_nancheck.c          lapacke_ztf_nancheck.c
-lapacke_ctf_nancheck.c          lapacke_dtp_trans.c             lapacke_stp_trans.c             lapacke_ztf_trans.c
-lapacke_ctf_trans.c             lapacke_dtr_nancheck.c          lapacke_str_nancheck.c          lapacke_ztp_nancheck.c
-lapacke_ctp_nancheck.c          lapacke_dtr_trans.c             lapacke_str_trans.c             lapacke_ztp_trans.c
-lapacke_ctp_trans.c             lapacke_lsame.c                 lapacke_xerbla.c                lapacke_ztr_nancheck.c
-lapacke_ctr_nancheck.c          lapacke_make_complex_double.c   lapacke_z_nancheck.c            lapacke_ztr_trans.c
+lapacke_c_nancheck.c          lapacke_d_nancheck.c          lapacke_s_nancheck.c          lapacke_z_nancheck.c
+lapacke_cgb_nancheck.c        lapacke_dgb_nancheck.c        lapacke_sgb_nancheck.c        lapacke_zgb_trans.c
+lapacke_cgb_trans.c           lapacke_dgb_trans.c           lapacke_sgb_trans.c           lapacke_zgb_nancheck.c
+lapacke_cge_nancheck.c        lapacke_dge_nancheck.c        lapacke_sge_nancheck.c        lapacke_zge_nancheck.c
+lapacke_cge_trans.c           lapacke_dge_trans.c           lapacke_sge_trans.c           lapacke_zge_trans.c
+lapacke_cgg_nancheck.c        lapacke_dgg_nancheck.c        lapacke_sgg_nancheck.c        lapacke_zgg_nancheck.c
+lapacke_cgg_trans.c           lapacke_dgg_trans.c           lapacke_sgg_trans.c           lapacke_zgg_trans.c
+lapacke_cgt_nancheck.c        lapacke_dgt_nancheck.c        lapacke_sgt_nancheck.c        lapacke_zgt_nancheck.c
+lapacke_chb_nancheck.c        lapacke_dsb_nancheck.c        lapacke_ssb_nancheck.c        lapacke_zhb_nancheck.c
+lapacke_chb_trans.c           lapacke_dsb_trans.c           lapacke_ssb_trans.c           lapacke_zhb_trans.c
+lapacke_che_nancheck.c                                                                    lapacke_zhe_nancheck.c
+lapacke_che_trans.c                                                                       lapacke_zhe_trans.c
+lapacke_chp_nancheck.c                                                                    lapacke_zhp_nancheck.c
+lapacke_chp_trans.c                                                                       lapacke_zhp_trans.c
+lapacke_chs_nancheck.c        lapacke_dhs_nancheck.c        lapacke_shs_nancheck.c        lapacke_zhs_nancheck.c
+lapacke_chs_trans.c           lapacke_dhs_trans.c           lapacke_shs_trans.c           lapacke_zhs_trans.c
+lapacke_cpb_nancheck.c        lapacke_dpb_nancheck.c        lapacke_spb_nancheck.c        lapacke_zpb_nancheck.c
+lapacke_cpb_trans.c           lapacke_dpb_trans.c           lapacke_spb_trans.c           lapacke_zpb_trans.c
+lapacke_cpf_nancheck.c        lapacke_dpf_nancheck.c        lapacke_spf_nancheck.c        lapacke_zpf_nancheck.c
+lapacke_cpf_trans.c           lapacke_dpf_trans.c           lapacke_spf_trans.c           lapacke_zpf_trans.c
+lapacke_cpo_nancheck.c        lapacke_dpo_nancheck.c        lapacke_spo_nancheck.c        lapacke_zpo_nancheck.c
+lapacke_cpo_trans.c           lapacke_dpo_trans.c           lapacke_spo_trans.c           lapacke_zpo_trans.c
+lapacke_cpp_nancheck.c        lapacke_dpp_nancheck.c        lapacke_spp_nancheck.c        lapacke_zpp_nancheck.c
+lapacke_cpp_trans.c           lapacke_dpp_trans.c           lapacke_spp_trans.c           lapacke_zpp_trans.c
+lapacke_cpt_nancheck.c        lapacke_dpt_nancheck.c        lapacke_spt_nancheck.c        lapacke_zpt_nancheck.c
+lapacke_csp_nancheck.c        lapacke_dsp_nancheck.c        lapacke_ssp_nancheck.c        lapacke_zsp_nancheck.c
+lapacke_csp_trans.c           lapacke_dsp_trans.c           lapacke_ssp_trans.c           lapacke_zsp_trans.c
+lapacke_cst_nancheck.c        lapacke_dst_nancheck.c        lapacke_sst_nancheck.c        lapacke_zst_nancheck.c
+lapacke_csy_nancheck.c        lapacke_dsy_nancheck.c        lapacke_ssy_nancheck.c        lapacke_zsy_nancheck.c
+lapacke_csy_trans.c           lapacke_dsy_trans.c           lapacke_ssy_trans.c           lapacke_zsy_trans.c
+lapacke_ctb_nancheck.c        lapacke_dtb_nancheck.c        lapacke_stb_nancheck.c        lapacke_ztb_nancheck.c
+lapacke_ctb_trans.c           lapacke_dtb_trans.c           lapacke_stb_trans.c           lapacke_ztb_trans.c
+lapacke_ctf_nancheck.c        lapacke_dtf_nancheck.c        lapacke_stf_nancheck.c        lapacke_ztf_nancheck.c
+lapacke_ctf_trans.c           lapacke_dtf_trans.c           lapacke_stf_trans.c           lapacke_ztf_trans.c
+lapacke_ctp_nancheck.c        lapacke_dtp_nancheck.c        lapacke_stp_nancheck.c        lapacke_ztp_nancheck.c
+lapacke_ctp_trans.c           lapacke_dtp_trans.c           lapacke_stp_trans.c           lapacke_ztp_trans.c
+lapacke_ctr_nancheck.c        lapacke_dtr_nancheck.c        lapacke_str_nancheck.c        lapacke_ztr_nancheck.c
+lapacke_ctr_trans.c           lapacke_dtr_trans.c           lapacke_str_trans.c           lapacke_ztr_trans.c
+lapacke_ctz_nancheck.c        lapacke_dtz_nancheck.c        lapacke_stz_nancheck.c        lapacke_ztz_nancheck.c
+
+lapacke_make_complex_float.c                                                              lapacke_make_complex_double.c
+lapacke_lsame.c
+lapacke_xerbla.c
 )
+
+
+
+
+
+
+
+

--- a/LAPACKE/utils/Makefile
+++ b/LAPACKE/utils/Makefile
@@ -76,6 +76,7 @@ OBJ = lapacke_cgb_nancheck.o \
       lapacke_ctp_trans.o \
       lapacke_ctr_nancheck.o \
       lapacke_ctr_trans.o \
+			lapacke_ctz_nancheck.o \
       lapacke_dgb_nancheck.o \
       lapacke_dgb_trans.o \
       lapacke_dge_nancheck.o \
@@ -110,6 +111,7 @@ OBJ = lapacke_cgb_nancheck.o \
       lapacke_dtp_trans.o \
       lapacke_dtr_nancheck.o \
       lapacke_dtr_trans.o \
+      lapacke_dtz_nancheck.o \
       lapacke_lsame.o \
       lapacke_sgb_nancheck.o \
       lapacke_sgb_trans.o \
@@ -145,6 +147,7 @@ OBJ = lapacke_cgb_nancheck.o \
       lapacke_stp_trans.o \
       lapacke_str_nancheck.o \
       lapacke_str_trans.o \
+      lapacke_stz_nancheck.o \
       lapacke_xerbla.o \
       lapacke_zgb_nancheck.o \
       lapacke_zgb_trans.o \
@@ -184,6 +187,7 @@ OBJ = lapacke_cgb_nancheck.o \
       lapacke_ztp_trans.o \
       lapacke_ztr_nancheck.o \
       lapacke_ztr_trans.o \
+      lapacke_ztz_nancheck.o \
       lapacke_make_complex_float.o \
       lapacke_make_complex_double.o
 

--- a/LAPACKE/utils/Makefile
+++ b/LAPACKE/utils/Makefile
@@ -76,7 +76,7 @@ OBJ = lapacke_cgb_nancheck.o \
       lapacke_ctp_trans.o \
       lapacke_ctr_nancheck.o \
       lapacke_ctr_trans.o \
-			lapacke_ctz_nancheck.o \
+      lapacke_ctz_nancheck.o \
       lapacke_dgb_nancheck.o \
       lapacke_dgb_trans.o \
       lapacke_dge_nancheck.o \

--- a/LAPACKE/utils/lapacke_ctz_nancheck.c
+++ b/LAPACKE/utils/lapacke_ctz_nancheck.c
@@ -1,0 +1,142 @@
+/*****************************************************************************
+  Copyright (c) 2022, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************
+* Contents: Native C interface to LAPACK utility function
+* Author: Simon Märtens
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+/*****************************************************************************
+  Check a trapezoidal matrix for NaN entries. The shape of the trapezoidal
+  matrix is determined by the arguments `direct` and `uplo`. `Direct` chooses
+  the diagonal which shall be considered and `uplo` tells us whether we use the
+  upper or lower part of the matrix with respect to the chosen diagonal.
+
+      Diagonals 'F' (front / forward) and 'B' (back / backward):
+
+        A = ( F       )           A = ( F     B       )
+            (    F    )               (    F     B    )
+            ( B     F )               (       F     B )
+            (    B    )
+            (       B )
+
+      direct = 'F', uplo = 'L':
+
+        A = ( *       )           A = ( *             )
+            ( *  *    )               ( *  *          )
+            ( *  *  * )               ( *  *  *       )
+            ( *  *  * )
+            ( *  *  * )
+
+      direct = 'F', uplo = 'U':
+
+        A = ( *  *  * )           A = ( *  *  *  *  * )
+            (    *  * )               (    *  *  *  * )
+            (       * )               (       *  *  * )
+            (         )
+            (         )
+
+      direct = 'B', uplo = 'L':
+
+        A = (         )           A = ( *  *  *       )
+            (         )               ( *  *  *  *    )
+            ( *       )               ( *  *  *  *  * )
+            ( *  *    )
+            ( *  *  * )
+
+      direct = 'B', uplo = 'U':
+
+        A = ( *  *  * )           A = (       *  *  * )
+            ( *  *  * )               (          *  * )
+            ( *  *  * )               (             * )
+            (    *  * )
+            (       * )
+
+*****************************************************************************/
+
+lapack_logical LAPACKE_ctz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const lapack_complex_float *a,
+                                     lapack_int lda )
+{
+    lapack_logical colmaj, front, lower, unit;
+
+    if( a == NULL ) return (lapack_logical) 0;
+
+    colmaj = ( matrix_layout == LAPACK_COL_MAJOR );
+    front  = LAPACKE_lsame( direct, 'f' );
+    lower  = LAPACKE_lsame( uplo, 'l' );
+    unit   = LAPACKE_lsame( diag, 'u' );
+
+    if( ( !colmaj && ( matrix_layout != LAPACK_ROW_MAJOR ) ) ||
+        ( !front  && !LAPACKE_lsame( uplo, 'b' ) ) ||
+        ( !lower  && !LAPACKE_lsame( uplo, 'u' ) ) ||
+        ( !unit   && !LAPACKE_lsame( diag, 'n' ) ) ) {
+        /* Just exit if any of input parameters are wrong */
+        return (lapack_logical) 0;
+    }
+
+    /* Initial offsets and sizes of triangular and rectangular parts */
+    lapack_int tri_offset = 0;
+    lapack_int tri_n = MIN(m,n);
+    lapack_int rect_offset = -1;
+    lapack_int rect_m = (m > n) ? m - n : m;
+    lapack_int rect_n = (n > m) ? n - m : n;
+
+    /* Fix offsets depending on the shape of the matrix */
+    if( front ) {
+        if( lower && m > n) {
+            rect_offset = tri_n * (!colmaj ? lda : 1);
+        } else if( !lower && n > m) {
+            rect_offset = tri_n * (colmaj ? lda : 1);
+        }
+    } else {
+        if( m > n) {
+            tri_offset = rect_m * (!colmaj ? lda : 1);
+            if( !lower ) {
+                rect_offset = 0;
+            }
+        } else if( n > m) {
+            tri_offset = rect_n * (colmaj ? lda : 1);
+            if( lower ) {
+                rect_offset = 0;
+            }
+        }
+    }
+
+    /* Check rectangular part */
+    if( rect_offset >= 0 ) {
+        if( LAPACKE_cge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+            return (lapack_logical) 1;
+        }
+    }
+
+    /* Check triangular part */
+    return LAPACKE_ctr_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+}

--- a/LAPACKE/utils/lapacke_ctz_nancheck.c
+++ b/LAPACKE/utils/lapacke_ctz_nancheck.c
@@ -132,11 +132,13 @@ lapack_logical LAPACKE_ctz_nancheck( int matrix_layout, char direct, char uplo,
 
     /* Check rectangular part */
     if( rect_offset >= 0 ) {
-        if( LAPACKE_cge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+        if( LAPACKE_cge_nancheck( matrix_layout, rect_m, rect_n,
+                                  &a[rect_offset], lda) ) {
             return (lapack_logical) 1;
         }
     }
 
     /* Check triangular part */
-    return LAPACKE_ctr_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+    return LAPACKE_ctr_nancheck( matrix_layout, uplo, diag, tri_n,
+                                 &a[tri_offset], lda );
 }

--- a/LAPACKE/utils/lapacke_dtz_nancheck.c
+++ b/LAPACKE/utils/lapacke_dtz_nancheck.c
@@ -131,11 +131,13 @@ lapack_logical LAPACKE_dtz_nancheck( int matrix_layout, char direct, char uplo,
 
     /* Check rectangular part */
     if( rect_offset >= 0 ) {
-        if( LAPACKE_dge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+        if( LAPACKE_dge_nancheck( matrix_layout, rect_m, rect_n,
+                                  &a[rect_offset], lda) ) {
             return (lapack_logical) 1;
         }
     }
 
     /* Check triangular part */
-    return LAPACKE_dtr_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+    return LAPACKE_dtr_nancheck( matrix_layout, uplo, diag, tri_n,
+                                 &a[tri_offset], lda );
 }

--- a/LAPACKE/utils/lapacke_dtz_nancheck.c
+++ b/LAPACKE/utils/lapacke_dtz_nancheck.c
@@ -1,0 +1,141 @@
+/*****************************************************************************
+  Copyright (c) 2022, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************
+* Contents: Native C interface to LAPACK utility function
+* Author: Simon Märtens
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+/*****************************************************************************
+  Check a trapezoidal matrix for NaN entries. The shape of the trapezoidal
+  matrix is determined by the arguments `direct` and `uplo`. `Direct` chooses
+  the diagonal which shall be considered and `uplo` tells us whether we use the
+  upper or lower part of the matrix with respect to the chosen diagonal.
+
+      Diagonals 'F' (front / forward) and 'B' (back / backward):
+
+        A = ( F       )           A = ( F     B       )
+            (    F    )               (    F     B    )
+            ( B     F )               (       F     B )
+            (    B    )
+            (       B )
+
+      direct = 'F', uplo = 'L':
+
+        A = ( *       )           A = ( *             )
+            ( *  *    )               ( *  *          )
+            ( *  *  * )               ( *  *  *       )
+            ( *  *  * )
+            ( *  *  * )
+
+      direct = 'F', uplo = 'U':
+
+        A = ( *  *  * )           A = ( *  *  *  *  * )
+            (    *  * )               (    *  *  *  * )
+            (       * )               (       *  *  * )
+            (         )
+            (         )
+
+      direct = 'B', uplo = 'L':
+
+        A = (         )           A = ( *  *  *       )
+            (         )               ( *  *  *  *    )
+            ( *       )               ( *  *  *  *  * )
+            ( *  *    )
+            ( *  *  * )
+
+      direct = 'B', uplo = 'U':
+
+        A = ( *  *  * )           A = (       *  *  * )
+            ( *  *  * )               (          *  * )
+            ( *  *  * )               (             * )
+            (    *  * )
+            (       * )
+
+*****************************************************************************/
+
+lapack_logical LAPACKE_dtz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const double *a, lapack_int lda )
+{
+    lapack_logical colmaj, front, lower, unit;
+
+    if( a == NULL ) return (lapack_logical) 0;
+
+    colmaj = ( matrix_layout == LAPACK_COL_MAJOR );
+    front  = LAPACKE_lsame( direct, 'f' );
+    lower  = LAPACKE_lsame( uplo, 'l' );
+    unit   = LAPACKE_lsame( diag, 'u' );
+
+    if( ( !colmaj && ( matrix_layout != LAPACK_ROW_MAJOR ) ) ||
+        ( !front  && !LAPACKE_lsame( uplo, 'b' ) ) ||
+        ( !lower  && !LAPACKE_lsame( uplo, 'u' ) ) ||
+        ( !unit   && !LAPACKE_lsame( diag, 'n' ) ) ) {
+        /* Just exit if any of input parameters are wrong */
+        return (lapack_logical) 0;
+    }
+
+    /* Initial offsets and sizes of triangular and rectangular parts */
+    lapack_int tri_offset = 0;
+    lapack_int tri_n = MIN(m,n);
+    lapack_int rect_offset = -1;
+    lapack_int rect_m = (m > n) ? m - n : m;
+    lapack_int rect_n = (n > m) ? n - m : n;
+
+    /* Fix offsets depending on the shape of the matrix */
+    if( front ) {
+        if( lower && m > n) {
+            rect_offset = tri_n * (!colmaj ? lda : 1);
+        } else if( !lower && n > m) {
+            rect_offset = tri_n * (colmaj ? lda : 1);
+        }
+    } else {
+        if( m > n) {
+            tri_offset = rect_m * (!colmaj ? lda : 1);
+            if( !lower ) {
+                rect_offset = 0;
+            }
+        } else if( n > m) {
+            tri_offset = rect_n * (colmaj ? lda : 1);
+            if( lower ) {
+                rect_offset = 0;
+            }
+        }
+    }
+
+    /* Check rectangular part */
+    if( rect_offset >= 0 ) {
+        if( LAPACKE_dge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+            return (lapack_logical) 1;
+        }
+    }
+
+    /* Check triangular part */
+    return LAPACKE_dtr_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+}

--- a/LAPACKE/utils/lapacke_stz_nancheck.c
+++ b/LAPACKE/utils/lapacke_stz_nancheck.c
@@ -131,11 +131,13 @@ lapack_logical LAPACKE_stz_nancheck( int matrix_layout, char direct, char uplo,
 
     /* Check rectangular part */
     if( rect_offset >= 0 ) {
-        if( LAPACKE_sge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+        if( LAPACKE_sge_nancheck( matrix_layout, rect_m, rect_n,
+                                  &a[rect_offset], lda) ) {
             return (lapack_logical) 1;
         }
     }
 
     /* Check triangular part */
-    return LAPACKE_str_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+    return LAPACKE_str_nancheck( matrix_layout, uplo, diag, tri_n,
+                                 &a[tri_offset], lda );
 }

--- a/LAPACKE/utils/lapacke_stz_nancheck.c
+++ b/LAPACKE/utils/lapacke_stz_nancheck.c
@@ -1,0 +1,141 @@
+/*****************************************************************************
+  Copyright (c) 2022, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************
+* Contents: Native C interface to LAPACK utility function
+* Author: Simon Märtens
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+/*****************************************************************************
+  Check a trapezoidal matrix for NaN entries. The shape of the trapezoidal
+  matrix is determined by the arguments `direct` and `uplo`. `Direct` chooses
+  the diagonal which shall be considered and `uplo` tells us whether we use the
+  upper or lower part of the matrix with respect to the chosen diagonal.
+
+      Diagonals 'F' (front / forward) and 'B' (back / backward):
+
+        A = ( F       )           A = ( F     B       )
+            (    F    )               (    F     B    )
+            ( B     F )               (       F     B )
+            (    B    )
+            (       B )
+
+      direct = 'F', uplo = 'L':
+
+        A = ( *       )           A = ( *             )
+            ( *  *    )               ( *  *          )
+            ( *  *  * )               ( *  *  *       )
+            ( *  *  * )
+            ( *  *  * )
+
+      direct = 'F', uplo = 'U':
+
+        A = ( *  *  * )           A = ( *  *  *  *  * )
+            (    *  * )               (    *  *  *  * )
+            (       * )               (       *  *  * )
+            (         )
+            (         )
+
+      direct = 'B', uplo = 'L':
+
+        A = (         )           A = ( *  *  *       )
+            (         )               ( *  *  *  *    )
+            ( *       )               ( *  *  *  *  * )
+            ( *  *    )
+            ( *  *  * )
+
+      direct = 'B', uplo = 'U':
+
+        A = ( *  *  * )           A = (       *  *  * )
+            ( *  *  * )               (          *  * )
+            ( *  *  * )               (             * )
+            (    *  * )
+            (       * )
+
+*****************************************************************************/
+
+lapack_logical LAPACKE_stz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const float *a, lapack_int lda )
+{
+    lapack_logical colmaj, front, lower, unit;
+
+    if( a == NULL ) return (lapack_logical) 0;
+
+    colmaj = ( matrix_layout == LAPACK_COL_MAJOR );
+    front  = LAPACKE_lsame( direct, 'f' );
+    lower  = LAPACKE_lsame( uplo, 'l' );
+    unit   = LAPACKE_lsame( diag, 'u' );
+
+    if( ( !colmaj && ( matrix_layout != LAPACK_ROW_MAJOR ) ) ||
+        ( !front  && !LAPACKE_lsame( uplo, 'b' ) ) ||
+        ( !lower  && !LAPACKE_lsame( uplo, 'u' ) ) ||
+        ( !unit   && !LAPACKE_lsame( diag, 'n' ) ) ) {
+        /* Just exit if any of input parameters are wrong */
+        return (lapack_logical) 0;
+    }
+
+    /* Initial offsets and sizes of triangular and rectangular parts */
+    lapack_int tri_offset = 0;
+    lapack_int tri_n = MIN(m,n);
+    lapack_int rect_offset = -1;
+    lapack_int rect_m = (m > n) ? m - n : m;
+    lapack_int rect_n = (n > m) ? n - m : n;
+
+    /* Fix offsets depending on the shape of the matrix */
+    if( front ) {
+        if( lower && m > n) {
+            rect_offset = tri_n * (!colmaj ? lda : 1);
+        } else if( !lower && n > m) {
+            rect_offset = tri_n * (colmaj ? lda : 1);
+        }
+    } else {
+        if( m > n) {
+            tri_offset = rect_m * (!colmaj ? lda : 1);
+            if( !lower ) {
+                rect_offset = 0;
+            }
+        } else if( n > m) {
+            tri_offset = rect_n * (colmaj ? lda : 1);
+            if( lower ) {
+                rect_offset = 0;
+            }
+        }
+    }
+
+    /* Check rectangular part */
+    if( rect_offset >= 0 ) {
+        if( LAPACKE_sge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+            return (lapack_logical) 1;
+        }
+    }
+
+    /* Check triangular part */
+    return LAPACKE_str_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+}

--- a/LAPACKE/utils/lapacke_ztz_nancheck.c
+++ b/LAPACKE/utils/lapacke_ztz_nancheck.c
@@ -1,0 +1,142 @@
+/*****************************************************************************
+  Copyright (c) 2022, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************
+* Contents: Native C interface to LAPACK utility function
+* Author: Simon Märtens
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+/*****************************************************************************
+  Check a trapezoidal matrix for NaN entries. The shape of the trapezoidal
+  matrix is determined by the arguments `direct` and `uplo`. `Direct` chooses
+  the diagonal which shall be considered and `uplo` tells us whether we use the
+  upper or lower part of the matrix with respect to the chosen diagonal.
+
+      Diagonals 'F' (front / forward) and 'B' (back / backward):
+
+        A = ( F       )           A = ( F     B       )
+            (    F    )               (    F     B    )
+            ( B     F )               (       F     B )
+            (    B    )
+            (       B )
+
+      direct = 'F', uplo = 'L':
+
+        A = ( *       )           A = ( *             )
+            ( *  *    )               ( *  *          )
+            ( *  *  * )               ( *  *  *       )
+            ( *  *  * )
+            ( *  *  * )
+
+      direct = 'F', uplo = 'U':
+
+        A = ( *  *  * )           A = ( *  *  *  *  * )
+            (    *  * )               (    *  *  *  * )
+            (       * )               (       *  *  * )
+            (         )
+            (         )
+
+      direct = 'B', uplo = 'L':
+
+        A = (         )           A = ( *  *  *       )
+            (         )               ( *  *  *  *    )
+            ( *       )               ( *  *  *  *  * )
+            ( *  *    )
+            ( *  *  * )
+
+      direct = 'B', uplo = 'U':
+
+        A = ( *  *  * )           A = (       *  *  * )
+            ( *  *  * )               (          *  * )
+            ( *  *  * )               (             * )
+            (    *  * )
+            (       * )
+
+*****************************************************************************/
+
+lapack_logical LAPACKE_ztz_nancheck( int matrix_layout, char direct, char uplo,
+                                     char diag, lapack_int m, lapack_int n,
+                                     const lapack_complex_double *a,
+                                     lapack_int lda )
+{
+    lapack_logical colmaj, front, lower, unit;
+
+    if( a == NULL ) return (lapack_logical) 0;
+
+    colmaj = ( matrix_layout == LAPACK_COL_MAJOR );
+    front  = LAPACKE_lsame( direct, 'f' );
+    lower  = LAPACKE_lsame( uplo, 'l' );
+    unit   = LAPACKE_lsame( diag, 'u' );
+
+    if( ( !colmaj && ( matrix_layout != LAPACK_ROW_MAJOR ) ) ||
+        ( !front  && !LAPACKE_lsame( uplo, 'b' ) ) ||
+        ( !lower  && !LAPACKE_lsame( uplo, 'u' ) ) ||
+        ( !unit   && !LAPACKE_lsame( diag, 'n' ) ) ) {
+        /* Just exit if any of input parameters are wrong */
+        return (lapack_logical) 0;
+    }
+
+    /* Initial offsets and sizes of triangular and rectangular parts */
+    lapack_int tri_offset = 0;
+    lapack_int tri_n = MIN(m,n);
+    lapack_int rect_offset = -1;
+    lapack_int rect_m = (m > n) ? m - n : m;
+    lapack_int rect_n = (n > m) ? n - m : n;
+
+    /* Fix offsets depending on the shape of the matrix */
+    if( front ) {
+        if( lower && m > n) {
+            rect_offset = tri_n * (!colmaj ? lda : 1);
+        } else if( !lower && n > m) {
+            rect_offset = tri_n * (colmaj ? lda : 1);
+        }
+    } else {
+        if( m > n) {
+            tri_offset = rect_m * (!colmaj ? lda : 1);
+            if( !lower ) {
+                rect_offset = 0;
+            }
+        } else if( n > m) {
+            tri_offset = rect_n * (colmaj ? lda : 1);
+            if( lower ) {
+                rect_offset = 0;
+            }
+        }
+    }
+
+    /* Check rectangular part */
+    if( rect_offset >= 0 ) {
+        if( LAPACKE_zge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+            return (lapack_logical) 1;
+        }
+    }
+
+    /* Check triangular part */
+    return LAPACKE_ztr_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+}

--- a/LAPACKE/utils/lapacke_ztz_nancheck.c
+++ b/LAPACKE/utils/lapacke_ztz_nancheck.c
@@ -132,11 +132,13 @@ lapack_logical LAPACKE_ztz_nancheck( int matrix_layout, char direct, char uplo,
 
     /* Check rectangular part */
     if( rect_offset >= 0 ) {
-        if( LAPACKE_zge_nancheck(matrix_layout, rect_m, rect_n, &a[rect_offset], lda) ) {
+        if( LAPACKE_zge_nancheck( matrix_layout, rect_m, rect_n,
+                                  &a[rect_offset], lda) ) {
             return (lapack_logical) 1;
         }
     }
 
     /* Check triangular part */
-    return LAPACKE_ztr_nancheck(matrix_layout, uplo, diag, tri_n, &a[tri_offset], lda);
+    return LAPACKE_ztr_nancheck( matrix_layout, uplo, diag, tri_n,
+                                 &a[tri_offset], lda );
 }


### PR DESCRIPTION
**Description**

Following up on #737 I've implemented a NaN check for trapezoidal matrices. I've added a`direct` argument to support a whole bunch of trapezoidal matrices (e.g. those which occur in `xLARFB`):

```
Diagonals 'F' (front / forward) and 'B' (back / backward):

        A = ( F       )           A = ( F     B       )
            (    F    )               (    F     B    )
            ( B     F )               (       F     B )
            (    B    )
            (       B )

      direct = 'F', uplo = 'L':

        A = ( *       )           A = ( *             )
            ( *  *    )               ( *  *          )
            ( *  *  * )               ( *  *  *       )
            ( *  *  * )
            ( *  *  * )

      direct = 'F', uplo = 'U':

        A = ( *  *  * )           A = ( *  *  *  *  * )
            (    *  * )               (    *  *  *  * )
            (       * )               (       *  *  * )
            (         )
            (         )

      direct = 'B', uplo = 'L':

        A = (         )           A = ( *  *  *       )
            (         )               ( *  *  *  *    )
            ( *       )               ( *  *  *  *  * )
            ( *  *    )
            ( *  *  * )

      direct = 'B', uplo = 'U':

        A = ( *  *  * )           A = (       *  *  * )
            ( *  *  * )               (          *  * )
            ( *  *  * )               (             * )
            (    *  * )
            (       * )
```

For now, I've only applied the new NaN check to  `LAPACKE_?lantr`. But the NaN check is designed to also work for `LAPACKE_?larfb` and potential other routines. @langou I'll investigate those later since I want first confirm with you that the interface that I've chosen is alright.

Additionally, I fixed some missing symbols in the Makefile which I forgot to add in my last PR for #722.

**Checklist**

- [x] Fixed missing symbols for `LAPACKE_?langb` in Makefile.
- [x] Implemented NaN check for trapezoidal matrices.
- [x] Fixed NaN check in `LAPACKE_?lantr`.
- [ ] Apply trapezoidal NaN check in `LAPACKE_?larfb` and maybe other routines. 
- [x] Closes #737