### PR TITLE
Fixed memory leak in testing framework

### DIFF
--- a/TESTING/LIN/cchkaa.F
+++ b/TESTING/LIN/cchkaa.F
@@ -1232,6 +1232,8 @@
 *
       DEALLOCATE (A, STAT = AllocateStatus)
       DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (E, STAT = AllocateStatus)
+      DEALLOCATE (S, STAT = AllocateStatus)
       DEALLOCATE (WORK, STAT = AllocateStatus)
       DEALLOCATE (RWORK,  STAT = AllocateStatus)
 *

--- a/TESTING/LIN/dchkaa.F
+++ b/TESTING/LIN/dchkaa.F
@@ -1076,6 +1076,8 @@
 *
       DEALLOCATE (A, STAT = AllocateStatus)
       DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (E, STAT = AllocateStatus)
+      DEALLOCATE (S, STAT = AllocateStatus)
       DEALLOCATE (WORK, STAT = AllocateStatus)
       DEALLOCATE (RWORK,  STAT = AllocateStatus)
 *

--- a/TESTING/LIN/schkaa.F
+++ b/TESTING/LIN/schkaa.F
@@ -1070,6 +1070,8 @@
 *
       DEALLOCATE (A, STAT = AllocateStatus)
       DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (E, STAT = AllocateStatus)
+      DEALLOCATE (S, STAT = AllocateStatus)
       DEALLOCATE (WORK, STAT = AllocateStatus)
       DEALLOCATE (RWORK,  STAT = AllocateStatus)
 *

--- a/TESTING/LIN/zchkaa.F
+++ b/TESTING/LIN/zchkaa.F
@@ -1268,6 +1268,8 @@
 *
       DEALLOCATE (A, STAT = AllocateStatus)
       DEALLOCATE (B, STAT = AllocateStatus)
+      DEALLOCATE (E, STAT = AllocateStatus)
+      DEALLOCATE (S, STAT = AllocateStatus)
       DEALLOCATE (RWORK, STAT = AllocateStatus)
       DEALLOCATE (WORK,  STAT = AllocateStatus)
 *


### PR DESCRIPTION
**Description**

There was a small memory leak in the test framework.

**Checklist**

- [n/a] The documentation has been updated.
- [n/a] If the PR solves a specific issue, it is set to be closed on merge.