### PR TITLE
Reciprocal scaling with less accumulation errors

### DIFF
--- a/SRC/csrscl.f
+++ b/SRC/csrscl.f
@@ -18,14 +18,14 @@
 *  Definition:
 *  ===========
 *
-*       SUBROUTINE CSRSCL( N, SA, SX, INCX )
+*       SUBROUTINE CSRSCL( N, SA, CX, INCX )
 *
 *       .. Scalar Arguments ..
 *       INTEGER            INCX, N
 *       REAL               SA
 *       ..
 *       .. Array Arguments ..
-*       COMPLEX            SX( * )
+*       COMPLEX            CX( * )
 *       ..
 *
 *
@@ -55,9 +55,9 @@
 *>          SA must be >= 0, or the subroutine will divide by zero.
 *> \endverbatim
 *>
-*> \param[in,out] SX
+*> \param[in,out] CX
 *> \verbatim
-*>          SX is COMPLEX array, dimension
+*>          CX is COMPLEX array, dimension
 *>                         (1+(N-1)*abs(INCX))
 *>          The n-element vector x.
 *> \endverbatim
@@ -65,8 +65,8 @@
 *> \param[in] INCX
 *> \verbatim
 *>          INCX is INTEGER
-*>          The increment between successive values of the vector SX.
-*>          > 0:  SX(1) = X(1) and SX(1+(i-1)*INCX) = x(i),     1< i<= n
+*>          The increment between successive values of the vector CX.
+*>          > 0:  CX(1) = X(1) and CX(1+(i-1)*INCX) = x(i),     1< i<= n
 *> \endverbatim
 *
 *  Authors:
@@ -80,7 +80,7 @@
 *> \ingroup complexOTHERauxiliary
 *
 *  =====================================================================
-      SUBROUTINE CSRSCL( N, SA, SX, INCX )
+      SUBROUTINE CSRSCL( N, SA, CX, INCX )
 *
 *  -- LAPACK auxiliary routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -91,79 +91,38 @@
       REAL               SA
 *     ..
 *     .. Array Arguments ..
-      COMPLEX            SX( * )
+      COMPLEX            CX( * )
 *     ..
 *
 * =====================================================================
 *
-*     .. Parameters ..
-      REAL               ZERO, ONE
-      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
-*     ..
 *     .. Local Scalars ..
-      LOGICAL            DONE
-      REAL               BIGNUM, CDEN, CDEN1, CNUM, CNUM1, MUL, SMLNUM
+      INTEGER I,NINCX
 *     ..
-*     .. External Functions ..
-      REAL               SLAMCH
-      EXTERNAL           SLAMCH
-*     ..
-*     .. External Subroutines ..
-      EXTERNAL           CSSCAL, SLABAD
+*     .. Parameters ..
+      REAL ONE
+      PARAMETER (ONE=1.0E+0)
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS
+      INTRINSIC AIMAG,CMPLX,REAL
 *     ..
-*     .. Executable Statements ..
+      IF (N.LE.0 .OR. INCX.LE.0 .OR. SA.EQ.ONE) RETURN
+      IF (INCX.EQ.1) THEN
 *
-*     Quick return if possible
+*        code for increment equal to 1
 *
-      IF( N.LE.0 )
-     $   RETURN
-*
-*     Get machine parameters
-*
-      SMLNUM = SLAMCH( 'S' )
-      BIGNUM = ONE / SMLNUM
-      CALL SLABAD( SMLNUM, BIGNUM )
-*
-*     Initialize the denominator to SA and the numerator to 1.
-*
-      CDEN = SA
-      CNUM = ONE
-*
-   10 CONTINUE
-      CDEN1 = CDEN*SMLNUM
-      CNUM1 = CNUM / BIGNUM
-      IF( ABS( CDEN1 ).GT.ABS( CNUM ) .AND. CNUM.NE.ZERO ) THEN
-*
-*        Pre-multiply X by SMLNUM if CDEN is large compared to CNUM.
-*
-         MUL = SMLNUM
-         DONE = .FALSE.
-         CDEN = CDEN1
-      ELSE IF( ABS( CNUM1 ).GT.ABS( CDEN ) ) THEN
-*
-*        Pre-multiply X by BIGNUM if CDEN is small compared to CNUM.
-*
-         MUL = BIGNUM
-         DONE = .FALSE.
-         CNUM = CNUM1
+         DO I = 1,N
+            CX(I) = CMPLX(REAL(CX(I))/SA,AIMAG(CX(I))/SA)
+         END DO
       ELSE
 *
