### PR TITLE
Appveyor CI: Expressly request flang 11.0.1 from conda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang jom
+  - conda install -c conda-forge --yes --quiet flang=11.0.1 jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"


### PR DESCRIPTION
**Description**
fixes #919 by making sure that it is always the flang "classic" version 11 that gets installed, rather than the new 17.x
**Checklist**

- [ ] The documentation has been updated.
- [ x] If the PR solves a specific issue, it is set to be closed on merge.