### PR TITLE
Updates the documentation of xGEMV and xGBMV related to when M=0 and N=0

### DIFF
--- a/BLAS/SRC/cgbmv.f
+++ b/BLAS/SRC/cgbmv.f
@@ -148,6 +148,7 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/cgbmv.f
+++ b/BLAS/SRC/cgbmv.f
@@ -148,7 +148,8 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/cgemv.f
+++ b/BLAS/SRC/cgemv.f
@@ -119,6 +119,7 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/cgemv.f
+++ b/BLAS/SRC/cgemv.f
@@ -119,7 +119,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/dgbmv.f
+++ b/BLAS/SRC/dgbmv.f
@@ -146,7 +146,8 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/dgbmv.f
+++ b/BLAS/SRC/dgbmv.f
@@ -146,6 +146,7 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/dgemv.f
+++ b/BLAS/SRC/dgemv.f
@@ -117,7 +117,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/dgemv.f
+++ b/BLAS/SRC/dgemv.f
@@ -117,6 +117,7 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/sgbmv.f
+++ b/BLAS/SRC/sgbmv.f
@@ -146,7 +146,8 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/sgbmv.f
+++ b/BLAS/SRC/sgbmv.f
@@ -146,6 +146,7 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/sgemv.f
+++ b/BLAS/SRC/sgemv.f
@@ -117,7 +117,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/sgemv.f
+++ b/BLAS/SRC/sgemv.f
@@ -117,6 +117,7 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/zgbmv.f
+++ b/BLAS/SRC/zgbmv.f
@@ -148,6 +148,7 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/zgbmv.f
+++ b/BLAS/SRC/zgbmv.f
@@ -148,7 +148,8 @@
 *>           ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
 *>           Before entry, the incremented array Y must contain the
 *>           vector y. On exit, Y is overwritten by the updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/zgemv.f
+++ b/BLAS/SRC/zgemv.f
@@ -119,6 +119,7 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/BLAS/SRC/zgemv.f
+++ b/BLAS/SRC/zgemv.f
@@ -119,7 +119,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
-*>           If either m or n is zero, then Y not referenced.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/cla_gbamv.f
+++ b/SRC/cla_gbamv.f
@@ -158,6 +158,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/cla_geamv.f
+++ b/SRC/cla_geamv.f
@@ -147,6 +147,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/dla_gbamv.f
+++ b/SRC/dla_gbamv.f
@@ -157,6 +157,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/dla_geamv.f
+++ b/SRC/dla_geamv.f
@@ -146,6 +146,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/sla_gbamv.f
+++ b/SRC/sla_gbamv.f
@@ -157,6 +157,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/sla_geamv.f
+++ b/SRC/sla_geamv.f
@@ -146,6 +146,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/zla_gbamv.f
+++ b/SRC/zla_gbamv.f
@@ -158,6 +158,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY

--- a/SRC/zla_geamv.f
+++ b/SRC/zla_geamv.f
@@ -147,6 +147,8 @@
 *>           Before entry with BETA non-zero, the incremented array Y
 *>           must contain the vector y. On exit, Y is overwritten by the
 *>           updated vector y.
+*>           If either m or n is zero, then Y not referenced and the function
+*>           performs a quick return.
 *> \endverbatim
 *>
 *> \param[in] INCY


### PR DESCRIPTION
Closes #248.
Closes #788.

The documentation of GEMV (and GBMV) misses a boundary case, namely when M=0 or N=0. There are two possibilities for the solution of this issue:

1. The behavior of GEMV (and GBMV) does not seem to match the behavior of GEMM, SYRK, SYR2K, HERK and HER2K regarding matrices with zero input sizes. In GEMM, for instance, C gets updated even if the internal dimension K is zero. In GEMV (and GBMV), if the internal dimension (M or N) is zero, Y does not get updated. The first solution is, therefore, to change the condition in GEMV (and GBMV) to be compatible to the lv3 BLAS.

2. The behavior of GEMV (and GBMV) is aligned to its original proposal (https://dl.acm.org/doi/10.1145/42288.42291) that says:
`
Note that it is permissible to call the routines with M or N = 0, in which case the routines exit immediately without referencing their vector or matrix arguments.
`
    Moreover, tests in ([testBLAS](https://github.com/tlapack/testblas)) confirm that several BLAS implementations conform with this rule.
    
This PR proposes a fix for the issue using (2), which preserves the current behavior and is compatible to several BLAS implementations.