### PR TITLE
{D,Z}BBCSD: stricter zero criterion

### DIFF
--- a/SRC/dbbcsd.f
+++ b/SRC/dbbcsd.f
@@ -302,7 +302,7 @@
 *  =========================
 *>
 *> \verbatim
-*>  TOLMUL  DOUBLE PRECISION, default = MAX(10,MIN(100,EPS**(-1/8)))
+*>  TOLMUL  DOUBLE PRECISION, default = 10
 *>          TOLMUL controls the convergence criterion of the QR loop.
 *>          Angles THETA(i), PHI(i) are rounded to 0 or PI/2 when they
 *>          are within TOLMUL*EPS of either bound.
@@ -451,7 +451,7 @@
 *
       EPS = DLAMCH( 'Epsilon' )
       UNFL = DLAMCH( 'Safe minimum' )
-      TOLMUL = MAX( TEN, MIN( HUNDRED, EPS**MEIGHTH ) )
+      TOLMUL = TEN
       TOL = TOLMUL*EPS
       THRESH = MAX( TOL, MAXITR*Q*Q*UNFL )
 *

--- a/SRC/zbbcsd.f
+++ b/SRC/zbbcsd.f
@@ -302,7 +302,7 @@
 *  =========================
 *>
 *> \verbatim
-*>  TOLMUL  DOUBLE PRECISION, default = MAX(10,MIN(100,EPS**(-1/8)))
+*>  TOLMUL  DOUBLE PRECISION, default = 10
 *>          TOLMUL controls the convergence criterion of the QR loop.
 *>          Angles THETA(i), PHI(i) are rounded to 0 or PI/2 when they
 *>          are within TOLMUL*EPS of either bound.
@@ -450,7 +450,7 @@
 *
       EPS = DLAMCH( 'Epsilon' )
       UNFL = DLAMCH( 'Safe minimum' )
-      TOLMUL = MAX( TEN, MIN( HUNDRED, EPS**MEIGHTH ) )
+      TOLMUL = TEN
       TOL = TOLMUL*EPS
       THRESH = MAX( TOL, MAXITR*Q*Q*UNFL )
 *


### PR DESCRIPTION
**Description**

The tolerance below which matrix entries are considered zero is tightened to avoid insufficiently accurate singular vectors.

I cannot locate more information about the zero criterion and the choice may be too conservative: there is no information in the git history about it (only the final code was committed in 2010) and in the article [_Computing the Complete CS Decomposition_](https://arxiv.org/abs/0707.1838) (2008) from the code author, it only says:
> To encourage fast termination, some angles in θ(n) and φ(n) may need to be rounded when they are negligibly far from 0 or π/2. The best test for negligibility will be the subject of future work.

The article [_Stable Computation of the CS Decomposition: Simultaneous Bidiagonalization_](https://epubs.siam.org/doi/10.1137/100813002) does not discuss the zero criterion.

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.