### PR TITLE
Fix bug in new test case for LAPACK 3.11 SLATRS3

### DIFF
--- a/SRC/iparam2stage.F
+++ b/SRC/iparam2stage.F
@@ -178,7 +178,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. Executable Statements ..
 *
@@ -310,7 +311,7 @@
 *
 *     Will add the VECT OPTION HERE next release
          VECT  = OPTS(1:1)
-         IF( VECT.EQ.'N' ) THEN
+         IF( LSAME( VECT, 'N' ) ) THEN
             LHOUS = MAX( 1, 4*NI )
          ELSE
 *           This is not correct, it need to call the ALGO and the stage2

--- a/TESTING/LIN/schktr.f
+++ b/TESTING/LIN/schktr.f
@@ -559,7 +559,7 @@
      $                            -1, -1, -1, IMAT, NFAIL, NERRS, NOUT )
 *
                   CALL STRT03( UPLO, TRANS, DIAG, N, 1, A, LDA,
-     $                         SCALE3 ( 1 ), RWORK, ONE, B( N+1 ), LDA,
+     $                         SCALE3 ( 1 ), RWORK, ONE, B( 1 ), LDA,
      $                         X, LDA, WORK, RESULT( 10 ) )
                   CALL SSCAL( N, BIGNUM, X, 1 )
                   CALL STRT03( UPLO, TRANS, DIAG, N, 1, A, LDA,


### PR DESCRIPTION
**Fixed bug in new test case for LAPACK 3.11 SLATRS3**

1. In new test case 10 from `xlintsts_stest` wrong indexation in array B leads to failure of the test.
2. Also added use of LSAME in function iparam2stage 

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.