### PR TITLE
Clarify documentation of singularity/rank-deficiency checks

### DIFF
--- a/SRC/cgels.f
+++ b/SRC/cgels.f
@@ -37,7 +37,17 @@
 *>
 *> CGELS solves overdetermined or underdetermined complex linear systems
 *> involving an M-by-N matrix A, or its conjugate-transpose, using a QR
-*> or LQ factorization of A.  It is assumed that A has full rank.
+*> or LQ factorization of A.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -161,7 +171,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/cgelst.f
+++ b/SRC/cgelst.f
@@ -38,7 +38,16 @@
 *> CGELST solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, or its conjugate-transpose, using a QR
 *> or LQ factorization of A with compact WY representation of Q.
-*> It is assumed that A has full rank.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -163,7 +172,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/cgetsls.f
+++ b/SRC/cgetsls.f
@@ -22,8 +22,17 @@
 *>
 *> CGETSLS solves overdetermined or underdetermined complex linear systems
 *> involving an M-by-N matrix A, using a tall skinny QR or short wide LQ
-*> factorization of A.  It is assumed that A has full rank.
+*> factorization of A.
 *>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *>
 *> The following options are provided:
@@ -141,7 +150,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/cggglm.f
+++ b/SRC/cggglm.f
@@ -61,6 +61,16 @@
 *>                  x
 *>
 *> where inv(B) denotes the inverse of B.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The CTRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized QR
+*> factorization of the pair (A, B) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -159,12 +169,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with A in the
-*>                generalized QR factorization of the pair (A, B) is
+*>                generalized QR factorization of the pair (A, B) is exactly
 *>                singular, so that rank(A) < M; the least squares
 *>                solution could not be computed.
 *>          = 2:  the bottom (N-M) by (N-M) part of the upper trapezoidal
 *>                factor T associated with B in the generalized QR
-*>                factorization of the pair (A, B) is singular, so that
+*>                factorization of the pair (A, B) is exactly singular, so that
 *>                rank( A B ) < N; the least squares solution could not
 *>                be computed.
 *> \endverbatim

--- a/SRC/cgglse.f
+++ b/SRC/cgglse.f
@@ -52,6 +52,16 @@
 *> matrices (B, A) given by
 *>
 *>    B = (0 R)*Q,   A = Z*T*Q.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The CTRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized RQ
+*> factorization of the pair (B, A) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -153,12 +163,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with B in the
-*>                generalized RQ factorization of the pair (B, A) is
+*>                generalized RQ factorization of the pair (B, A) is exactly
 *>                singular, so that rank(B) < P; the least squares
 *>                solution could not be computed.
 *>          = 2:  the (N-P) by (N-P) part of the upper trapezoidal factor
 *>                T associated with A in the generalized RQ factorization
-*>                of the pair (B, A) is singular, so that
+*>                of the pair (B, A) is exactly singular, so that
 *>                rank( (A) ) < N; the least squares solution could not
 *>                    ( (B) )
 *>                be computed.

--- a/SRC/ctbtrs.f
+++ b/SRC/ctbtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B,  A**T * X = B,  or  A**H * X = B,
 *>
-*> where A is a triangular band matrix of order N, and B is an
-*> N-by-NRHS matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular band matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/ctbtrs.f
+++ b/SRC/ctbtrs.f
@@ -131,7 +131,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/ctptrs.f
+++ b/SRC/ctptrs.f
@@ -38,9 +38,14 @@
 *>
 *>    A * X = B,  A**T * X = B,  or  A**H * X = B,
 *>
-*> where A is a triangular matrix of order N stored in packed format,
-*> and B is an N-by-NRHS matrix.  A check is made to verify that A is
-*> nonsingular.
+*> where A is a triangular matrix of order N stored in packed format, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:
@@ -110,7 +115,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/ctrtrs.f
+++ b/SRC/ctrtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B,  A**T * X = B,  or  A**H * X = B,
 *>
-*> where A is a triangular matrix of order N, and B is an N-by-NRHS
-*> matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/ctrtrs.f
+++ b/SRC/ctrtrs.f
@@ -125,7 +125,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0: if INFO = -i, the i-th argument had an illegal value
-*>          > 0: if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>               indicating that the matrix is singular and the solutions
 *>               X have not been computed.
 *> \endverbatim

--- a/SRC/dgels.f
+++ b/SRC/dgels.f
@@ -37,7 +37,17 @@
 *>
 *> DGELS solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, or its transpose, using a QR or LQ
