### PR TITLE
Attempt to fix Appveyor on Windows

### DIFF
--- a/TESTING/EIG/csyl01.f
+++ b/TESTING/EIG/csyl01.f
@@ -120,13 +120,15 @@
       COMPLEX            RMUL
 *     ..
 *     .. Local Arrays ..
-      COMPLEX            A( MAXM, MAXM ), B( MAXN, MAXN ),
-     $                   C( MAXM, MAXN ), CC( MAXM, MAXN ),
-     $                   X( MAXM, MAXN ),
-     $                   DUML( MAXM ), DUMR( MAXN ),
+      COMPLEX            DUML( MAXM ), DUMR( MAXN ),
      $                   D( MAX( MAXM, MAXN ) )
-      REAL               SWORK( LDSWORK, 54 ), DUM( MAXN ), VM( 2 )
+      REAL               DUM( MAXN ), VM( 2 )
       INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 )
+*     ..
+*     .. Allocatable Arrays ..
+      INTEGER            AllocateStatus
+      COMPLEX, DIMENSION(:,:), ALLOCATABLE :: A, B, C, CC, X
+      REAL,    DIMENSION(:,:), ALLOCATABLE :: SWORK
 *     ..
 *     .. External Functions ..
       LOGICAL            SISNAN
@@ -138,6 +140,20 @@
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, REAL, MAX
+*     ..
+*     .. Allocate memory dynamically ..
+      ALLOCATE ( A( MAXM, MAXM ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( B( MAXN, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( C( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( CC( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( X( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( SWORK( LDSWORK, 54 ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
 *     ..
 *     .. Executable Statements ..
 *
@@ -286,6 +302,13 @@
             END DO
          END DO
       END DO
+*
+      DEALLOCATE (A, STAT = AllocateStatus)
+      DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (C, STAT = AllocateStatus)
+      DEALLOCATE (CC, STAT = AllocateStatus)
+      DEALLOCATE (X, STAT = AllocateStatus)
+      DEALLOCATE (SWORK, STAT = AllocateStatus)
 *
       RETURN
 *

--- a/TESTING/EIG/dsyl01.f
+++ b/TESTING/EIG/dsyl01.f
@@ -117,13 +117,15 @@
      $                   SCALE, SCALE3, SMLNUM, TNRM, XNRM
 *     ..
 *     .. Local Arrays ..
-      DOUBLE PRECISION   A( MAXM, MAXM ), B( MAXN, MAXN ),
-     $                   C( MAXM, MAXN ), CC( MAXM, MAXN ),
-     $                   X( MAXM, MAXN ),
-     $                   DUML( MAXM ), DUMR( MAXN ),
+      DOUBLE PRECISION   DUML( MAXM ), DUMR( MAXN ),
      $                   D( MAX( MAXM, MAXN ) ), DUM( MAXN ),
-     $                   SWORK( LDSWORK, 126 ), VM( 2 )
-      INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 ), IDUM( 2 )
+     $                   VM( 2 )
+      INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 )
+*     ..
+*     .. Allocatable Arrays ..
+      INTEGER            AllocateStatus
+      DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: A, B, C, CC, X,
+     $                   SWORK
 *     ..
 *     .. External Functions ..
       LOGICAL            DISNAN
@@ -135,6 +137,20 @@
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, DBLE, MAX
+*     ..
+*     .. Allocate memory dynamically ..
+      ALLOCATE ( A( MAXM, MAXM ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( B( MAXN, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( C( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( CC( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( X( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( SWORK( LDSWORK, 126 ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
 *     ..
 *     .. Executable Statements ..
 *
@@ -280,6 +296,13 @@
             END DO
          END DO
       END DO
+*
+      DEALLOCATE (A, STAT = AllocateStatus)
+      DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (C, STAT = AllocateStatus)
+      DEALLOCATE (CC, STAT = AllocateStatus)
+      DEALLOCATE (X, STAT = AllocateStatus)
+      DEALLOCATE (SWORK, STAT = AllocateStatus)
 *
       RETURN
 *

--- a/TESTING/EIG/ssyl01.f
+++ b/TESTING/EIG/ssyl01.f
@@ -117,13 +117,15 @@
      $                   SCALE, SCALE3, SMLNUM, TNRM, XNRM
 *     ..
 *     .. Local Arrays ..
-      REAL               A( MAXM, MAXM ), B( MAXN, MAXN ),
-     $                   C( MAXM, MAXN ), CC( MAXM, MAXN ),
-     $                   X( MAXM, MAXN ),
-     $                   DUML( MAXM ), DUMR( MAXN ),
+      REAL               DUML( MAXM ), DUMR( MAXN ),
      $                   D( MAX( MAXM, MAXN ) ), DUM( MAXN ),
-     $                   SWORK( LDSWORK, 54 ), VM( 2 )
-      INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 ), IDUM( 2 )
+     $                   VM( 2 )
+      INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 )
+*     ..
+*     .. Allocatable Arrays ..
+      INTEGER            AllocateStatus
+      REAL, DIMENSION(:,:), ALLOCATABLE :: A, B, C, CC, X,
+     $                   SWORK
 *     ..
 *     .. External Functions ..
       LOGICAL            SISNAN
@@ -135,6 +137,20 @@
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, REAL, MAX
+*     ..
+*     .. Allocate memory dynamically ..
+      ALLOCATE ( A( MAXM, MAXM ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( B( MAXN, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( C( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( CC( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( X( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( SWORK( LDSWORK, 54 ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
 *     ..
 *     .. Executable Statements ..
 *
@@ -280,6 +296,13 @@
             END DO
          END DO
       END DO
+*
+      DEALLOCATE (A, STAT = AllocateStatus)
+      DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (C, STAT = AllocateStatus)
+      DEALLOCATE (CC, STAT = AllocateStatus)
+      DEALLOCATE (X, STAT = AllocateStatus)
+      DEALLOCATE (SWORK, STAT = AllocateStatus)
 *
       RETURN
 *

--- a/TESTING/EIG/zsyl01.f
+++ b/TESTING/EIG/zsyl01.f
@@ -120,13 +120,15 @@
       COMPLEX*16         RMUL
 *     ..
 *     .. Local Arrays ..
-      COMPLEX*16         A( MAXM, MAXM ), B( MAXN, MAXN ),
-     $                   C( MAXM, MAXN ), CC( MAXM, MAXN ),
-     $                   X( MAXM, MAXN ),
-     $                   DUML( MAXM ), DUMR( MAXN ),
+      COMPLEX*16         DUML( MAXM ), DUMR( MAXN ),
      $                   D( MAX( MAXM, MAXN ) )
-      DOUBLE PRECISION   SWORK( LDSWORK, 103 ), DUM( MAXN ), VM( 2 )
+      DOUBLE PRECISION   DUM( MAXN ), VM( 2 )
       INTEGER            ISEED( 4 ), IWORK( MAXM + MAXN + 2 )
+*     ..
+*     .. Allocatable Arrays ..
+      INTEGER            AllocateStatus
+      COMPLEX*16,       DIMENSION(:,:), ALLOCATABLE :: A, B, C, CC, X
+      DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: SWORK
 *     ..
 *     .. External Functions ..
       LOGICAL            DISNAN
@@ -138,6 +140,20 @@
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, DBLE, MAX, SQRT
+*     ..
+*     .. Allocate memory dynamically ..
+      ALLOCATE ( A( MAXM, MAXM ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( B( MAXN, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( C( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( CC( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( X( MAXM, MAXN ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
+      ALLOCATE ( SWORK( LDSWORK, 103 ), STAT = AllocateStatus )
+      IF( AllocateStatus /= 0 ) STOP "*** Not enough memory ***"
 *     ..
 *     .. Executable Statements ..
 *
@@ -286,6 +302,13 @@
             END DO
          END DO
       END DO
+*
+      DEALLOCATE (A, STAT = AllocateStatus)
+      DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (C, STAT = AllocateStatus)
+      DEALLOCATE (CC, STAT = AllocateStatus)
+      DEALLOCATE (X, STAT = AllocateStatus)
+      DEALLOCATE (SWORK, STAT = AllocateStatus)
 *
       RETURN
 *


### PR DESCRIPTION
The test log says that the failures in Appveyor are due to a stack overflow. In the past, this was fixed by moving to dynamic allocation, see https://github.com/Reference-LAPACK/lapack/issues/548. Let's give it a try and see if the errors vanish.