### PR TITLE
CMake: Disable TEST_FORTRAN_COMPILER for cross-builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,12 @@ if(_is_coverage_build)
 endif()
 
 # By default test Fortran compiler complex abs and complex division
-option(TEST_FORTRAN_COMPILER "Test Fortran compiler complex abs and complex division" ON)
+if (CMAKE_CROSSCOMPILING AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
+  option(TEST_FORTRAN_COMPILER "Test Fortran compiler complex abs and complex division" OFF)
+else ()
+  option(TEST_FORTRAN_COMPILER "Test Fortran compiler complex abs and complex division" ON)
+endif ()
+
 if( TEST_FORTRAN_COMPILER )
 
   add_executable( test_zcomplexabs ${LAPACK_SOURCE_DIR}/INSTALL/test_zcomplexabs.f )


### PR DESCRIPTION
see #757 