-*        Multiply X by CNUM / CDEN and return.
+*        code for increment not equal to 1
 *
-         MUL = CNUM / CDEN
-         DONE = .TRUE.
+         NINCX = N*INCX
+         DO I = 1,NINCX,INCX
+            CX(I) = CMPLX(REAL(CX(I))/SA,AIMAG(CX(I))/SA)
+         END DO
       END IF
-*
-*     Scale the vector X by MUL
-*
-      CALL CSSCAL( N, MUL, SX, INCX )
-*
-      IF( .NOT.DONE )
-     $   GO TO 10
-*
       RETURN
 *
 *     End of CSRSCL

--- a/SRC/drscl.f
+++ b/SRC/drscl.f
@@ -18,14 +18,14 @@
 *  Definition:
 *  ===========
 *
-*       SUBROUTINE DRSCL( N, SA, SX, INCX )
+*       SUBROUTINE DRSCL( N, DA, DX, INCX )
 *
 *       .. Scalar Arguments ..
 *       INTEGER            INCX, N
-*       DOUBLE PRECISION   SA
+*       DOUBLE PRECISION   DA
 *       ..
 *       .. Array Arguments ..
-*       DOUBLE PRECISION   SX( * )
+*       DOUBLE PRECISION   DX( * )
 *       ..
 *
 *
@@ -48,16 +48,16 @@
 *>          The number of components of the vector x.
 *> \endverbatim
 *>
-*> \param[in] SA
+*> \param[in] DA
 *> \verbatim
-*>          SA is DOUBLE PRECISION
+*>          DA is DOUBLE PRECISION
 *>          The scalar a which is used to divide each component of x.
-*>          SA must be >= 0, or the subroutine will divide by zero.
+*>          DA must be >= 0, or the subroutine will divide by zero.
 *> \endverbatim
 *>
-*> \param[in,out] SX
+*> \param[in,out] DX
 *> \verbatim
-*>          SX is DOUBLE PRECISION array, dimension
+*>          DX is DOUBLE PRECISION array, dimension
 *>                         (1+(N-1)*abs(INCX))
 *>          The n-element vector x.
 *> \endverbatim
@@ -65,8 +65,8 @@
 *> \param[in] INCX
 *> \verbatim
 *>          INCX is INTEGER
-*>          The increment between successive values of the vector SX.
-*>          > 0:  SX(1) = X(1) and SX(1+(i-1)*INCX) = x(i),     1< i<= n
+*>          The increment between successive values of the vector DX.
+*>          > 0:  DX(1) = X(1) and DX(1+(i-1)*INCX) = x(i),     1< i<= n
 *> \endverbatim
 *
 *  Authors:
@@ -80,7 +80,7 @@
 *> \ingroup doubleOTHERauxiliary
 *
 *  =====================================================================
-      SUBROUTINE DRSCL( N, SA, SX, INCX )
+      SUBROUTINE DRSCL( N, DA, DX, INCX )
 *
 *  -- LAPACK auxiliary routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -88,82 +88,38 @@
 *
 *     .. Scalar Arguments ..
       INTEGER            INCX, N
-      DOUBLE PRECISION   SA
+      DOUBLE PRECISION   DA
 *     ..
 *     .. Array Arguments ..
-      DOUBLE PRECISION   SX( * )
+      DOUBLE PRECISION   DX( * )
 *     ..
 *
 * =====================================================================
 *
-*     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
-*     ..
 *     .. Local Scalars ..
