### PR TITLE
Check for NaNs in *GECON

### DIFF
--- a/SRC/cgecon.f
+++ b/SRC/cgecon.f
@@ -106,6 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
+*>          =-5:  if ANORM is NAN or negative.
 *> \endverbatim
 *
 *  Authors:
@@ -153,10 +154,10 @@
       INTEGER            ISAVE( 3 )
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       INTEGER            ICAMAX
       REAL               SLAMCH
-      EXTERNAL           LSAME, ICAMAX, SLAMCH
+      EXTERNAL           LSAME, ICAMAX, SLAMCH, SISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CLACN2, CLATRS, CSRSCL, XERBLA
@@ -182,7 +183,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO ) THEN
+      ELSE IF( ANORM.LT.ZERO .OR. SISNAN( ANORM ) ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN

--- a/SRC/dgecon.f
+++ b/SRC/dgecon.f
@@ -106,6 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
+*>          =-5:  if ANORM is NAN or negative.
 *> \endverbatim
 *
 *  Authors:
@@ -152,10 +153,10 @@
       INTEGER            ISAVE( 3 )
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, DISNAN
       INTEGER            IDAMAX
       DOUBLE PRECISION   DLAMCH
-      EXTERNAL           LSAME, IDAMAX, DLAMCH
+      EXTERNAL           LSAME, IDAMAX, DLAMCH, DISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DLACN2, DLATRS, DRSCL, XERBLA
@@ -175,7 +176,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO ) THEN
+      ELSE IF( ANORM.LT.ZERO .OR. DISNAN( ANORM ) ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN

--- a/SRC/sgecon.f
+++ b/SRC/sgecon.f
@@ -106,6 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
+*>          =-5:  if ANORM is NAN or negative.
 *> \endverbatim
 *
 *  Authors:
@@ -152,10 +153,10 @@
       INTEGER            ISAVE( 3 )
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       INTEGER            ISAMAX
       REAL               SLAMCH
-      EXTERNAL           LSAME, ISAMAX, SLAMCH
+      EXTERNAL           LSAME, ISAMAX, SLAMCH, SISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SLACN2, SLATRS, SRSCL, XERBLA
@@ -175,7 +176,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO ) THEN
+      ELSE IF( ANORM.LT.ZERO .OR. SISNAN( ANORM ) ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN

--- a/SRC/zgecon.f
+++ b/SRC/zgecon.f
@@ -106,6 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
+*>          =-5:  if ANORM is NAN or negative.
 *> \endverbatim
 *
 *  Authors:
@@ -153,10 +154,10 @@
       INTEGER            ISAVE( 3 )
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, DISNAN
       INTEGER            IZAMAX
       DOUBLE PRECISION   DLAMCH
-      EXTERNAL           LSAME, IZAMAX, DLAMCH
+      EXTERNAL           LSAME, IZAMAX, DLAMCH, DISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZDRSCL, ZLACN2, ZLATRS
@@ -182,7 +183,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO ) THEN
+      ELSE IF( ANORM.LT.ZERO .OR. DISNAN( ANORM ) ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN


### PR DESCRIPTION
Adds NaN as a invalid value for ANORM.

Closes #763.