### PR TITLE
Fix actual arguments in some procedure calls

### DIFF
--- a/SRC/cgelqt3.f
+++ b/SRC/cgelqt3.f
@@ -159,7 +159,8 @@
 *
 *        Compute Householder transform when M=1
 *
-         CALL CLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
+         CALL CLARFG( N, A( 1, 1 ), A( 1, MIN( 2, N ) ), LDA,
+     &                T( 1, 1 ) )
          T(1,1)=CONJG(T(1,1))
 *
       ELSE

--- a/SRC/dgelqt3.f
+++ b/SRC/dgelqt3.f
@@ -173,7 +173,8 @@
 *
 *        Compute Householder transform when M=1
 *
-         CALL DLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
+         CALL DLARFG( N, A( 1, 1 ), A( 1, MIN( 2, N ) ), LDA,
+     &                T( 1, 1 ) )
 *
       ELSE
 *

--- a/SRC/dlatrs.f
+++ b/SRC/dlatrs.f
@@ -261,6 +261,9 @@
       DOUBLE PRECISION   BIGNUM, GROW, REC, SMLNUM, SUMJ, TJJ, TJJS,
      $                   TMAX, TSCAL, USCAL, XBND, XJ, XMAX
 *     ..
+*     .. Local Arrays ..
+      DOUBLE PRECISION   WORK(1)
+*     ..
 *     .. External Functions ..
       LOGICAL            LSAME
       INTEGER            IDAMAX
@@ -362,7 +365,7 @@
 *              A is upper triangular.
 *
                DO J = 2, N
-                  TMAX = MAX( DLANGE( 'M', J-1, 1, A( 1, J ), 1, SUMJ ),
+                  TMAX = MAX( DLANGE( 'M', J-1, 1, A( 1, J ), 1, WORK ),
      $                        TMAX )
                END DO
             ELSE
@@ -371,7 +374,7 @@
 *
                DO J = 1, N - 1
                   TMAX = MAX( DLANGE( 'M', N-J, 1, A( J+1, J ), 1,
-     $                        SUMJ ), TMAX )
+     $                        WORK ), TMAX )
                END DO
             END IF
 *

--- a/SRC/dtrsyl3.f
+++ b/SRC/dtrsyl3.f
@@ -1220,7 +1220,7 @@
 *
          SCALOC = MIN( BIGNUM / SCAL, ONE / BUF )
          BUF = BUF * SCALOC
-         CALL DLASCL( 'G', -1, -1, ONE, SCALOC, M, N, C, LDC, IWORK )
+         CALL DLASCL( 'G', -1, -1, ONE, SCALOC, M, N, C, LDC, IWORK(1) )
       END IF
 *
 *     Combine with buffer scaling factor. SCALE will be flushed if

--- a/SRC/sgelqt3.f
+++ b/SRC/sgelqt3.f
@@ -158,7 +158,8 @@
 *
 *        Compute Householder transform when M=1
 *
-         CALL SLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
+         CALL SLARFG( N, A( 1, 1 ), A( 1, MIN( 2, N ) ), LDA,
+     &                T( 1, 1 ) )
 *
       ELSE
 *

--- a/SRC/slatrs.f
+++ b/SRC/slatrs.f
@@ -261,6 +261,9 @@
       REAL               BIGNUM, GROW, REC, SMLNUM, SUMJ, TJJ, TJJS,
      $                   TMAX, TSCAL, USCAL, XBND, XJ, XMAX
 *     ..
+*     .. Local Arrays ..
+      REAL               WORK(1)
+*     ..
 *     .. External Functions ..
       LOGICAL            LSAME
       INTEGER            ISAMAX
@@ -362,7 +365,7 @@
 *              A is upper triangular.
 *
                DO J = 2, N
-                  TMAX = MAX( SLANGE( 'M', J-1, 1, A( 1, J ), 1, SUMJ ),
+                  TMAX = MAX( SLANGE( 'M', J-1, 1, A( 1, J ), 1, WORK ),
      $                        TMAX )
                END DO
             ELSE
@@ -371,7 +374,7 @@
 *
                DO J = 1, N - 1
                   TMAX = MAX( SLANGE( 'M', N-J, 1, A( J+1, J ), 1,
-     $                        SUMJ ), TMAX )
+     $                        WORK ), TMAX )
                END DO
             END IF
 *

--- a/SRC/strsyl3.f
+++ b/SRC/strsyl3.f
@@ -1223,7 +1223,7 @@
 *
          SCALOC = MIN( BIGNUM / SCAL, ONE / BUF )
          BUF = BUF * SCALOC
