### PR TITLE
Added missing declaration for LAPACKE_ctrsyl3_work

### DIFF
--- a/LAPACKE/include/lapacke.h
+++ b/LAPACKE/include/lapacke.h
@@ -10233,6 +10233,13 @@ lapack_int LAPACKE_dtrsyl3_work( int matrix_layout, char trana, char tranb,
                                  double* c, lapack_int ldc, double* scale,
                                  lapack_int* iwork, lapack_int liwork,
                                  double* swork, lapack_int ldswork );
+lapack_int LAPACKE_ctrsyl3_work( int matrix_layout, char trana, char tranb,
+                                 lapack_int isgn, lapack_int m, lapack_int n,
+                                 const lapack_complex_float* a, lapack_int lda,
+                                 const lapack_complex_float* b, lapack_int ldb,
+                                 lapack_complex_float* c, lapack_int ldc,
+                                 float* scale, float* swork,
+                                 lapack_int ldswork );
 lapack_int LAPACKE_ztrsyl3_work( int matrix_layout, char trana, char tranb,
                                  lapack_int isgn, lapack_int m, lapack_int n,
                                  const lapack_complex_double* a, lapack_int lda,


### PR DESCRIPTION
**Description**

`LAPACKE_ctrsyl3_work` didn't have a declaration in `lapacke.h`.