### PR TITLE
In LAPACKE tgsen, allocate iwork when ijob = 0. Fixes #772.

### DIFF
--- a/LAPACKE/src/lapacke_ctgsen.c
+++ b/LAPACKE/src/lapacke_ctgsen.c
@@ -86,12 +86,10 @@ lapack_int LAPACKE_ctgsen( int matrix_layout, lapack_int ijob,
     liwork = iwork_query;
     lwork = LAPACK_C2INT( work_query );
     /* Allocate memory for work arrays */
-    if( ijob != 0 ) {
-        iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
-        if( iwork == NULL ) {
-            info = LAPACK_WORK_MEMORY_ERROR;
-            goto exit_level_0;
-        }
+    iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
+    if( iwork == NULL ) {
+        info = LAPACK_WORK_MEMORY_ERROR;
+        goto exit_level_0;
     }
     work = (lapack_complex_float*)
         LAPACKE_malloc( sizeof(lapack_complex_float) * lwork );
@@ -106,9 +104,7 @@ lapack_int LAPACKE_ctgsen( int matrix_layout, lapack_int ijob,
     /* Release memory and exit */
     LAPACKE_free( work );
 exit_level_1:
-    if( ijob != 0 ) {
-        LAPACKE_free( iwork );
-    }
+    LAPACKE_free( iwork );
 exit_level_0:
     if( info == LAPACK_WORK_MEMORY_ERROR ) {
         LAPACKE_xerbla( "LAPACKE_ctgsen", info );

--- a/LAPACKE/src/lapacke_dtgsen.c
+++ b/LAPACKE/src/lapacke_dtgsen.c
@@ -83,12 +83,10 @@ lapack_int LAPACKE_dtgsen( int matrix_layout, lapack_int ijob,
     liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
-    if( ijob != 0 ) {
-        iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
-        if( iwork == NULL ) {
-            info = LAPACK_WORK_MEMORY_ERROR;
-            goto exit_level_0;
-        }
+    iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
+    if( iwork == NULL ) {
+        info = LAPACK_WORK_MEMORY_ERROR;
+        goto exit_level_0;
     }
     work = (double*)LAPACKE_malloc( sizeof(double) * lwork );
     if( work == NULL ) {
@@ -103,9 +101,7 @@ lapack_int LAPACKE_dtgsen( int matrix_layout, lapack_int ijob,
     /* Release memory and exit */
     LAPACKE_free( work );
 exit_level_1:
-    if( ijob != 0 ) {
-        LAPACKE_free( iwork );
-    }
+    LAPACKE_free( iwork );
 exit_level_0:
     if( info == LAPACK_WORK_MEMORY_ERROR ) {
         LAPACKE_xerbla( "LAPACKE_dtgsen", info );

--- a/LAPACKE/src/lapacke_stgsen.c
+++ b/LAPACKE/src/lapacke_stgsen.c
@@ -83,12 +83,10 @@ lapack_int LAPACKE_stgsen( int matrix_layout, lapack_int ijob,
     liwork = iwork_query;
     lwork = (lapack_int)work_query;
     /* Allocate memory for work arrays */
-    if( ijob != 0 ) {
-        iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
-        if( iwork == NULL ) {
-            info = LAPACK_WORK_MEMORY_ERROR;
-            goto exit_level_0;
-        }
+    iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
+    if( iwork == NULL ) {
+        info = LAPACK_WORK_MEMORY_ERROR;
+        goto exit_level_0;
     }
     work = (float*)LAPACKE_malloc( sizeof(float) * lwork );
     if( work == NULL ) {
@@ -103,9 +101,7 @@ lapack_int LAPACKE_stgsen( int matrix_layout, lapack_int ijob,
     /* Release memory and exit */
     LAPACKE_free( work );
 exit_level_1:
-    if( ijob != 0 ) {
-        LAPACKE_free( iwork );
-    }
+    LAPACKE_free( iwork );
 exit_level_0:
     if( info == LAPACK_WORK_MEMORY_ERROR ) {
         LAPACKE_xerbla( "LAPACKE_stgsen", info );

--- a/LAPACKE/src/lapacke_ztgsen.c
+++ b/LAPACKE/src/lapacke_ztgsen.c
@@ -86,12 +86,10 @@ lapack_int LAPACKE_ztgsen( int matrix_layout, lapack_int ijob,
     liwork = iwork_query;
     lwork = LAPACK_Z2INT( work_query );
     /* Allocate memory for work arrays */
-    if( ijob != 0 ) {
-        iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
-        if( iwork == NULL ) {
-            info = LAPACK_WORK_MEMORY_ERROR;
-            goto exit_level_0;
-        }
+    iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * liwork );
+    if( iwork == NULL ) {
+        info = LAPACK_WORK_MEMORY_ERROR;
+        goto exit_level_0;
     }
     work = (lapack_complex_double*)
         LAPACKE_malloc( sizeof(lapack_complex_double) * lwork );
@@ -106,9 +104,7 @@ lapack_int LAPACKE_ztgsen( int matrix_layout, lapack_int ijob,
     /* Release memory and exit */
     LAPACKE_free( work );
 exit_level_1:
-    if( ijob != 0 ) {
-        LAPACKE_free( iwork );
-    }
+    LAPACKE_free( iwork );
 exit_level_0:
     if( info == LAPACK_WORK_MEMORY_ERROR ) {
         LAPACKE_xerbla( "LAPACKE_ztgsen", info );


### PR DESCRIPTION
**Description**
Allocates iwork when ijob = 0. See issue #772.
Before, ijob = 0 segfaults:
```
lapackpp/test> ./tester --ijob 1,2,3,4,5,0 --dim 10 tgsen
LAPACK++ version 2022.07.00, id c878e31
input: ./tester --ijob '1,2,3,4,5,0' --dim 10 tgsen
                                                                              
type   ijob  jobvl  jobvr       n     error   time (s)  ref time (s)  status  
   d      1  novec  novec      10  0.00e+00   0.000617      0.000517  pass    
   d      2  novec  novec      10  0.00e+00    0.00151       0.00160  pass    
   d      3  novec  novec      10  0.00e+00    0.00405       0.00277  pass    
   d      4  novec  novec      10  0.00e+00    0.00120       0.00121  pass    
   d      5  novec  novec      10  0.00e+00    0.00345       0.00319  pass    
Segmentation fault
```
After, it passes:
```
lapackpp/test> ./tester --ijob 1,2,3,4,5,0 --dim 10 tgsen
LAPACK++ version 2022.07.00, id c878e31
input: ./tester --ijob '1,2,3,4,5,0' --dim 10 tgsen
                                                                              
type   ijob  jobvl  jobvr       n     error   time (s)  ref time (s)  status  
   d      1  novec  novec      10  0.00e+00    0.00132       0.00121  pass    
   d      2  novec  novec      10  0.00e+00    0.00272       0.00283  pass    
   d      3  novec  novec      10  0.00e+00    0.00376       0.00300  pass    
   d      4  novec  novec      10  0.00e+00    0.00131       0.00122  pass    
   d      5  novec  novec      10  0.00e+00    0.00314       0.00312  pass    
   d      0  novec  novec      10  0.00e+00   0.000246      0.000236  pass    
All tests passed for tgsen.
```

**Checklist**

- [ ] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.