-*> factorization of A.  It is assumed that A has full rank.
+*> factorization of A.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -162,7 +172,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/dgelst.f
+++ b/SRC/dgelst.f
@@ -38,7 +38,16 @@
 *> DGELST solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, or its transpose, using a QR or LQ
 *> factorization of A with compact WY representation of Q.
-*> It is assumed that A has full rank.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -163,7 +172,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/dgetsls.f
+++ b/SRC/dgetsls.f
@@ -22,8 +22,17 @@
 *>
 *> DGETSLS solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, using a tall skinny QR or short wide LQ
-*> factorization of A.  It is assumed that A has full rank.
+*> factorization of A.
 *>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *>
 *> The following options are provided:
@@ -141,7 +150,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/dggglm.f
+++ b/SRC/dggglm.f
@@ -61,6 +61,16 @@
 *>                  x
 *>
 *> where inv(B) denotes the inverse of B.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The DTRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized QR
+*> factorization of the pair (A, B) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -159,12 +169,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with A in the
-*>                generalized QR factorization of the pair (A, B) is
+*>                generalized QR factorization of the pair (A, B) is exactly
 *>                singular, so that rank(A) < M; the least squares
 *>                solution could not be computed.
 *>          = 2:  the bottom (N-M) by (N-M) part of the upper trapezoidal
 *>                factor T associated with B in the generalized QR
-*>                factorization of the pair (A, B) is singular, so that
+*>                factorization of the pair (A, B) is exactly singular, so that
 *>                rank( A B ) < N; the least squares solution could not
 *>                be computed.
 *> \endverbatim

--- a/SRC/dgglse.f
+++ b/SRC/dgglse.f
@@ -52,6 +52,16 @@
 *> matrices (B, A) given by
 *>
 *>    B = (0 R)*Q,   A = Z*T*Q.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The DTRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized RQ
+*> factorization of the pair (B, A) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -153,12 +163,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with B in the
-*>                generalized RQ factorization of the pair (B, A) is
+*>                generalized RQ factorization of the pair (B, A) is exactly
 *>                singular, so that rank(B) < P; the least squares
 *>                solution could not be computed.
 *>          = 2:  the (N-P) by (N-P) part of the upper trapezoidal factor
 *>                T associated with A in the generalized RQ factorization
-*>                of the pair (B, A) is singular, so that
+*>                of the pair (B, A) is exactly singular, so that
 *>                rank( (A) ) < N; the least squares solution could not
 *>                    ( (B) )
 *>                be computed.

--- a/SRC/dtbtrs.f
+++ b/SRC/dtbtrs.f
@@ -131,7 +131,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/dtbtrs.f
+++ b/SRC/dtbtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B  or  A**T * X = B,
 *>
-*> where A is a triangular band matrix of order N, and B is an
-*> N-by NRHS matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular band matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/dtptrs.f
+++ b/SRC/dtptrs.f
@@ -38,9 +38,14 @@
 *>
 *>    A * X = B  or  A**T * X = B,
 *>
-*> where A is a triangular matrix of order N stored in packed format,
-*> and B is an N-by-NRHS matrix.  A check is made to verify that A is
-*> nonsingular.
+*> where A is a triangular matrix of order N stored in packed format, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:
@@ -110,7 +115,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/dtrtrs.f
+++ b/SRC/dtrtrs.f
@@ -125,7 +125,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0: if INFO = -i, the i-th argument had an illegal value
-*>          > 0: if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>               indicating that the matrix is singular and the solutions
 *>               X have not been computed.
 *> \endverbatim

--- a/SRC/dtrtrs.f
+++ b/SRC/dtrtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B  or  A**T * X = B,
 *>
-*> where A is a triangular matrix of order N, and B is an N-by-NRHS
-*> matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/sgels.f
+++ b/SRC/sgels.f
@@ -37,7 +37,17 @@
 *>
 *> SGELS solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, or its transpose, using a QR or LQ
-*> factorization of A.  It is assumed that A has full rank.
+*> factorization of A.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -162,7 +172,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/sgelst.f
+++ b/SRC/sgelst.f
@@ -38,7 +38,16 @@
 *> SGELST solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, or its transpose, using a QR or LQ
 *> factorization of A with compact WY representation of Q.
-*> It is assumed that A has full rank.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -163,7 +172,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/sgetsls.f
+++ b/SRC/sgetsls.f
@@ -22,8 +22,17 @@
 *>
 *> SGETSLS solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, using a tall skinny QR or short wide LQ
