### PR TITLE
Fix uninitialized M when quick return in DLARRD and SLARRD

### DIFF
--- a/SRC/dlarrd.f
+++ b/SRC/dlarrd.f
@@ -381,6 +381,7 @@
 *     .. Executable Statements ..
 *
       INFO = 0
+      M = 0
 *
 *     Quick return if possible
 *
@@ -424,13 +425,8 @@
       END IF
 
 *     Initialize error flags
-      INFO = 0
       NCNVRG = .FALSE.
       TOOFEW = .FALSE.
-
-*     Quick return if possible
-      M = 0
-      IF( N.EQ.0 ) RETURN
 
 *     Simplification:
       IF( IRANGE.EQ.INDRNG .AND. IL.EQ.1 .AND. IU.EQ.N ) IRANGE = 1

--- a/SRC/slarrd.f
+++ b/SRC/slarrd.f
@@ -381,6 +381,7 @@
 *     .. Executable Statements ..
 *
       INFO = 0
+      M = 0
 *
 *     Quick return if possible
 *
@@ -424,13 +425,8 @@
       END IF
 
 *     Initialize error flags
-      INFO = 0
       NCNVRG = .FALSE.
       TOOFEW = .FALSE.
-
-*     Quick return if possible
-      M = 0
-      IF( N.EQ.0 ) RETURN
 
 *     Simplification:
       IF( IRANGE.EQ.INDRNG .AND. IL.EQ.1 .AND. IU.EQ.N ) IRANGE = 1


### PR DESCRIPTION
**Description**
Quick return in DLARRD and SLARRD for `N .LE. 0` happens too early, the output parameter `M` is left unset. This may lead to crash in ScaLAPACK's DLARRE2 and SLARRE2 respectfully, where the value returned in the `M` parameter is used to run a loop.

The fix:
1. Moves the zero initialization of `M` before deciding to quick return.
2. Removes duplicate initialization of `INFO` and duplicate check for quick return

**Note**

Most likely there are similar issues in other ?LARR? functions introduced on 16db9c24ea.