### PR TITLE
[WIP, Testing] Update cmake in Appveyor CI for llvm17 with flang-new

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - conda info --envs
   - conda env list
   - conda list
-  - conda install -c conda-forge --yes --quiet flang jom cmake
+  - conda install -c conda-forge --yes --quiet flang=11.0.1 jom cmake
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
@@ -30,7 +30,7 @@ install:
 before_build:
   - ps: if (-Not (Test-Path .\build)) { mkdir build }
   - cd build
-  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang-new -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
 
 build_script:
   - cmake --build .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,7 @@ install:
 #  - conda config --set auto_update_conda false
   - conda info --envs
   - conda env list
+  - conda list
   - conda install -c conda-forge --yes --quiet flang jom cmake
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,8 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda update -y cmake
-  - conda install -c conda-forge --yes --quiet flang jom
+  - conda install -c conda-forge --yes --quiet flang jom cmake
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
+  - conda update -y cmake
   - conda install -c conda-forge --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
@@ -27,7 +28,7 @@ install:
 before_build:
   - ps: if (-Not (Test-Path .\build)) { mkdir build }
   - cd build
-  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang-new -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
 
 build_script:
   - cmake --build .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,8 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
+  - conda info --envs
+  - conda env list
   - conda install -c conda-forge --yes --quiet flang jom cmake
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"


### PR DESCRIPTION
**Description**
conda's update of llvm to 17.0.x includes the rewritten llvmflang or "flang-new". this needs at least cmake 3.24.x for detection as some of its properties are now more like gfortran 
**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.