### PR TITLE
Fixed search phrase for determining the amount of successful tests

### DIFF
--- a/lapack_testing.py
+++ b/lapack_testing.py
@@ -136,7 +136,7 @@ def run_summary_test( f, cmdline, short_summary):
         for line in pipe.readlines():
             f.write(str(line))
             words_in_line=line.split()
-            if (line.find("run")!=-1):
+            if (line.find("run)")!=-1):
 #                  print line
                 whereisrun=words_in_line.index("run)")
                 nb_test_run+=int(words_in_line[whereisrun-2])


### PR DESCRIPTION
**Description**

In the `lapack_testing.py` script we search for `run)` to determine the amount of succesful tests:

```
if (line.find("run")!=-1):
    whereisrun=words_in_line.index("run)")
```

The problem is that in the if clause we only looked for `run` which can match other things like for example "truncated QR". That means if the truncated QR routine fails, the test summary will fail as well with the following message:

```
ValueError: 'run)' is not in list
```

**Checklist**

- [n/a] The documentation has been updated.
- [n/a] If the PR solves a specific issue, it is set to be closed on merge.