### PR TITLE
dtgex2: add 2 to iwork length to prevent OOB interaction in Dtgsy2

### DIFF
--- a/SRC/dtgex2.f
+++ b/SRC/dtgex2.f
@@ -254,7 +254,7 @@
      $                   THRESHA, THRESHB
 *     ..
 *     .. Local Arrays ..
-      INTEGER            IWORK( LDST )
+      INTEGER            IWORK( LDST + 2 )
       DOUBLE PRECISION   AI( 2 ), AR( 2 ), BE( 2 ), IR( LDST, LDST ),
      $                   IRCOP( LDST, LDST ), LI( LDST, LDST ),
      $                   LICOP( LDST, LDST ), S( LDST, LDST ),

--- a/SRC/stgex2.f
+++ b/SRC/stgex2.f
@@ -255,7 +255,7 @@
      $                   THRESHA, THRESHB
 *     ..
 *     .. Local Arrays ..
-      INTEGER            IWORK( LDST )
+      INTEGER            IWORK( LDST + 2 )
       REAL               AI( 2 ), AR( 2 ), BE( 2 ), IR( LDST, LDST ),
      $                   IRCOP( LDST, LDST ), LI( LDST, LDST ),
      $                   LICOP( LDST, LDST ), S( LDST, LDST ),


### PR DESCRIPTION
**Description**
This is to fix what seems like a bug, I may be confused however.

Explanation starting from the top/last of the call stack:
- [Dtgsy2](https://www.netlib.org/lapack/explore-html/d9/df5/group__double_s_yauxiliary_gaa6de4c854b216a9afb2f6d00eaaa3b45.html#gaa6de4c854b216a9afb2f6d00eaaa3b45) requires `iwork` of length `m+n+2` 
- Dtgsy2 is called from Dtgex2 with arguments `m=n1`, `n=n2`
- [Dtgex2](https://www.netlib.org/lapack/explore-html/de/d39/group__double_g_eauxiliary_gaa3c93490c68259c80285d72cb61cbd99.html#gaa3c93490c68259c80285d72cb61cbd99) requires both n1 and n2 to be either 0, 1, or 2.
- Dtgex2 declares iwork with length `ldst=4`, so that constrains calling Dtgsy2 with `m+n+2<=4`
- [Dtgexc](https://www.netlib.org/lapack/explore-html/dd/d9a/group__double_g_ecomputational_ga2510d68d70194719d570cbcfe24b3e74.html#ga2510d68d70194719d570cbcfe24b3e74) has a branch (immediately below goto label 20) in which Dtgex2 is called with n1=2 and n2=1
  - This propagates to Dtgsy2 with m=2, n=1, which then fails the iwork length requirement by 1.
  
  You will notice I added 2 to iwork's length since it is my understanding that both `n1` and `n2` can both be 2, which would mean a required iwork length of 6 in Dtgsy2.
  

**Checklist**

> - [x] The documentation has been updated.

No need?

- [x] If the PR solves a specific issue, it is set to be closed on merge.

DNE.