-*> factorization of A.  It is assumed that A has full rank.
+*> factorization of A.
 *>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *>
 *> The following options are provided:
@@ -141,7 +150,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/sggglm.f
+++ b/SRC/sggglm.f
@@ -61,6 +61,16 @@
 *>                  x
 *>
 *> where inv(B) denotes the inverse of B.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The STRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized QR
+*> factorization of the pair (A, B) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -159,12 +169,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with A in the
-*>                generalized QR factorization of the pair (A, B) is
+*>                generalized QR factorization of the pair (A, B) is exactly
 *>                singular, so that rank(A) < M; the least squares
 *>                solution could not be computed.
 *>          = 2:  the bottom (N-M) by (N-M) part of the upper trapezoidal
 *>                factor T associated with B in the generalized QR
-*>                factorization of the pair (A, B) is singular, so that
+*>                factorization of the pair (A, B) is exactly singular, so that
 *>                rank( A B ) < N; the least squares solution could not
 *>                be computed.
 *> \endverbatim

--- a/SRC/sgglse.f
+++ b/SRC/sgglse.f
@@ -52,6 +52,16 @@
 *> matrices (B, A) given by
 *>
 *>    B = (0 R)*Q,   A = Z*T*Q.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The STRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized RQ
+*> factorization of the pair (B, A) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -153,12 +163,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with B in the
-*>                generalized RQ factorization of the pair (B, A) is
+*>                generalized RQ factorization of the pair (B, A) is exactly
 *>                singular, so that rank(B) < P; the least squares
 *>                solution could not be computed.
 *>          = 2:  the (N-P) by (N-P) part of the upper trapezoidal factor
 *>                T associated with A in the generalized RQ factorization
-*>                of the pair (B, A) is singular, so that
+*>                of the pair (B, A) is exactly singular, so that
 *>                rank( (A) ) < N; the least squares solution could not
 *>                    ( (B) )
 *>                be computed.

--- a/SRC/stbtrs.f
+++ b/SRC/stbtrs.f
@@ -131,7 +131,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/stbtrs.f
+++ b/SRC/stbtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B  or  A**T * X = B,
 *>
-*> where A is a triangular band matrix of order N, and B is an
-*> N-by NRHS matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular band matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/stptrs.f
+++ b/SRC/stptrs.f
@@ -38,9 +38,14 @@
 *>
 *>    A * X = B  or  A**T * X = B,
 *>
-*> where A is a triangular matrix of order N stored in packed format,
-*> and B is an N-by-NRHS matrix.  A check is made to verify that A is
-*> nonsingular.
+*> where A is a triangular matrix of order N stored in packed format, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:
@@ -110,7 +115,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/strtrs.f
+++ b/SRC/strtrs.f
@@ -125,7 +125,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0: if INFO = -i, the i-th argument had an illegal value
-*>          > 0: if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>               indicating that the matrix is singular and the solutions
 *>               X have not been computed.
 *> \endverbatim

--- a/SRC/strtrs.f
+++ b/SRC/strtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B  or  A**T * X = B,
 *>
-*> where A is a triangular matrix of order N, and B is an N-by-NRHS
-*> matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/zgels.f
+++ b/SRC/zgels.f
@@ -37,7 +37,17 @@
 *>
 *> ZGELS solves overdetermined or underdetermined complex linear systems
 *> involving an M-by-N matrix A, or its conjugate-transpose, using a QR
-*> or LQ factorization of A.  It is assumed that A has full rank.
+*> or LQ factorization of A.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -161,7 +171,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/zgelst.f
+++ b/SRC/zgelst.f
@@ -38,7 +38,16 @@
 *> ZGELST solves overdetermined or underdetermined real linear systems
 *> involving an M-by-N matrix A, or its conjugate-transpose, using a QR
 *> or LQ factorization of A with compact WY representation of Q.
-*> It is assumed that A has full rank.
+*>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *> The following options are provided:
 *>
@@ -163,7 +172,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/zgetsls.f
+++ b/SRC/zgetsls.f
@@ -22,8 +22,17 @@
 *>
 *> ZGETSLS solves overdetermined or underdetermined complex linear systems
 *> involving an M-by-N matrix A, using a tall skinny QR or short wide LQ
-*> factorization of A.  It is assumed that A has full rank.
+*> factorization of A.
 *>
