### PR TITLE
Removes usage of Experimental (interactive) mode in ctest

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -103,27 +103,19 @@ jobs:
         -D BUILD_SHARED_LIBS:BOOL=ON
 
     - name: Build
-      working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: |
-        ctest -D ExperimentalStart
-        ctest -D ExperimentalConfigure
-        ctest -D ExperimentalBuild --verbose
+      run: cmake --build build --config ${{env.BUILD_TYPE}}
 
     - name: Test with OpenMP
       working-directory: ${{github.workspace}}/build
       if: ${{ contains( matrix.fflags, 'openmp' ) && (matrix.os != 'windows-latest') }}
-      run: |
-        ctest -D ExperimentalTest --schedule-random -j1 --output-on-failure --timeout 100
-        ctest -D ExperimentalSubmit
+      run: ctest -C ${{env.BUILD_TYPE}} --schedule-random -j1 --output-on-failure --timeout 100
 
     - name: Test
       working-directory: ${{github.workspace}}/build
       if: ${{ !contains( matrix.fflags, 'openmp' ) && (matrix.os != 'windows-latest') }}
-      run: |
-        ctest -D ExperimentalTest --schedule-random -j2 --output-on-failure --timeout 100
-        ctest -D ExperimentalSubmit
+      run: ctest -C ${{env.BUILD_TYPE}} --schedule-random -j2 --output-on-failure --timeout 100
 
     - name: Install
       run: cmake --build build --target install -j2


### PR DESCRIPTION
The command `ctest -D ExperimentalSubmit` is not working properly in the Github Actions. See https://github.com/Reference-LAPACK/lapack/actions/runs/5588808844, and other recent runs failing at https://github.com/Reference-LAPACK/lapack/actions/workflows/cmake.yml. This PR removes the Experimental build and uses a regular CTest call for tests.

The Experimental mode is an interactive debug mode in CMake. "Prior to CMake 3.11, interactive mode on Windows allowed system debug popup windows to appear. Now, due to CTest's use of libuv to launch test processes, all system debug popup windows are always blocked." (https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-interactive-debug-mode).