### PR TITLE
Fix uninitialized out variables in *LARR* functions

### DIFF
--- a/SRC/dlarra.f
+++ b/SRC/dlarra.f
@@ -164,6 +164,7 @@
 *     .. Executable Statements ..
 *
       INFO = 0
+      NSPLIT = 1
 *
 *     Quick return if possible
 *
@@ -172,7 +173,6 @@
       END IF
 *
 *     Compute splitting points
-      NSPLIT = 1
       IF(SPLTOL.LT.ZERO) THEN
 *        Criterion based on absolute off-diagonal value
          TMP1 = ABS(SPLTOL)* TNRM

--- a/SRC/dlarrc.f
+++ b/SRC/dlarrc.f
@@ -167,6 +167,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
+      LCNT = 0
+      RCNT = 0
+      EIGCNT = 0
 *
 *     Quick return if possible
 *
@@ -174,9 +177,6 @@
          RETURN
       END IF
 *
-      LCNT = 0
-      RCNT = 0
-      EIGCNT = 0
       MATT = LSAME( JOBT, 'T' )
 
 

--- a/SRC/dlarre.f
+++ b/SRC/dlarre.f
@@ -367,6 +367,8 @@
 *
 
       INFO = 0
+      NSPLIT = 0
+      M = 0
 *
 *     Quick return if possible
 *
@@ -383,8 +385,6 @@
       ELSE IF( LSAME( RANGE, 'I' ) ) THEN
          IRANGE = INDRNG
       END IF
-
-      M = 0
 
 *     Get machine constants
       SAFMIN = DLAMCH( 'S' )

--- a/SRC/slarra.f
+++ b/SRC/slarra.f
@@ -164,6 +164,7 @@
 *     .. Executable Statements ..
 *
       INFO = 0
+      NSPLIT = 1
 *
 *     Quick return if possible
 *
@@ -172,7 +173,6 @@
       END IF
 *
 *     Compute splitting points
-      NSPLIT = 1
       IF(SPLTOL.LT.ZERO) THEN
 *        Criterion based on absolute off-diagonal value
          TMP1 = ABS(SPLTOL)* TNRM

--- a/SRC/slarrc.f
+++ b/SRC/slarrc.f
@@ -167,6 +167,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
+      LCNT = 0
+      RCNT = 0
+      EIGCNT = 0
 *
 *     Quick return if possible
 *
@@ -174,9 +177,6 @@
          RETURN
       END IF
 *
-      LCNT = 0
-      RCNT = 0
-      EIGCNT = 0
       MATT = LSAME( JOBT, 'T' )
 
 

--- a/SRC/slarre.f
+++ b/SRC/slarre.f
@@ -367,6 +367,8 @@
 *
 
       INFO = 0
+      NSPLIT = 0
+      M = 0
 *
 *     Quick return if possible
 *
@@ -383,8 +385,6 @@
       ELSE IF( LSAME( RANGE, 'I' ) ) THEN
          IRANGE = INDRNG
       END IF
-
-      M = 0
 
 *     Get machine constants
       SAFMIN = SLAMCH( 'S' )


### PR DESCRIPTION
This is a follow-up on #770. Thanks to @akobotov for spotting a couple more similar issues.

I added initialization for all integer scalar outputs but there are some places when double scalar outputs are left uninitialized after quick return, here is the list (listing double precision only):

- dlarrd.f: `WL`, `WU`
- dlarre.f: `PIVMIN`
- dlarrf.f: `SIGMA`
- dlarrk.f: `W`, `WERR`

They describe some characteristics of the resulting computation. For example `WL`, `WU` describe the range of output eigenvalues. But quick return implies no computation and no eigenvalues. So it might be fine to keep them uninitialized but I would like to hear feedback from others. Please let me know if you think those should be initialized too, I'll extend the PR.

