### PR TITLE
Exits xLARUV when N < 1

### DIFF
--- a/SRC/dlaruv.f
+++ b/SRC/dlaruv.f
@@ -383,6 +383,11 @@
 *     ..
 *     .. Executable Statements ..
 *
+*     Quick return for N < 1
+      IF ( N < 1 ) THEN
+         RETURN
+      END IF
+*
       I1 = ISEED( 1 )
       I2 = ISEED( 2 )
       I3 = ISEED( 3 )

--- a/SRC/slaruv.f
+++ b/SRC/slaruv.f
@@ -383,6 +383,11 @@
 *     ..
 *     .. Executable Statements ..
 *
+*     Quick return for N < 1
+      IF ( N < 1 ) THEN
+         RETURN
+      END IF
+*
       I1 = ISEED( 1 )
       I2 = ISEED( 2 )
       I3 = ISEED( 3 )


### PR DESCRIPTION
This is the same fix proposed by @zerothi in #225.

Closes #182.