### PR TITLE
Update of the documentation to the pull request "Truncated QR with Pivoting #891" 

### DIFF
--- a/SRC/cgeqp3rk.f
+++ b/SRC/cgeqp3rk.f
@@ -55,7 +55,7 @@
 *> where:
 *>
 *>  P(K)            is an N-by-N permutation matrix;
-*>  Q(K)            is an M-by-M orthogonal matrix;
+*>  Q(K)            is an M-by-M unitary matrix;
 *>  R(K)_approx   = ( R11(K), R12(K) ) is a rank K approximation of the
 *>                    full rank factor R with K-by-K upper-triangular
 *>                    R11(K) and K-by-N rectangular R12(K). The diagonal
@@ -124,14 +124,14 @@
 *>     d) RELMAXC2NRMK equals MAXC2NRMK divided by MAXC2NRM, the maximum
 *>        column 2-norm of the original matrix A, which is equal
 *>        to abs(R(1,1)), ( if K = min(M,N), RELMAXC2NRMK = 0.0 );
-*>     e) Q(K)**H * B, the matrix B with the orthogonal
+*>     e) Q(K)**H * B, the matrix B with the unitary
 *>        transformation Q(K)**H applied on the left.
 *>
 *> The N-by-N permutation matrix P(K) is stored in a compact form in
 *> the integer array JPIV. For 1 <= j <= N, column j
 *> of the matrix A was interchanged with column JPIV(j).
 *>
-*> The M-by-M orthogonal matrix Q is represented as a product
+*> The M-by-M unitary matrix Q is represented as a product
 *> of elementary Householder reflectors
 *>
 *>     Q(K) = H(1) *  H(2) * . . . * H(K),
@@ -300,7 +300,7 @@
 *>
 *>              1. The elements below the diagonal of the subarray
 *>                 A(1:M,1:K) together with TAU(1:K) represent the
-*>                 orthogonal matrix Q(K) as a product of K Householder
+*>                 unitary matrix Q(K) as a product of K Householder
 *>                 elementary reflectors.
 *>
 *>              2. The elements on and above the diagonal of

--- a/SRC/cgeqp3rk.f
+++ b/SRC/cgeqp3rk.f
@@ -579,8 +579,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  Computer Science Division, EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/cgeqp3rk.f
+++ b/SRC/cgeqp3rk.f
@@ -579,7 +579,7 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division, EECS Department,
+*>                  EECS Department,
 *>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim

--- a/SRC/claqp2rk.f
+++ b/SRC/claqp2rk.f
@@ -332,7 +332,7 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division, EECS Department,
+*>                  EECS Department,
 *>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim

--- a/SRC/claqp2rk.f
+++ b/SRC/claqp2rk.f
@@ -178,7 +178,7 @@
 *>          On exit:
 *>          1. The elements in block A(IOFFSET+1:M,1:K) below
 *>             the diagonal together with the array TAU represent
-*>             the orthogonal matrix Q(K) as a product of elementary
+*>             the unitary matrix Q(K) as a product of elementary
 *>             reflectors.
 *>          2. The upper triangular block of the matrix A stored
 *>             in A(IOFFSET+1:M,1:K) is the triangular factor obtained.

--- a/SRC/claqp2rk.f
+++ b/SRC/claqp2rk.f
@@ -332,8 +332,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  Computer Science Division, EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/claqp3rk.f
+++ b/SRC/claqp3rk.f
@@ -383,8 +383,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  Computer Science Division, EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/claqp3rk.f
+++ b/SRC/claqp3rk.f
@@ -383,7 +383,7 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division, EECS Department,
+*>                  EECS Department,
 *>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim

--- a/SRC/claqp3rk.f
+++ b/SRC/claqp3rk.f
@@ -196,7 +196,7 @@
 *>          On exit:
 *>          1. The elements in block A(IOFFSET+1:M,1:KB) below
 *>             the diagonal together with the array TAU represent
-*>             the orthogonal matrix Q(KB) as a product of elementary
+*>             the unitary matrix Q(KB) as a product of elementary
 *>             reflectors.
 *>          2. The upper triangular block of the matrix A stored
 *>             in A(IOFFSET+1:M,1:KB) is the triangular factor obtained.

--- a/SRC/dgeqp3rk.f
+++ b/SRC/dgeqp3rk.f
@@ -573,8 +573,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/dlaqp2rk.f
+++ b/SRC/dlaqp2rk.f
@@ -331,8 +331,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/dlaqp3rk.f
+++ b/SRC/dlaqp3rk.f
@@ -389,8 +389,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/sgeqp3rk.f
+++ b/SRC/sgeqp3rk.f
@@ -573,8 +573,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/slaqp2rk.f
+++ b/SRC/slaqp2rk.f
@@ -331,8 +331,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/slaqp3rk.f
+++ b/SRC/slaqp3rk.f
@@ -389,8 +389,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/zgeqp3rk.f
+++ b/SRC/zgeqp3rk.f
@@ -55,7 +55,7 @@
 *> where:
 *>
 *>  P(K)            is an N-by-N permutation matrix;
