### PR TITLE
In CMake, install BLAS::BLAS and LAPACK::LAPACK

### DIFF
--- a/BLAS/SRC/CMakeLists.txt
+++ b/BLAS/SRC/CMakeLists.txt
@@ -29,6 +29,8 @@
 #  Level 1 BLAS
 #---------------------------------------------------------
 
+set(LAPACK_INSTALL_EXPORT_NAME ${BLASLIB}-targets)
+
 set(SBLAS1 isamax.f sasum.f saxpy.f scopy.f sdot.f snrm2.f90
 	srot.f srotg.f90 sscal.f sswap.f sdsdot.f srotmg.f srotm.f)
 
@@ -116,6 +118,14 @@ set_target_properties(
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
 lapack_install_library(${BLASLIB})
+
+add_library(BLAS::BLAS ALIAS ${BLASLIB})
+install(EXPORT ${BLASLIB}-targets
+    FILE ${BLASLIB}-targets.cmake
+    NAMESPACE BLAS::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKLIB}-${LAPACK_VERSION}
+    COMPONENT Development
+)
 
 if( TEST_FORTRAN_COMPILER )
   add_dependencies( ${BLASLIB} run_test_zcomplexabs run_test_zcomplexdiv run_test_zcomplexmult run_test_zminMax )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,10 @@ endif()
 # install tree, if any.
 set(_lapack_config_install_guard_target "")
 if(ALL_TARGETS)
+  add_library(LAPACK::LAPACK ALIAS ${LAPACKLIB})
   install(EXPORT ${LAPACKLIB}-targets
+    FILE ${LAPACKLIB}-targets.cmake
+    NAMESPACE LAPACK::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKLIB}-${LAPACK_VERSION}
     COMPONENT Development
     )


### PR DESCRIPTION
Attempt to close #483.

Currently, FindLAPACK in CMake offers two ways to link LAPACK libraries:
1. use the variable `LAPACK_LIBRARIES`, an "uncached list of libraries (using full path name) to link against to use LAPACK". 
2. use the target `LAPACK::LAPACK`, which is a CMake target.

In current version of LAPACK, we install a target `${LAPACKLIB}`, where LAPACKLIB is a variable that has to do with the name of the library installed in the system.

This PR changes the installation to `LAPACK::LAPACK` which agrees with FindLAPACK from CMake. The variable `LAPACK_LIBRARIES` remains unchanged. I also install `BLAS::BLAS` instead of the target `${BLASLIB}` to conform with FindBLAS from CMake.

Notice that the only thing this PR does is to rename of two CMake variables (3, if we consider LAPACK::TMGLIB).

Comments are welcome!