### PR TITLE
GECON returns 1 if RCOND is NaN

### DIFF
--- a/SRC/cgecon.f
+++ b/SRC/cgecon.f
@@ -106,7 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          =-5:  if ANORM is NAN or negative.
+*>          = 1:  RCOND = NaN.
 *> \endverbatim
 *
 *  Authors:
@@ -183,7 +183,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO .OR. SISNAN( ANORM ) ) THEN
+      ELSE IF( ANORM.LT.ZERO ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN
@@ -198,6 +198,10 @@
          RCOND = ONE
          RETURN
       ELSE IF( ANORM.EQ.ZERO ) THEN
+         RETURN
+      ELSE IF( SISNAN( ANORM ) ) THEN
+         RCOND = ANORM
+         INFO = 1
          RETURN
       END IF
 *
@@ -258,6 +262,11 @@
 *
       IF( AINVNM.NE.ZERO )
      $   RCOND = ( ONE / AINVNM ) / ANORM
+*
+*     Check for NaNs
+*
+      IF( SISNAN( RCOND ) )
+     $   INFO = 1
 *
    20 CONTINUE
       RETURN

--- a/SRC/cgecon.f
+++ b/SRC/cgecon.f
@@ -105,8 +105,15 @@
 *> \verbatim
 *>          INFO is INTEGER
 *>          = 0:  successful exit
-*>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          = 1:  RCOND = NaN.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>                NaNs are illegal values for ANORM, and they propagate to
+*>                the output parameter RCOND.
+*>                Infinity is illegal for ANORM, and it propagates to the output
+*>                parameter RCOND as 0.
+*>          = 1:  if RCOND = NaN, or
+*>                   RCOND = Inf, or
+*>                   the computed norm of the inverse of A is 0.
+*>                In the latter, RCOND = 0 is returned.
 *> \endverbatim
 *
 *  Authors:
@@ -147,7 +154,7 @@
       LOGICAL            ONENRM
       CHARACTER          NORMIN
       INTEGER            IX, KASE, KASE1
-      REAL               AINVNM, SCALE, SL, SMLNUM, SU
+      REAL               AINVNM, SCALE, SL, SMLNUM, SU, HUGEVAL
       COMPLEX            ZDUM
 *     ..
 *     .. Local Arrays ..
@@ -172,6 +179,8 @@
       CABS1( ZDUM ) = ABS( REAL( ZDUM ) ) + ABS( AIMAG( ZDUM ) )
 *     ..
 *     .. Executable Statements ..
+*
+      HUGEVAL = SLAMCH( 'Overflow' )
 *
 *     Test the input parameters.
 *
@@ -201,7 +210,10 @@
          RETURN
       ELSE IF( SISNAN( ANORM ) ) THEN
          RCOND = ANORM
-         INFO = 1
+         INFO = -5
+         RETURN
+      ELSE IF( ANORM.GT.HUGEVAL ) THEN
+         INFO = -5
          RETURN
       END IF
 *
@@ -260,12 +272,16 @@
 *
 *     Compute the estimate of the reciprocal condition number.
 *
-      IF( AINVNM.NE.ZERO )
-     $   RCOND = ( ONE / AINVNM ) / ANORM
+      IF( AINVNM.NE.ZERO ) THEN
+         RCOND = ( ONE / AINVNM ) / ANORM
+      ELSE
+         INFO = 1
+         RETURN
+      END IF
 *
-*     Check for NaNs
+*     Check for NaNs and Infs
 *
-      IF( SISNAN( RCOND ) )
+      IF( SISNAN( RCOND ) .OR. RCOND.GT.HUGEVAL )
      $   INFO = 1
 *
    20 CONTINUE

--- a/SRC/dgecon.f
+++ b/SRC/dgecon.f
@@ -105,8 +105,15 @@
 *> \verbatim
 *>          INFO is INTEGER
 *>          = 0:  successful exit
-*>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          = 1:  RCOND = NaN.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>                NaNs are illegal values for ANORM, and they propagate to
+*>                the output parameter RCOND.
+*>                Infinity is illegal for ANORM, and it propagates to the output
+*>                parameter RCOND as 0.
+*>          = 1:  if RCOND = NaN, or
+*>                   RCOND = Inf, or
+*>                   the computed norm of the inverse of A is 0.
+*>                In the latter, RCOND = 0 is returned.
 *> \endverbatim
 *
 *  Authors:
@@ -147,7 +154,7 @@
       LOGICAL            ONENRM
       CHARACTER          NORMIN
       INTEGER            IX, KASE, KASE1
-      DOUBLE PRECISION   AINVNM, SCALE, SL, SMLNUM, SU
+      DOUBLE PRECISION   AINVNM, SCALE, SL, SMLNUM, SU, HUGEVAL
 *     ..
 *     .. Local Arrays ..
       INTEGER            ISAVE( 3 )
@@ -165,6 +172,8 @@
       INTRINSIC          ABS, MAX
 *     ..
 *     .. Executable Statements ..
+*
+      HUGEVAL = DLAMCH( 'Overflow' )
 *
 *     Test the input parameters.
 *
@@ -194,7 +203,10 @@
          RETURN
       ELSE IF( DISNAN( ANORM ) ) THEN
          RCOND = ANORM
-         INFO = 1
+         INFO = -5
+         RETURN
+      ELSE IF( ANORM.GT.HUGEVAL ) THEN
+         INFO = -5
          RETURN
       END IF
 *
@@ -252,12 +264,16 @@
 *
 *     Compute the estimate of the reciprocal condition number.
 *
-      IF( AINVNM.NE.ZERO )
-     $   RCOND = ( ONE / AINVNM ) / ANORM
+      IF( AINVNM.NE.ZERO ) THEN
+         RCOND = ( ONE / AINVNM ) / ANORM
+      ELSE
+         INFO = 1
+         RETURN
+      END IF
 *
-*     Check for NaNs
+*     Check for NaNs and Infs
 *
-      IF( DISNAN( RCOND ) )
+      IF( DISNAN( RCOND ) .OR. RCOND.GT.HUGEVAL )
      $   INFO = 1
 *
    20 CONTINUE

--- a/SRC/dgecon.f
+++ b/SRC/dgecon.f
@@ -106,7 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          =-5:  if ANORM is NAN or negative.
+*>          = 1:  RCOND = NaN.
 *> \endverbatim
 *
 *  Authors:
@@ -176,7 +176,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO .OR. DISNAN( ANORM ) ) THEN
+      ELSE IF( ANORM.LT.ZERO ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN
@@ -191,6 +191,10 @@
          RCOND = ONE
          RETURN
       ELSE IF( ANORM.EQ.ZERO ) THEN
+         RETURN
+      ELSE IF( DISNAN( ANORM ) ) THEN
+         RCOND = ANORM
+         INFO = 1
          RETURN
       END IF
 *
@@ -250,6 +254,11 @@
 *
       IF( AINVNM.NE.ZERO )
      $   RCOND = ( ONE / AINVNM ) / ANORM
+*
+*     Check for NaNs
+*
+      IF( DISNAN( RCOND ) )
+     $   INFO = 1
 *
    20 CONTINUE
       RETURN

--- a/SRC/sgecon.f
+++ b/SRC/sgecon.f
@@ -106,7 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          =-5:  if ANORM is NAN or negative.
+*>          = 1:  RCOND = NaN.
 *> \endverbatim
 *
 *  Authors:
@@ -176,7 +176,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO .OR. SISNAN( ANORM ) ) THEN
+      ELSE IF( ANORM.LT.ZERO ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN
@@ -191,6 +191,10 @@
          RCOND = ONE
          RETURN
       ELSE IF( ANORM.EQ.ZERO ) THEN
+         RETURN
+      ELSE IF( SISNAN( ANORM ) ) THEN
+         RCOND = ANORM
+         INFO = 1
          RETURN
       END IF
 *
@@ -250,6 +254,11 @@
 *
       IF( AINVNM.NE.ZERO )
      $   RCOND = ( ONE / AINVNM ) / ANORM
+*
+*     Check for NaNs
+*
+      IF( SISNAN( RCOND ) )
+     $   INFO = 1
 *
    20 CONTINUE
       RETURN

--- a/SRC/zgecon.f
+++ b/SRC/zgecon.f
@@ -106,7 +106,7 @@
 *>          INFO is INTEGER
 *>          = 0:  successful exit
 *>          < 0:  if INFO = -i, the i-th argument had an illegal value
-*>          =-5:  if ANORM is NAN or negative.
+*>          = 1:  RCOND = NaN.
 *> \endverbatim
 *
 *  Authors:
@@ -183,7 +183,7 @@
          INFO = -2
       ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
          INFO = -4
-      ELSE IF( ANORM.LT.ZERO .OR. DISNAN( ANORM ) ) THEN
+      ELSE IF( ANORM.LT.ZERO ) THEN
          INFO = -5
       END IF
       IF( INFO.NE.0 ) THEN
@@ -198,6 +198,10 @@
          RCOND = ONE
          RETURN
       ELSE IF( ANORM.EQ.ZERO ) THEN
+         RETURN
+      ELSE IF( DISNAN( ANORM ) ) THEN
+         RCOND = ANORM
+         INFO = 1
          RETURN
       END IF
 *
@@ -258,6 +262,11 @@
 *
       IF( AINVNM.NE.ZERO )
      $   RCOND = ( ONE / AINVNM ) / ANORM
+*
+*     Check for NaNs
+*
+      IF( DISNAN( RCOND ) )
+     $   INFO = 1
 *
    20 CONTINUE
       RETURN


### PR DESCRIPTION
This is aligned to the behavior in the routines that compute norms, i.e., to propagate NaNs instead of calling `XERBLA`.

This PR also solves the issue about `INFO` returning zero when `RCOND=NAN`. This PR makes GECON return 1 if `RCOND=NAN`. The return `INFO=1` is aligned to what we propose in the exception handling for LAPACK at https://arxiv.org/pdf/2207.09281.pdf

Complete behavior for `INFO`:
```Fortran
*> \param[out] INFO
*> \verbatim
*>          INFO is INTEGER
*>          = 0:  successful exit
*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
*>                NaNs are illegal values for ANORM, and they propagate to
*>                the output parameter RCOND.
*>                Infinity values are valid inputs for ANORM, because the values
*>                in A can still be finite and, thus, norm of the inverse can be
*>                computed as a strictly positive number.
*>          = 1:  if RCOND = NaN or RCOND = Inf.
*> \endverbatim
```

Related to #763.