-      LOGICAL            DONE
-      DOUBLE PRECISION   BIGNUM, CDEN, CDEN1, CNUM, CNUM1, MUL, SMLNUM
+      INTEGER I,NINCX
 *     ..
-*     .. External Functions ..
-      DOUBLE PRECISION   DLAMCH
-      EXTERNAL           DLAMCH
+*     .. Parameters ..
+      DOUBLE PRECISION ONE
+      PARAMETER (ONE=1.0D+0)
 *     ..
-*     .. External Subroutines ..
-      EXTERNAL           DSCAL, DLABAD
-*     ..
-*     .. Intrinsic Functions ..
-      INTRINSIC          ABS
-*     ..
-*     .. Executable Statements ..
+      IF (N.LE.0 .OR. INCX.LE.0 .OR. DA.EQ.ONE) RETURN
+      IF (INCX.EQ.1) THEN
 *
-*     Quick return if possible
+*        code for increment equal to 1
 *
-      IF( N.LE.0 )
-     $   RETURN
-*
-*     Get machine parameters
-*
-      SMLNUM = DLAMCH( 'S' )
-      BIGNUM = ONE / SMLNUM
-      CALL DLABAD( SMLNUM, BIGNUM )
-*
-*     Initialize the denominator to SA and the numerator to 1.
-*
-      CDEN = SA
-      CNUM = ONE
-*
-   10 CONTINUE
-      CDEN1 = CDEN*SMLNUM
-      CNUM1 = CNUM / BIGNUM
-      IF( ABS( CDEN1 ).GT.ABS( CNUM ) .AND. CNUM.NE.ZERO ) THEN
-*
-*        Pre-multiply X by SMLNUM if CDEN is large compared to CNUM.
-*
-         MUL = SMLNUM
-         DONE = .FALSE.
-         CDEN = CDEN1
-      ELSE IF( ABS( CNUM1 ).GT.ABS( CDEN ) ) THEN
-*
-*        Pre-multiply X by BIGNUM if CDEN is small compared to CNUM.
-*
-         MUL = BIGNUM
-         DONE = .FALSE.
-         CNUM = CNUM1
+         DO I = 1,N
+            DX(I) = DX(I)/DA
+         END DO
       ELSE
 *
-*        Multiply X by CNUM / CDEN and return.
+*        code for increment not equal to 1
 *
-         MUL = CNUM / CDEN
-         DONE = .TRUE.
+         NINCX = N*INCX
+         DO I = 1,NINCX,INCX
+            DX(I) = DX(I)/DA
+         END DO
       END IF
-*
-*     Scale the vector X by MUL
-*
-      CALL DSCAL( N, MUL, SX, INCX )
-*
-      IF( .NOT.DONE )
-     $   GO TO 10
-*
       RETURN
 *
 *     End of DRSCL

--- a/SRC/srscl.f
+++ b/SRC/srscl.f
@@ -96,74 +96,30 @@
 *
 * =====================================================================
 *
-*     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
-*     ..
 *     .. Local Scalars ..
-      LOGICAL            DONE
-      REAL               BIGNUM, CDEN, CDEN1, CNUM, CNUM1, MUL, SMLNUM
+      INTEGER I,NINCX
 *     ..
-*     .. External Functions ..
-      REAL               SLAMCH
-      EXTERNAL           SLAMCH
+*     .. Parameters ..
+      REAL ONE
+      PARAMETER (ONE=1.0E+0)
 *     ..
-*     .. External Subroutines ..
-      EXTERNAL           SLABAD, SSCAL
-*     ..
-*     .. Intrinsic Functions ..
-      INTRINSIC          ABS
-*     ..
-*     .. Executable Statements ..
+      IF (N.LE.0 .OR. INCX.LE.0 .OR. SA.EQ.ONE) RETURN
+      IF (INCX.EQ.1) THEN
 *
-*     Quick return if possible
+*        code for increment equal to 1
 *