+*> It is assumed that A has full rank, and only a rudimentary protection
+*> against rank-deficient matrices is provided. This subroutine only detects
+*> exact rank-deficiency, where a diagonal element of the triangular factor
+*> of A is exactly zero.
+*>
+*> It is conceivable for one (or more) of the diagonal elements of the triangular
+*> factor of A to be subnormally tiny numbers without this subroutine signalling
+*> an error. The solutions computed for such almost-rank-deficient matrices may
+*> be less accurate due to a loss of numerical precision.
 *>
 *>
 *> The following options are provided:
@@ -141,7 +150,7 @@
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
 *>          > 0:  if INFO =  i, the i-th diagonal element of the
-*>                triangular factor of A is zero, so that A does not have
+*>                triangular factor of A is exactly zero, so that A does not have
 *>                full rank; the least squares solution could not be
 *>                computed.
 *> \endverbatim

--- a/SRC/zggglm.f
+++ b/SRC/zggglm.f
@@ -61,6 +61,16 @@
 *>                  x
 *>
 *> where inv(B) denotes the inverse of B.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The ZTRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized QR
+*> factorization of the pair (A, B) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -159,12 +169,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with A in the
-*>                generalized QR factorization of the pair (A, B) is
+*>                generalized QR factorization of the pair (A, B) is exactly
 *>                singular, so that rank(A) < M; the least squares
 *>                solution could not be computed.
 *>          = 2:  the bottom (N-M) by (N-M) part of the upper trapezoidal
 *>                factor T associated with B in the generalized QR
-*>                factorization of the pair (A, B) is singular, so that
+*>                factorization of the pair (A, B) is exactly singular, so that
 *>                rank( A B ) < N; the least squares solution could not
 *>                be computed.
 *> \endverbatim

--- a/SRC/zgglse.f
+++ b/SRC/zgglse.f
@@ -52,6 +52,16 @@
 *> matrices (B, A) given by
 *>
 *>    B = (0 R)*Q,   A = Z*T*Q.
+*>
+*> Callers of this subroutine should note that the singularity/rank-deficiency checks
+*> implemented in this subroutine are rudimentary. The ZTRTRS subroutine called by this
+*> subroutine only signals a failure due to singularity if the problem is exactly singular.
+*>
+*> It is conceivable for one (or more) of the factors involved in the generalized RQ
+*> factorization of the pair (B, A) to be subnormally close to singularity without this
+*> subroutine signalling an error. The solutions computed for such almost-rank-deficient
+*> problems may be less accurate due to a loss of numerical precision.
+*> 
 *> \endverbatim
 *
 *  Arguments:
@@ -153,12 +163,12 @@
 *>          = 0:  successful exit.
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value.
 *>          = 1:  the upper triangular factor R associated with B in the
-*>                generalized RQ factorization of the pair (B, A) is
+*>                generalized RQ factorization of the pair (B, A) is exactly
 *>                singular, so that rank(B) < P; the least squares
 *>                solution could not be computed.
 *>          = 2:  the (N-P) by (N-P) part of the upper trapezoidal factor
 *>                T associated with A in the generalized RQ factorization
-*>                of the pair (B, A) is singular, so that
+*>                of the pair (B, A) is exactly singular, so that
 *>                rank( (A) ) < N; the least squares solution could not
 *>                    ( (B) )
 *>                be computed.

--- a/SRC/ztbtrs.f
+++ b/SRC/ztbtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B,  A**T * X = B,  or  A**H * X = B,
 *>
-*> where A is a triangular band matrix of order N, and B is an
-*> N-by-NRHS matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular band matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/ztbtrs.f
+++ b/SRC/ztbtrs.f
@@ -131,7 +131,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/ztptrs.f
+++ b/SRC/ztptrs.f
@@ -38,9 +38,14 @@
 *>
 *>    A * X = B,  A**T * X = B,  or  A**H * X = B,
 *>
-*> where A is a triangular matrix of order N stored in packed format,
-*> and B is an N-by-NRHS matrix.  A check is made to verify that A is
-*> nonsingular.
+*> where A is a triangular matrix of order N stored in packed format, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:
@@ -110,7 +115,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          > 0:  if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>                indicating that the matrix is singular and the
 *>                solutions X have not been computed.
 *> \endverbatim

--- a/SRC/ztrtrs.f
+++ b/SRC/ztrtrs.f
@@ -39,8 +39,14 @@
 *>
 *>    A * X = B,  A**T * X = B,  or  A**H * X = B,
 *>