-*>  Q(K)            is an M-by-M orthogonal matrix;
+*>  Q(K)            is an M-by-M unitary matrix;
 *>  R(K)_approx   = ( R11(K), R12(K) ) is a rank K approximation of the
 *>                    full rank factor R with K-by-K upper-triangular
 *>                    R11(K) and K-by-N rectangular R12(K). The diagonal
@@ -124,14 +124,14 @@
 *>     d) RELMAXC2NRMK equals MAXC2NRMK divided by MAXC2NRM, the maximum
 *>        column 2-norm of the original matrix A, which is equal
 *>        to abs(R(1,1)), ( if K = min(M,N), RELMAXC2NRMK = 0.0 );
-*>     e) Q(K)**H * B, the matrix B with the orthogonal
+*>     e) Q(K)**H * B, the matrix B with the unitary
 *>        transformation Q(K)**H applied on the left.
 *>
 *> The N-by-N permutation matrix P(K) is stored in a compact form in
 *> the integer array JPIV. For 1 <= j <= N, column j
 *> of the matrix A was interchanged with column JPIV(j).
 *>
-*> The M-by-M orthogonal matrix Q is represented as a product
+*> The M-by-M unitary matrix Q is represented as a product
 *> of elementary Householder reflectors
 *>
 *>     Q(K) = H(1) *  H(2) * . . . * H(K),
@@ -300,7 +300,7 @@
 *>
 *>              1. The elements below the diagonal of the subarray
 *>                 A(1:M,1:K) together with TAU(1:K) represent the
-*>                 orthogonal matrix Q(K) as a product of K Householder
+*>                 unitary matrix Q(K) as a product of K Householder
 *>                 elementary reflectors.
 *>
 *>              2. The elements on and above the diagonal of

--- a/SRC/zgeqp3rk.f
+++ b/SRC/zgeqp3rk.f
@@ -579,8 +579,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  Computer Science Division, EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/zgeqp3rk.f
+++ b/SRC/zgeqp3rk.f
@@ -579,7 +579,7 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division, EECS Department,
+*>                  EECS Department,
 *>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim

--- a/SRC/zlaqp2rk.f
+++ b/SRC/zlaqp2rk.f
@@ -332,7 +332,7 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division, EECS Department,
+*>                  EECS Department,
 *>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim

--- a/SRC/zlaqp2rk.f
+++ b/SRC/zlaqp2rk.f
@@ -178,7 +178,7 @@
 *>          On exit:
 *>          1. The elements in block A(IOFFSET+1:M,1:K) below
 *>             the diagonal together with the array TAU represent
-*>             the orthogonal matrix Q(K) as a product of elementary
+*>             the unitary matrix Q(K) as a product of elementary
 *>             reflectors.
 *>          2. The upper triangular block of the matrix A stored
 *>             in A(IOFFSET+1:M,1:K) is the triangular factor obtained.

--- a/SRC/zlaqp2rk.f
+++ b/SRC/zlaqp2rk.f
@@ -332,8 +332,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  Computer Science Division, EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/zlaqp3rk.f
+++ b/SRC/zlaqp3rk.f
@@ -383,8 +383,8 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division,
-*>                  University of California, Berkeley
+*>                  Computer Science Division, EECS Department,
+*>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim
 *

--- a/SRC/zlaqp3rk.f
+++ b/SRC/zlaqp3rk.f
@@ -383,7 +383,7 @@
 *> \verbatim
 *>
 *>  November  2023, Igor Kozachenko, James Demmel,
-*>                  Computer Science Division, EECS Department,
+*>                  EECS Department,
 *>                  University of California, Berkeley, USA.
 *>
 *> \endverbatim

--- a/SRC/zlaqp3rk.f
+++ b/SRC/zlaqp3rk.f
@@ -196,7 +196,7 @@
 *>          On exit:
 *>          1. The elements in block A(IOFFSET+1:M,1:KB) below
 *>             the diagonal together with the array TAU represent
-*>             the orthogonal matrix Q(KB) as a product of elementary
+*>             the unitary matrix Q(KB) as a product of elementary
 *>             reflectors.
 *>          2. The upper triangular block of the matrix A stored
 *>             in A(IOFFSET+1:M,1:KB) is the triangular factor obtained.


### PR DESCRIPTION
**Update of the documentation to the pull request "Truncated QR with Pivoting #891"**

This fix of the documentation for the complex truncated QR routines {C,Z} GEQP3Rk, LAQP3RK, LAQP2RK.
The word "orthogonal" has been replaced with "unitary".

**Checklist**

- [x] The documentation has been updated.
