### PR TITLE
Fixed `void main()` for AppleClang

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
 endif()
 
 include(CheckCSourceCompiles)
-check_c_source_compiles("void __attribute__((weak)) main() {};"
+check_c_source_compiles("int __attribute__((weak)) main() {};"
                         HAS_ATTRIBUTE_WEAK_SUPPORT)
 
 include_directories(include ${LAPACK_BINARY_DIR}/include)


### PR DESCRIPTION
**Description**

AppleClang doesn't allow `void main()` which caused the weak attribute support check to fail when using AppleClang.

**Checklist**

- [n/a] The documentation has been updated.
- [n/a] If the PR solves a specific issue, it is set to be closed on merge.