### PR TITLE
Fix Y misscale in GEMV for some cases

### DIFF
--- a/BLAS/SRC/cgemv.f
+++ b/BLAS/SRC/cgemv.f
@@ -215,11 +215,6 @@
           RETURN
       END IF
 *
-*     Quick return if possible.
-*
-      IF ((M.EQ.0) .OR. (N.EQ.0) .OR.
-     +    ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE))) RETURN
-*
       NOCONJ = LSAME(TRANS,'T')
 *
 *     Set  LENX  and  LENY, the lengths of the vectors x and y, and set
@@ -242,6 +237,11 @@
       ELSE
           KY = 1 - (LENY-1)*INCY
       END IF
+*
+*     Return, if Y does not change
+*
+      IF ((LENY.EQ.0) .OR. ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE)))
+     +    RETURN
 *
 *     Start the operations. In this version the elements of A are
 *     accessed sequentially with one pass through A.
@@ -274,7 +274,11 @@
               END IF
           END IF
       END IF
-      IF (ALPHA.EQ.ZERO) RETURN
+*
+*     Return, if Y does not change after scale
+*
+      IF ((ALPHA.EQ.ZERO) .OR. (LENX.EQ.0)) RETURN
+*
       IF (LSAME(TRANS,'N')) THEN
 *
 *        Form  y := alpha*A*x + y.

--- a/BLAS/SRC/dgemv.f
+++ b/BLAS/SRC/dgemv.f
@@ -210,11 +210,6 @@
           RETURN
       END IF
 *
-*     Quick return if possible.
-*
-      IF ((M.EQ.0) .OR. (N.EQ.0) .OR.
-     +    ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE))) RETURN
-*
 *     Set  LENX  and  LENY, the lengths of the vectors x and y, and set
 *     up the start points in  X  and  Y.
 *
@@ -235,6 +230,11 @@
       ELSE
           KY = 1 - (LENY-1)*INCY
       END IF
+*
+*     Return, if Y does not change
+*
+      IF ((LENY.EQ.0) .OR. ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE)))
+     +    RETURN
 *
 *     Start the operations. In this version the elements of A are
 *     accessed sequentially with one pass through A.
@@ -267,7 +267,11 @@
               END IF
           END IF
       END IF
-      IF (ALPHA.EQ.ZERO) RETURN
+*
+*     Return, if Y does not change after scale
+*
+      IF ((ALPHA.EQ.ZERO) .OR. (LENX.EQ.0)) RETURN
+*
       IF (LSAME(TRANS,'N')) THEN
 *
 *        Form  y := alpha*A*x + y.

--- a/BLAS/SRC/sgemv.f
+++ b/BLAS/SRC/sgemv.f
@@ -210,11 +210,6 @@
           RETURN
       END IF
 *
-*     Quick return if possible.
-*
-      IF ((M.EQ.0) .OR. (N.EQ.0) .OR.
-     +    ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE))) RETURN
-*
 *     Set  LENX  and  LENY, the lengths of the vectors x and y, and set
 *     up the start points in  X  and  Y.
 *
@@ -235,6 +230,11 @@
       ELSE
           KY = 1 - (LENY-1)*INCY
       END IF
+*
+*     Return, if Y does not change
+*
+      IF ((LENY.EQ.0) .OR. ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE)))
+     +    RETURN
 *
 *     Start the operations. In this version the elements of A are
 *     accessed sequentially with one pass through A.
@@ -267,7 +267,11 @@
               END IF
           END IF
       END IF
-      IF (ALPHA.EQ.ZERO) RETURN
+*
+*     Return, if Y does not change after scale
+*
+      IF ((ALPHA.EQ.ZERO) .OR. (LENX.EQ.0)) RETURN
+*
       IF (LSAME(TRANS,'N')) THEN
 *
 *        Form  y := alpha*A*x + y.

--- a/BLAS/SRC/zgemv.f
+++ b/BLAS/SRC/zgemv.f
@@ -215,11 +215,6 @@
           RETURN
       END IF
 *
-*     Quick return if possible.
-*
-      IF ((M.EQ.0) .OR. (N.EQ.0) .OR.
-     +    ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE))) RETURN
-*
       NOCONJ = LSAME(TRANS,'T')
 *
 *     Set  LENX  and  LENY, the lengths of the vectors x and y, and set
@@ -242,6 +237,11 @@
       ELSE
           KY = 1 - (LENY-1)*INCY
       END IF
+*
+*     Return, if Y does not change
+*
+      IF ((LENY.EQ.0) .OR. ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE)))
+     +    RETURN
 *
 *     Start the operations. In this version the elements of A are
 *     accessed sequentially with one pass through A.
@@ -274,7 +274,11 @@
               END IF
           END IF
       END IF
-      IF (ALPHA.EQ.ZERO) RETURN
+*
+*     Return, if Y does not change after scale
+*
+      IF ((ALPHA.EQ.ZERO) .OR. (LENX.EQ.0)) RETURN
+*
       IF (LSAME(TRANS,'N')) THEN
 *
 *        Form  y := alpha*A*x + y.


### PR DESCRIPTION
**Description**

According to the description, $M$ and $N$ could be zero. It is expected that the vector $\mathbf{y}$ will be correctly scaled by scalar for such cases. 

For example, let GEMV computes
$\mathbf{y} := 0 \cdot \mathbf{y} + \mathbf{A}\mathbf{x}$
and $\mathbf{x}$ is zero length vector.  It is expected, that $\mathbf{y} = 0$ after GEMV, but it is not scaled due to statement in implementation:
```
- 	 IF ((M.EQ.0) .OR. (N.EQ.0) .OR.
-     +    ((ALPHA.EQ.ZERO).AND. (BETA.EQ.ONE))) RETURN
```

This pull request is objected to fix the behavior in such cases.

