### PR TITLE
allow absolute GNU install dirs

### DIFF
--- a/CBLAS/cmake/cblas-config-install.cmake.in
+++ b/CBLAS/cmake/cblas-config-install.cmake.in
@@ -1,11 +1,8 @@
 # Compute locations from <prefix>/@{LIBRARY_DIR@/cmake/lapacke-<v>/<self>.cmake
 get_filename_component(_CBLAS_SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_CBLAS_PREFIX "${_CBLAS_SELF_DIR}" PATH)
-get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
-get_filename_component(_CBLAS_PREFIX "${_CBLAS_PREFIX}" PATH)
 
 # Load the LAPACK package with which we were built.
-set(LAPACK_DIR "${_CBLAS_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/@LAPACKLIB@-@LAPACK_VERSION@")
+set(LAPACK_DIR "@CMAKE_INSTALL_FULL_LIBDIR@/cmake/@LAPACKLIB@-@LAPACK_VERSION@")
 find_package(LAPACK NO_MODULE)
 
 # Load lapacke targets from the install tree.
@@ -14,10 +11,9 @@ if(NOT TARGET @CBLASLIB@)
 endif()
 
 # Report lapacke header search locations.
-set(CBLAS_INCLUDE_DIRS ${_CBLAS_PREFIX}/include)
+set(CBLAS_INCLUDE_DIRS @CMAKE_INSTALL_FULL_INCLUDEDIR@)
 
 # Report lapacke libraries.
 set(CBLAS_LIBRARIES @CBLASLIB@)
 
-unset(_CBLAS_PREFIX)
 unset(_CBLAS_SELF_DIR)

--- a/LAPACKE/cmake/lapacke-config-install.cmake.in
+++ b/LAPACKE/cmake/lapacke-config-install.cmake.in
@@ -1,11 +1,8 @@
 # Compute locations from <prefix>/@{LIBRARY_DIR@/cmake/lapacke-<v>/<self>.cmake
 get_filename_component(_LAPACKE_SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_SELF_DIR}" PATH)
-get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
-get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
 
 # Load the LAPACK package with which we were built.
-set(LAPACK_DIR "${_LAPACKE_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/@LAPACKLIB@-@LAPACK_VERSION@")
+set(LAPACK_DIR "@CMAKE_INSTALL_FULL_LIBDIR@/cmake/@LAPACKLIB@-@LAPACK_VERSION@")
 find_package(LAPACK NO_MODULE)
 
 # Load lapacke targets from the install tree.
@@ -17,10 +14,9 @@ endif()
 set(LAPACKE_Fortran_COMPILER_ID ${LAPACK_Fortran_COMPILER_ID})
 
 # Report lapacke header search locations.
-set(LAPACKE_INCLUDE_DIRS ${_LAPACKE_PREFIX}/include)
+set(LAPACKE_INCLUDE_DIRS @CMAKE_INSTALL_FULL_INCLUDEDIR@)
 
 # Report lapacke libraries.
 set(LAPACKE_LIBRARIES @LAPACKELIB@ ${LAPACK_LIBRARIES})
 
-unset(_LAPACKE_PREFIX)
 unset(_LAPACKE_SELF_DIR)


### PR DESCRIPTION
**Description**

`CMAKE_INSTALL_LIBDIR` is allowed to be an absolute path as per [CMake docs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html). This patch changes the build script to use `CMAKE_INSTALL_FULL_LIBDIR` instead, and gets rid of the prefix detection code (many other libraries, such as LLVM, have gotten rid of it already as it's quite finicky in practice due to absolute dirs being allowed).

Absolute `CMAKE_INSTALL_LIBDIR`s are used at least on NixOS. This is because NixOS packages are allowed to have multiple outputs (e.g. put docs in one dir, headers and other files for development to another, the binaries to a third one), and NixOS isn't FHS-compliant (There's no `/usr`, each package output has its own directory instead).

GNU Guix is a similar distro, but I'm not sure how CMake packages are built there. Either way, it's good to fully conform to the spec.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.