### PR TITLE
appveyor: output test failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ skip_commits:
 environment:
   global:
     CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
+    CTEST_OUTPUT_ON_FAILURE: 1
 
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat


### PR DESCRIPTION
**Description**

Output tests failures on appveyor, as it is currently failing in #821, without more hints than:

```
The following tests FAILED:
	 41 - LAPACK-xeigtstd_dec_in (Failed)
	 85 - LAPACK-xeigtstz_zec_in (Failed)
```

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.