### PR TITLE
Adding in quotes in cmake for Intel ifx and linux build 

### DIFF
--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -20,7 +20,7 @@ if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
     if ( WIN32 )
         set(FOPT_ILP64 /integer-size:64)
     else ()
-        set(FOPT_ILP64 -integer-size 64)
+        set(FOPT_ILP64 "-integer-size 64")
     endif()
 elseif( (CMAKE_Fortran_COMPILER_ID STREQUAL "VisualAge" ) OR  # CMake 2.6
         (CMAKE_Fortran_COMPILER_ID STREQUAL "XL" ) )          # CMake 2.8


### PR DESCRIPTION
This is following up on https://github.com/Reference-LAPACK/lapack/issues/915. 

This adds in quotes around a flag passed to the Intel compiler. Otherwise we see a cmake error, as shown in https://github.com/Reference-LAPACK/lapack/issues/915.

**Description**

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.