-      IF( N.LE.0 )
-     $   RETURN
-*
-*     Get machine parameters
-*
-      SMLNUM = SLAMCH( 'S' )
-      BIGNUM = ONE / SMLNUM
-      CALL SLABAD( SMLNUM, BIGNUM )
-*
-*     Initialize the denominator to SA and the numerator to 1.
-*
-      CDEN = SA
-      CNUM = ONE
-*
-   10 CONTINUE
-      CDEN1 = CDEN*SMLNUM
-      CNUM1 = CNUM / BIGNUM
-      IF( ABS( CDEN1 ).GT.ABS( CNUM ) .AND. CNUM.NE.ZERO ) THEN
-*
-*        Pre-multiply X by SMLNUM if CDEN is large compared to CNUM.
-*
-         MUL = SMLNUM
-         DONE = .FALSE.
-         CDEN = CDEN1
-      ELSE IF( ABS( CNUM1 ).GT.ABS( CDEN ) ) THEN
-*
-*        Pre-multiply X by BIGNUM if CDEN is small compared to CNUM.
-*
-         MUL = BIGNUM
-         DONE = .FALSE.
-         CNUM = CNUM1
+         DO I = 1,N
+            SX(I) = SX(I)/SA
+         END DO
       ELSE
 *
-*        Multiply X by CNUM / CDEN and return.
+*        code for increment not equal to 1
 *
-         MUL = CNUM / CDEN
-         DONE = .TRUE.
+         NINCX = N*INCX
+         DO I = 1,NINCX,INCX
+            SX(I) = SX(I)/SA
+         END DO
       END IF
-*
-*     Scale the vector X by MUL
-*
-      CALL SSCAL( N, MUL, SX, INCX )
-*
-      IF( .NOT.DONE )
-     $   GO TO 10
-*
       RETURN
 *
 *     End of SRSCL

--- a/SRC/zdrscl.f
+++ b/SRC/zdrscl.f
@@ -18,14 +18,14 @@
 *  Definition:
 *  ===========
 *
-*       SUBROUTINE ZDRSCL( N, SA, SX, INCX )
+*       SUBROUTINE ZDRSCL( N, DA, ZX, INCX )
 *
 *       .. Scalar Arguments ..
 *       INTEGER            INCX, N
-*       DOUBLE PRECISION   SA
+*       DOUBLE PRECISION   DA
 *       ..
 *       .. Array Arguments ..
-*       COMPLEX*16         SX( * )
+*       COMPLEX*16         ZX( * )
 *       ..
 *
 *
@@ -48,16 +48,16 @@
 *>          The number of components of the vector x.
 *> \endverbatim
 *>
-*> \param[in] SA
+*> \param[in] DA
 *> \verbatim
-*>          SA is DOUBLE PRECISION
+*>          DA is DOUBLE PRECISION
 *>          The scalar a which is used to divide each component of x.
-*>          SA must be >= 0, or the subroutine will divide by zero.
+*>          DA must be >= 0, or the subroutine will divide by zero.
 *> \endverbatim
 *>
-*> \param[in,out] SX
+*> \param[in,out] ZX
 *> \verbatim
-*>          SX is COMPLEX*16 array, dimension
+*>          ZX is COMPLEX*16 array, dimension
 *>                         (1+(N-1)*abs(INCX))
 *>          The n-element vector x.
 *> \endverbatim
@@ -65,8 +65,8 @@
 *> \param[in] INCX
 *> \verbatim
 *>          INCX is INTEGER
-*>          The increment between successive values of the vector SX.
-*>          > 0:  SX(1) = X(1) and SX(1+(i-1)*INCX) = x(i),     1< i<= n
+*>          The increment between successive values of the vector ZX.
+*>          > 0:  ZX(1) = X(1) and ZX(1+(i-1)*INCX) = x(i),     1< i<= n
 *> \endverbatim
 *
 *  Authors:
@@ -80,7 +80,7 @@
 *> \ingroup complex16OTHERauxiliary
 *
 *  =====================================================================
-      SUBROUTINE ZDRSCL( N, SA, SX, INCX )
+      SUBROUTINE ZDRSCL( N, DA, ZX, INCX )
 *
 *  -- LAPACK auxiliary routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -88,82 +88,40 @@
 *
 *     .. Scalar Arguments ..
       INTEGER            INCX, N
