### PR TITLE
Fixed `HAS_ATTRIBUTE_WEAK_SUPPORT` flag for CBLAS objects

### DIFF
--- a/CBLAS/src/CMakeLists.txt
+++ b/CBLAS/src/CMakeLists.txt
@@ -119,6 +119,9 @@ list(REMOVE_DUPLICATES SOURCES)
 
 add_library(${CBLASLIB}_obj OBJECT ${SOURCES})
 set_target_properties(${CBLASLIB}_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(HAS_ATTRIBUTE_WEAK_SUPPORT)
+  target_compile_definitions(${CBLASLIB}_obj PRIVATE HAS_ATTRIBUTE_WEAK_SUPPORT)
+endif()
 
 if(BUILD_INDEX64_EXT_API)
   # 64bit Integer Interface
@@ -143,6 +146,9 @@ if(BUILD_INDEX64_EXT_API)
           LINKER_LANGUAGE C)
   target_compile_options(${CBLASLIB}_64_cobj PRIVATE -DWeirdNEC -DCBLAS_API64)
   target_compile_options(${CBLASLIB}_64_fobj PRIVATE ${FOPT_ILP64})
+  if(HAS_ATTRIBUTE_WEAK_SUPPORT)
+    target_compile_definitions(${CBLASLIB}_64_cobj PRIVATE HAS_ATTRIBUTE_WEAK_SUPPORT)
+  endif()
   #Add suffix to all Fortran functions via macros
   foreach(F IN LISTS SOURCES_64_F)
       set(COPT_64_F)
@@ -169,11 +175,8 @@ set_target_properties(
   SOVERSION ${LAPACK_MAJOR_VERSION}
   POSITION_INDEPENDENT_CODE ON
   )
-if(HAS_ATTRIBUTE_WEAK_SUPPORT)
-  target_compile_definitions(${CBLASLIB} PRIVATE HAS_ATTRIBUTE_WEAK_SUPPORT)
-endif()
+
 target_include_directories(${CBLASLIB} PUBLIC
-  $<BUILD_INTERFACE:${LAPACK_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(${CBLASLIB} PUBLIC ${BLAS_LIBRARIES})


### PR DESCRIPTION
**Description**

The `HAS_ATTRIBUTE_WEAK_SUPPORT` was applied to the `${CBLASLIB}` target, but since that target doesn't actually compile the CBLAS sources the flag was never used. I changed it such that the flag is applied to the `${CBLASLIB}_obj` target which actually triggers the compilations.

Additionally I removed the build interface include directory from the `${CBLASLIB}` target. Same logic applies here ... there is no compilation in the target where the include directory is used.

**Checklist**

- [n/a] The documentation has been updated.
- [n/a] If the PR solves a specific issue, it is set to be closed on merge.