### PR TITLE
Fixes for the NAG Fortran compiler

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -14,6 +14,10 @@ if(CMAKE_Fortran_COMPILER)
   FortranCInterface_HEADER(${LAPACK_BINARY_DIR}/include/cblas_mangling.h
                           MACRO_NAMESPACE "F77_"
                           SYMBOL_NAMESPACE "F77_")
+
+  # Check for any necessary platform specific compiler flags
+  include(CheckLAPACKCompilerFlags)
+  CheckLAPACKCompilerFlags()
 endif()
 if(NOT FortranCInterface_GLOBAL_FOUND OR NOT FortranCInterface_MODULE_FOUND)
   message(WARNING "Reverting to pre-defined include/cblas_mangling.h")

--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -177,6 +177,7 @@ elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "NAG" )
   endif()
 
   # Suppress compiler banner and summary
+  include(CheckFortranCompilerFlag)
   check_fortran_compiler_flag("-quiet" _quiet)
   if( _quiet AND NOT ("${CMAKE_Fortran_FLAGS}" MATCHES "[-/]quiet") )
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -quiet")

--- a/SRC/claqp2rk.f
+++ b/SRC/claqp2rk.f
@@ -378,7 +378,7 @@
       EXTERNAL           CLARF, CLARFG, CSWAP
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, REAL, CONJG, IMAG, MAX, MIN, SQRT
+      INTRINSIC          ABS, REAL, CONJG, AIMAG, MAX, MIN, SQRT
 *     ..
 *     .. External Functions ..
       LOGICAL            SISNAN
@@ -599,8 +599,8 @@
 *
          IF( SISNAN( REAL( TAU(KK) ) ) ) THEN
             TAUNAN = REAL( TAU(KK) )
-         ELSE IF( SISNAN( IMAG( TAU(KK) ) ) ) THEN
-            TAUNAN = IMAG( TAU(KK) )
+         ELSE IF( SISNAN( AIMAG( TAU(KK) ) ) ) THEN
+            TAUNAN = AIMAG( TAU(KK) )
          ELSE
             TAUNAN = ZERO
          END IF

--- a/SRC/claqp3rk.f
+++ b/SRC/claqp3rk.f
@@ -431,7 +431,7 @@
       EXTERNAL           CGEMM, CGEMV, CLARFG, CSWAP
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, REAL, CONJG, IMAG, MAX, MIN, SQRT
+      INTRINSIC          ABS, REAL, CONJG, AIMAG, MAX, MIN, SQRT
 *     ..
 *     .. External Functions ..
       LOGICAL            SISNAN
@@ -739,8 +739,8 @@
 *
          IF( SISNAN( REAL( TAU(K) ) ) ) THEN
             TAUNAN = REAL( TAU(K) )
-         ELSE IF( SISNAN( IMAG( TAU(K) ) ) ) THEN
-            TAUNAN = IMAG( TAU(K) )
+         ELSE IF( SISNAN( AIMAG( TAU(K) ) ) ) THEN
+            TAUNAN = AIMAG( TAU(K) )
          ELSE
             TAUNAN = ZERO
          END IF

--- a/TESTING/LIN/alahd.f
+++ b/TESTING/LIN/alahd.f
@@ -954,7 +954,7 @@
      $        4X, '10. Random, Last columns are zero starting from',
      $                 ' MINMN/2+1, CNDNUM = 2', /
      $        4X, '11. Random, Half MINMN columns in the middle are',
-     $                 ' zero starting from MINMN/2-(MINMN/2)/2+1',
+     $                 ' zero starting from MINMN/2-(MINMN/2)/2+1,',
      $                 ' CNDNUM = 2', /
      $        4X, '12. Random, Odd columns are ZERO, CNDNUM = 2', /
      $        4X, '13. Random, Even columns are ZERO, CNDNUM = 2', /

--- a/TESTING/LIN/alahd.f
+++ b/TESTING/LIN/alahd.f
@@ -954,7 +954,7 @@
      $        4X, '10. Random, Last columns are zero starting from',
      $                 ' MINMN/2+1, CNDNUM = 2', /
      $        4X, '11. Random, Half MINMN columns in the middle are',
-     $                 ' zero starting from MINMN/2-(MINMN/2)/2+1,'
+     $                 ' zero starting from MINMN/2-(MINMN/2)/2+1',
      $                 ' CNDNUM = 2', /
      $        4X, '12. Random, Odd columns are ZERO, CNDNUM = 2', /
      $        4X, '13. Random, Even columns are ZERO, CNDNUM = 2', /


### PR DESCRIPTION
**Description**

There were several issues with using the NAG Fortran compiler in the new release:

- usage of non-standard `IMAG` function. I replaced it with `AIMAG`.
- missing `check_fortran_compiler_flag` macro include
- propagation of Fortran flags to the CBLAS subdirectory
- missing comma in `FORMAT` expression in the test framework

**Checklist**

- [n/a] The documentation has been updated.
- [n/a] If the PR solves a specific issue, it is set to be closed on merge.