-      DOUBLE PRECISION   SA
+      DOUBLE PRECISION   DA
 *     ..
 *     .. Array Arguments ..
-      COMPLEX*16         SX( * )
+      COMPLEX*16         ZX( * )
 *     ..
 *
 * =====================================================================
 *
-*     .. Parameters ..
-      DOUBLE PRECISION   ZERO, ONE
-      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
-*     ..
 *     .. Local Scalars ..
-      LOGICAL            DONE
-      DOUBLE PRECISION   BIGNUM, CDEN, CDEN1, CNUM, CNUM1, MUL, SMLNUM
-*     ..
-*     .. External Functions ..
-      DOUBLE PRECISION   DLAMCH
-      EXTERNAL           DLAMCH
-*     ..
-*     .. External Subroutines ..
-      EXTERNAL           DLABAD, ZDSCAL
+      INTEGER I,NINCX
+*     .. Parameters ..
+      DOUBLE PRECISION ONE
+      PARAMETER (ONE=1.0D+0)
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS
+      INTRINSIC DBLE, DCMPLX, DIMAG
 *     ..
-*     .. Executable Statements ..
+      IF (N.LE.0 .OR. INCX.LE.0 .OR. DA.EQ.ONE) RETURN
+      IF (INCX.EQ.1) THEN
 *
-*     Quick return if possible
+*        code for increment equal to 1
 *
-      IF( N.LE.0 )
-     $   RETURN
-*
-*     Get machine parameters
-*
-      SMLNUM = DLAMCH( 'S' )
-      BIGNUM = ONE / SMLNUM
-      CALL DLABAD( SMLNUM, BIGNUM )
-*
-*     Initialize the denominator to SA and the numerator to 1.
-*
-      CDEN = SA
-      CNUM = ONE
-*
-   10 CONTINUE
-      CDEN1 = CDEN*SMLNUM
-      CNUM1 = CNUM / BIGNUM
-      IF( ABS( CDEN1 ).GT.ABS( CNUM ) .AND. CNUM.NE.ZERO ) THEN
-*
-*        Pre-multiply X by SMLNUM if CDEN is large compared to CNUM.
-*
-         MUL = SMLNUM
-         DONE = .FALSE.
-         CDEN = CDEN1
-      ELSE IF( ABS( CNUM1 ).GT.ABS( CDEN ) ) THEN
-*
-*        Pre-multiply X by BIGNUM if CDEN is small compared to CNUM.
-*
-         MUL = BIGNUM
-         DONE = .FALSE.
-         CNUM = CNUM1
+         DO I = 1,N
+            ZX(I) = DCMPLX(DBLE(ZX(I))/DA,DIMAG(ZX(I))/DA)
+         END DO
       ELSE
 *
-*        Multiply X by CNUM / CDEN and return.
+*        code for increment not equal to 1
 *
-         MUL = CNUM / CDEN
-         DONE = .TRUE.
+         NINCX = N*INCX
+         DO I = 1,NINCX,INCX
+            ZX(I) = DCMPLX(DBLE(ZX(I))/DA,DIMAG(ZX(I))/DA)
+         END DO
       END IF
-*
-*     Scale the vector X by MUL
-*
-      CALL ZDSCAL( N, MUL, SX, INCX )
-*
-      IF( .NOT.DONE )
-     $   GO TO 10
-*
       RETURN
 *
 *     End of ZDRSCL


### PR DESCRIPTION
Reciprocal scaling of a vector is currently implemented in LAPACK as `(1/r)*x` instead of `x/r`.

1. In general, the former formula will have higher accumulation error. This is because it needs 2 floating-point operations per entry.
2. The former needs scaling procedure to handle small and large `r`. The latter doesn't.
3. One could argue that the former algorithm relies on BLAS SCAL to obtain higher performance. However, some vendors (MKL) already implement RSCL. I think we should have the more accurate algorithm in LAPACK for this specific case.

If so, this is the PR that implements the reciprocal scaling using a simple division.