### PR TITLE
fix bug in complex precision tests (c|z)het21

### DIFF
--- a/TESTING/EIG/chet21.f
+++ b/TESTING/EIG/chet21.f
@@ -304,9 +304,9 @@
    10    CONTINUE
 *
          IF( N.GT.1 .AND. KBAND.EQ.1 ) THEN
-            DO 20 J = 2, N - 1
+            DO 20 J = 1, N - 1
                CALL CHER2( CUPLO, N, -CMPLX( E( J ) ), U( 1, J ), 1,
-     $                     U( 1, J-1 ), 1, WORK, N )
+     $                     U( 1, J+1 ), 1, WORK, N )
    20       CONTINUE
          END IF
          WNORM = CLANHE( '1', CUPLO, N, WORK, N, RWORK )

--- a/TESTING/EIG/zhet21.f
+++ b/TESTING/EIG/zhet21.f
@@ -304,9 +304,9 @@
    10    CONTINUE
 *
          IF( N.GT.1 .AND. KBAND.EQ.1 ) THEN
-            DO 20 J = 2, N - 1
+            DO 20 J = 1, N - 1
                CALL ZHER2( CUPLO, N, -DCMPLX( E( J ) ), U( 1, J ), 1,
-     $                     U( 1, J-1 ), 1, WORK, N )
+     $                     U( 1, J+1 ), 1, WORK, N )
    20       CONTINUE
          END IF
          WNORM = ZLANHE( '1', CUPLO, N, WORK, N, RWORK )


### PR DESCRIPTION
Hi!

I try to use `(s|d)syt21` and `(c|z)het21` to validate `(sy|he)trd` and `(or|un)gtr`.
I use `ITYPE=1` to validate output matrix from `(or|un)gtr`. Validation for `orgtr` is fine, but it is breaking down for `ungtr` in RESULT(1) = | A - U S U**H | / ( |A| n ulp ).

It seems like you have a bug in `(c|z)het21`. I fix it. Please, review.