### PR TITLE
xORBDB6/xUNBDB6: fix a constant

### DIFF
--- a/SRC/cunbdb6.f
+++ b/SRC/cunbdb6.f
@@ -174,7 +174,7 @@
 *
 *     .. Parameters ..
       REAL               ALPHA, REALONE, REALZERO
-      PARAMETER          ( ALPHA = 0.01E0, REALONE = 1.0E0,
+      PARAMETER          ( ALPHA = 0.1E0, REALONE = 1.0E0,
      $                     REALZERO = 0.0E0 )
       COMPLEX            NEGONE, ONE, ZERO
       PARAMETER          ( NEGONE = (-1.0E0,0.0E0), ONE = (1.0E0,0.0E0),

--- a/SRC/dorbdb6.f
+++ b/SRC/dorbdb6.f
@@ -174,7 +174,7 @@
 *
 *     .. Parameters ..
       DOUBLE PRECISION   ALPHA, REALONE, REALZERO
-      PARAMETER          ( ALPHA = 0.01D0, REALONE = 1.0D0,
+      PARAMETER          ( ALPHA = 0.1D0, REALONE = 1.0D0,
      $                     REALZERO = 0.0D0 )
       DOUBLE PRECISION   NEGONE, ONE, ZERO
       PARAMETER          ( NEGONE = -1.0D0, ONE = 1.0D0, ZERO = 0.0D0 )

--- a/SRC/sorbdb6.f
+++ b/SRC/sorbdb6.f
@@ -174,7 +174,7 @@
 *
 *     .. Parameters ..
       REAL               ALPHA, REALONE, REALZERO
-      PARAMETER          ( ALPHA = 0.01E0, REALONE = 1.0E0,
+      PARAMETER          ( ALPHA = 0.1E0, REALONE = 1.0E0,
      $                     REALZERO = 0.0E0 )
       REAL               NEGONE, ONE, ZERO
       PARAMETER          ( NEGONE = -1.0E0, ONE = 1.0E0, ZERO = 0.0E0 )

--- a/SRC/zunbdb6.f
+++ b/SRC/zunbdb6.f
@@ -174,7 +174,7 @@
 *
 *     .. Parameters ..
       DOUBLE PRECISION   ALPHA, REALONE, REALZERO
-      PARAMETER          ( ALPHA = 0.01D0, REALONE = 1.0D0,
+      PARAMETER          ( ALPHA = 0.1D0, REALONE = 1.0D0,
      $                     REALZERO = 0.0D0 )
       COMPLEX*16         NEGONE, ONE, ZERO
       PARAMETER          ( NEGONE = (-1.0D0,0.0D0), ONE = (1.0D0,0.0D0),


### PR DESCRIPTION
**Description**

The commits listed below updated xORBDB6/xUNBDB6 with the aim of improving numerical stability by avoiding the use of squared values. With the exception of SORBDB6 these commits did not properly up a magic constant called `ALPHA` in the code. SORBDB6 was initially updated correctly before commit a015b21445ad6f43746ced7615438fe6c82a1b66 inserted an incorrect value again.

The incorrect magic constant may lead to early returns with only partially orthogonalized output vectors.

Relevant commits:
* 54b3964b0f6879b22d1587f821a50f512c2dd10c
* 6479e0f53116987e4898aa5dc98a842ffbeae38d
* 94419e8bfae9212e44ac5acf24031b83d84f9251

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.