### PR TITLE
Add verbose build to CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,7 +109,7 @@ jobs:
       run: |
         ctest -D ExperimentalStart
         ctest -D ExperimentalConfigure
-        ctest -D ExperimentalBuild
+        ctest -D ExperimentalBuild --verbose
 
     - name: Test with OpenMP
       working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
**Description**

This PR enables verbose build by default for better debuggability in case of build issues, since all warnings and errors are printed to the log instead of "*" and "!". No changes to source code, only CI config file.

Please note, this change impacts the build logs size.