### PR TITLE
Reduce number of macros in fortran compilation line for BLAS _64 API

### DIFF
--- a/BLAS/SRC/CMakeLists.txt
+++ b/BLAS/SRC/CMakeLists.txt
@@ -110,13 +110,20 @@ endif()
 list(REMOVE_DUPLICATES SOURCES)
 
 add_library(${BLASLIB}_obj OBJECT ${SOURCES})
-target_compile_options(${BLASLIB}_obj PRIVATE -fPIC)
+set_target_properties(${BLASLIB}_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if(BUILD_INDEX64_EXT_API)
+  set(SOURCES_64_F)
+  # Copy files so we can set source property specific to /${BLASLIB}_64_obj target
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${BLASLIB}_64_obj)
+  file(COPY ${SOURCES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${BLASLIB}_64_obj)
+  file(GLOB SOURCES_64_F ${CMAKE_CURRENT_BINARY_DIR}/${BLASLIB}_64_obj/*.f*)
+  add_library(${BLASLIB}_64_obj OBJECT ${SOURCES_64_F})
+  target_compile_options(${BLASLIB}_64_obj PRIVATE ${FOPT_ILP64})
+  set_target_properties(${BLASLIB}_64_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
   #Add _64 suffix to all Fortran functions via macros
-  set(COPT_64_F)
-  list(APPEND COPT_64_F -cpp)
-  foreach(F IN LISTS SOURCES)
+  foreach(F IN LISTS SOURCES_64_F)
+      set(COPT_64_F -cpp)
       file(STRINGS ${F} ${F}.lst)
       list(FILTER ${F}.lst INCLUDE REGEX "subroutine|SUBROUTINE|external|EXTERNAL|function|FUNCTION")
       list(FILTER ${F}.lst EXCLUDE REGEX "^!.*")
@@ -128,10 +135,9 @@ if(BUILD_INDEX64_EXT_API)
         string(STRIP ${FUNC} FUNC)
         list(APPEND COPT_64_F "-D${FUNC}=${FUNC}_64")
       endforeach()
+      list(REMOVE_DUPLICATES COPT_64_F)
+      set_source_files_properties(${F} PROPERTIES COMPILE_OPTIONS "${COPT_64_F}")
   endforeach()
-  list(REMOVE_DUPLICATES COPT_64_F)
-  add_library(${BLASLIB}_64_obj OBJECT ${SOURCES})
-  target_compile_options(${BLASLIB}_64_obj PRIVATE -fPIC ${FOPT_ILP64} ${COPT_64_F})
 endif()
 
 add_library(${BLASLIB}
@@ -142,6 +148,7 @@ set_target_properties(
   ${BLASLIB} PROPERTIES
   VERSION ${LAPACK_VERSION}
   SOVERSION ${LAPACK_MAJOR_VERSION}
+  POSITION_INDEPENDENT_CODE ON
   )
 lapack_install_library(${BLASLIB})
 

--- a/CBLAS/src/CMakeLists.txt
+++ b/CBLAS/src/CMakeLists.txt
@@ -122,16 +122,29 @@ set_target_properties(${CBLASLIB}_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if(BUILD_INDEX64_EXT_API)
   # 64bit Integer Interface
+  # Define list of C files
   set(SOURCES_64_C)
-  set(SOURCES_64_F)
   list(APPEND SOURCES_64_C ${SOURCES})
-  list(APPEND SOURCES_64_F ${SOURCES})
   list(FILTER SOURCES_64_C  EXCLUDE REGEX "\.f$")
-  list(FILTER SOURCES_64_F  INCLUDE REGEX "\.f$")
   list(REMOVE_ITEM SOURCES_64_C cblas_globals.c)
+  # Define list of Fortran files
+  set(SOURCES_64_F)
+  list(APPEND SOURCES_64_F ${SOURCES})
+  list(FILTER SOURCES_64_F  INCLUDE REGEX "\.f$")
+  # Copy files so we can set source property specific to /${CBLASLIB}_64_obj target
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}_64_fobj)
+  file(COPY ${SOURCES_64_F} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}_64_fobj)
+  file(GLOB SOURCES_64_F ${CMAKE_CURRENT_BINARY_DIR}/${CBLASLIB}_64_fobj/*)
+  add_library(${CBLASLIB}_64_cobj OBJECT ${SOURCES_64_C})
+  add_library(${CBLASLIB}_64_fobj OBJECT ${SOURCES_64_F})
+  set_target_properties(${CBLASLIB}_64_cobj ${CBLASLIB}_64_fobj PROPERTIES
+          POSITION_INDEPENDENT_CODE ON
+          Fortran_PREPROCESS ON)
+  target_compile_options(${CBLASLIB}_64_cobj PRIVATE -DWeirdNEC -DCBLAS_API64)
+  target_compile_options(${CBLASLIB}_64_fobj PRIVATE ${FOPT_ILP64})
   #Add suffix to all Fortran functions via macros
-  set(COPT_64_F)
   foreach(F IN LISTS SOURCES_64_F)
+      set(COPT_64_F)
       file(STRINGS ${F} ${F}.lst)
       list(FILTER ${F}.lst INCLUDE REGEX "subroutine|external")
       foreach(FUNC IN LISTS ${F}.lst)
@@ -139,14 +152,8 @@ if(BUILD_INDEX64_EXT_API)
         string(REGEX REPLACE "[(][a-zA-Z0-9, ]*[)]" "" FUNC ${FUNC})
         list(APPEND COPT_64_F "-D${FUNC}=${FUNC}_64")
       endforeach()
+      set_source_files_properties(${F} PROPERTIES COMPILE_OPTIONS "${COPT_64_F}")
   endforeach()
-  add_library(${CBLASLIB}_64_cobj OBJECT ${SOURCES_64_C})
-  add_library(${CBLASLIB}_64_fobj OBJECT ${SOURCES_64_F})
-  set_target_properties(${CBLASLIB}_64_cobj ${CBLASLIB}_64_fobj PROPERTIES
-          POSITION_INDEPENDENT_CODE ON
-          Fortran_PREPROCESS ON)
-  target_compile_options(${CBLASLIB}_64_cobj PRIVATE -DWeirdNEC -DCBLAS_API64)
-  target_compile_options(${CBLASLIB}_64_fobj PRIVATE ${FOPT_ILP64} ${COPT_64_F})
 endif()
 
 add_library(${CBLASLIB}


### PR DESCRIPTION
**Description**

The PR removes the problem with very long list of `... -DISAMAX=ISAMAX_64 -DSASUM=SASUM_64 -DSAXPY=SAXPY_64 -D...` options in BLAS_64 compilation lines. This PR adds only required macros for each particular file instead of generating list of macros for all files.

Compilation line before:
```
/usr/bin/f95   -frecursive -O2 -DNDEBUG -O2 -fPIC -fdefault-integer-8 -cpp -DISAMAX=ISAMAX_64 -DSASUM=SASUM_64 -DSAXPY=SAXPY_64 -DSCOPY=SCOPY_64 -DSDOT=SDOT_64 -DSNRM2=SNRM2_64 -DSROT=SROT_64 -DSROTG=SROTG_64 -DSSCAL=SSCAL_64 -DSSWAP=SSWAP_64 -DSDSDOT=SDSDOT_64 -DSROTMG=SROTMG_64 -DSROTM=SROTM_64 -DLSAME=LSAME_64 -DXERBLA=XERBLA_64 -DXERBLA_ARRAY=XERBLA_ARRAY_64 -DSGEMV=SGEMV_64 -DSGBMV=SGBMV_64 -DSSYMV=SSYMV_64 -DSSBMV=SSBMV_64 -DSSPMV=SSPMV_64 -DSTRMV=STRMV_64 -DSTBMV=STBMV_64 -DSTPMV=STPMV_64 -DSTRSV=STRSV_64 -DSTBSV=STBSV_64 -DSTPSV=STPSV_64 -DSGER=SGER_64 -DSSYR=SSYR_64 -DSSPR=SSPR_64 -DSSYR2=SSYR2_64 -DSSPR2=SSPR2_64 -DSGEMM=SGEMM_64 -DSSYMM=SSYMM_64 -DSSYRK=SSYRK_64 -DSSYR2K=SSYR2K_64 -DSTRMM=STRMM_64 -DSTRSM=STRSM_64 -DIDAMAX=IDAMAX_64 -DDASUM=DASUM_64 -DDAXPY=DAXPY_64 -DDCOPY=DCOPY_64 -DDDOT=DDOT_64 -DDNRM2=DNRM2_64 -DDROT=DROT_64 -DDROTG=DROTG_64 -DDSCAL=DSCAL_64 -DDSDOT=DSDOT_64 -DDSWAP=DSWAP_64 -DDROTMG=DROTMG_64 -DDROTM=DROTM_64 -DDGEMV=DGEMV_64 -DDGBMV=DGBMV_64 -DDSYMV=DSYMV_64 -DDSBMV=DSBMV_64 -DDSPMV=DSPMV_64 -DDTRMV=DTRMV_64 -DDTBMV=DTBMV_64 -DDTPMV=DTPMV_64 -DDTRSV=DTRSV_64 -DDTBSV=DTBSV_64 -DDTPSV=DTPSV_64 -DDGER=DGER_64 -DDSYR=DSYR_64 -DDSPR=DSPR_64 -DDSYR2=DSYR2_64 -DDSPR2=DSPR2_64 -DDGEMM=DGEMM_64 -DDSYMM=DSYMM_64 -DDSYRK=DSYRK_64 -DDSYR2K=DSYR2K_64 -DDTRMM=DTRMM_64 -DDTRSM=DTRSM_64 -DSCABS1=SCABS1_64 -DSCASUM=SCASUM_64 -DSCNRM2=SCNRM2_64 -DICAMAX=ICAMAX_64 -DCAXPY=CAXPY_64 -DCCOPY=CCOPY_64 -DCDOTC=CDOTC_64 -DCDOTU=CDOTU_64 -DCSSCAL=CSSCAL_64 -DCROTG=CROTG_64 -DCSCAL=CSCAL_64 -DCSWAP=CSWAP_64 -DCSROT=CSROT_64 -DCGEMV=CGEMV_64 -DCGBMV=CGBMV_64 -DCHEMV=CHEMV_64 -DCHBMV=CHBMV_64 -DCHPMV=CHPMV_64 -DCTRMV=CTRMV_64 -DCTBMV=CTBMV_64 -DCTPMV=CTPMV_64 -DCTRSV=CTRSV_64 -DCTBSV=CTBSV_64 -DCTPSV=CTPSV_64 -DCGERC=CGERC_64 -DCGERU=CGERU_64 -DCHER=CHER_64 -DCHPR=CHPR_64 -DCHER2=CHER2_64 -DCHPR2=CHPR2_64 -DCGEMM=CGEMM_64 -DCSYMM=CSYMM_64 -DCSYRK=CSYRK_64 -DCSYR2K=CSYR2K_64 -DCTRMM=CTRMM_64 -DCTRSM=CTRSM_64 -DCHEMM=CHEMM_64 -DCHERK=CHERK_64 -DCHER2K=CHER2K_64 -DDCABS1=DCABS1_64 -DDZASUM=DZASUM_64 -DDZNRM2=DZNRM2_64 -DIZAMAX=IZAMAX_64 -DZAXPY=ZAXPY_64 -DZCOPY=ZCOPY_64 -DZDOTC=ZDOTC_64 -DZDOTU=ZDOTU_64 -DZDSCAL=ZDSCAL_64 -DZROTG=ZROTG_64 -DZSCAL=ZSCAL_64 -DZSWAP=ZSWAP_64 -DZDROT=ZDROT_64 -DZGEMV=ZGEMV_64 -DZGBMV=ZGBMV_64 -DZHEMV=ZHEMV_64 -DZHBMV=ZHBMV_64 -DZHPMV=ZHPMV_64 -DZTRMV=ZTRMV_64 -DZTBMV=ZTBMV_64 -DZTPMV=ZTPMV_64 -DZTRSV=ZTRSV_64 -DZTBSV=ZTBSV_64 -DZTPSV=ZTPSV_64 -DZGERC=ZGERC_64 -DZGERU=ZGERU_64 -DZHER=ZHER_64 -DZHPR=ZHPR_64 -DZHER2=ZHER2_64 -DZHPR2=ZHPR2_64 -DZGEMM=ZGEMM_64 -DZSYMM=ZSYMM_64 -DZSYRK=ZSYRK_64 -DZSYR2K=ZSYR2K_64 -DZTRMM=ZTRMM_64 -DZTRSM=ZTRSM_64 -DZHEMM=ZHEMM_64 -DZHERK=ZHERK_64 -DZHER2K=ZHER2K_64 -c /sandbox/netlib/lapack/BLAS/SRC/zsyr2k.f -o CMakeFiles/blas_64_obj.dir/zsyr2k.f.o 
```

Compilation line after:
```
/usr/bin/f95   -frecursive -O2 -DNDEBUG -O2 -fPIC -cpp -DZSYR2K=ZSYR2K_64 -DLSAME=LSAME_64 -DXERBLA=XERBLA_64 -c /sandbox/netlib/lapack/BLAS/SRC/zsyr2k.f -o CMakeFiles/blas_obj.dir/zsyr2k.f.o
```

Minor changes:
* replace platform specific `fPIC` with `POSITION_INDEPENDENT_CODE` property in BLAS CMake config

**Checklist**

- [x] The documentation has been updated. N/A, since the changes are implementation detail to the excising functionality
- [x] If the PR solves a specific issue, it is set to be closed on merge. PR resolves one potential problem mentioned in https://github.com/Reference-LAPACK/lapack/issues/666