-*> where A is a triangular matrix of order N, and B is an N-by-NRHS
-*> matrix.  A check is made to verify that A is nonsingular.
+*> where A is a triangular matrix of order N, and B is an N-by-NRHS matrix.
+*>
+*> This subroutine verifies that A is nonsingular, but callers should note that only exact
+*> singularity is detected. It is conceivable for one or more diagonal elements of A to be
+*> subnormally tiny numbers without this subroutine signalling an error.
+*>
+*> If a possible loss of numerical precision due to near-singular matrices is a concern, the
+*> caller should verify that A is nonsingular within some tolerance before calling this subroutine.
 *> \endverbatim
 *
 *  Arguments:

--- a/SRC/ztrtrs.f
+++ b/SRC/ztrtrs.f
@@ -125,7 +125,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0: if INFO = -i, the i-th argument had an illegal value
-*>          > 0: if INFO = i, the i-th diagonal element of A is zero,
+*>          > 0:  if INFO = i, the i-th diagonal element of A is exactly zero,
 *>               indicating that the matrix is singular and the solutions
 *>               X have not been computed.
 *> \endverbatim


### PR DESCRIPTION
### Description
This PR fixes and closes #918, by changing the relevant parts of the docs.

### *TRTRS, *TBTRS and *TPTRS
- [X] In *TRTRS, *TBTRS and *TPTRS, replace `A check is made to verify that A is nonsingular.` with the following:
```
This subroutine verifies that A is nonsingular, but callers should note that only exact
singularity is detected. It is conceivable for one or more diagonal elements of A to be
subnormally tiny numbers without this subroutine signalling an error.

If a possible loss of numerical precision due to near-singular matrices is a concern, the
caller should verify that A is nonsingular within some tolerance before calling this subroutine.
```
- [X] In *TRTRS, *TBTRS and *TPTRS, replace `> 0:  if INFO = i, the i-th diagonal element of A is zero,` with `> 0:  if INFO = i, the i-th diagonal element of A is exactly zero,`

### Callers of *TRTRS: *GELS, *GELST, *GETSLS, *GGLSE, *GGGLM 
- [X] In *GELS, *GELST, *GETSLS replace `It is assumed that A has full rank.` with the following:
```
It is assumed that A has full rank, and only a rudimentary protection
against rank-deficient matrices is provided. This subroutine only detects
exact rank-deficiency, where a diagonal element of the triangular factor
of A is exactly zero.

It is conceivable for one (or more) of the diagonal elements of the triangular
factor of A to be subnormally tiny numbers without this subroutine signalling
an error. The solutions computed for such almost-rank-deficient matrices may
be less accurate due to a loss of numerical precision.
```
- [X] In *GELS, *GELST, *GETSLS replace `> 0:  if INFO =  i, the i-th diagonal element of the triangular factor of A is zero` with `> 0:  if INFO =  i, the i-th diagonal element of the triangular factor of A is exactly zero`
- [x] In *GGLSE, add the following:
```
Callers of this subroutine should note that the singularity/rank-deficiency checks
implemented in this subroutine are rudimentary. The <S,D,C,Z>TRTRS subroutine called by this
subroutine only signals a failure due to singularity if the problem is exactly singular.

It is conceivable for one (or more) of the factors involved in the generalized RQ
factorization of the pair (B, A) to be subnormally close to singularity without this
subroutine signalling an error. The solutions computed for such almost-rank-deficient
problems may be less accurate due to a loss of numerical precision.
```
- [x] In *GGLSE, replace `RQ factorization of the pair (B, A) is singular` with `RQ factorization of the pair (B, A) is exactly singular`
- [x] In *GGGLM, add the following:
```
Callers of this subroutine should note that the singularity/rank-deficiency checks
implemented in this subroutine are rudimentary. The <S,D,C,Z>TRTRS subroutine called by this
subroutine only signals a failure due to singularity if the problem is exactly singular.

It is conceivable for one (or more) of the factors involved in the generalized QR
factorization of the pair (A, B) to be subnormally close to singularity without this
subroutine signalling an error. The solutions computed for such almost-rank-deficient
problems may be less accurate due to a loss of numerical precision.
```
- [x] In *GGGLM, replace `QR factorization of the pair (A, B) is singular` with `QR factorization of the pair (A, B) is exactly singular`

### Callers of *TBTRS: 
- [x] Apart from the testing subroutines, there appear to be no internal callers of *TBTRS in LAPACK.

### Callers of *TPTRS: 
- [x] Apart from the testing subroutines, there appear to be no internal callers of *TPTRS in LAPACK.

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.