-         CALL SLASCL( 'G', -1, -1, ONE, SCALOC, M, N, C, LDC, IWORK )
+         CALL SLASCL( 'G', -1, -1, ONE, SCALOC, M, N, C, LDC, IWORK(1) )
       END IF
 *
 *     Combine with buffer scaling factor. SCALE will be flushed if

--- a/SRC/zgelqt3.f
+++ b/SRC/zgelqt3.f
@@ -174,7 +174,8 @@
 *
 *        Compute Householder transform when M=1
 *
-         CALL ZLARFG( N, A, A( 1, MIN( 2, N ) ), LDA, T )
+         CALL ZLARFG( N, A( 1, 1 ), A( 1, MIN( 2, N ) ), LDA,
+     &                T( 1, 1 ) )
          T(1,1)=CONJG(T(1,1))
 *
       ELSE

--- a/TESTING/EIG/cerrst.f
+++ b/TESTING/EIG/cerrst.f
@@ -160,13 +160,13 @@
 *
          SRNAMT = 'CHETD2'
          INFOT = 1
-         CALL CHETD2( '/', 0, A, 1, D, E, TAU, W, 1, INFO )
+         CALL CHETD2( '/', 0, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'CHETD2', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL CHETD2( 'U', -1, A, 1, D, E, TAU, W, 1, INFO )
+         CALL CHETD2( 'U', -1, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'CHETD2', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL CHETD2( 'U', 2, A, 1, D, E, TAU, W, 1, INFO )
+         CALL CHETD2( 'U', 2, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'CHETD2', INFOT, NOUT, LERR, OK )
          NT = NT + 3
 *

--- a/TESTING/EIG/derrst.f
+++ b/TESTING/EIG/derrst.f
@@ -161,13 +161,13 @@
 *
          SRNAMT = 'DSYTD2'
          INFOT = 1
-         CALL DSYTD2( '/', 0, A, 1, D, E, TAU, W, 1, INFO )
+         CALL DSYTD2( '/', 0, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'DSYTD2', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL DSYTD2( 'U', -1, A, 1, D, E, TAU, W, 1, INFO )
+         CALL DSYTD2( 'U', -1, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'DSYTD2', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL DSYTD2( 'U', 2, A, 1, D, E, TAU, W, 1, INFO )
+         CALL DSYTD2( 'U', 2, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'DSYTD2', INFOT, NOUT, LERR, OK )
          NT = NT + 3
 *

--- a/TESTING/EIG/serrst.f
+++ b/TESTING/EIG/serrst.f
@@ -161,13 +161,13 @@
 *
          SRNAMT = 'SSYTD2'
          INFOT = 1
-         CALL SSYTD2( '/', 0, A, 1, D, E, TAU, W, 1, INFO )
+         CALL SSYTD2( '/', 0, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'SSYTD2', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL SSYTD2( 'U', -1, A, 1, D, E, TAU, W, 1, INFO )
+         CALL SSYTD2( 'U', -1, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'SSYTD2', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL SSYTD2( 'U', 2, A, 1, D, E, TAU, W, 1, INFO )
+         CALL SSYTD2( 'U', 2, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'SSYTD2', INFOT, NOUT, LERR, OK )
          NT = NT + 3
 *

--- a/TESTING/EIG/zerrst.f
+++ b/TESTING/EIG/zerrst.f
@@ -160,13 +160,13 @@
 *
          SRNAMT = 'ZHETD2'
          INFOT = 1
-         CALL ZHETD2( '/', 0, A, 1, D, E, TAU, W, 1, INFO )
+         CALL ZHETD2( '/', 0, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'ZHETD2', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL ZHETD2( 'U', -1, A, 1, D, E, TAU, W, 1, INFO )
+         CALL ZHETD2( 'U', -1, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'ZHETD2', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL ZHETD2( 'U', 2, A, 1, D, E, TAU, W, 1, INFO )
+         CALL ZHETD2( 'U', 2, A, 1, D, E, TAU, INFO )
          CALL CHKXER( 'ZHETD2', INFOT, NOUT, LERR, OK )
          NT = NT + 3
 *

--- a/TESTING/LIN/cchktr.f
+++ b/TESTING/LIN/cchktr.f
@@ -201,7 +201,8 @@
 *     .. Local Arrays ..
       CHARACTER          TRANSS( NTRAN ), UPLOS( 2 )
       INTEGER            ISEED( 4 ), ISEEDY( 4 )
-      REAL               RESULT( NTESTS ), SCALE3( 2 )
+      REAL               RESULT( NTESTS ), RWORK2( 2*NMAX ),
+     $                   SCALE3( 2 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -542,10 +543,10 @@
                   SRNAMT = 'CLATRS3'
                   CALL CCOPY( N, X, 1, B, 1 )
                   CALL CCOPY( N, X, 1, B( N+1 ), 1 )
-                  CALL CSCAL( N, BIGNUM, B( N+1 ), 1 )
+                  CALL CSSCAL( N, BIGNUM, B( N+1 ), 1 )
                   CALL CLATRS3( UPLO, TRANS, DIAG, 'N', N, 2, A, LDA,
-     $                          B, MAX(1, N), SCALE3, RWORK, WORK, NMAX,
-     $                          INFO )
+     $                          B, MAX(1, N), SCALE3, RWORK, RWORK2,
+     $                          2*NMAX, INFO )
 *
 *                 Check error code from CLATRS3.
 *

--- a/TESTING/LIN/cerrtr.f
+++ b/TESTING/LIN/cerrtr.f
@@ -70,7 +70,7 @@
 *     .. Local Scalars ..
       CHARACTER*2        C2
       INTEGER            INFO
-      REAL               RCOND, SCALE
+      REAL               RCOND, SCALE, SCALES(0)
 *     ..
 *     .. Local Arrays ..
       REAL               R1( NMAX ), R2( NMAX ), RW( NMAX )
@@ -245,40 +245,40 @@
 *
          SRNAMT = 'CLATRS3'
          INFOT = 1
-         CALL CLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL CLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 3
-         CALL CLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL CLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 5
-         CALL CLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 6
-         CALL CLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 8
-         CALL CLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 10
-         CALL CLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL CLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 14
-         CALL CLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 0, INFO )
+         CALL CLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 0, INFO )
          CALL CHKXER( 'CLATRS3', INFOT, NOUT, LERR, OK )
 *
 *     Test error exits for the packed triangular routines.

--- a/TESTING/LIN/derrtr.f
+++ b/TESTING/LIN/derrtr.f
@@ -71,7 +71,7 @@
 *     .. Local Scalars ..
       CHARACTER*2        C2
       INTEGER            INFO
-      DOUBLE PRECISION   RCOND, SCALE
+      DOUBLE PRECISION   RCOND, SCALE, SCALES(0)
 *     ..
 *     .. Local Arrays ..
       INTEGER            IW( NMAX )
@@ -250,40 +250,40 @@
 *
          SRNAMT = 'DLATRS3'
          INFOT = 1
-         CALL DLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL DLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 3
-         CALL DLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL DLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 5
-         CALL DLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 6
-         CALL DLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 8
-         CALL DLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 10
-         CALL DLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL DLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 14
-         CALL DLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 0, INFO )
+         CALL DLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 0, INFO )
          CALL CHKXER( 'DLATRS3', INFOT, NOUT, LERR, OK )
 *
       ELSE IF( LSAMEN( 2, C2, 'TP' ) ) THEN

--- a/TESTING/LIN/serrtr.f
+++ b/TESTING/LIN/serrtr.f
@@ -71,7 +71,7 @@
 *     .. Local Scalars ..
       CHARACTER*2        C2
       INTEGER            INFO
-      REAL               RCOND, SCALE
+      REAL               RCOND, SCALE, SCALES(0)
 *     ..
 *     .. Local Arrays ..
       INTEGER            IW( NMAX )
@@ -250,40 +250,40 @@
 *
          SRNAMT = 'SLATRS3'
          INFOT = 1
-         CALL SLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL SLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 3
-         CALL SLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL SLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 5
-         CALL SLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 6
-         CALL SLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 8
-         CALL SLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 10
-         CALL SLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALE, W,
-     $                 W( 2 ), 1, INFO )
+         CALL SLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALES,
+     $                 W, W( 2 ), 1, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 14
-         CALL SLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALE, W,
-     $                 W( 2 ), 0, INFO )
+         CALL SLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALES,
+     $                 W, W( 2 ), 0, INFO )
          CALL CHKXER( 'SLATRS3', INFOT, NOUT, LERR, OK )
 *
       ELSE IF( LSAMEN( 2, C2, 'TP' ) ) THEN

--- a/TESTING/LIN/zchktr.f
+++ b/TESTING/LIN/zchktr.f
@@ -201,7 +201,8 @@
 *     .. Local Arrays ..
       CHARACTER          TRANSS( NTRAN ), UPLOS( 2 )
       INTEGER            ISEED( 4 ), ISEEDY( 4 )
-      DOUBLE PRECISION   RESULT( NTESTS ), SCALE3( 2 )
+      DOUBLE PRECISION   RESULT( NTESTS ), RWORK2( 2*NMAX ),
+     $                   SCALE3( 2 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -544,8 +545,8 @@
                   CALL ZCOPY( N, X, 1, B( N+1 ), 1 )
                   CALL ZDSCAL( N, BIGNUM, B( N+1 ), 1 )
                   CALL ZLATRS3( UPLO, TRANS, DIAG, 'N', N, 2, A, LDA,
-     $                          B, MAX(1, N), SCALE3, RWORK, WORK, NMAX,
-     $                          INFO )
+     $                          B, MAX(1, N), SCALE3, RWORK, RWORK2,
+     $                          2*NMAX, INFO )
 *
 *                 Check error code from ZLATRS3.
 *

--- a/TESTING/LIN/zerrtr.f
+++ b/TESTING/LIN/zerrtr.f
@@ -70,7 +70,7 @@
 *     .. Local Scalars ..
       CHARACTER*2        C2
       INTEGER            INFO
-      DOUBLE PRECISION   RCOND, SCALE
+      DOUBLE PRECISION   RCOND, SCALE, SCALES(0)
 *     ..
 *     .. Local Arrays ..
       DOUBLE PRECISION   R1( NMAX ), R2( NMAX ), RW( NMAX )
@@ -245,40 +245,40 @@
 *
          SRNAMT = 'ZLATRS3'
          INFOT = 1
-         CALL ZLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( '/', 'N', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 2
-         CALL ZLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( 'U', '/', 'N', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 3
-         CALL ZLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( 'U', 'N', '/', 'N', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 4
-         CALL ZLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( 'U', 'N', 'N', '/', 0, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 5
-         CALL ZLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( 'U', 'N', 'N', 'N', -1, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 6
-         CALL ZLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( 'U', 'N', 'N', 'N', 0, -1, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 8
-         CALL ZLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 10
-         CALL ZLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALE, RW,
-     $                 RW( 2 ), 1, INFO )
+         CALL ZLATRS3( 'U', 'N', 'N', 'N', 2, 0, A, 2, X, 1, SCALES,
+     $                 RW, RW( 2 ), 1, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
          INFOT = 14
-         CALL ZLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALE, RW,
-     $                 RW( 2 ), 0, INFO )
+         CALL ZLATRS3( 'U', 'N', 'N', 'N', 1, 0, A, 1, X, 1, SCALES,
+     $                 RW, RW( 2 ), 0, INFO )
          CALL CHKXER( 'ZLATRS3', INFOT, NOUT, LERR, OK )
 *
 *     Test error exits for the packed triangular routines.


### PR DESCRIPTION
**Description**

Some internal and some testing calls did not match the actual procedure definitions:

* Rank mismatch in call to `xLARFG` from `xGELQT3`: `xLARFG` expects scalars for `ALPHA` and `TAU`,  but arrays were passed
* Rank mismatch in call to `xLANGE` from `xLATRS`: `xLANGE` expects array for `WORK`, but scalar was passed. Note that `WORK` is not referenced with `NORM /= 'I'`, so the returned value does not need to be used.
* Rank mismatch in call to `xLASCL` from `xTRSYL3`: `xLASCL` expects scalar for `INFO`, but array was passed
* Too many arguments in calls to `xSYTD2`/`xHETD2` from test `xERRST`
* Rank mismatch in call to `xLATRS3` from test `xERRTR`: `xLATRS3` expects array for `SCALE`, but scalar was passed
* Type mismatch in call to `CSCAL` from test `CCHKTR`: `CSCAL` expects `COMPLEX`, but `REAL` was passed. Since `ZCHKTR` calls `ZDSCAL` in that place, this should probably be a call to `CSSCAL` instead, for which the types fit.
* Type mismatch in call to `xLATRS3` from test `xCHKTR`: `xLATRS3` expects real array for `WORK`, but complex array was passed. Passing a real array with the previous number of elements `LWORK=NMAX` leads to invalid memory reference inside `xLATRS3`. Passing a real array of the same size `LWORK=2*NMAX` as before fixes that. Though I am not quite sure what the intention was here; the requirement for `LWORK` is not quite trivial and `NMAX` just seems to be an opaque test function parameter?

Found these by replacing external procedure declarations with full interface definitions using a [script](https://gist.github.com/mjacobse/98689c21cdd18a5835db9049798a9a86).

**Checklist**

~~- [ ] The documentation has been updated.~~
~~- [ ] If the PR solves a specific issue, it is set to be closed on merge.~~