### PR TITLE
Fix build for CMake >= 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 
 project(LAPACK Fortran C)
 

--- a/INSTALL/CMakeLists.txt
+++ b/INSTALL/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(TIMING Fortran)
 add_executable(secondtst_NONE second_NONE.f secondtst.f)
 add_executable(secondtst_EXT_ETIME second_EXT_ETIME.f secondtst.f)

--- a/LAPACKE/mangling/CMakeLists.txt
+++ b/LAPACKE/mangling/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(MANGLING C Fortran)
 
 add_executable(xintface Fintface.f Cintface.c)

--- a/lapack_build.cmake
+++ b/lapack_build.cmake
@@ -4,7 +4,7 @@
 ## HINTS: ctest -Ddashboard_model=Nightly      -S $(pwd)/lapack/lapack_build.cmake
 ##
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 ###################################################################
 # The values in this section must always be provided
 ###################################################################
@@ -249,5 +249,3 @@ ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE res)
 message("  Submit")
 ctest_submit(RETURN_VALUE res)
 message("  All done")
-
-


### PR DESCRIPTION
CMake >= 3.27 [warns](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings) if `cmake_minimum_required(VERSION )` is less than 3.5. 

CMake for Lapack was already using CMake 3.6 features.
