### PR TITLE
Fixed bug in array bounds in complex syl01 test

### DIFF
--- a/TESTING/EIG/csyl01.f
+++ b/TESTING/EIG/csyl01.f
@@ -124,7 +124,7 @@
      $                   C( MAXM, MAXN ), CC( MAXM, MAXN ),
      $                   X( MAXM, MAXN ),
      $                   DUML( MAXM ), DUMR( MAXN ),
-     $                   D( MIN( MAXM, MAXN ) )
+     $                   D( MAX( MAXM, MAXN ) )
       REAL               SWORK( LDSWORK, 54 ), DUM( MAXN ), VM( 2 )
       INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 )
 *     ..

--- a/TESTING/EIG/zsyl01.f
+++ b/TESTING/EIG/zsyl01.f
@@ -124,7 +124,7 @@
      $                   C( MAXM, MAXN ), CC( MAXM, MAXN ),
      $                   X( MAXM, MAXN ),
      $                   DUML( MAXM ), DUMR( MAXN ),
-     $                   D( MIN( MAXM, MAXN ) )
+     $                   D( MAX( MAXM, MAXN ) )
       DOUBLE PRECISION   SWORK( LDSWORK, 103 ), DUM( MAXN ), VM( 2 )
       INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 )
 *     ..


### PR DESCRIPTION
**Fixed bug in array bounds in complex syl01 test**

In my environment tests `eigtstc_cec` and `eigtstz_zec` were failed due to wrong bounds of array D. Function `MIN` was changed into `MAX` to fix this.