### PR TITLE
Windows build fix

### DIFF
--- a/LAPACKE/utils/lapacke_ctz_trans.c
+++ b/LAPACKE/utils/lapacke_ctz_trans.c
@@ -147,7 +147,7 @@ void LAPACKE_ctz_trans( int matrix_layout, char direct, char uplo,
     }
 
     /* Copy & transpose triangular part */
-    return LAPACKE_ctr_trans( matrix_layout, uplo, diag, tri_n,
-                              &in[tri_in_offset], ldin,
-                              &out[tri_out_offset], ldout );
+    LAPACKE_ctr_trans( matrix_layout, uplo, diag, tri_n,
+                       &in[tri_in_offset], ldin,
+                       &out[tri_out_offset], ldout );
 }

--- a/LAPACKE/utils/lapacke_dtz_trans.c
+++ b/LAPACKE/utils/lapacke_dtz_trans.c
@@ -147,7 +147,7 @@ void LAPACKE_dtz_trans( int matrix_layout, char direct, char uplo,
     }
 
     /* Copy & transpose triangular part */
-    return LAPACKE_dtr_trans( matrix_layout, uplo, diag, tri_n,
-                              &in[tri_in_offset], ldin,
-                              &out[tri_out_offset], ldout );
+    LAPACKE_dtr_trans( matrix_layout, uplo, diag, tri_n,
+                       &in[tri_in_offset], ldin,
+                       &out[tri_out_offset], ldout );
 }

--- a/LAPACKE/utils/lapacke_stz_trans.c
+++ b/LAPACKE/utils/lapacke_stz_trans.c
@@ -147,7 +147,7 @@ void LAPACKE_stz_trans( int matrix_layout, char direct, char uplo,
     }
 
     /* Copy & transpose triangular part */
-    return LAPACKE_str_trans( matrix_layout, uplo, diag, tri_n,
-                              &in[tri_in_offset], ldin,
-                              &out[tri_out_offset], ldout );
+    LAPACKE_str_trans( matrix_layout, uplo, diag, tri_n,
+                       &in[tri_in_offset], ldin,
+                       &out[tri_out_offset], ldout );
 }

--- a/LAPACKE/utils/lapacke_ztz_trans.c
+++ b/LAPACKE/utils/lapacke_ztz_trans.c
@@ -147,7 +147,7 @@ void LAPACKE_ztz_trans( int matrix_layout, char direct, char uplo,
     }
 
     /* Copy & transpose triangular part */
-    return LAPACKE_ztr_trans( matrix_layout, uplo, diag, tri_n,
-                              &in[tri_in_offset], ldin,
-                              &out[tri_out_offset], ldout );
+    LAPACKE_ztr_trans( matrix_layout, uplo, diag, tri_n,
+                       &in[tri_in_offset], ldin,
+                       &out[tri_out_offset], ldout );
 }

--- a/TESTING/EIG/derred.f
+++ b/TESTING/EIG/derred.f
@@ -99,7 +99,7 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CHKXER, DGEES, DGEESX, DGEEV, DGEEVX, DGEJSV,
-     $                   DGESDD, DGESVD, DGESVDX, DGESVQ
+     $                   DGESDD, DGESVD, DGESVDX, DGESVDQ
 *     ..
 *     .. External Functions ..
       LOGICAL            DSLECT, LSAMEN

--- a/TESTING/EIG/zerred.f
+++ b/TESTING/EIG/zerred.f
@@ -100,7 +100,7 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CHKXER, ZGEES, ZGEESX, ZGEEV, ZGEEVX, ZGESVJ,
-     $                   ZGESDD, ZGESVD, ZGESVDX, ZGESVQ
+     $                   ZGESDD, ZGESVD, ZGESVDX, ZGESVDQ
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAMEN, ZSLECT


### PR DESCRIPTION
**Description**

I encountered a build failure on Windows due to a missing symbol `DGESVQ` which doesn't exist. It was a typo in the test framework and should be `DGESVDQ`.

Also, I removed some unnecessary return statements in the trapezoidal transposition functions which I introduced by mistake in #742.