### PR TITLE
Fix SLATRS3 and CLATRS3 tests

### DIFF
--- a/TESTING/LIN/cchktr.f
+++ b/TESTING/LIN/cchktr.f
@@ -541,7 +541,7 @@
 *
                   SRNAMT = 'CLATRS3'
                   CALL CCOPY( N, X, 1, B, 1 )
-                  CALL CCOPY( N, X, 1, B, 1 )
+                  CALL CCOPY( N, X, 1, B( N+1 ), 1 )
                   CALL CSCAL( N, BIGNUM, B( N+1 ), 1 )
                   CALL CLATRS3( UPLO, TRANS, DIAG, 'N', N, 2, A, LDA,
      $                          B, MAX(1, N), SCALE3, RWORK, WORK, NMAX,
@@ -551,7 +551,7 @@
 *
                   IF( INFO.NE.0 )
      $               CALL ALAERH( PATH, 'CLATRS3', INFO, 0,
-     $                            UPLO // TRANS // DIAG // 'Y', N, N,
+     $                            UPLO // TRANS // DIAG // 'N', N, N,
      $                            -1, -1, -1, IMAT, NFAIL, NERRS, NOUT )
                   CALL CTRT03( UPLO, TRANS, DIAG, N, 1, A, LDA,
      $                         SCALE3( 1 ), RWORK, ONE, B( 1 ), LDA,
@@ -559,7 +559,7 @@
                   CALL CSSCAL( N, BIGNUM, X, 1 )
                   CALL CTRT03( UPLO, TRANS, DIAG, N, 1, A, LDA,
      $                         SCALE3( 2 ), RWORK, ONE, B( N+1 ), LDA,
-     $                         X, LDA, WORK, RESULT( 10 ) )
+     $                         X, LDA, WORK, RES )
                   RESULT( 10 ) = MAX( RESULT( 10 ), RES )
 *
 *                 Print information about the tests that did not pass

--- a/TESTING/LIN/schktr.f
+++ b/TESTING/LIN/schktr.f
@@ -555,11 +555,11 @@
 *
                   IF( INFO.NE.0 )
      $               CALL ALAERH( PATH, 'SLATRS3', INFO, 0,
-     $                            UPLO // TRANS // DIAG // 'Y', N, N,
+     $                            UPLO // TRANS // DIAG // 'N', N, N,
      $                            -1, -1, -1, IMAT, NFAIL, NERRS, NOUT )
 *
                   CALL STRT03( UPLO, TRANS, DIAG, N, 1, A, LDA,
-     $                         SCALE3 ( 1 ), RWORK, ONE, B( N+1 ), LDA,
+     $                         SCALE3( 1 ), RWORK, ONE, B( 1 ), LDA,
      $                         X, LDA, WORK, RESULT( 10 ) )
                   CALL SSCAL( N, BIGNUM, X, 1 )
                   CALL STRT03( UPLO, TRANS, DIAG, N, 1, A, LDA,


### PR DESCRIPTION
Some SLATRS3 tests were failing with OpenBLAS where the RHS has a BIGNUM (=Infinity in this test) component. OpenBLAS SSCAL, when multiplying with 0, will turn this component into 0, unlike reference BLAS which turns it into NaN. While NaN looks more correct it still did not explain why DLATRS3 tests were succeeding where DSCAL has the same difference between reference and OpenBLAS.

Diffing the test code unmasked a few bugs, which makes the test succeed and also unmasked a bug in the CLATRS3 test.

The ZLATRS3 and DLATRS3 tests look correct to me.

@angsch can you please review as test author (#651)?