### PR TITLE
Re-sync Makefile with CMake

### DIFF
--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -47,7 +47,10 @@ set(ALLAUX
    ilauplo.f
    iladiag.f
    chla_transtype.f
+   la_constants.f90
    la_xisnan.F90
+   sisnan.f
+   slaisnan.f
    ../INSTALL/ilaver.f
    ../INSTALL/lsame.f
    xerbla.f
@@ -55,7 +58,6 @@ set(ALLAUX
    ../INSTALL/slamch.f)
 
 set(SCLAUX
-   la_constants.f90
    sbdsvdx.f
    sbdsdc.f
    sbdsqr.f
@@ -134,7 +136,6 @@ set(SCLAUX
    ${SECOND_SRC})
 
 set(DZLAUX
-   la_constants.f90
    dbdsdc.f
    dbdsvdx.f
    dbdsqr.f
@@ -616,8 +617,6 @@ set(DSLASRC
    sgetrf.f
    sgetrf2.f
    sgetrs.f
-   sisnan.f
-   slaisnan.f
    slaswp.f
    spotrf.f
    spotrf2.f
@@ -1165,9 +1164,7 @@ set(ZCLASRC
    claswp.f
    cpotrf.f
    cpotrf2.f
-   cpotrs.f
-   sisnan.f
-   slaisnan.f)
+   cpotrs.f)
 
 set(DLASRC
    dgbbrd.f

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -705,7 +705,6 @@ set(CLASRC
    cgesvx.f
    cgetc2.f
    cgetf2.f
-   cgetrf2.f
    cgetri.f
    cggbak.f
    cggbal.f
@@ -888,7 +887,6 @@ set(CLASRC
    claset.f
    clasr.f
    classq.f90
-   claswp.f
    clasyf.f
    clasyf_rook.f
    clasyf_rk.f
@@ -917,7 +915,6 @@ set(CLASRC
    cposv.f
    cposvx.f
    cpotf2.f
-   cpotrf2.f
    cpotri.f
    cpstrf.f
    cpstf2.f
@@ -1169,14 +1166,10 @@ set(ZCLASRC
    cpotrf.f
    cpotrf2.f
    cpotrs.f
-   cgetrs.f
-   cpotrf.f
-   cgetrf.f
    sisnan.f
    slaisnan.f)
 
 set(DLASRC
-   dbdsvdx.f
    dgbbrd.f
    dgbcon.f
    dgbequ.f

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -35,462 +35,2152 @@
 #
 #######################################################################
 
-set(ALLAUX ilaenv.f ilaenv2stage.f ieeeck.f lsamen.f iparmq.f iparam2stage.F
-   ilaprec.f ilatrans.f ilauplo.f iladiag.f chla_transtype.f la_xisnan.F90
-   ../INSTALL/ilaver.f ../INSTALL/lsame.f xerbla.f xerbla_array.f
+set(ALLAUX
+   ilaenv.f
+   ilaenv2stage.f
+   ieeeck.f
+   lsamen.f
+   iparmq.f
+   iparam2stage.F
+   ilaprec.f
+   ilatrans.f
+   ilauplo.f
+   iladiag.f
+   chla_transtype.f
+   la_xisnan.F90
+   ../INSTALL/ilaver.f
+   ../INSTALL/lsame.f
+   xerbla.f
+   xerbla_array.f
    ../INSTALL/slamch.f)
 
 set(SCLAUX
    la_constants.f90
-   sbdsvdx.f sbdsdc.f
-   sbdsqr.f sdisna.f slabad.f slacpy.f sladiv.f slae2.f  slaebz.f
-   slaed0.f slaed1.f slaed2.f slaed3.f slaed4.f slaed5.f slaed6.f
-   slaed7.f slaed8.f slaed9.f slaeda.f slaev2.f slagtf.f
-   slagts.f slamrg.f slanst.f
-   slapy2.f slapy3.f slarnv.f
-   slarra.f slarrb.f slarrc.f slarrd.f slarre.f slarrf.f slarrj.f
-   slarrk.f slarrr.f slaneg.f
-   slartg.f90 slaruv.f slas2.f  slascl.f
-   slasd0.f slasd1.f slasd2.f slasd3.f slasd4.f slasd5.f slasd6.f
-   slasd7.f slasd8.f slasda.f slasdq.f slasdt.f
-   slaset.f slasq1.f slasq2.f slasq3.f slasq4.f slasq5.f slasq6.f
-   slasr.f  slasrt.f slassq.f90 slasv2.f spttrf.f sstebz.f sstedc.f
-   sstein.f ssteqr.f ssterf.f sstevx.f
-   slartgp.f slartgs.f ../INSTALL/sroundup_lwork.f
+   sbdsvdx.f
+   sbdsdc.f
+   sbdsqr.f
+   sdisna.f
+   slabad.f
+   slacpy.f
+   sladiv.f
+   slae2.f
+   slaebz.f
+   slaed0.f
+   slaed1.f
+   slaed2.f
+   slaed3.f
+   slaed4.f
+   slaed5.f
+   slaed6.f
+   slaed7.f
+   slaed8.f
+   slaed9.f
+   slaeda.f
+   slaev2.f
+   slagtf.f
+   slagts.f
+   slamrg.f
+   slanst.f
+   slapy2.f
+   slapy3.f
+   slarnv.f
+   slarra.f
+   slarrb.f
+   slarrc.f
+   slarrd.f
+   slarre.f
+   slarrf.f
+   slarrj.f
+   slarrk.f
+   slarrr.f
+   slaneg.f
+   slartg.f90
+   slaruv.f
+   slas2.f
+   slascl.f
+   slasd0.f
+   slasd1.f
+   slasd2.f
+   slasd3.f
+   slasd4.f
+   slasd5.f
+   slasd6.f
+   slasd7.f
+   slasd8.f
+   slasda.f
+   slasdq.f
+   slasdt.f
+   slaset.f
+   slasq1.f
+   slasq2.f
+   slasq3.f
+   slasq4.f
+   slasq5.f
+   slasq6.f
+   slasr.f
+   slasrt.f
+   slassq.f90
+   slasv2.f
+   spttrf.f
+   sstebz.f
+   sstedc.f
+   sstein.f
+   ssteqr.f
+   ssterf.f
+   sstevx.f
+   slartgp.f
+   slartgs.f
+   ../INSTALL/sroundup_lwork.f
    ${SECOND_SRC})
 
 set(DZLAUX
    la_constants.f90
-   dbdsdc.f dbdsvdx.f
-   dbdsqr.f ddisna.f
+   dbdsdc.f
+   dbdsvdx.f
+   dbdsqr.f
+   ddisna.f
    disnan.f
-   dlabad.f dlacpy.f dladiv.f dlae2.f  dlaebz.f
-   dlaed0.f dlaed1.f dlaed2.f dlaed3.f dlaed4.f dlaed5.f dlaed6.f
-   dlaed7.f dlaed8.f dlaed9.f dlaeda.f dlaev2.f dlagtf.f
-   dlagts.f dlamrg.f dlanst.f
-   dlapy2.f dlapy3.f dlarnv.f
-   dlarra.f dlarrb.f dlarrc.f dlarrd.f dlarre.f dlarrf.f dlarrj.f
-   dlarrk.f dlarrr.f dlaneg.f
-   dlartg.f90 dlaruv.f dlas2.f  dlascl.f
-   dlasd0.f dlasd1.f dlasd2.f dlasd3.f dlasd4.f dlasd5.f dlasd6.f
-   dlasd7.f dlasd8.f dlasda.f dlasdq.f dlasdt.f
-   dlaset.f dlasq1.f dlasq2.f dlasq3.f dlasq4.f dlasq5.f dlasq6.f
-   dlasr.f  dlasrt.f dlassq.f90 dlasv2.f dlaisnan.f
+   dlabad.f
+   dlacpy.f
+   dladiv.f
+   dlae2.f
+   dlaebz.f
+   dlaed0.f
+   dlaed1.f
+   dlaed2.f
+   dlaed3.f
+   dlaed4.f
+   dlaed5.f
+   dlaed6.f
+   dlaed7.f
+   dlaed8.f
+   dlaed9.f
+   dlaeda.f
+   dlaev2.f
+   dlagtf.f
+   dlagts.f
+   dlamrg.f
+   dlanst.f
+   dlapy2.f
+   dlapy3.f
+   dlarnv.f
+   dlarra.f
+   dlarrb.f
+   dlarrc.f
+   dlarrd.f
+   dlarre.f
+   dlarrf.f
+   dlarrj.f
+   dlarrk.f
+   dlarrr.f
+   dlaneg.f
+   dlartg.f90
+   dlaruv.f
+   dlas2.f
+   dlascl.f
+   dlasd0.f
+   dlasd1.f
+   dlasd2.f
+   dlasd3.f
+   dlasd4.f
+   dlasd5.f
+   dlasd6.f
+   dlasd7.f
+   dlasd8.f
+   dlasda.f
+   dlasdq.f
+   dlasdt.f
+   dlaset.f
+   dlasq1.f
+   dlasq2.f
+   dlasq3.f
+   dlasq4.f
+   dlasq5.f
+   dlasq6.f
+   dlasr.f
+   dlasrt.f
+   dlassq.f90
+   dlasv2.f
+   dlaisnan.f
    dpttrf.f
-   dstebz.f dstedc.f dstein.f dsteqr.f dsterf.f dstevx.f
-   dlartgp.f dlartgs.f ../INSTALL/droundup_lwork.f
-   ../INSTALL/dlamch.f ${DSECOND_SRC})
+   dstebz.f
+   dstedc.f
+   dstein.f
+   dsteqr.f
+   dsterf.f
+   dstevx.f
+   dlartgp.f
+   dlartgs.f
+   ../INSTALL/droundup_lwork.f
+   ../INSTALL/dlamch.f
+   ${DSECOND_SRC})
 
 set(SLASRC
-   sgbbrd.f sgbcon.f sgbequ.f sgbrfs.f sgbsv.f
-   sgbsvx.f sgbtf2.f sgbtrf.f sgbtrs.f sgebak.f sgebal.f sgebd2.f
-   sgebrd.f sgecon.f sgeequ.f sgees.f  sgeesx.f sgeev.f  sgeevx.f
-   sgehd2.f sgehrd.f sgelq2.f sgelqf.f
-   sgels.f  sgelst.f  sgelsd.f sgelss.f sgelsy.f sgeql2.f sgeqlf.f
-   sgeqp3.f sgeqp3rk.f sgeqr2.f sgeqr2p.f sgeqrf.f sgeqrfp.f sgerfs.f sgerq2.f sgerqf.f
-   sgesc2.f sgesdd.f sgesv.f  sgesvd.f sgesvdx.f sgesvx.f sgetc2.f sgetf2.f
+   sgbbrd.f
+   sgbcon.f
+   sgbequ.f
+   sgbrfs.f
+   sgbsv.f
+   sgbsvx.f
+   sgbtf2.f
+   sgbtrf.f
+   sgbtrs.f
+   sgebak.f
+   sgebal.f
+   sgebd2.f
+   sgebrd.f
+   sgecon.f
+   sgeequ.f
+   sgees.f
+   sgeesx.f
+   sgeev.f
+   sgeevx.f
+   sgehd2.f
+   sgehrd.f
+   sgelq2.f
+   sgelqf.f
+   sgels.f
+   sgelst.f
+   sgelsd.f
+   sgelss.f
+   sgelsy.f
+   sgeql2.f
+   sgeqlf.f
+   sgeqp3.f
+   sgeqp3rk.f
+   sgeqr2.f
+   sgeqr2p.f
+   sgeqrf.f
+   sgeqrfp.f
+   sgerfs.f
+   sgerq2.f
+   sgerqf.f
+   sgesc2.f
+   sgesdd.f
+   sgesv.f
+   sgesvd.f
+   sgesvdx.f
+   sgesvx.f
+   sgetc2.f
+   sgetf2.f
    sgetri.f
-   sggbak.f sggbal.f
-   sgges.f  sgges3.f sggesx.f sggev.f  sggev3.f sggevx.f
-   sggglm.f sgghrd.f sgghd3.f sgglse.f sggqrf.f
-   sggrqf.f sggsvd3.f sggsvp3.f sgtcon.f sgtrfs.f sgtsv.f
-   sgtsvx.f sgttrf.f sgttrs.f sgtts2.f shgeqz.f
-   slaqz0.f slaqz1.f slaqz2.f slaqz3.f slaqz4.f
-   shsein.f shseqr.f slabrd.f slacon.f slacn2.f
-   slaein.f slaexc.f slag2.f  slags2.f slagtm.f slagv2.f slahqr.f
-   slahr2.f slaic1.f slaln2.f slals0.f slalsa.f slalsd.f
-   slangb.f slange.f slangt.f slanhs.f slansb.f slansp.f
-   slansy.f slantb.f slantp.f slantr.f slanv2.f
-   slapll.f slapmt.f
-   slaqgb.f slaqge.f slaqp2.f slaqps.f slaqp2rk.f slaqp3rk.f slaqsb.f slaqsp.f slaqsy.f
-   slaqr0.f slaqr1.f slaqr2.f slaqr3.f slaqr4.f slaqr5.f
-   slaqtr.f slar1v.f slar2v.f ilaslr.f ilaslc.f
-   slarf.f  slarfb.f slarfb_gett.f slarfg.f slarfgp.f slarft.f slarfx.f slarfy.f
-   slargv.f slarmm.f slarrv.f slartv.f
-   slarz.f  slarzb.f slarzt.f slasy2.f
-   slasyf.f slasyf_rook.f slasyf_rk.f slasyf_aa.f
-   slatbs.f slatdf.f slatps.f slatrd.f slatrs.f slatrs3.f slatrz.f
-   slauu2.f slauum.f sopgtr.f sopmtr.f sorg2l.f sorg2r.f
-   sorgbr.f sorghr.f sorgl2.f sorglq.f sorgql.f sorgqr.f sorgr2.f
-   sorgrq.f sorgtr.f sorgtsqr.f sorgtsqr_row.f sorm2l.f sorm2r.f sorm22.f
-   sormbr.f sormhr.f sorml2.f sormlq.f sormql.f sormqr.f sormr2.f
-   sormr3.f sormrq.f sormrz.f sormtr.f spbcon.f spbequ.f spbrfs.f
-   spbstf.f spbsv.f  spbsvx.f
-   spbtf2.f spbtrf.f spbtrs.f spocon.f spoequ.f sporfs.f sposv.f
-   sposvx.f spotf2.f spotri.f spstrf.f spstf2.f
-   sppcon.f sppequ.f
-   spprfs.f sppsv.f  sppsvx.f spptrf.f spptri.f spptrs.f sptcon.f
-   spteqr.f sptrfs.f sptsv.f  sptsvx.f spttrs.f sptts2.f srscl.f
-   ssbev.f  ssbevd.f ssbevx.f ssbgst.f ssbgv.f  ssbgvd.f ssbgvx.f
-   ssbtrd.f sspcon.f sspev.f  sspevd.f sspevx.f sspgst.f
-   sspgv.f  sspgvd.f sspgvx.f ssprfs.f sspsv.f  sspsvx.f ssptrd.f
-   ssptrf.f ssptri.f ssptrs.f sstegr.f sstev.f  sstevd.f sstevr.f
-   ssycon.f ssyev.f  ssyevd.f ssyevr.f ssyevx.f ssygs2.f
-   ssygst.f ssygv.f  ssygvd.f ssygvx.f ssyrfs.f ssysv.f  ssysvx.f
-   ssytd2.f ssytf2.f ssytrd.f ssytrf.f ssytri.f ssytri2.f ssytri2x.f
-   ssyswapr.f ssytrs.f ssytrs2.f
-   ssyconv.f ssyconvf.f ssyconvf_rook.f
-   ssytf2_rook.f ssytrf_rook.f ssytrs_rook.f
-   ssytri_rook.f ssycon_rook.f ssysv_rook.f
-   ssytf2_rk.f ssytrf_rk.f ssytrs_3.f
-   ssytri_3.f ssytri_3x.f ssycon_3.f ssysv_rk.f
-   ssysv_aa.f ssytrf_aa.f ssytrs_aa.f
-   ssysv_aa_2stage.f ssytrf_aa_2stage.f ssytrs_aa_2stage.f
+   sggbak.f
+   sggbal.f
+   sgges.f
+   sgges3.f
+   sggesx.f
+   sggev.f
+   sggev3.f
+   sggevx.f
+   sggglm.f
+   sgghrd.f
+   sgghd3.f
+   sgglse.f
+   sggqrf.f
+   sggrqf.f
+   sggsvd3.f
+   sggsvp3.f
+   sgtcon.f
+   sgtrfs.f
+   sgtsv.f
+   sgtsvx.f
+   sgttrf.f
+   sgttrs.f
+   sgtts2.f
+   shgeqz.f
+   slaqz0.f
+   slaqz1.f
+   slaqz2.f
+   slaqz3.f
+   slaqz4.f
+   shsein.f
+   shseqr.f
+   slabrd.f
+   slacon.f
+   slacn2.f
+   slaein.f
+   slaexc.f
+   slag2.f
+   slags2.f
+   slagtm.f
+   slagv2.f
+   slahqr.f
+   slahr2.f
+   slaic1.f
+   slaln2.f
+   slals0.f
+   slalsa.f
+   slalsd.f
+   slangb.f
+   slange.f
+   slangt.f
+   slanhs.f
+   slansb.f
+   slansp.f
+   slansy.f
+   slantb.f
+   slantp.f
+   slantr.f
+   slanv2.f
+   slapll.f
+   slapmt.f
+   slaqgb.f
+   slaqge.f
+   slaqp2.f
+   slaqps.f
+   slaqp2rk.f
+   slaqp3rk.f
+   slaqsb.f
+   slaqsp.f
+   slaqsy.f
+   slaqr0.f
+   slaqr1.f
+   slaqr2.f
+   slaqr3.f
+   slaqr4.f
+   slaqr5.f
+   slaqtr.f
+   slar1v.f
+   slar2v.f
+   ilaslr.f
+   ilaslc.f
+   slarf.f
+   slarfb.f
+   slarfb_gett.f
+   slarfg.f
+   slarfgp.f
+   slarft.f
+   slarfx.f
+   slarfy.f
+   slargv.f
+   slarmm.f
+   slarrv.f
+   slartv.f
+   slarz.f
+   slarzb.f
+   slarzt.f
+   slasy2.f
+   slasyf.f
+   slasyf_rook.f
+   slasyf_rk.f
+   slasyf_aa.f
+   slatbs.f
+   slatdf.f
+   slatps.f
+   slatrd.f
+   slatrs.f
+   slatrs3.f
+   slatrz.f
+   slauu2.f
+   slauum.f
+   sopgtr.f
+   sopmtr.f
+   sorg2l.f
+   sorg2r.f
+   sorgbr.f
+   sorghr.f
+   sorgl2.f
+   sorglq.f
+   sorgql.f
+   sorgqr.f
+   sorgr2.f
+   sorgrq.f
+   sorgtr.f
+   sorgtsqr.f
+   sorgtsqr_row.f
+   sorm2l.f
+   sorm2r.f
+   sorm22.f
+   sormbr.f
+   sormhr.f
+   sorml2.f
+   sormlq.f
+   sormql.f
+   sormqr.f
+   sormr2.f
+   sormr3.f
+   sormrq.f
+   sormrz.f
+   sormtr.f
+   spbcon.f
+   spbequ.f
+   spbrfs.f
+   spbstf.f
+   spbsv.f
+   spbsvx.f
+   spbtf2.f
+   spbtrf.f
+   spbtrs.f
+   spocon.f
+   spoequ.f
+   sporfs.f
+   sposv.f
+   sposvx.f
+   spotf2.f
+   spotri.f
+   spstrf.f
+   spstf2.f
+   sppcon.f
+   sppequ.f
+   spprfs.f
+   sppsv.f
+   sppsvx.f
+   spptrf.f
+   spptri.f
+   spptrs.f
+   sptcon.f
+   spteqr.f
+   sptrfs.f
+   sptsv.f
+   sptsvx.f
+   spttrs.f
+   sptts2.f
+   srscl.f
+   ssbev.f
+   ssbevd.f
+   ssbevx.f
+   ssbgst.f
+   ssbgv.f
+   ssbgvd.f
+   ssbgvx.f
+   ssbtrd.f
+   sspcon.f
+   sspev.f
+   sspevd.f
+   sspevx.f
+   sspgst.f
+   sspgv.f
+   sspgvd.f
+   sspgvx.f
+   ssprfs.f
+   sspsv.f
+   sspsvx.f
+   ssptrd.f
+   ssptrf.f
+   ssptri.f
+   ssptrs.f
+   sstegr.f
+   sstev.f
+   sstevd.f
+   sstevr.f
+   ssycon.f
+   ssyev.f
+   ssyevd.f
+   ssyevr.f
+   ssyevx.f
+   ssygs2.f
+   ssygst.f
+   ssygv.f
+   ssygvd.f
+   ssygvx.f
+   ssyrfs.f
+   ssysv.f
+   ssysvx.f
+   ssytd2.f
+   ssytf2.f
+   ssytrd.f
+   ssytrf.f
+   ssytri.f
+   ssytri2.f
+   ssytri2x.f
+   ssyswapr.f
+   ssytrs.f
+   ssytrs2.f
+   ssyconv.f
+   ssyconvf.f
+   ssyconvf_rook.f
+   ssytf2_rook.f
+   ssytrf_rook.f
+   ssytrs_rook.f
+   ssytri_rook.f
+   ssycon_rook.f
+   ssysv_rook.f
+   ssytf2_rk.f
+   ssytrf_rk.f
+   ssytrs_3.f
+   ssytri_3.f
+   ssytri_3x.f
+   ssycon_3.f
+   ssysv_rk.f
+   ssysv_aa.f
+   ssytrf_aa.f
+   ssytrs_aa.f
+   ssysv_aa_2stage.f
+   ssytrf_aa_2stage.f
+   ssytrs_aa_2stage.f
    stbcon.f
-   stbrfs.f stbtrs.f stgevc.f stgex2.f stgexc.f stgsen.f
-   stgsja.f stgsna.f stgsy2.f stgsyl.f stpcon.f stprfs.f stptri.f
+   stbrfs.f
+   stbtrs.f
+   stgevc.f
+   stgex2.f
+   stgexc.f
+   stgsen.f
+   stgsja.f
+   stgsna.f
+   stgsy2.f
+   stgsyl.f
+   stpcon.f
+   stprfs.f
+   stptri.f
    stptrs.f
-   strcon.f strevc.f strevc3.f strexc.f strrfs.f strsen.f strsna.f strsyl.f
-   strsyl3.f strti2.f strtri.f strtrs.f stzrzf.f sstemr.f
-   slansf.f spftrf.f spftri.f spftrs.f ssfrk.f stfsm.f stftri.f stfttp.f
-   stfttr.f stpttf.f stpttr.f strttf.f strttp.f
-   sgejsv.f sgesvj.f sgsvj0.f sgsvj1.f
-   sgeequb.f ssyequb.f spoequb.f sgbequb.f
-   sbbcsd.f slapmr.f sorbdb.f sorbdb1.f sorbdb2.f sorbdb3.f sorbdb4.f
-   sorbdb5.f sorbdb6.f sorcsd.f sorcsd2by1.f
-   sgeqrt.f sgeqrt2.f sgeqrt3.f sgemqrt.f
-   stpqrt.f stpqrt2.f stpmqrt.f stprfb.f
-   sgelqt.f sgelqt3.f sgemlqt.f
-   sgetsls.f sgetsqrhrt.f sgeqr.f slatsqr.f slamtsqr.f sgemqr.f
-   sgelq.f slaswlq.f slamswlq.f sgemlq.f
-   stplqt.f stplqt2.f stpmlqt.f
-   sorhr_col.f slaorhr_col_getrfnp.f slaorhr_col_getrfnp2.f
-   ssytrd_2stage.f ssytrd_sy2sb.f ssytrd_sb2st.F ssb2st_kernels.f
-   ssyevd_2stage.f ssyev_2stage.f ssyevx_2stage.f ssyevr_2stage.f
-   ssbev_2stage.f ssbevx_2stage.f ssbevd_2stage.f ssygv_2stage.f
-   sgesvdq.f sgedmd.f90 sgedmdq.f90)
+   strcon.f
+   strevc.f
+   strevc3.f
+   strexc.f
+   strrfs.f
+   strsen.f
+   strsna.f
+   strsyl.f
+   strsyl3.f
+   strti2.f
+   strtri.f
+   strtrs.f
+   stzrzf.f
+   sstemr.f
+   slansf.f
+   spftrf.f
+   spftri.f
+   spftrs.f
+   ssfrk.f
+   stfsm.f
+   stftri.f
+   stfttp.f
+   stfttr.f
+   stpttf.f
+   stpttr.f
+   strttf.f
+   strttp.f
+   sgejsv.f
+   sgesvj.f
+   sgsvj0.f
+   sgsvj1.f
+   sgeequb.f
+   ssyequb.f
+   spoequb.f
+   sgbequb.f
+   sbbcsd.f
+   slapmr.f
+   sorbdb.f
+   sorbdb1.f
+   sorbdb2.f
+   sorbdb3.f
+   sorbdb4.f
+   sorbdb5.f
+   sorbdb6.f
+   sorcsd.f
+   sorcsd2by1.f
+   sgeqrt.f
+   sgeqrt2.f
+   sgeqrt3.f
+   sgemqrt.f
+   stpqrt.f
+   stpqrt2.f
+   stpmqrt.f
+   stprfb.f
+   sgelqt.f
+   sgelqt3.f
+   sgemlqt.f
+   sgetsls.f
+   sgetsqrhrt.f
+   sgeqr.f
+   slatsqr.f
+   slamtsqr.f
+   sgemqr.f
+   sgelq.f
+   slaswlq.f
+   slamswlq.f
+   sgemlq.f
+   stplqt.f
+   stplqt2.f
+   stpmlqt.f
+   sorhr_col.f
+   slaorhr_col_getrfnp.f
+   slaorhr_col_getrfnp2.f
+   ssytrd_2stage.f
+   ssytrd_sy2sb.f
+   ssytrd_sb2st.F
+   ssb2st_kernels.f
+   ssyevd_2stage.f
+   ssyev_2stage.f
+   ssyevx_2stage.f
+   ssyevr_2stage.f
+   ssbev_2stage.f
+   ssbevx_2stage.f
+   ssbevd_2stage.f
+   ssygv_2stage.f
+   sgesvdq.f
+   sgedmd.f90
+   sgedmdq.f90)
 
 set(DSLASRC
-    sgetrf.f sgetrf2.f sgetrs.f sisnan.f slaisnan.f slaswp.f spotrf.f spotrf2.f
-    spotrs.f)
+   sgetrf.f
+   sgetrf2.f
+   sgetrs.f
+   sisnan.f
+   slaisnan.f
+   slaswp.f
+   spotrf.f
+   spotrf2.f
+   spotrs.f)
 
-set(SXLASRC sgesvxx.f sgerfsx.f sla_gerfsx_extended.f sla_geamv.f
-   sla_gercond.f sla_gerpvgrw.f ssysvxx.f ssyrfsx.f
-   sla_syrfsx_extended.f sla_syamv.f sla_syrcond.f sla_syrpvgrw.f
-   sposvxx.f sporfsx.f sla_porfsx_extended.f sla_porcond.f
-   sla_porpvgrw.f sgbsvxx.f sgbrfsx.f sla_gbrfsx_extended.f
-   sla_gbamv.f sla_gbrcond.f sla_gbrpvgrw.f sla_lin_berr.f slarscl2.f
-   slascl2.f sla_wwaddw.f)
+set(SXLASRC
+   sgesvxx.f
+   sgerfsx.f
+   sla_gerfsx_extended.f
+   sla_geamv.f
+   sla_gercond.f
+   sla_gerpvgrw.f
+   ssysvxx.f
+   ssyrfsx.f
+   sla_syrfsx_extended.f
+   sla_syamv.f
+   sla_syrcond.f
+   sla_syrpvgrw.f
+   sposvxx.f
+   sporfsx.f
+   sla_porfsx_extended.f
+   sla_porcond.f
+   sla_porpvgrw.f
+   sgbsvxx.f
+   sgbrfsx.f
+   sla_gbrfsx_extended.f
+   sla_gbamv.f
+   sla_gbrcond.f
+   sla_gbrpvgrw.f
+   sla_lin_berr.f
+   slarscl2.f
+   slascl2.f
+   sla_wwaddw.f)
 
 set(CLASRC
-   cbdsqr.f cgbbrd.f cgbcon.f cgbequ.f cgbrfs.f cgbsv.f  cgbsvx.f
-   cgbtf2.f cgbtrf.f cgbtrs.f cgebak.f cgebal.f cgebd2.f cgebrd.f
-   cgecon.f cgeequ.f cgees.f  cgeesx.f cgeev.f  cgeevx.f
-   cgehd2.f cgehrd.f cgelq2.f cgelqf.f
-   cgels.f  cgelst.f cgelsd.f cgelss.f cgelsy.f cgeql2.f cgeqlf.f
-   cgeqp3.f cgeqp3rk.f
-   cgeqr2.f cgeqr2p.f cgeqrf.f cgeqrfp.f cgerfs.f cgerq2.f cgerqf.f
-   cgesc2.f cgesdd.f cgesv.f  cgesvd.f cgesvdx.f
-   cgesvj.f cgejsv.f cgsvj0.f cgsvj1.f
-   cgesvx.f cgetc2.f cgetf2.f cgetrf2.f
+   cbdsqr.f
+   cgbbrd.f
+   cgbcon.f
+   cgbequ.f
+   cgbrfs.f
+   cgbsv.f
+   cgbsvx.f
+   cgbtf2.f
+   cgbtrf.f
+   cgbtrs.f
+   cgebak.f
+   cgebal.f
+   cgebd2.f
+   cgebrd.f
+   cgecon.f
+   cgeequ.f
+   cgees.f
+   cgeesx.f
+   cgeev.f
+   cgeevx.f
+   cgehd2.f
+   cgehrd.f
+   cgelq2.f
+   cgelqf.f
+   cgels.f
+   cgelst.f
+   cgelsd.f
+   cgelss.f
+   cgelsy.f
+   cgeql2.f
+   cgeqlf.f
+   cgeqp3.f
+   cgeqp3rk.f
+   cgeqr2.f
+   cgeqr2p.f
+   cgeqrf.f
+   cgeqrfp.f
+   cgerfs.f
+   cgerq2.f
+   cgerqf.f
+   cgesc2.f
+   cgesdd.f
+   cgesv.f
+   cgesvd.f
+   cgesvdx.f
+   cgesvj.f
+   cgejsv.f
+   cgsvj0.f
+   cgsvj1.f
+   cgesvx.f
+   cgetc2.f
+   cgetf2.f
+   cgetrf2.f
    cgetri.f
-   cggbak.f cggbal.f
-   cgges.f  cgges3.f cggesx.f cggev.f  cggev3.f cggevx.f
-   cggglm.f cgghrd.f cgghd3.f cgglse.f cggqrf.f cggrqf.f
-   cggsvd3.f cggsvp3.f
-   cgtcon.f cgtrfs.f cgtsv.f  cgtsvx.f cgttrf.f cgttrs.f cgtts2.f chbev.f
-   chbevd.f chbevx.f chbgst.f chbgv.f  chbgvd.f chbgvx.f chbtrd.f
-   checon.f cheev.f  cheevd.f cheevr.f cheevx.f chegs2.f chegst.f
-   chegv.f  chegvd.f chegvx.f cherfs.f chesv.f  chesvx.f chetd2.f
-   chetf2.f chetrd.f
-   chetrf.f chetri.f chetri2.f chetri2x.f cheswapr.f
-   chetrs.f chetrs2.f
-   chetf2_rook.f chetrf_rook.f chetri_rook.f
-   chetrs_rook.f checon_rook.f chesv_rook.f
-   chetf2_rk.f chetrf_rk.f chetri_3.f chetri_3x.f
-   chetrs_3.f checon_3.f chesv_rk.f
-   chesv_aa.f chetrf_aa.f chetrs_aa.f
-   chesv_aa_2stage.f chetrf_aa_2stage.f chetrs_aa_2stage.f
-   chgeqz.f chpcon.f chpev.f  chpevd.f
-   claqz0.f claqz1.f claqz2.f claqz3.f
-   chpevx.f chpgst.f chpgv.f  chpgvd.f chpgvx.f chprfs.f chpsv.f
+   cggbak.f
+   cggbal.f
+   cgges.f
+   cgges3.f
+   cggesx.f
+   cggev.f
+   cggev3.f
+   cggevx.f
+   cggglm.f
+   cgghrd.f
+   cgghd3.f
+   cgglse.f
+   cggqrf.f
+   cggrqf.f
+   cggsvd3.f
+   cggsvp3.f
+   cgtcon.f
+   cgtrfs.f
+   cgtsv.f
+   cgtsvx.f
+   cgttrf.f
+   cgttrs.f
+   cgtts2.f
+   chbev.f
+   chbevd.f
+   chbevx.f
+   chbgst.f
+   chbgv.f
+   chbgvd.f
+   chbgvx.f
+   chbtrd.f
+   checon.f
+   cheev.f
+   cheevd.f
+   cheevr.f
+   cheevx.f
+   chegs2.f
+   chegst.f
+   chegv.f
+   chegvd.f
+   chegvx.f
+   cherfs.f
+   chesv.f
+   chesvx.f
+   chetd2.f
+   chetf2.f
+   chetrd.f
+   chetrf.f
+   chetri.f
+   chetri2.f
+   chetri2x.f
+   cheswapr.f
+   chetrs.f
+   chetrs2.f
+   chetf2_rook.f
+   chetrf_rook.f
+   chetri_rook.f
+   chetrs_rook.f
+   checon_rook.f
+   chesv_rook.f
+   chetf2_rk.f
+   chetrf_rk.f
+   chetri_3.f
+   chetri_3x.f
+   chetrs_3.f
+   checon_3.f
+   chesv_rk.f
+   chesv_aa.f
+   chetrf_aa.f
+   chetrs_aa.f
+   chesv_aa_2stage.f
+   chetrf_aa_2stage.f
+   chetrs_aa_2stage.f
+   chgeqz.f
+   chpcon.f
+   chpev.f
+   chpevd.f
+   claqz0.f
+   claqz1.f
+   claqz2.f
+   claqz3.f
+   chpevx.f
+   chpgst.f
+   chpgv.f
+   chpgvd.f
+   chpgvx.f
+   chprfs.f
+   chpsv.f
    chpsvx.f
-   chptrd.f chptrf.f chptri.f chptrs.f chsein.f chseqr.f clabrd.f
-   clacgv.f clacon.f clacn2.f clacp2.f clacpy.f clacrm.f clacrt.f cladiv.f
-   claed0.f claed7.f claed8.f
-   claein.f claesy.f claev2.f clags2.f clagtm.f
-   clahef.f clahef_rook.f clahef_rk.f clahef_aa.f clahqr.f
-   clahr2.f claic1.f clals0.f clalsa.f clalsd.f clangb.f clange.f clangt.f
-   clanhb.f clanhe.f
-   clanhp.f clanhs.f clanht.f clansb.f clansp.f clansy.f clantb.f
-   clantp.f clantr.f clapll.f clapmt.f clarcm.f claqgb.f claqge.f
-   claqhb.f claqhe.f claqhp.f claqp2.f claqps.f claqp2rk.f claqp3rk.f claqsb.f
-   claqr0.f claqr1.f claqr2.f claqr3.f claqr4.f claqr5.f
-   claqsp.f claqsy.f clar1v.f clar2v.f ilaclr.f ilaclc.f
-   clarf.f  clarfb.f clarfb_gett.f clarfg.f clarfgp.f clarft.f
-   clarfx.f clarfy.f clargv.f clarnv.f clarrv.f clartg.f90 clartv.f
-   clarz.f  clarzb.f clarzt.f clascl.f claset.f clasr.f  classq.f90
-   claswp.f clasyf.f clasyf_rook.f clasyf_rk.f clasyf_aa.f
-   clatbs.f clatdf.f clatps.f clatrd.f clatrs.f clatrs3.f clatrz.f
-   clauu2.f clauum.f cpbcon.f cpbequ.f cpbrfs.f cpbstf.f cpbsv.f
-   cpbsvx.f cpbtf2.f cpbtrf.f cpbtrs.f cpocon.f cpoequ.f cporfs.f
-   cposv.f  cposvx.f cpotf2.f cpotrf2.f cpotri.f cpstrf.f cpstf2.f
-   cppcon.f cppequ.f cpprfs.f cppsv.f  cppsvx.f cpptrf.f cpptri.f cpptrs.f
-   cptcon.f cpteqr.f cptrfs.f cptsv.f  cptsvx.f cpttrf.f cpttrs.f cptts2.f
-   crot.f   cspcon.f cspmv.f  cspr.f   csprfs.f cspsv.f
-   cspsvx.f csptrf.f csptri.f csptrs.f csrscl.f crscl.f cstedc.f
-   cstegr.f cstein.f csteqr.f csycon.f csymv.f
-   csyr.f   csyrfs.f csysv.f  csysvx.f csytf2.f csytrf.f csytri.f
-   csytri2.f csytri2x.f csyswapr.f
-   csytrs.f csytrs2.f
-   csyconv.f csyconvf.f csyconvf_rook.f
-   csytf2_rook.f csytrf_rook.f csytrs_rook.f
-   csytri_rook.f csycon_rook.f csysv_rook.f
-   csytf2_rk.f csytrf_rk.f csytrf_aa.f csytrs_3.f csytrs_aa.f
-   csytri_3.f csytri_3x.f csycon_3.f csysv_rk.f csysv_aa.f
-   csysv_aa_2stage.f csytrf_aa_2stage.f csytrs_aa_2stage.f
-   ctbcon.f ctbrfs.f ctbtrs.f ctgevc.f ctgex2.f
-   ctgexc.f ctgsen.f ctgsja.f ctgsna.f ctgsy2.f ctgsyl.f ctpcon.f
-   ctprfs.f ctptri.f
-   ctptrs.f ctrcon.f ctrevc.f ctrevc3.f ctrexc.f ctrrfs.f ctrsen.f ctrsna.f
-   ctrsyl.f ctrsyl3.f ctrti2.f ctrtri.f ctrtrs.f ctzrzf.f cung2l.f cung2r.f
-   cungbr.f cunghr.f cungl2.f cunglq.f cungql.f cungqr.f cungr2.f
-   cungrq.f cungtr.f cungtsqr.f cungtsqr_row.f cunm2l.f cunm2r.f cunmbr.f cunmhr.f cunml2.f cunm22.f
-   cunmlq.f cunmql.f cunmqr.f cunmr2.f cunmr3.f cunmrq.f cunmrz.f
-   cunmtr.f cupgtr.f cupmtr.f icmax1.f scsum1.f cstemr.f
-   chfrk.f ctfttp.f clanhf.f cpftrf.f cpftri.f cpftrs.f ctfsm.f ctftri.f
-   ctfttr.f ctpttf.f ctpttr.f ctrttf.f ctrttp.f
-   cgeequb.f cgbequb.f csyequb.f cpoequb.f cheequb.f
-   cbbcsd.f clapmr.f cunbdb.f cunbdb1.f cunbdb2.f cunbdb3.f cunbdb4.f
-   cunbdb5.f cunbdb6.f cuncsd.f cuncsd2by1.f
-   cgeqrt.f cgeqrt2.f cgeqrt3.f cgemqrt.f
-   ctpqrt.f ctpqrt2.f ctpmqrt.f ctprfb.f
-   cgelqt.f cgelqt3.f cgemlqt.f
-   cgetsls.f cgetsqrhrt.f cgeqr.f clatsqr.f clamtsqr.f cgemqr.f
-   cgelq.f claswlq.f clamswlq.f cgemlq.f
-   ctplqt.f ctplqt2.f ctpmlqt.f
-   cunhr_col.f claunhr_col_getrfnp.f claunhr_col_getrfnp2.f
-   chetrd_2stage.f chetrd_he2hb.f chetrd_hb2st.F chb2st_kernels.f
-   cheevd_2stage.f cheev_2stage.f cheevx_2stage.f cheevr_2stage.f
-   chbev_2stage.f chbevx_2stage.f chbevd_2stage.f chegv_2stage.f
-   cgesvdq.f cgedmd.f90 cgedmdq.f90)
+   chptrd.f
+   chptrf.f
+   chptri.f
+   chptrs.f
+   chsein.f
+   chseqr.f
+   clabrd.f
+   clacgv.f
+   clacon.f
+   clacn2.f
+   clacp2.f
+   clacpy.f
+   clacrm.f
+   clacrt.f
+   cladiv.f
+   claed0.f
+   claed7.f
+   claed8.f
+   claein.f
+   claesy.f
+   claev2.f
+   clags2.f
+   clagtm.f
+   clahef.f
+   clahef_rook.f
+   clahef_rk.f
+   clahef_aa.f
+   clahqr.f
+   clahr2.f
+   claic1.f
+   clals0.f
+   clalsa.f
+   clalsd.f
+   clangb.f
+   clange.f
+   clangt.f
+   clanhb.f
+   clanhe.f
+   clanhp.f
+   clanhs.f
+   clanht.f
+   clansb.f
+   clansp.f
+   clansy.f
+   clantb.f
+   clantp.f
+   clantr.f
+   clapll.f
+   clapmt.f
+   clarcm.f
+   claqgb.f
+   claqge.f
+   claqhb.f
+   claqhe.f
+   claqhp.f
+   claqp2.f
+   claqps.f
+   claqp2rk.f
+   claqp3rk.f
+   claqsb.f
+   claqr0.f
+   claqr1.f
+   claqr2.f
+   claqr3.f
+   claqr4.f
+   claqr5.f
+   claqsp.f
+   claqsy.f
+   clar1v.f
+   clar2v.f
+   ilaclr.f
+   ilaclc.f
+   clarf.f
+   clarfb.f
+   clarfb_gett.f
+   clarfg.f
+   clarfgp.f
+   clarft.f
+   clarfx.f
+   clarfy.f
+   clargv.f
+   clarnv.f
+   clarrv.f
+   clartg.f90
+   clartv.f
+   clarz.f
+   clarzb.f
+   clarzt.f
+   clascl.f
+   claset.f
+   clasr.f
+   classq.f90
+   claswp.f
+   clasyf.f
+   clasyf_rook.f
+   clasyf_rk.f
+   clasyf_aa.f
+   clatbs.f
+   clatdf.f
+   clatps.f
+   clatrd.f
+   clatrs.f
+   clatrs3.f
+   clatrz.f
+   clauu2.f
+   clauum.f
+   cpbcon.f
+   cpbequ.f
+   cpbrfs.f
+   cpbstf.f
+   cpbsv.f
+   cpbsvx.f
+   cpbtf2.f
+   cpbtrf.f
+   cpbtrs.f
+   cpocon.f
+   cpoequ.f
+   cporfs.f
+   cposv.f
+   cposvx.f
+   cpotf2.f
+   cpotrf2.f
+   cpotri.f
+   cpstrf.f
+   cpstf2.f
+   cppcon.f
+   cppequ.f
+   cpprfs.f
+   cppsv.f
+   cppsvx.f
+   cpptrf.f
+   cpptri.f
+   cpptrs.f
+   cptcon.f
+   cpteqr.f
+   cptrfs.f
+   cptsv.f
+   cptsvx.f
+   cpttrf.f
+   cpttrs.f
+   cptts2.f
+   crot.f
+   cspcon.f
+   cspmv.f
+   cspr.f
+   csprfs.f
+   cspsv.f
+   cspsvx.f
+   csptrf.f
+   csptri.f
+   csptrs.f
+   csrscl.f
+   crscl.f
+   cstedc.f
+   cstegr.f
+   cstein.f
+   csteqr.f
+   csycon.f
+   csymv.f
+   csyr.f
+   csyrfs.f
+   csysv.f
+   csysvx.f
+   csytf2.f
+   csytrf.f
+   csytri.f
+   csytri2.f
+   csytri2x.f
+   csyswapr.f
+   csytrs.f
+   csytrs2.f
+   csyconv.f
+   csyconvf.f
+   csyconvf_rook.f
+   csytf2_rook.f
+   csytrf_rook.f
+   csytrs_rook.f
+   csytri_rook.f
+   csycon_rook.f
+   csysv_rook.f
+   csytf2_rk.f
+   csytrf_rk.f
+   csytrf_aa.f
+   csytrs_3.f
+   csytrs_aa.f
+   csytri_3.f
+   csytri_3x.f
+   csycon_3.f
+   csysv_rk.f
+   csysv_aa.f
+   csysv_aa_2stage.f
+   csytrf_aa_2stage.f
+   csytrs_aa_2stage.f
+   ctbcon.f
+   ctbrfs.f
+   ctbtrs.f
+   ctgevc.f
+   ctgex2.f
+   ctgexc.f
+   ctgsen.f
+   ctgsja.f
+   ctgsna.f
+   ctgsy2.f
+   ctgsyl.f
+   ctpcon.f
+   ctprfs.f
+   ctptri.f
+   ctptrs.f
+   ctrcon.f
+   ctrevc.f
+   ctrevc3.f
+   ctrexc.f
+   ctrrfs.f
+   ctrsen.f
+   ctrsna.f
+   ctrsyl.f
+   ctrsyl3.f
+   ctrti2.f
+   ctrtri.f
+   ctrtrs.f
+   ctzrzf.f
+   cung2l.f
+   cung2r.f
+   cungbr.f
+   cunghr.f
+   cungl2.f
+   cunglq.f
+   cungql.f
+   cungqr.f
+   cungr2.f
+   cungrq.f
+   cungtr.f
+   cungtsqr.f
+   cungtsqr_row.f
+   cunm2l.f
+   cunm2r.f
+   cunmbr.f
+   cunmhr.f
+   cunml2.f
+   cunm22.f
+   cunmlq.f
+   cunmql.f
+   cunmqr.f
+   cunmr2.f
+   cunmr3.f
+   cunmrq.f
+   cunmrz.f
+   cunmtr.f
+   cupgtr.f
+   cupmtr.f
+   icmax1.f
+   scsum1.f
+   cstemr.f
+   chfrk.f
+   ctfttp.f
+   clanhf.f
+   cpftrf.f
+   cpftri.f
+   cpftrs.f
+   ctfsm.f
+   ctftri.f
+   ctfttr.f
+   ctpttf.f
+   ctpttr.f
+   ctrttf.f
+   ctrttp.f
+   cgeequb.f
+   cgbequb.f
+   csyequb.f
+   cpoequb.f
+   cheequb.f
+   cbbcsd.f
+   clapmr.f
+   cunbdb.f
+   cunbdb1.f
+   cunbdb2.f
+   cunbdb3.f
+   cunbdb4.f
+   cunbdb5.f
+   cunbdb6.f
+   cuncsd.f
+   cuncsd2by1.f
+   cgeqrt.f
+   cgeqrt2.f
+   cgeqrt3.f
+   cgemqrt.f
+   ctpqrt.f
+   ctpqrt2.f
+   ctpmqrt.f
+   ctprfb.f
+   cgelqt.f
+   cgelqt3.f
+   cgemlqt.f
+   cgetsls.f
+   cgetsqrhrt.f
+   cgeqr.f
+   clatsqr.f
+   clamtsqr.f
+   cgemqr.f
+   cgelq.f
+   claswlq.f
+   clamswlq.f
+   cgemlq.f
+   ctplqt.f
+   ctplqt2.f
+   ctpmlqt.f
+   cunhr_col.f
+   claunhr_col_getrfnp.f
+   claunhr_col_getrfnp2.f
+   chetrd_2stage.f
+   chetrd_he2hb.f
+   chetrd_hb2st.F
+   chb2st_kernels.f
+   cheevd_2stage.f
+   cheev_2stage.f
+   cheevx_2stage.f
+   cheevr_2stage.f
+   chbev_2stage.f
+   chbevx_2stage.f
+   chbevd_2stage.f
+   chegv_2stage.f
+   cgesvdq.f
+   cgedmd.f90
+   cgedmdq.f90)
 
-set(CXLASRC cgesvxx.f cgerfsx.f cla_gerfsx_extended.f cla_geamv.f
-   cla_gercond_c.f cla_gercond_x.f cla_gerpvgrw.f
-   csysvxx.f csyrfsx.f cla_syrfsx_extended.f cla_syamv.f
-   cla_syrcond_c.f cla_syrcond_x.f cla_syrpvgrw.f
-   cposvxx.f cporfsx.f cla_porfsx_extended.f
-   cla_porcond_c.f cla_porcond_x.f cla_porpvgrw.f
-   cgbsvxx.f cgbrfsx.f cla_gbrfsx_extended.f cla_gbamv.f
-   cla_gbrcond_c.f cla_gbrcond_x.f cla_gbrpvgrw.f
-   chesvxx.f cherfsx.f cla_herfsx_extended.f cla_heamv.f
-   cla_hercond_c.f cla_hercond_x.f cla_herpvgrw.f
-   cla_lin_berr.f clarscl2.f clascl2.f cla_wwaddw.f)
+set(CXLASRC
+   cgesvxx.f
+   cgerfsx.f
+   cla_gerfsx_extended.f
+   cla_geamv.f
+   cla_gercond_c.f
+   cla_gercond_x.f
+   cla_gerpvgrw.f
+   csysvxx.f
+   csyrfsx.f
+   cla_syrfsx_extended.f
+   cla_syamv.f
+   cla_syrcond_c.f
+   cla_syrcond_x.f
+   cla_syrpvgrw.f
+   cposvxx.f
+   cporfsx.f
+   cla_porfsx_extended.f
+   cla_porcond_c.f
+   cla_porcond_x.f
+   cla_porpvgrw.f
+   cgbsvxx.f
+   cgbrfsx.f
+   cla_gbrfsx_extended.f
+   cla_gbamv.f
+   cla_gbrcond_c.f
+   cla_gbrcond_x.f
+   cla_gbrpvgrw.f
+   chesvxx.f
+   cherfsx.f
+   cla_herfsx_extended.f
+   cla_heamv.f
+   cla_hercond_c.f
+   cla_hercond_x.f
+   cla_herpvgrw.f
+   cla_lin_berr.f
+   clarscl2.f
+   clascl2.f
+   cla_wwaddw.f)
 
 set(ZCLASRC
-    cgetrf.f cgetrf2.f cgetrs.f claswp.f cpotrf.f cpotrf2.f cpotrs.f cgetrs.f
-    cpotrf.f cgetrf.f
-    sisnan.f slaisnan.f)
+   cgetrf.f
+   cgetrf2.f
+   cgetrs.f
+   claswp.f
+   cpotrf.f
+   cpotrf2.f
+   cpotrs.f
+   cgetrs.f
+   cpotrf.f
+   cgetrf.f
+   sisnan.f
+   slaisnan.f)
 
 set(DLASRC
-   dbdsvdx.f dgbbrd.f dgbcon.f dgbequ.f dgbrfs.f dgbsv.f
-   dgbsvx.f dgbtf2.f dgbtrf.f dgbtrs.f dgebak.f dgebal.f dgebd2.f
-   dgebrd.f dgecon.f dgeequ.f dgees.f  dgeesx.f dgeev.f  dgeevx.f
-   dgehd2.f dgehrd.f dgelq2.f dgelqf.f
-   dgels.f  dgelst.f dgelsd.f dgelss.f dgelsy.f dgeql2.f dgeqlf.f
-   dgeqp3.f dgeqp3rk.f dgeqr2.f dgeqr2p.f dgeqrf.f dgeqrfp.f dgerfs.f dgerq2.f dgerqf.f
-   dgesc2.f dgesdd.f dgesv.f  dgesvd.f dgesvdx.f dgesvx.f dgetc2.f dgetf2.f
-   dgetrf.f dgetrf2.f dgetri.f
-   dgetrs.f dggbak.f dggbal.f
-   dgges.f  dgges3.f dggesx.f dggev.f  dggev3.f dggevx.f
-   dggglm.f dgghrd.f dgghd3.f dgglse.f dggqrf.f
-   dggrqf.f dggsvd3.f dggsvp3.f dgtcon.f dgtrfs.f dgtsv.f
-   dgtsvx.f dgttrf.f dgttrs.f dgtts2.f dhgeqz.f
-   dlaqz0.f dlaqz1.f dlaqz2.f dlaqz3.f dlaqz4.f
-   dhsein.f dhseqr.f dlabrd.f dlacon.f dlacn2.f
-   dlaein.f dlaexc.f dlag2.f  dlags2.f dlagtm.f dlagv2.f dlahqr.f
-   dlahr2.f dlaic1.f dlaln2.f dlals0.f dlalsa.f dlalsd.f
-   dlangb.f dlange.f dlangt.f dlanhs.f dlansb.f dlansp.f
-   dlansy.f dlantb.f dlantp.f dlantr.f dlanv2.f
-   dlapll.f dlapmt.f
-   dlaqgb.f dlaqge.f dlaqp2.f dlaqps.f dlaqp2rk.f dlaqp3rk.f dlaqsb.f dlaqsp.f dlaqsy.f
-   dlaqr0.f dlaqr1.f dlaqr2.f dlaqr3.f dlaqr4.f dlaqr5.f
-   dlaqtr.f dlar1v.f dlar2v.f iladlr.f iladlc.f
-   dlarf.f  dlarfb.f dlarfb_gett.f dlarfg.f dlarfgp.f dlarft.f dlarfx.f dlarfy.f
-   dlargv.f dlarmm.f dlarrv.f dlartv.f
-   dlarz.f  dlarzb.f dlarzt.f dlaswp.f dlasy2.f
-   dlasyf.f dlasyf_rook.f dlasyf_rk.f dlasyf_aa.f
-   dlatbs.f dlatdf.f dlatps.f dlatrd.f dlatrs.f dlatrs3.f dlatrz.f dlauu2.f
-   dlauum.f dopgtr.f dopmtr.f dorg2l.f dorg2r.f
-   dorgbr.f dorghr.f dorgl2.f dorglq.f dorgql.f dorgqr.f dorgr2.f
-   dorgrq.f dorgtr.f dorgtsqr.f dorgtsqr_row.f dorm2l.f dorm2r.f dorm22.f
-   dormbr.f dormhr.f dorml2.f dormlq.f dormql.f dormqr.f dormr2.f
-   dormr3.f dormrq.f dormrz.f dormtr.f dpbcon.f dpbequ.f dpbrfs.f
-   dpbstf.f dpbsv.f  dpbsvx.f
-   dpbtf2.f dpbtrf.f dpbtrs.f dpocon.f dpoequ.f dporfs.f dposv.f
-   dposvx.f dpotf2.f dpotrf.f dpotrf2.f dpotri.f dpotrs.f dpstrf.f dpstf2.f
-   dppcon.f dppequ.f
-   dpprfs.f dppsv.f  dppsvx.f dpptrf.f dpptri.f dpptrs.f dptcon.f
-   dpteqr.f dptrfs.f dptsv.f  dptsvx.f dpttrs.f dptts2.f drscl.f
-   dsbev.f  dsbevd.f dsbevx.f dsbgst.f dsbgv.f  dsbgvd.f dsbgvx.f
-   dsbtrd.f dspcon.f dspev.f  dspevd.f dspevx.f dspgst.f
-   dspgv.f  dspgvd.f dspgvx.f dsprfs.f dspsv.f  dspsvx.f dsptrd.f
-   dsptrf.f dsptri.f dsptrs.f dstegr.f dstev.f  dstevd.f dstevr.f
-   dsycon.f dsyev.f  dsyevd.f dsyevr.f
-   dsyevx.f dsygs2.f dsygst.f dsygv.f  dsygvd.f dsygvx.f dsyrfs.f
-   dsysv.f  dsysvx.f
-   dsytd2.f dsytf2.f dsytrd.f dsytrf.f dsytri.f dsytrs.f dsytrs2.f
-   dsytri2.f dsytri2x.f dsyswapr.f
-   dsyconv.f dsyconvf.f dsyconvf_rook.f
-   dsytf2_rook.f dsytrf_rook.f dsytrs_rook.f
-   dsytri_rook.f dsycon_rook.f dsysv_rook.f
-   dsytf2_rk.f dsytrf_rk.f dsytrs_3.f
-   dsytri_3.f dsytri_3x.f dsycon_3.f dsysv_rk.f
-   dsysv_aa.f dsytrf_aa.f dsytrs_aa.f
-   dsysv_aa_2stage.f dsytrf_aa_2stage.f dsytrs_aa_2stage.f
+   dbdsvdx.f
+   dgbbrd.f
+   dgbcon.f
+   dgbequ.f
+   dgbrfs.f
+   dgbsv.f
+   dgbsvx.f
+   dgbtf2.f
+   dgbtrf.f
+   dgbtrs.f
+   dgebak.f
+   dgebal.f
+   dgebd2.f
+   dgebrd.f
+   dgecon.f
+   dgeequ.f
+   dgees.f
+   dgeesx.f
+   dgeev.f
+   dgeevx.f
+   dgehd2.f
+   dgehrd.f
+   dgelq2.f
+   dgelqf.f
+   dgels.f
+   dgelst.f
+   dgelsd.f
+   dgelss.f
+   dgelsy.f
+   dgeql2.f
+   dgeqlf.f
+   dgeqp3.f
+   dgeqp3rk.f
+   dgeqr2.f
+   dgeqr2p.f
+   dgeqrf.f
+   dgeqrfp.f
+   dgerfs.f
+   dgerq2.f
+   dgerqf.f
+   dgesc2.f
+   dgesdd.f
+   dgesv.f
+   dgesvd.f
+   dgesvdx.f
+   dgesvx.f
+   dgetc2.f
+   dgetf2.f
+   dgetrf.f
+   dgetrf2.f
+   dgetri.f
+   dgetrs.f
+   dggbak.f
+   dggbal.f
+   dgges.f
+   dgges3.f
+   dggesx.f
+   dggev.f
+   dggev3.f
+   dggevx.f
+   dggglm.f
+   dgghrd.f
+   dgghd3.f
+   dgglse.f
+   dggqrf.f
+   dggrqf.f
+   dggsvd3.f
+   dggsvp3.f
+   dgtcon.f
+   dgtrfs.f
+   dgtsv.f
+   dgtsvx.f
+   dgttrf.f
+   dgttrs.f
+   dgtts2.f
+   dhgeqz.f
+   dlaqz0.f
+   dlaqz1.f
+   dlaqz2.f
+   dlaqz3.f
+   dlaqz4.f
+   dhsein.f
+   dhseqr.f
+   dlabrd.f
+   dlacon.f
+   dlacn2.f
+   dlaein.f
+   dlaexc.f
+   dlag2.f
+   dlags2.f
+   dlagtm.f
+   dlagv2.f
+   dlahqr.f
+   dlahr2.f
+   dlaic1.f
+   dlaln2.f
+   dlals0.f
+   dlalsa.f
+   dlalsd.f
+   dlangb.f
+   dlange.f
+   dlangt.f
+   dlanhs.f
+   dlansb.f
+   dlansp.f
+   dlansy.f
+   dlantb.f
+   dlantp.f
+   dlantr.f
+   dlanv2.f
+   dlapll.f
+   dlapmt.f
+   dlaqgb.f
+   dlaqge.f
+   dlaqp2.f
+   dlaqps.f
+   dlaqp2rk.f
+   dlaqp3rk.f
+   dlaqsb.f
+   dlaqsp.f
+   dlaqsy.f
+   dlaqr0.f
+   dlaqr1.f
+   dlaqr2.f
+   dlaqr3.f
+   dlaqr4.f
+   dlaqr5.f
+   dlaqtr.f
+   dlar1v.f
+   dlar2v.f
+   iladlr.f
+   iladlc.f
+   dlarf.f
+   dlarfb.f
+   dlarfb_gett.f
+   dlarfg.f
+   dlarfgp.f
+   dlarft.f
+   dlarfx.f
+   dlarfy.f
+   dlargv.f
+   dlarmm.f
+   dlarrv.f
+   dlartv.f
+   dlarz.f
+   dlarzb.f
+   dlarzt.f
+   dlaswp.f
+   dlasy2.f
+   dlasyf.f
+   dlasyf_rook.f
+   dlasyf_rk.f
+   dlasyf_aa.f
+   dlatbs.f
+   dlatdf.f
+   dlatps.f
+   dlatrd.f
+   dlatrs.f
+   dlatrs3.f
+   dlatrz.f
+   dlauu2.f
+   dlauum.f
+   dopgtr.f
+   dopmtr.f
+   dorg2l.f
+   dorg2r.f
+   dorgbr.f
+   dorghr.f
+   dorgl2.f
+   dorglq.f
+   dorgql.f
+   dorgqr.f
+   dorgr2.f
+   dorgrq.f
+   dorgtr.f
+   dorgtsqr.f
+   dorgtsqr_row.f
+   dorm2l.f
+   dorm2r.f
+   dorm22.f
+   dormbr.f
+   dormhr.f
+   dorml2.f
+   dormlq.f
+   dormql.f
+   dormqr.f
+   dormr2.f
+   dormr3.f
+   dormrq.f
+   dormrz.f
+   dormtr.f
+   dpbcon.f
+   dpbequ.f
+   dpbrfs.f
+   dpbstf.f
+   dpbsv.f
+   dpbsvx.f
+   dpbtf2.f
+   dpbtrf.f
+   dpbtrs.f
+   dpocon.f
+   dpoequ.f
+   dporfs.f
+   dposv.f
+   dposvx.f
+   dpotf2.f
+   dpotrf.f
+   dpotrf2.f
+   dpotri.f
+   dpotrs.f
+   dpstrf.f
+   dpstf2.f
+   dppcon.f
+   dppequ.f
+   dpprfs.f
+   dppsv.f
+   dppsvx.f
+   dpptrf.f
+   dpptri.f
+   dpptrs.f
+   dptcon.f
+   dpteqr.f
+   dptrfs.f
+   dptsv.f
+   dptsvx.f
+   dpttrs.f
+   dptts2.f
+   drscl.f
+   dsbev.f
+   dsbevd.f
+   dsbevx.f
+   dsbgst.f
+   dsbgv.f
+   dsbgvd.f
+   dsbgvx.f
+   dsbtrd.f
+   dspcon.f
+   dspev.f
+   dspevd.f
+   dspevx.f
+   dspgst.f
+   dspgv.f
+   dspgvd.f
+   dspgvx.f
+   dsprfs.f
+   dspsv.f
+   dspsvx.f
+   dsptrd.f
+   dsptrf.f
+   dsptri.f
+   dsptrs.f
+   dstegr.f
+   dstev.f
+   dstevd.f
+   dstevr.f
+   dsycon.f
+   dsyev.f
+   dsyevd.f
+   dsyevr.f
+   dsyevx.f
+   dsygs2.f
+   dsygst.f
+   dsygv.f
+   dsygvd.f
+   dsygvx.f
+   dsyrfs.f
+   dsysv.f
+   dsysvx.f
+   dsytd2.f
+   dsytf2.f
+   dsytrd.f
+   dsytrf.f
+   dsytri.f
+   dsytrs.f
+   dsytrs2.f
+   dsytri2.f
+   dsytri2x.f
+   dsyswapr.f
+   dsyconv.f
+   dsyconvf.f
+   dsyconvf_rook.f
+   dsytf2_rook.f
+   dsytrf_rook.f
+   dsytrs_rook.f
+   dsytri_rook.f
+   dsycon_rook.f
+   dsysv_rook.f
+   dsytf2_rk.f
+   dsytrf_rk.f
+   dsytrs_3.f
+   dsytri_3.f
+   dsytri_3x.f
+   dsycon_3.f
+   dsysv_rk.f
+   dsysv_aa.f
+   dsytrf_aa.f
+   dsytrs_aa.f
+   dsysv_aa_2stage.f
+   dsytrf_aa_2stage.f
+   dsytrs_aa_2stage.f
    dtbcon.f
-   dtbrfs.f dtbtrs.f dtgevc.f dtgex2.f dtgexc.f dtgsen.f
-   dtgsja.f dtgsna.f dtgsy2.f dtgsyl.f dtpcon.f dtprfs.f dtptri.f
+   dtbrfs.f
+   dtbtrs.f
+   dtgevc.f
+   dtgex2.f
+   dtgexc.f
+   dtgsen.f
+   dtgsja.f
+   dtgsna.f
+   dtgsy2.f
+   dtgsyl.f
+   dtpcon.f
+   dtprfs.f
+   dtptri.f
    dtptrs.f
-   dtrcon.f dtrevc.f dtrevc3.f dtrexc.f dtrrfs.f dtrsen.f dtrsna.f dtrsyl.f
-   dtrsyl3.f dtrti2.f dtrtri.f dtrtrs.f dtzrzf.f dstemr.f
-   dsgesv.f dsposv.f dlag2s.f slag2d.f dlat2s.f
-   dlansf.f dpftrf.f dpftri.f dpftrs.f dsfrk.f dtfsm.f dtftri.f dtfttp.f
-   dtfttr.f dtpttf.f dtpttr.f dtrttf.f dtrttp.f
-   dgejsv.f dgesvj.f dgsvj0.f dgsvj1.f
-   dgeequb.f dsyequb.f dpoequb.f dgbequb.f
-   dbbcsd.f dlapmr.f dorbdb.f dorbdb1.f dorbdb2.f dorbdb3.f dorbdb4.f
-   dorbdb5.f dorbdb6.f dorcsd.f dorcsd2by1.f
-   dgeqrt.f dgeqrt2.f dgeqrt3.f dgemqrt.f
-   dtpqrt.f dtpqrt2.f dtpmqrt.f dtprfb.f
-   dgelqt.f dgelqt3.f dgemlqt.f
-   dgetsls.f dgetsqrhrt.f dgeqr.f dlatsqr.f dlamtsqr.f dgemqr.f
-   dgelq.f dlaswlq.f dlamswlq.f dgemlq.f
-   dtplqt.f dtplqt2.f dtpmlqt.f
-   dorhr_col.f dlaorhr_col_getrfnp.f dlaorhr_col_getrfnp2.f
-   dsytrd_2stage.f dsytrd_sy2sb.f dsytrd_sb2st.F dsb2st_kernels.f
-   dsyevd_2stage.f dsyev_2stage.f dsyevx_2stage.f dsyevr_2stage.f
-   dsbev_2stage.f dsbevx_2stage.f dsbevd_2stage.f dsygv_2stage.f
-   dgesvdq.f dgedmd.f90 dgedmdq.f90)
+   dtrcon.f
+   dtrevc.f
+   dtrevc3.f
+   dtrexc.f
+   dtrrfs.f
+   dtrsen.f
+   dtrsna.f
+   dtrsyl.f
+   dtrsyl3.f
+   dtrti2.f
+   dtrtri.f
+   dtrtrs.f
+   dtzrzf.f
+   dstemr.f
+   dsgesv.f
+   dsposv.f
+   dlag2s.f
+   slag2d.f
+   dlat2s.f
+   dlansf.f
+   dpftrf.f
+   dpftri.f
+   dpftrs.f
+   dsfrk.f
+   dtfsm.f
+   dtftri.f
+   dtfttp.f
+   dtfttr.f
+   dtpttf.f
+   dtpttr.f
+   dtrttf.f
+   dtrttp.f
+   dgejsv.f
+   dgesvj.f
+   dgsvj0.f
+   dgsvj1.f
+   dgeequb.f
+   dsyequb.f
+   dpoequb.f
+   dgbequb.f
+   dbbcsd.f
+   dlapmr.f
+   dorbdb.f
+   dorbdb1.f
+   dorbdb2.f
+   dorbdb3.f
+   dorbdb4.f
+   dorbdb5.f
+   dorbdb6.f
+   dorcsd.f
+   dorcsd2by1.f
+   dgeqrt.f
+   dgeqrt2.f
+   dgeqrt3.f
+   dgemqrt.f
+   dtpqrt.f
+   dtpqrt2.f
+   dtpmqrt.f
+   dtprfb.f
+   dgelqt.f
+   dgelqt3.f
+   dgemlqt.f
+   dgetsls.f
+   dgetsqrhrt.f
+   dgeqr.f
+   dlatsqr.f
+   dlamtsqr.f
+   dgemqr.f
+   dgelq.f
+   dlaswlq.f
+   dlamswlq.f
+   dgemlq.f
+   dtplqt.f
+   dtplqt2.f
+   dtpmlqt.f
+   dorhr_col.f
+   dlaorhr_col_getrfnp.f
+   dlaorhr_col_getrfnp2.f
+   dsytrd_2stage.f
+   dsytrd_sy2sb.f
+   dsytrd_sb2st.F
+   dsb2st_kernels.f
+   dsyevd_2stage.f
+   dsyev_2stage.f
+   dsyevx_2stage.f
+   dsyevr_2stage.f
+   dsbev_2stage.f
+   dsbevx_2stage.f
+   dsbevd_2stage.f
+   dsygv_2stage.f
+   dgesvdq.f
+   dgedmd.f90
+   dgedmdq.f90)
 
-set(DXLASRC dgesvxx.f dgerfsx.f dla_gerfsx_extended.f dla_geamv.f
-   dla_gercond.f dla_gerpvgrw.f dsysvxx.f dsyrfsx.f
-   dla_syrfsx_extended.f dla_syamv.f dla_syrcond.f dla_syrpvgrw.f
-   dposvxx.f dporfsx.f dla_porfsx_extended.f dla_porcond.f
-   dla_porpvgrw.f dgbsvxx.f dgbrfsx.f dla_gbrfsx_extended.f
-   dla_gbamv.f dla_gbrcond.f dla_gbrpvgrw.f dla_lin_berr.f dlarscl2.f
-   dlascl2.f dla_wwaddw.f)
+set(DXLASRC
+   dgesvxx.f
+   dgerfsx.f
+   dla_gerfsx_extended.f
+   dla_geamv.f
+   dla_gercond.f
+   dla_gerpvgrw.f
+   dsysvxx.f
+   dsyrfsx.f
+   dla_syrfsx_extended.f
+   dla_syamv.f
+   dla_syrcond.f
+   dla_syrpvgrw.f
+   dposvxx.f
+   dporfsx.f
+   dla_porfsx_extended.f
+   dla_porcond.f
+   dla_porpvgrw.f
+   dgbsvxx.f
+   dgbrfsx.f
+   dla_gbrfsx_extended.f
+   dla_gbamv.f
+   dla_gbrcond.f
+   dla_gbrpvgrw.f
+   dla_lin_berr.f
+   dlarscl2.f
+   dlascl2.f
+   dla_wwaddw.f)
 
 set(ZLASRC
-   zbdsqr.f zgbbrd.f zgbcon.f zgbequ.f zgbrfs.f zgbsv.f  zgbsvx.f
-   zgbtf2.f zgbtrf.f zgbtrs.f zgebak.f zgebal.f zgebd2.f zgebrd.f
-   zgecon.f zgeequ.f zgees.f  zgeesx.f zgeev.f  zgeevx.f
-   zgehd2.f zgehrd.f zgelq2.f zgelqf.f
-   zgels.f zgelst.f zgelsd.f zgelss.f zgelsy.f zgeql2.f zgeqlf.f
-   zgeqp3.f zgeqp3rk.f
-   zgeqr2.f zgeqr2p.f zgeqrf.f zgeqrfp.f zgerfs.f zgerq2.f zgerqf.f
-   zgesc2.f zgesdd.f zgesv.f  zgesvd.f zgesvdx.f zgesvx.f
-   zgesvj.f zgejsv.f zgsvj0.f zgsvj1.f
-   zgetc2.f zgetf2.f zgetrf.f zgetrf2.f
-   zgetri.f zgetrs.f
-   zggbak.f zggbal.f
-   zgges.f  zgges3.f zggesx.f zggev.f  zggev3.f zggevx.f
-   zggglm.f zgghrd.f zgghd3.f zgglse.f zggqrf.f zggrqf.f
-   zggsvd3.f zggsvp3.f
-   zgtcon.f zgtrfs.f zgtsv.f  zgtsvx.f zgttrf.f zgttrs.f zgtts2.f zhbev.f
-   zhbevd.f zhbevx.f zhbgst.f zhbgv.f  zhbgvd.f zhbgvx.f zhbtrd.f
-   zhecon.f zheev.f  zheevd.f zheevr.f zheevx.f zhegs2.f zhegst.f
-   zhegv.f  zhegvd.f zhegvx.f zherfs.f zhesv.f  zhesvx.f zhetd2.f
-   zhetf2.f zhetrd.f
-   zhetrf.f zhetri.f zhetri2.f zhetri2x.f zheswapr.f
-   zhetrs.f zhetrs2.f
-   zhetf2_rook.f zhetrf_rook.f zhetri_rook.f
-   zhetrs_rook.f zhecon_rook.f zhesv_rook.f
-   zhetf2_rk.f zhetrf_rk.f zhetri_3.f zhetri_3x.f
-   zhetrs_3.f zhecon_3.f zhesv_rk.f
-   zhesv_aa.f zhetrf_aa.f zhetrs_aa.f
-   zhesv_aa_2stage.f zhetrf_aa_2stage.f zhetrs_aa_2stage.f
-   zhgeqz.f zhpcon.f zhpev.f  zhpevd.f
-   zlaqz0.f zlaqz1.f zlaqz2.f zlaqz3.f
-   zhpevx.f zhpgst.f zhpgv.f  zhpgvd.f zhpgvx.f zhprfs.f zhpsv.f
+   zbdsqr.f
+   zgbbrd.f
+   zgbcon.f
+   zgbequ.f
+   zgbrfs.f
+   zgbsv.f
+   zgbsvx.f
+   zgbtf2.f
+   zgbtrf.f
+   zgbtrs.f
+   zgebak.f
+   zgebal.f
+   zgebd2.f
+   zgebrd.f
+   zgecon.f
+   zgeequ.f
+   zgees.f
+   zgeesx.f
+   zgeev.f
+   zgeevx.f
+   zgehd2.f
+   zgehrd.f
+   zgelq2.f
+   zgelqf.f
+   zgels.f
+   zgelst.f
+   zgelsd.f
+   zgelss.f
+   zgelsy.f
+   zgeql2.f
+   zgeqlf.f
+   zgeqp3.f
+   zgeqp3rk.f
+   zgeqr2.f
+   zgeqr2p.f
+   zgeqrf.f
+   zgeqrfp.f
+   zgerfs.f
+   zgerq2.f
+   zgerqf.f
+   zgesc2.f
+   zgesdd.f
+   zgesv.f
+   zgesvd.f
+   zgesvdx.f
+   zgesvx.f
+   zgesvj.f
+   zgejsv.f
+   zgsvj0.f
+   zgsvj1.f
+   zgetc2.f
+   zgetf2.f
+   zgetrf.f
+   zgetrf2.f
+   zgetri.f
+   zgetrs.f
+   zggbak.f
+   zggbal.f
+   zgges.f
+   zgges3.f
+   zggesx.f
+   zggev.f
+   zggev3.f
+   zggevx.f
+   zggglm.f
+   zgghrd.f
+   zgghd3.f
+   zgglse.f
+   zggqrf.f
+   zggrqf.f
+   zggsvd3.f
+   zggsvp3.f
+   zgtcon.f
+   zgtrfs.f
+   zgtsv.f
+   zgtsvx.f
+   zgttrf.f
+   zgttrs.f
+   zgtts2.f
+   zhbev.f
+   zhbevd.f
+   zhbevx.f
+   zhbgst.f
+   zhbgv.f
+   zhbgvd.f
+   zhbgvx.f
+   zhbtrd.f
+   zhecon.f
+   zheev.f
+   zheevd.f
+   zheevr.f
+   zheevx.f
+   zhegs2.f
+   zhegst.f
+   zhegv.f
+   zhegvd.f
+   zhegvx.f
+   zherfs.f
+   zhesv.f
+   zhesvx.f
+   zhetd2.f
+   zhetf2.f
+   zhetrd.f
+   zhetrf.f
+   zhetri.f
+   zhetri2.f
+   zhetri2x.f
+   zheswapr.f
+   zhetrs.f
+   zhetrs2.f
+   zhetf2_rook.f
+   zhetrf_rook.f
+   zhetri_rook.f
+   zhetrs_rook.f
+   zhecon_rook.f
+   zhesv_rook.f
+   zhetf2_rk.f
+   zhetrf_rk.f
+   zhetri_3.f
+   zhetri_3x.f
+   zhetrs_3.f
+   zhecon_3.f
+   zhesv_rk.f
+   zhesv_aa.f
+   zhetrf_aa.f
+   zhetrs_aa.f
+   zhesv_aa_2stage.f
+   zhetrf_aa_2stage.f
+   zhetrs_aa_2stage.f
+   zhgeqz.f
+   zhpcon.f
+   zhpev.f
+   zhpevd.f
+   zlaqz0.f
+   zlaqz1.f
+   zlaqz2.f
+   zlaqz3.f
+   zhpevx.f
+   zhpgst.f
+   zhpgv.f
+   zhpgvd.f
+   zhpgvx.f
+   zhprfs.f
+   zhpsv.f
    zhpsvx.f
-   zhptrd.f zhptrf.f zhptri.f zhptrs.f zhsein.f zhseqr.f zlabrd.f
-   zlacgv.f zlacon.f zlacn2.f zlacp2.f zlacpy.f zlacrm.f zlacrt.f zladiv.f
-   zlaed0.f zlaed7.f zlaed8.f
-   zlaein.f zlaesy.f zlaev2.f zlags2.f zlagtm.f
-   zlahef.f zlahef_rook.f zlahef_rk.f zlahef_aa.f zlahqr.f
-   zlahr2.f zlaic1.f zlals0.f zlalsa.f zlalsd.f zlangb.f zlange.f
-   zlangt.f zlanhb.f
+   zhptrd.f
+   zhptrf.f
+   zhptri.f
+   zhptrs.f
+   zhsein.f
+   zhseqr.f
+   zlabrd.f
+   zlacgv.f
+   zlacon.f
+   zlacn2.f
+   zlacp2.f
+   zlacpy.f
+   zlacrm.f
+   zlacrt.f
+   zladiv.f
+   zlaed0.f
+   zlaed7.f
+   zlaed8.f
+   zlaein.f
+   zlaesy.f
+   zlaev2.f
+   zlags2.f
+   zlagtm.f
+   zlahef.f
+   zlahef_rook.f
+   zlahef_rk.f
+   zlahef_aa.f
+   zlahqr.f
+   zlahr2.f
+   zlaic1.f
+   zlals0.f
+   zlalsa.f
+   zlalsd.f
+   zlangb.f
+   zlange.f
+   zlangt.f
+   zlanhb.f
    zlanhe.f
-   zlanhp.f zlanhs.f zlanht.f zlansb.f zlansp.f zlansy.f zlantb.f
-   zlantp.f zlantr.f zlapll.f zlapmt.f zlaqgb.f zlaqge.f
-   zlaqhb.f zlaqhe.f zlaqhp.f zlaqp2.f zlaqps.f zlaqp2rk.f zlaqp3rk.f zlaqsb.f
-   zlaqr0.f zlaqr1.f zlaqr2.f zlaqr3.f zlaqr4.f zlaqr5.f
-   zlaqsp.f zlaqsy.f zlar1v.f zlar2v.f ilazlr.f ilazlc.f
-   zlarcm.f zlarf.f  zlarfb.f zlarfb_gett.f
-   zlarfg.f zlarfgp.f zlarft.f
-   zlarfx.f zlarfy.f zlargv.f zlarnv.f zlarrv.f zlartg.f90 zlartv.f
-   zlarz.f  zlarzb.f zlarzt.f zlascl.f zlaset.f zlasr.f
-   zlassq.f90 zlaswp.f zlasyf.f zlasyf_rook.f zlasyf_rk.f zlasyf_aa.f
-   zlatbs.f zlatdf.f zlatps.f zlatrd.f zlatrs.f zlatrs3.f zlatrz.f zlauu2.f
-   zlauum.f zpbcon.f zpbequ.f zpbrfs.f zpbstf.f zpbsv.f
-   zpbsvx.f zpbtf2.f zpbtrf.f zpbtrs.f zpocon.f zpoequ.f zporfs.f
-   zposv.f  zposvx.f zpotf2.f zpotrf.f zpotrf2.f zpotri.f zpotrs.f zpstrf.f zpstf2.f
-   zppcon.f zppequ.f zpprfs.f zppsv.f  zppsvx.f zpptrf.f zpptri.f zpptrs.f
-   zptcon.f zpteqr.f zptrfs.f zptsv.f  zptsvx.f zpttrf.f zpttrs.f zptts2.f
-   zrot.f   zspcon.f zspmv.f  zspr.f   zsprfs.f zspsv.f
-   zspsvx.f zsptrf.f zsptri.f zsptrs.f zdrscl.f zrscl.f zstedc.f
-   zstegr.f zstein.f zsteqr.f zsycon.f zsymv.f
-   zsyr.f   zsyrfs.f zsysv.f  zsysvx.f zsytf2.f zsytrf.f zsytri.f
-   zsytri2.f zsytri2x.f zsyswapr.f
-   zsytrs.f zsytrs2.f
-   zsyconv.f zsyconvf.f zsyconvf_rook.f
-   zsytf2_rook.f zsytrf_rook.f zsytrs_rook.f zsytrs_aa.f
-   zsytri_rook.f zsycon_rook.f zsysv_rook.f
-   zsytf2_rk.f zsytrf_rk.f zsytrf_aa.f zsytrs_3.f
-   zsysv_aa_2stage.f zsytrf_aa_2stage.f zsytrs_aa_2stage.f
-   zsytri_3.f zsytri_3x.f zsycon_3.f zsysv_rk.f zsysv_aa.f
-   ztbcon.f ztbrfs.f ztbtrs.f ztgevc.f ztgex2.f
-   ztgexc.f ztgsen.f ztgsja.f ztgsna.f ztgsy2.f ztgsyl.f ztpcon.f
-   ztprfs.f ztptri.f
-   ztptrs.f ztrcon.f ztrevc.f ztrevc3.f ztrexc.f ztrrfs.f ztrsen.f ztrsna.f
-   ztrsyl.f ztrsyl3.f ztrti2.f ztrtri.f ztrtrs.f ztzrzf.f zung2l.f
-   zung2r.f zungbr.f zunghr.f zungl2.f zunglq.f zungql.f zungqr.f zungr2.f
-   zungrq.f zungtr.f zungtsqr.f zungtsqr_row.f zunm2l.f zunm2r.f zunmbr.f zunmhr.f zunml2.f zunm22.f
-   zunmlq.f zunmql.f zunmqr.f zunmr2.f zunmr3.f zunmrq.f zunmrz.f
-   zunmtr.f zupgtr.f
-   zupmtr.f izmax1.f dzsum1.f zstemr.f
-   zcgesv.f zcposv.f zlag2c.f clag2z.f zlat2c.f
-   zhfrk.f ztfttp.f zlanhf.f zpftrf.f zpftri.f zpftrs.f ztfsm.f ztftri.f
-   ztfttr.f ztpttf.f ztpttr.f ztrttf.f ztrttp.f
-   zgeequb.f zgbequb.f zsyequb.f zpoequb.f zheequb.f
-   zbbcsd.f zlapmr.f zunbdb.f zunbdb1.f zunbdb2.f zunbdb3.f zunbdb4.f
-   zunbdb5.f zunbdb6.f zuncsd.f zuncsd2by1.f
-   zgeqrt.f zgeqrt2.f zgeqrt3.f zgemqrt.f
-   ztpqrt.f ztpqrt2.f ztpmqrt.f ztprfb.f
-   ztplqt.f ztplqt2.f ztpmlqt.f
-   zgelqt.f zgelqt3.f zgemlqt.f
-   zgetsls.f zgetsqrhrt.f zgeqr.f zlatsqr.f zlamtsqr.f zgemqr.f
-   zgelq.f zlaswlq.f zlamswlq.f zgemlq.f
-   zunhr_col.f zlaunhr_col_getrfnp.f zlaunhr_col_getrfnp2.f
-   zhetrd_2stage.f zhetrd_he2hb.f zhetrd_hb2st.F zhb2st_kernels.f
-   zheevd_2stage.f zheev_2stage.f zheevx_2stage.f zheevr_2stage.f
-   zhbev_2stage.f zhbevx_2stage.f zhbevd_2stage.f zhegv_2stage.f
-   zgesvdq.f zgedmd.f90 zgedmdq.f90)
+   zlanhp.f
+   zlanhs.f
+   zlanht.f
+   zlansb.f
+   zlansp.f
+   zlansy.f
+   zlantb.f
+   zlantp.f
+   zlantr.f
+   zlapll.f
+   zlapmt.f
+   zlaqgb.f
+   zlaqge.f
+   zlaqhb.f
+   zlaqhe.f
+   zlaqhp.f
+   zlaqp2.f
+   zlaqps.f
+   zlaqp2rk.f
+   zlaqp3rk.f
+   zlaqsb.f
+   zlaqr0.f
+   zlaqr1.f
+   zlaqr2.f
+   zlaqr3.f
+   zlaqr4.f
+   zlaqr5.f
+   zlaqsp.f
+   zlaqsy.f
+   zlar1v.f
+   zlar2v.f
+   ilazlr.f
+   ilazlc.f
+   zlarcm.f
+   zlarf.f
+   zlarfb.f
+   zlarfb_gett.f
+   zlarfg.f
+   zlarfgp.f
+   zlarft.f
+   zlarfx.f
+   zlarfy.f
+   zlargv.f
+   zlarnv.f
+   zlarrv.f
+   zlartg.f90
+   zlartv.f
+   zlarz.f
+   zlarzb.f
+   zlarzt.f
+   zlascl.f
+   zlaset.f
+   zlasr.f
+   zlassq.f90
+   zlaswp.f
+   zlasyf.f
+   zlasyf_rook.f
+   zlasyf_rk.f
+   zlasyf_aa.f
+   zlatbs.f
+   zlatdf.f
+   zlatps.f
+   zlatrd.f
+   zlatrs.f
+   zlatrs3.f
+   zlatrz.f
+   zlauu2.f
+   zlauum.f
+   zpbcon.f
+   zpbequ.f
+   zpbrfs.f
+   zpbstf.f
+   zpbsv.f
+   zpbsvx.f
+   zpbtf2.f
+   zpbtrf.f
+   zpbtrs.f
+   zpocon.f
+   zpoequ.f
+   zporfs.f
+   zposv.f
+   zposvx.f
+   zpotf2.f
+   zpotrf.f
+   zpotrf2.f
+   zpotri.f
+   zpotrs.f
+   zpstrf.f
+   zpstf2.f
+   zppcon.f
+   zppequ.f
+   zpprfs.f
+   zppsv.f
+   zppsvx.f
+   zpptrf.f
+   zpptri.f
+   zpptrs.f
+   zptcon.f
+   zpteqr.f
+   zptrfs.f
+   zptsv.f
+   zptsvx.f
+   zpttrf.f
+   zpttrs.f
+   zptts2.f
+   zrot.f
+   zspcon.f
+   zspmv.f
+   zspr.f
+   zsprfs.f
+   zspsv.f
+   zspsvx.f
+   zsptrf.f
+   zsptri.f
+   zsptrs.f
+   zdrscl.f
+   zrscl.f
+   zstedc.f
+   zstegr.f
+   zstein.f
+   zsteqr.f
+   zsycon.f
+   zsymv.f
+   zsyr.f
+   zsyrfs.f
+   zsysv.f
+   zsysvx.f
+   zsytf2.f
+   zsytrf.f
+   zsytri.f
+   zsytri2.f
+   zsytri2x.f
+   zsyswapr.f
+   zsytrs.f
+   zsytrs2.f
+   zsyconv.f
+   zsyconvf.f
+   zsyconvf_rook.f
+   zsytf2_rook.f
+   zsytrf_rook.f
+   zsytrs_rook.f
+   zsytrs_aa.f
+   zsytri_rook.f
+   zsycon_rook.f
+   zsysv_rook.f
+   zsytf2_rk.f
+   zsytrf_rk.f
+   zsytrf_aa.f
+   zsytrs_3.f
+   zsysv_aa_2stage.f
+   zsytrf_aa_2stage.f
+   zsytrs_aa_2stage.f
+   zsytri_3.f
+   zsytri_3x.f
+   zsycon_3.f
+   zsysv_rk.f
+   zsysv_aa.f
+   ztbcon.f
+   ztbrfs.f
+   ztbtrs.f
+   ztgevc.f
+   ztgex2.f
+   ztgexc.f
+   ztgsen.f
+   ztgsja.f
+   ztgsna.f
+   ztgsy2.f
+   ztgsyl.f
+   ztpcon.f
+   ztprfs.f
+   ztptri.f
+   ztptrs.f
+   ztrcon.f
+   ztrevc.f
+   ztrevc3.f
+   ztrexc.f
+   ztrrfs.f
+   ztrsen.f
+   ztrsna.f
+   ztrsyl.f
+   ztrsyl3.f
+   ztrti2.f
+   ztrtri.f
+   ztrtrs.f
+   ztzrzf.f
+   zung2l.f
+   zung2r.f
+   zungbr.f
+   zunghr.f
+   zungl2.f
+   zunglq.f
+   zungql.f
+   zungqr.f
+   zungr2.f
+   zungrq.f
+   zungtr.f
+   zungtsqr.f
+   zungtsqr_row.f
+   zunm2l.f
+   zunm2r.f
+   zunmbr.f
+   zunmhr.f
+   zunml2.f
+   zunm22.f
+   zunmlq.f
+   zunmql.f
+   zunmqr.f
+   zunmr2.f
+   zunmr3.f
+   zunmrq.f
+   zunmrz.f
+   zunmtr.f
+   zupgtr.f
+   zupmtr.f
+   izmax1.f
+   dzsum1.f
+   zstemr.f
+   zcgesv.f
+   zcposv.f
+   zlag2c.f
+   clag2z.f
+   zlat2c.f
+   zhfrk.f
+   ztfttp.f
+   zlanhf.f
+   zpftrf.f
+   zpftri.f
+   zpftrs.f
+   ztfsm.f
+   ztftri.f
+   ztfttr.f
+   ztpttf.f
+   ztpttr.f
+   ztrttf.f
+   ztrttp.f
+   zgeequb.f
+   zgbequb.f
+   zsyequb.f
+   zpoequb.f
+   zheequb.f
+   zbbcsd.f
+   zlapmr.f
+   zunbdb.f
+   zunbdb1.f
+   zunbdb2.f
+   zunbdb3.f
+   zunbdb4.f
+   zunbdb5.f
+   zunbdb6.f
+   zuncsd.f
+   zuncsd2by1.f
+   zgeqrt.f
+   zgeqrt2.f
+   zgeqrt3.f
+   zgemqrt.f
+   ztpqrt.f
+   ztpqrt2.f
+   ztpmqrt.f
+   ztprfb.f
+   ztplqt.f
+   ztplqt2.f
+   ztpmlqt.f
+   zgelqt.f
+   zgelqt3.f
+   zgemlqt.f
+   zgetsls.f
+   zgetsqrhrt.f
+   zgeqr.f
+   zlatsqr.f
+   zlamtsqr.f
+   zgemqr.f
+   zgelq.f
+   zlaswlq.f
+   zlamswlq.f
+   zgemlq.f
+   zunhr_col.f
+   zlaunhr_col_getrfnp.f
+   zlaunhr_col_getrfnp2.f
+   zhetrd_2stage.f
+   zhetrd_he2hb.f
+   zhetrd_hb2st.F
+   zhb2st_kernels.f
+   zheevd_2stage.f
+   zheev_2stage.f
+   zheevx_2stage.f
+   zheevr_2stage.f
+   zhbev_2stage.f
+   zhbevx_2stage.f
+   zhbevd_2stage.f
+   zhegv_2stage.f
+   zgesvdq.f
+   zgedmd.f90
+   zgedmdq.f90)
 
-set(ZXLASRC zgesvxx.f zgerfsx.f zla_gerfsx_extended.f zla_geamv.f
-   zla_gercond_c.f zla_gercond_x.f zla_gerpvgrw.f zsysvxx.f zsyrfsx.f
-   zla_syrfsx_extended.f zla_syamv.f zla_syrcond_c.f zla_syrcond_x.f
-   zla_syrpvgrw.f zposvxx.f zporfsx.f zla_porfsx_extended.f
-   zla_porcond_c.f zla_porcond_x.f zla_porpvgrw.f zgbsvxx.f zgbrfsx.f
-   zla_gbrfsx_extended.f zla_gbamv.f zla_gbrcond_c.f zla_gbrcond_x.f
-   zla_gbrpvgrw.f zhesvxx.f zherfsx.f zla_herfsx_extended.f
-   zla_heamv.f zla_hercond_c.f zla_hercond_x.f zla_herpvgrw.f
-   zla_lin_berr.f zlarscl2.f zlascl2.f zla_wwaddw.f)
+set(ZXLASRC
+   zgesvxx.f
+   zgerfsx.f
+   zla_gerfsx_extended.f
+   zla_geamv.f
+   zla_gercond_c.f
+   zla_gercond_x.f
+   zla_gerpvgrw.f
+   zsysvxx.f
+   zsyrfsx.f
+   zla_syrfsx_extended.f
+   zla_syamv.f
+   zla_syrcond_c.f
+   zla_syrcond_x.f
+   zla_syrpvgrw.f
+   zposvxx.f
+   zporfsx.f
+   zla_porfsx_extended.f
+   zla_porcond_c.f
+   zla_porcond_x.f
+   zla_porpvgrw.f
+   zgbsvxx.f
+   zgbrfsx.f
+   zla_gbrfsx_extended.f
+   zla_gbamv.f
+   zla_gbrcond_c.f
+   zla_gbrcond_x.f
+   zla_gbrpvgrw.f
+   zhesvxx.f
+   zherfsx.f
+   zla_herfsx_extended.f
+   zla_heamv.f
+   zla_hercond_c.f
+   zla_hercond_x.f
+   zla_herpvgrw.f
+   zla_lin_berr.f
+   zlarscl2.f
+   zlascl2.f
+   zla_wwaddw.f)
 
 if(BUILD_DEPRECATED)
-  list(APPEND SLASRC DEPRECATED/sgegs.f DEPRECATED/sgegv.f DEPRECATED/sgelqs.f
-    DEPRECATED/sgelsx.f DEPRECATED/sgeqpf.f DEPRECATED/sgeqrs.f DEPRECATED/sggsvd.f
-    DEPRECATED/sggsvp.f DEPRECATED/slahrd.f DEPRECATED/slatzm.f DEPRECATED/stzrqf.f)
-  list(APPEND DLASRC DEPRECATED/dgegs.f DEPRECATED/dgegv.f DEPRECATED/dgelqs.f
-    DEPRECATED/dgelsx.f DEPRECATED/dgeqpf.f DEPRECATED/dgeqrs.f DEPRECATED/dggsvd.f
-    DEPRECATED/dggsvp.f DEPRECATED/dlahrd.f DEPRECATED/dlatzm.f DEPRECATED/dtzrqf.f)
-  list(APPEND CLASRC DEPRECATED/cgegs.f DEPRECATED/cgegv.f DEPRECATED/cgelqs.f
-    DEPRECATED/cgelsx.f DEPRECATED/cgeqpf.f DEPRECATED/cgeqrs.f DEPRECATED/cggsvd.f
-    DEPRECATED/cggsvp.f DEPRECATED/clahrd.f DEPRECATED/clatzm.f DEPRECATED/ctzrqf.f)
-  list(APPEND ZLASRC DEPRECATED/zgegs.f DEPRECATED/zgegv.f DEPRECATED/zgelqs.f
-    DEPRECATED/zgelsx.f DEPRECATED/zgeqpf.f DEPRECATED/zgeqrs.f DEPRECATED/zggsvd.f
-    DEPRECATED/zggsvp.f DEPRECATED/zlahrd.f DEPRECATED/zlatzm.f DEPRECATED/ztzrqf.f)
+  list(APPEND SLASRC
+    DEPRECATED/sgegs.f
+    DEPRECATED/sgegv.f
+    DEPRECATED/sgelqs.f
+    DEPRECATED/sgelsx.f
+    DEPRECATED/sgeqpf.f
+    DEPRECATED/sgeqrs.f
+    DEPRECATED/sggsvd.f
+    DEPRECATED/sggsvp.f
+    DEPRECATED/slahrd.f
+    DEPRECATED/slatzm.f
+    DEPRECATED/stzrqf.f)
+  list(APPEND DLASRC
+    DEPRECATED/dgegs.f
+    DEPRECATED/dgegv.f
+    DEPRECATED/dgelqs.f
+    DEPRECATED/dgelsx.f
+    DEPRECATED/dgeqpf.f
+    DEPRECATED/dgeqrs.f
+    DEPRECATED/dggsvd.f
+    DEPRECATED/dggsvp.f
+    DEPRECATED/dlahrd.f
+    DEPRECATED/dlatzm.f
+    DEPRECATED/dtzrqf.f)
+  list(APPEND CLASRC
+    DEPRECATED/cgegs.f
+    DEPRECATED/cgegv.f
+    DEPRECATED/cgelqs.f
+    DEPRECATED/cgelsx.f
+    DEPRECATED/cgeqpf.f
+    DEPRECATED/cgeqrs.f
+    DEPRECATED/cggsvd.f
+    DEPRECATED/cggsvp.f
+    DEPRECATED/clahrd.f
+    DEPRECATED/clatzm.f
+    DEPRECATED/ctzrqf.f)
+  list(APPEND ZLASRC
+    DEPRECATED/zgegs.f
+    DEPRECATED/zgegv.f
+    DEPRECATED/zgelqs.f
+    DEPRECATED/zgelsx.f
+    DEPRECATED/zgeqpf.f
+    DEPRECATED/zgeqrs.f
+    DEPRECATED/zggsvd.f
+    DEPRECATED/zggsvp.f
+    DEPRECATED/zlahrd.f
+    DEPRECATED/zlatzm.f
+    DEPRECATED/ztzrqf.f)
 endif()
 
 if(USE_XBLAS)

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -1,7 +1,7 @@
 #######################################################################
 #  This is the makefile to create a library for LAPACK.
 #  The files are organized as follows:
-
+#
 #       ALLAUX  -- Auxiliary routines called from all precisions
 #       SCLAUX  -- Auxiliary routines called from single precision
 #       DZLAUX  -- Auxiliary routines called from double precision
@@ -51,16 +51,16 @@ set(ALLAUX
    la_xisnan.F90
    sisnan.f
    slaisnan.f
-   ../INSTALL/ilaver.f
-   ../INSTALL/lsame.f
    xerbla.f
    xerbla_array.f
+   ../INSTALL/ilaver.f
+   ../INSTALL/lsame.f
    ../INSTALL/slamch.f)
 
 set(SCLAUX
-   sbdsvdx.f
    sbdsdc.f
    sbdsqr.f
+   sbdsvdx.f
    sdisna.f
    slabad.f
    slacpy.f
@@ -137,10 +137,9 @@ set(SCLAUX
 
 set(DZLAUX
    dbdsdc.f
-   dbdsvdx.f
    dbdsqr.f
+   dbdsvdx.f
    ddisna.f
-   disnan.f
    dlabad.f
    dlacpy.f
    dladiv.f
@@ -202,7 +201,6 @@ set(DZLAUX
    dlasrt.f
    dlassq.f90
    dlasv2.f
-   dlaisnan.f
    dpttrf.f
    dstebz.f
    dstedc.f
@@ -210,6 +208,8 @@ set(DZLAUX
    dsteqr.f
    dsterf.f
    dstevx.f
+   dlaisnan.f
+   disnan.f
    dlartgp.f
    dlartgs.f
    ../INSTALL/droundup_lwork.f
@@ -259,9 +259,13 @@ set(SLASRC
    sgesc2.f
    sgesdd.f
    sgesv.f
+   sgesvx.f
    sgesvd.f
    sgesvdx.f
-   sgesvx.f
+   sgesvj.f
+   sgejsv.f
+   sgsvj0.f
+   sgsvj1.f
    sgetc2.f
    sgetf2.f
    sgetri.f
@@ -317,6 +321,7 @@ set(SLASRC
    slangt.f
    slanhs.f
    slansb.f
+   slansf.f
    slansp.f
    slansy.f
    slantb.f
@@ -461,6 +466,7 @@ set(SLASRC
    ssptri.f
    ssptrs.f
    sstegr.f
+   sstemr.f
    sstev.f
    sstevd.f
    sstevr.f
@@ -537,8 +543,6 @@ set(SLASRC
    strtri.f
    strtrs.f
    stzrzf.f
-   sstemr.f
-   slansf.f
    spftrf.f
    spftri.f
    spftrs.f
@@ -551,14 +555,10 @@ set(SLASRC
    stpttr.f
    strttf.f
    strttp.f
-   sgejsv.f
-   sgesvj.f
-   sgsvj0.f
-   sgsvj1.f
    sgeequb.f
+   sgbequb.f
    ssyequb.f
    spoequb.f
-   sgbequb.f
    sbbcsd.f
    slapmr.f
    sorbdb.f
@@ -695,13 +695,13 @@ set(CLASRC
    cgesc2.f
    cgesdd.f
    cgesv.f
+   cgesvx.f
    cgesvd.f
    cgesvdx.f
    cgesvj.f
    cgejsv.f
    cgsvj0.f
    cgsvj1.f
-   cgesvx.f
    cgetc2.f
    cgetf2.f
    cgetri.f
@@ -832,6 +832,7 @@ set(CLASRC
    clangt.f
    clanhb.f
    clanhe.f
+   clanhf.f
    clanhp.f
    clanhs.f
    clanht.f
@@ -843,7 +844,6 @@ set(CLASRC
    clantr.f
    clapll.f
    clapmt.f
-   clarcm.f
    claqgb.f
    claqge.f
    claqhb.f
@@ -854,18 +854,19 @@ set(CLASRC
    claqp2rk.f
    claqp3rk.f
    claqsb.f
+   claqsp.f
+   claqsy.f
    claqr0.f
    claqr1.f
    claqr2.f
    claqr3.f
    claqr4.f
    claqr5.f
-   claqsp.f
-   claqsy.f
    clar1v.f
    clar2v.f
    ilaclr.f
    ilaclc.f
+   clarcm.f
    clarf.f
    clarfb.f
    clarfb_gett.f
@@ -934,6 +935,8 @@ set(CLASRC
    cpttrs.f
    cptts2.f
    crot.f
+   csrscl.f
+   crscl.f
    cspcon.f
    cspmv.f
    cspr.f
@@ -943,11 +946,10 @@ set(CLASRC
    csptrf.f
    csptri.f
    csptrs.f
-   csrscl.f
-   crscl.f
    cstedc.f
    cstegr.f
    cstein.f
+   cstemr.f
    csteqr.f
    csycon.f
    csymv.f
@@ -974,14 +976,14 @@ set(CLASRC
    csysv_rook.f
    csytf2_rk.f
    csytrf_rk.f
-   csytrf_aa.f
    csytrs_3.f
-   csytrs_aa.f
    csytri_3.f
    csytri_3x.f
    csycon_3.f
    csysv_rk.f
    csysv_aa.f
+   csytrf_aa.f
+   csytrs_aa.f
    csysv_aa_2stage.f
    csytrf_aa_2stage.f
    csytrs_aa_2stage.f
@@ -1044,15 +1046,13 @@ set(CLASRC
    cupmtr.f
    icmax1.f
    scsum1.f
-   cstemr.f
    chfrk.f
-   ctfttp.f
-   clanhf.f
    cpftrf.f
    cpftri.f
    cpftrs.f
    ctfsm.f
    ctftri.f
+   ctfttp.f
    ctfttr.f
    ctpttf.f
    ctpttr.f
@@ -1209,9 +1209,13 @@ set(DLASRC
    dgesc2.f
    dgesdd.f
    dgesv.f
+   dgesvx.f
    dgesvd.f
    dgesvdx.f
-   dgesvx.f
+   dgesvj.f
+   dgejsv.f
+   dgsvj0.f
+   dgsvj1.f
    dgetc2.f
    dgetf2.f
    dgetrf.f
@@ -1270,6 +1274,7 @@ set(DLASRC
    dlangt.f
    dlanhs.f
    dlansb.f
+   dlansf.f
    dlansp.f
    dlansy.f
    dlantb.f
@@ -1418,6 +1423,7 @@ set(DLASRC
    dsptri.f
    dsptrs.f
    dstegr.f
+   dstemr.f
    dstev.f
    dstevd.f
    dstevr.f
@@ -1439,11 +1445,11 @@ set(DLASRC
    dsytrd.f
    dsytrf.f
    dsytri.f
-   dsytrs.f
-   dsytrs2.f
    dsytri2.f
    dsytri2x.f
    dsyswapr.f
+   dsytrs.f
+   dsytrs2.f
    dsyconv.f
    dsyconvf.f
    dsyconvf_rook.f
@@ -1494,13 +1500,11 @@ set(DLASRC
    dtrtri.f
    dtrtrs.f
    dtzrzf.f
-   dstemr.f
    dsgesv.f
    dsposv.f
    dlag2s.f
    slag2d.f
    dlat2s.f
-   dlansf.f
    dpftrf.f
    dpftri.f
    dpftrs.f
@@ -1513,14 +1517,10 @@ set(DLASRC
    dtpttr.f
    dtrttf.f
    dtrttp.f
-   dgejsv.f
-   dgesvj.f
-   dgsvj0.f
-   dgsvj1.f
    dgeequb.f
+   dgbequb.f
    dsyequb.f
    dpoequb.f
-   dgbequb.f
    dbbcsd.f
    dlapmr.f
    dorbdb.f
@@ -1648,9 +1648,9 @@ set(ZLASRC
    zgesc2.f
    zgesdd.f
    zgesv.f
+   zgesvx.f
    zgesvd.f
    zgesvdx.f
-   zgesvx.f
    zgesvj.f
    zgejsv.f
    zgsvj0.f
@@ -1788,6 +1788,7 @@ set(ZLASRC
    zlangt.f
    zlanhb.f
    zlanhe.f
+   zlanhf.f
    zlanhp.f
    zlanhs.f
    zlanht.f
@@ -1809,14 +1810,14 @@ set(ZLASRC
    zlaqp2rk.f
    zlaqp3rk.f
    zlaqsb.f
+   zlaqsp.f
+   zlaqsy.f
    zlaqr0.f
    zlaqr1.f
    zlaqr2.f
    zlaqr3.f
    zlaqr4.f
    zlaqr5.f
-   zlaqsp.f
-   zlaqsy.f
    zlar1v.f
    zlar2v.f
    ilazlr.f
@@ -1894,6 +1895,8 @@ set(ZLASRC
    zpttrs.f
    zptts2.f
    zrot.f
+   zdrscl.f
+   zrscl.f
    zspcon.f
    zspmv.f
    zspr.f
@@ -1903,11 +1906,10 @@ set(ZLASRC
    zsptrf.f
    zsptri.f
    zsptrs.f
-   zdrscl.f
-   zrscl.f
    zstedc.f
    zstegr.f
    zstein.f
+   zstemr.f
    zsteqr.f
    zsycon.f
    zsymv.f
@@ -1929,22 +1931,22 @@ set(ZLASRC
    zsytf2_rook.f
    zsytrf_rook.f
    zsytrs_rook.f
-   zsytrs_aa.f
    zsytri_rook.f
    zsycon_rook.f
    zsysv_rook.f
    zsytf2_rk.f
    zsytrf_rk.f
-   zsytrf_aa.f
    zsytrs_3.f
-   zsysv_aa_2stage.f
-   zsytrf_aa_2stage.f
-   zsytrs_aa_2stage.f
    zsytri_3.f
    zsytri_3x.f
    zsycon_3.f
    zsysv_rk.f
    zsysv_aa.f
+   zsytrf_aa.f
+   zsytrs_aa.f
+   zsysv_aa_2stage.f
+   zsytrf_aa_2stage.f
+   zsytrs_aa_2stage.f
    ztbcon.f
    ztbrfs.f
    ztbtrs.f
@@ -2004,20 +2006,18 @@ set(ZLASRC
    zupmtr.f
    izmax1.f
    dzsum1.f
-   zstemr.f
    zcgesv.f
    zcposv.f
    zlag2c.f
    clag2z.f
    zlat2c.f
    zhfrk.f
-   ztfttp.f
-   zlanhf.f
    zpftrf.f
    zpftri.f
    zpftrs.f
    ztfsm.f
    ztftri.f
+   ztfttp.f
    ztfttr.f
    ztpttf.f
    ztpttr.f
@@ -2047,9 +2047,6 @@ set(ZLASRC
    ztpqrt2.f
    ztpmqrt.f
    ztprfb.f
-   ztplqt.f
-   ztplqt2.f
-   ztpmlqt.f
    zgelqt.f
    zgelqt3.f
    zgemlqt.f
@@ -2063,6 +2060,9 @@ set(ZLASRC
    zlaswlq.f
    zlamswlq.f
    zgemlq.f
+   ztplqt.f
+   ztplqt2.f
+   ztpmlqt.f
    zunhr_col.f
    zlaunhr_col_getrfnp.f
    zlaunhr_col_getrfnp2.f

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -74,8 +74,6 @@ ALLAUX = \
    ilaenv2stage.o \
    ieeeck.o \
    lsamen.o \
-   xerbla.o \
-   xerbla_array.o \
    iparmq.o \
    iparam2stage.o \
    ilaprec.o \
@@ -87,6 +85,8 @@ ALLAUX = \
    la_xisnan.o \
    sisnan.o \
    slaisnan.o \
+   xerbla.o \
+   xerbla_array.o \
    ../INSTALL/ilaver.o \
    ../INSTALL/lsame.o \
    ../INSTALL/slamch.o
@@ -293,9 +293,13 @@ SLASRC = \
    sgesc2.o \
    sgesdd.o \
    sgesv.o \
+   sgesvx.o \
    sgesvd.o \
    sgesvdx.o \
-   sgesvx.o \
+   sgesvj.o \
+   sgejsv.o \
+   sgsvj0.o \
+   sgsvj1.o \
    sgetc2.o \
    sgetf2.o \
    sgetri.o \
@@ -351,6 +355,7 @@ SLASRC = \
    slangt.o \
    slanhs.o \
    slansb.o \
+   slansf.o \
    slansp.o \
    slansy.o \
    slantb.o \
@@ -398,6 +403,7 @@ SLASRC = \
    slasyf.o \
    slasyf_rook.o \
    slasyf_rk.o \
+   slasyf_aa.o \
    slatbs.o \
    slatdf.o \
    slatps.o \
@@ -494,6 +500,7 @@ SLASRC = \
    ssptri.o \
    ssptrs.o \
    sstegr.o \
+   sstemr.o \
    sstev.o \
    sstevd.o \
    sstevr.o \
@@ -536,7 +543,6 @@ SLASRC = \
    ssytri_3x.o \
    ssycon_3.o \
    ssysv_rk.o \
-   slasyf_aa.o \
    ssysv_aa.o \
    ssytrf_aa.o \
    ssytrs_aa.o \
@@ -571,8 +577,6 @@ SLASRC = \
    strtri.o \
    strtrs.o \
    stzrzf.o \
-   sstemr.o \
-   slansf.o \
    spftrf.o \
    spftri.o \
    spftrs.o \
@@ -585,14 +589,10 @@ SLASRC = \
    stpttr.o \
    strttf.o \
    strttp.o \
-   sgejsv.o \
-   sgesvj.o \
-   sgsvj0.o \
-   sgsvj1.o \
    sgeequb.o \
+   sgbequb.o \
    ssyequb.o \
    spoequb.o \
-   sgbequb.o \
    sbbcsd.o \
    slapmr.o \
    sorbdb.o \
@@ -731,13 +731,13 @@ CLASRC = \
    cgesc2.o \
    cgesdd.o \
    cgesv.o \
+   cgesvx.o \
    cgesvd.o \
    cgesvdx.o \
    cgesvj.o \
    cgejsv.o \
    cgsvj0.o \
    cgsvj1.o \
-   cgesvx.o \
    cgetc2.o \
    cgetf2.o \
    cgetri.o \
@@ -811,7 +811,6 @@ CLASRC = \
    chesv_aa.o \
    chetrf_aa.o \
    chetrs_aa.o \
-   clahef_aa.o \
    chesv_aa_2stage.o \
    chetrf_aa_2stage.o \
    chetrs_aa_2stage.o \
@@ -857,6 +856,7 @@ CLASRC = \
    clahef.o \
    clahef_rook.o \
    clahef_rk.o \
+   clahef_aa.o \
    clahqr.o \
    clahr2.o \
    claic1.o \
@@ -868,6 +868,7 @@ CLASRC = \
    clangt.o \
    clanhb.o \
    clanhe.o \
+   clanhf.o \
    clanhp.o \
    clanhs.o \
    clanht.o \
@@ -879,7 +880,6 @@ CLASRC = \
    clantr.o \
    clapll.o \
    clapmt.o \
-   clarcm.o \
    claqgb.o \
    claqge.o \
    claqhb.o \
@@ -890,24 +890,25 @@ CLASRC = \
    claqp2rk.o \
    claqp3rk.o \
    claqsb.o \
+   claqsp.o \
+   claqsy.o \
    claqr0.o \
    claqr1.o \
    claqr2.o \
    claqr3.o \
    claqr4.o \
    claqr5.o \
-   claqsp.o \
-   claqsy.o \
    clar1v.o \
    clar2v.o \
    ilaclr.o \
    ilaclc.o \
+   clarcm.o \
    clarf.o \
    clarfb.o \
    clarfb_gett.o \
    clarfg.o \
-   clarft.o \
    clarfgp.o \
+   clarft.o \
    clarfx.o \
    clarfy.o \
    clargv.o \
@@ -970,6 +971,8 @@ CLASRC = \
    cpttrs.o \
    cptts2.o \
    crot.o \
+   csrscl.o \
+   crscl.o \
    cspcon.o \
    cspmv.o \
    cspr.o \
@@ -979,11 +982,10 @@ CLASRC = \
    csptrf.o \
    csptri.o \
    csptrs.o \
-   csrscl.o \
-   crscl.o \
    cstedc.o \
    cstegr.o \
    cstein.o \
+   cstemr.o \
    csteqr.o \
    csycon.o \
    csymv.o \
@@ -1010,14 +1012,14 @@ CLASRC = \
    csysv_rook.o \
    csytf2_rk.o \
    csytrf_rk.o \
-   csytrf_aa.o \
    csytrs_3.o \
-   csytrs_aa.o \
    csytri_3.o \
    csytri_3x.o \
    csycon_3.o \
    csysv_rk.o \
    csysv_aa.o \
+   csytrf_aa.o \
+   csytrs_aa.o \
    csysv_aa_2stage.o \
    csytrf_aa_2stage.o \
    csytrs_aa_2stage.o \
@@ -1080,15 +1082,13 @@ CLASRC = \
    cupmtr.o \
    icmax1.o \
    scsum1.o \
-   cstemr.o \
    chfrk.o \
-   ctfttp.o \
-   clanhf.o \
    cpftrf.o \
    cpftri.o \
    cpftrs.o \
    ctfsm.o \
    ctftri.o \
+   ctfttp.o \
    ctfttr.o \
    ctpttf.o \
    ctpttr.o \
@@ -1205,8 +1205,6 @@ ZCLASRC = \
    cpotrs.o
 
 DLASRC = \
-   dpotrf2.o \
-   dgetrf2.o \
    dgbbrd.o \
    dgbcon.o \
    dgbequ.o \
@@ -1249,12 +1247,17 @@ DLASRC = \
    dgesc2.o \
    dgesdd.o \
    dgesv.o \
+   dgesvx.o \
    dgesvd.o \
    dgesvdx.o \
-   dgesvx.o \
+   dgesvj.o \
+   dgejsv.o \
+   dgsvj0.o \
+   dgsvj1.o \
    dgetc2.o \
    dgetf2.o \
    dgetrf.o \
+   dgetrf2.o \
    dgetri.o \
    dgetrs.o \
    dggbak.o \
@@ -1309,6 +1312,7 @@ DLASRC = \
    dlangt.o \
    dlanhs.o \
    dlansb.o \
+   dlansf.o \
    dlansp.o \
    dlansy.o \
    dlantb.o \
@@ -1357,6 +1361,7 @@ DLASRC = \
    dlasyf.o \
    dlasyf_rook.o \
    dlasyf_rk.o \
+   dlasyf_aa.o \
    dlatbs.o \
    dlatdf.o \
    dlatps.o \
@@ -1411,6 +1416,7 @@ DLASRC = \
    dposvx.o \
    dpotf2.o \
    dpotrf.o \
+   dpotrf2.o \
    dpotri.o \
    dpotrs.o \
    dpstrf.o \
@@ -1455,6 +1461,7 @@ DLASRC = \
    dsptri.o \
    dsptrs.o \
    dstegr.o \
+   dstemr.o \
    dstev.o \
    dstevd.o \
    dstevr.o \
@@ -1497,7 +1504,6 @@ DLASRC = \
    dsytri_3x.o \
    dsycon_3.o \
    dsysv_rk.o \
-   dlasyf_aa.o \
    dsysv_aa.o \
    dsytrf_aa.o \
    dsytrs_aa.o \
@@ -1532,13 +1538,11 @@ DLASRC = \
    dtrtri.o \
    dtrtrs.o \
    dtzrzf.o \
-   dstemr.o \
    dsgesv.o \
    dsposv.o \
    dlag2s.o \
    slag2d.o \
    dlat2s.o \
-   dlansf.o \
    dpftrf.o \
    dpftri.o \
    dpftrs.o \
@@ -1551,14 +1555,10 @@ DLASRC = \
    dtpttr.o \
    dtrttf.o \
    dtrttp.o \
-   dgejsv.o \
-   dgesvj.o \
-   dgsvj0.o \
-   dgsvj1.o \
    dgeequb.o \
+   dgbequb.o \
    dsyequb.o \
    dpoequb.o \
-   dgbequb.o \
    dbbcsd.o \
    dlapmr.o \
    dorbdb.o \
@@ -1645,8 +1645,6 @@ DXLASRC = \
 endif
 
 ZLASRC = \
-   zpotrf2.o \
-   zgetrf2.o \
    zbdsqr.o \
    zgbbrd.o \
    zgbcon.o \
@@ -1690,16 +1688,17 @@ ZLASRC = \
    zgesc2.o \
    zgesdd.o \
    zgesv.o \
+   zgesvx.o \
    zgesvd.o \
    zgesvdx.o \
    zgesvj.o \
    zgejsv.o \
    zgsvj0.o \
    zgsvj1.o \
-   zgesvx.o \
    zgetc2.o \
    zgetf2.o \
    zgetrf.o \
+   zgetrf2.o \
    zgetri.o \
    zgetrs.o \
    zggbak.o \
@@ -1772,7 +1771,6 @@ ZLASRC = \
    zhesv_aa.o \
    zhetrf_aa.o \
    zhetrs_aa.o \
-   zlahef_aa.o \
    zhesv_aa_2stage.o \
    zhetrf_aa_2stage.o \
    zhetrs_aa_2stage.o \
@@ -1818,6 +1816,7 @@ ZLASRC = \
    zlahef.o \
    zlahef_rook.o \
    zlahef_rk.o \
+   zlahef_aa.o \
    zlahqr.o \
    zlahr2.o \
    zlaic1.o \
@@ -1829,6 +1828,7 @@ ZLASRC = \
    zlangt.o \
    zlanhb.o \
    zlanhe.o \
+   zlanhf.o \
    zlanhp.o \
    zlanhs.o \
    zlanht.o \
@@ -1850,14 +1850,14 @@ ZLASRC = \
    zlaqp2rk.o \
    zlaqp3rk.o \
    zlaqsb.o \
+   zlaqsp.o \
+   zlaqsy.o \
    zlaqr0.o \
    zlaqr1.o \
    zlaqr2.o \
    zlaqr3.o \
    zlaqr4.o \
    zlaqr5.o \
-   zlaqsp.o \
-   zlaqsy.o \
    zlar1v.o \
    zlar2v.o \
    ilazlr.o \
@@ -1867,8 +1867,8 @@ ZLASRC = \
    zlarfb.o \
    zlarfb_gett.o \
    zlarfg.o \
-   zlarft.o \
    zlarfgp.o \
+   zlarft.o \
    zlarfx.o \
    zlarfy.o \
    zlargv.o \
@@ -1913,6 +1913,7 @@ ZLASRC = \
    zposvx.o \
    zpotf2.o \
    zpotrf.o \
+   zpotrf2.o \
    zpotri.o \
    zpotrs.o \
    zpstrf.o \
@@ -1934,6 +1935,8 @@ ZLASRC = \
    zpttrs.o \
    zptts2.o \
    zrot.o \
+   zdrscl.o \
+   zrscl.o \
    zspcon.o \
    zspmv.o \
    zspr.o \
@@ -1943,11 +1946,10 @@ ZLASRC = \
    zsptrf.o \
    zsptri.o \
    zsptrs.o \
-   zdrscl.o \
-   zrscl.o \
    zstedc.o \
    zstegr.o \
    zstein.o \
+   zstemr.o \
    zsteqr.o \
    zsycon.o \
    zsymv.o \
@@ -1969,22 +1971,22 @@ ZLASRC = \
    zsytf2_rook.o \
    zsytrf_rook.o \
    zsytrs_rook.o \
-   zsytrs_aa.o \
    zsytri_rook.o \
    zsycon_rook.o \
    zsysv_rook.o \
-   zsysv_aa_2stage.o \
-   zsytrf_aa_2stage.o \
-   zsytrs_aa_2stage.o \
    zsytf2_rk.o \
    zsytrf_rk.o \
-   zsytrf_aa.o \
    zsytrs_3.o \
    zsytri_3.o \
    zsytri_3x.o \
    zsycon_3.o \
    zsysv_rk.o \
    zsysv_aa.o \
+   zsytrf_aa.o \
+   zsytrs_aa.o \
+   zsysv_aa_2stage.o \
+   zsytrf_aa_2stage.o \
+   zsytrs_aa_2stage.o \
    ztbcon.o \
    ztbrfs.o \
    ztbtrs.o \
@@ -2044,20 +2046,18 @@ ZLASRC = \
    zupmtr.o \
    izmax1.o \
    dzsum1.o \
-   zstemr.o \
    zcgesv.o \
    zcposv.o \
    zlag2c.o \
    clag2z.o \
    zlat2c.o \
    zhfrk.o \
-   ztfttp.o \
-   zlanhf.o \
    zpftrf.o \
    zpftri.o \
    zpftrs.o \
    ztfsm.o \
    ztftri.o \
+   ztfttp.o \
    ztfttr.o \
    ztpttf.o \
    ztpttr.o \
@@ -2087,9 +2087,6 @@ ZLASRC = \
    ztpqrt2.o \
    ztpmqrt.o \
    ztprfb.o \
-   ztplqt.o \
-   ztplqt2.o \
-   ztpmlqt.o \
    zgelqt.o \
    zgelqt3.o \
    zgemlqt.o \
@@ -2103,6 +2100,9 @@ ZLASRC = \
    zlaswlq.o \
    zlamswlq.o \
    zgemlq.o \
+   ztplqt.o \
+   ztplqt2.o \
+   ztpmlqt.o \
    zunhr_col.o \
    zlaunhr_col_getrfnp.o \
    zlaunhr_col_getrfnp2.o \

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -78,20 +78,23 @@ ALLAUX = \
    xerbla_array.o \
    iparmq.o \
    iparam2stage.o \
-   la_xisnan.o \
    ilaprec.o \
    ilatrans.o \
    ilauplo.o \
    iladiag.o \
    chla_transtype.o \
+   la_constants.o \
+   la_xisnan.o \
+   sisnan.o \
+   slaisnan.o \
    ../INSTALL/ilaver.o \
    ../INSTALL/lsame.o \
    ../INSTALL/slamch.o
 
 SCLAUX = \
-   la_constants.o \
    sbdsdc.o \
    sbdsqr.o \
+   sbdsvdx.o \
    sdisna.o \
    slabad.o \
    slacpy.o \
@@ -157,19 +160,19 @@ SCLAUX = \
    spttrf.o \
    sstebz.o \
    sstedc.o \
+   sstein.o \
    ssteqr.o \
    ssterf.o \
-   slaisnan.o \
-   sisnan.o \
+   sstevx.o \
    slartgp.o \
    slartgs.o \
    ../INSTALL/sroundup_lwork.o \
    ../INSTALL/second_$(TIMER).o
 
 DZLAUX = \
-   la_constants.o \
    dbdsdc.o \
    dbdsqr.o \
+   dbdsvdx.o \
    ddisna.o \
    dlabad.o \
    dlacpy.o \
@@ -235,8 +238,10 @@ DZLAUX = \
    dpttrf.o \
    dstebz.o \
    dstedc.o \
+   dstein.o \
    dsteqr.o \
    dsterf.o \
+   dstevx.o \
    dlaisnan.o \
    disnan.o \
    dlartgp.o \
@@ -246,9 +251,6 @@ DZLAUX = \
    ../INSTALL/dsecnd_$(TIMER).o
 
 SLASRC = \
-   sbdsvdx.o \
-   spotrf2.o \
-   sgetrf2.o \
    sgbbrd.o \
    sgbcon.o \
    sgbequ.o \
@@ -392,7 +394,6 @@ SLASRC = \
    slarz.o \
    slarzb.o \
    slarzt.o \
-   slaswp.o \
    slasy2.o \
    slasyf.o \
    slasyf_rook.o \
@@ -493,11 +494,9 @@ SLASRC = \
    ssptri.o \
    ssptrs.o \
    sstegr.o \
-   sstein.o \
    sstev.o \
    sstevd.o \
    sstevr.o \
-   sstevx.o \
    ssycon.o \
    ssyev.o \
    ssyevd.o \
@@ -649,10 +648,13 @@ SLASRC = \
    sgedmdq.o
 
 DSLASRC = \
-   spotrs.o \
+   sgetrf.o \
+   sgetrf2.o \
    sgetrs.o \
+   slaswp.o \
    spotrf.o \
-   sgetrf.o
+   spotrf2.o \
+   spotrs.o
 
 ifdef USEXBLAS
 SXLASRC = \
@@ -686,8 +688,6 @@ SXLASRC = \
 endif
 
 CLASRC = \
-   cpotrf2.o \
-   cgetrf2.o \
    cbdsqr.o \
    cgbbrd.o \
    cgbcon.o \
@@ -922,7 +922,6 @@ CLASRC = \
    claset.o \
    clasr.o \
    classq.o \
-   claswp.o \
    clasyf.o \
    clasyf_rook.o \
    clasyf_rk.o \
@@ -1197,15 +1196,17 @@ CXLASRC = \
 endif
 
 ZCLASRC = \
-   cpotrs.o \
+   cgetrf.o \
+   cgetrf2.o \
    cgetrs.o \
+   claswp.o \
    cpotrf.o \
-   cgetrf.o
+   cpotrf2.o \
+   cpotrs.o
 
 DLASRC = \
    dpotrf2.o \
    dgetrf2.o \
-   dbdsvdx.o \
    dgbbrd.o \
    dgbcon.o \
    dgbequ.o \
@@ -1454,11 +1455,9 @@ DLASRC = \
    dsptri.o \
    dsptrs.o \
    dstegr.o \
-   dstein.o \
    dstev.o \
    dstevd.o \
    dstevr.o \
-   dstevx.o \
    dsycon.o \
    dsyev.o \
    dsyevd.o \

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -69,469 +69,2147 @@ ALLMOD = la_xisnan.mod la_constants.mod
 .o.mod:
 	@true
 
-ALLAUX = ilaenv.o ilaenv2stage.o ieeeck.o lsamen.o xerbla.o xerbla_array.o \
-   iparmq.o iparam2stage.o la_xisnan.o \
-   ilaprec.o ilatrans.o ilauplo.o iladiag.o chla_transtype.o \
-   ../INSTALL/ilaver.o ../INSTALL/lsame.o ../INSTALL/slamch.o
+ALLAUX = \
+   ilaenv.o \
+   ilaenv2stage.o \
+   ieeeck.o \
+   lsamen.o \
+   xerbla.o \
+   xerbla_array.o \
+   iparmq.o \
+   iparam2stage.o \
+   la_xisnan.o \
+   ilaprec.o \
+   ilatrans.o \
+   ilauplo.o \
+   iladiag.o \
+   chla_transtype.o \
+   ../INSTALL/ilaver.o \
+   ../INSTALL/lsame.o \
+   ../INSTALL/slamch.o
 
 SCLAUX = \
    la_constants.o \
    sbdsdc.o \
-   sbdsqr.o sdisna.o slabad.o slacpy.o sladiv.o slae2.o  slaebz.o \
-   slaed0.o slaed1.o slaed2.o slaed3.o slaed4.o slaed5.o slaed6.o \
-   slaed7.o slaed8.o slaed9.o slaeda.o slaev2.o slagtf.o \
-   slagts.o slamrg.o slanst.o \
-   slapy2.o slapy3.o slarnv.o \
-   slarra.o slarrb.o slarrc.o slarrd.o slarre.o slarrf.o slarrj.o \
-   slarrk.o slarrr.o slaneg.o \
-   slartg.o slaruv.o slas2.o  slascl.o \
-   slasd0.o slasd1.o slasd2.o slasd3.o slasd4.o slasd5.o slasd6.o \
-   slasd7.o slasd8.o slasda.o slasdq.o slasdt.o \
-   slaset.o slasq1.o slasq2.o slasq3.o slasq4.o slasq5.o slasq6.o \
-   slasr.o  slasrt.o slassq.o slasv2.o spttrf.o sstebz.o sstedc.o \
-   ssteqr.o ssterf.o slaisnan.o sisnan.o \
-   slartgp.o slartgs.o ../INSTALL/sroundup_lwork.o \
+   sbdsqr.o \
+   sdisna.o \
+   slabad.o \
+   slacpy.o \
+   sladiv.o \
+   slae2.o \
+   slaebz.o \
+   slaed0.o \
+   slaed1.o \
+   slaed2.o \
+   slaed3.o \
+   slaed4.o \
+   slaed5.o \
+   slaed6.o \
+   slaed7.o \
+   slaed8.o \
+   slaed9.o \
+   slaeda.o \
+   slaev2.o \
+   slagtf.o \
+   slagts.o \
+   slamrg.o \
+   slanst.o \
+   slapy2.o \
+   slapy3.o \
+   slarnv.o \
+   slarra.o \
+   slarrb.o \
+   slarrc.o \
+   slarrd.o \
+   slarre.o \
+   slarrf.o \
+   slarrj.o \
+   slarrk.o \
+   slarrr.o \
+   slaneg.o \
+   slartg.o \
+   slaruv.o \
+   slas2.o \
+   slascl.o \
+   slasd0.o \
+   slasd1.o \
+   slasd2.o \
+   slasd3.o \
+   slasd4.o \
+   slasd5.o \
+   slasd6.o \
+   slasd7.o \
+   slasd8.o \
+   slasda.o \
+   slasdq.o \
+   slasdt.o \
+   slaset.o \
+   slasq1.o \
+   slasq2.o \
+   slasq3.o \
+   slasq4.o \
+   slasq5.o \
+   slasq6.o \
+   slasr.o \
+   slasrt.o \
+   slassq.o \
+   slasv2.o \
+   spttrf.o \
+   sstebz.o \
+   sstedc.o \
+   ssteqr.o \
+   ssterf.o \
+   slaisnan.o \
+   sisnan.o \
+   slartgp.o \
+   slartgs.o \
+   ../INSTALL/sroundup_lwork.o \
    ../INSTALL/second_$(TIMER).o
 
 DZLAUX = \
    la_constants.o \
    dbdsdc.o \
-   dbdsqr.o ddisna.o dlabad.o dlacpy.o dladiv.o dlae2.o  dlaebz.o \
-   dlaed0.o dlaed1.o dlaed2.o dlaed3.o dlaed4.o dlaed5.o dlaed6.o \
-   dlaed7.o dlaed8.o dlaed9.o dlaeda.o dlaev2.o dlagtf.o \
-   dlagts.o dlamrg.o dlanst.o \
-   dlapy2.o dlapy3.o dlarnv.o \
-   dlarra.o dlarrb.o dlarrc.o dlarrd.o dlarre.o dlarrf.o dlarrj.o \
-   dlarrk.o dlarrr.o dlaneg.o \
-   dlartg.o dlaruv.o dlas2.o  dlascl.o \
-   dlasd0.o dlasd1.o dlasd2.o dlasd3.o dlasd4.o dlasd5.o dlasd6.o \
-   dlasd7.o dlasd8.o dlasda.o dlasdq.o dlasdt.o \
-   dlaset.o dlasq1.o dlasq2.o dlasq3.o dlasq4.o dlasq5.o dlasq6.o \
-   dlasr.o  dlasrt.o dlassq.o dlasv2.o dpttrf.o dstebz.o dstedc.o \
-   dsteqr.o dsterf.o dlaisnan.o disnan.o \
-   dlartgp.o dlartgs.o ../INSTALL/droundup_lwork.o \
-   ../INSTALL/dlamch.o ../INSTALL/dsecnd_$(TIMER).o
+   dbdsqr.o \
+   ddisna.o \
+   dlabad.o \
+   dlacpy.o \
+   dladiv.o \
+   dlae2.o \
+   dlaebz.o \
+   dlaed0.o \
+   dlaed1.o \
+   dlaed2.o \
+   dlaed3.o \
+   dlaed4.o \
+   dlaed5.o \
+   dlaed6.o \
+   dlaed7.o \
+   dlaed8.o \
+   dlaed9.o \
+   dlaeda.o \
+   dlaev2.o \
+   dlagtf.o \
+   dlagts.o \
+   dlamrg.o \
+   dlanst.o \
+   dlapy2.o \
+   dlapy3.o \
+   dlarnv.o \
+   dlarra.o \
+   dlarrb.o \
+   dlarrc.o \
+   dlarrd.o \
+   dlarre.o \
+   dlarrf.o \
+   dlarrj.o \
+   dlarrk.o \
+   dlarrr.o \
+   dlaneg.o \
+   dlartg.o \
+   dlaruv.o \
+   dlas2.o \
+   dlascl.o \
+   dlasd0.o \
+   dlasd1.o \
+   dlasd2.o \
+   dlasd3.o \
+   dlasd4.o \
+   dlasd5.o \
+   dlasd6.o \
+   dlasd7.o \
+   dlasd8.o \
+   dlasda.o \
+   dlasdq.o \
+   dlasdt.o \
+   dlaset.o \
+   dlasq1.o \
+   dlasq2.o \
+   dlasq3.o \
+   dlasq4.o \
+   dlasq5.o \
+   dlasq6.o \
+   dlasr.o \
+   dlasrt.o \
+   dlassq.o \
+   dlasv2.o \
+   dpttrf.o \
+   dstebz.o \
+   dstedc.o \
+   dsteqr.o \
+   dsterf.o \
+   dlaisnan.o \
+   disnan.o \
+   dlartgp.o \
+   dlartgs.o \
+   ../INSTALL/droundup_lwork.o \
+   ../INSTALL/dlamch.o \
+   ../INSTALL/dsecnd_$(TIMER).o
 
 SLASRC = \
-   sbdsvdx.o spotrf2.o sgetrf2.o \
-   sgbbrd.o sgbcon.o sgbequ.o sgbrfs.o sgbsv.o \
-   sgbsvx.o sgbtf2.o sgbtrf.o sgbtrs.o sgebak.o sgebal.o sgebd2.o \
-   sgebrd.o sgecon.o sgeequ.o sgees.o  sgeesx.o sgeev.o  sgeevx.o \
-   sgehd2.o sgehrd.o sgelq2.o sgelqf.o \
-   sgels.o  sgelst.o sgelsd.o sgelss.o sgelsy.o sgeql2.o sgeqlf.o \
-   sgeqp3.o sgeqp3rk.o sgeqr2.o sgeqr2p.o sgeqrf.o sgeqrfp.o sgerfs.o \
-   sgerq2.o sgerqf.o sgesc2.o sgesdd.o sgesv.o  sgesvd.o sgesvdx.o sgesvx.o \
-   sgetc2.o sgetf2.o sgetri.o \
-   sggbak.o sggbal.o sgges.o  sgges3.o sggesx.o \
-   sggev.o  sggev3.o sggevx.o \
-   sggglm.o sgghrd.o sgghd3.o sgglse.o sggqrf.o \
-   sggrqf.o sggsvd3.o sggsvp3.o sgtcon.o sgtrfs.o sgtsv.o \
-   sgtsvx.o sgttrf.o sgttrs.o sgtts2.o shgeqz.o \
-   slaqz0.o slaqz1.o slaqz2.o slaqz3.o slaqz4.o \
-   shsein.o shseqr.o slabrd.o slacon.o slacn2.o \
-   slaein.o slaexc.o slag2.o  slags2.o slagtm.o slagv2.o slahqr.o \
-   slahr2.o slaic1.o slaln2.o slals0.o slalsa.o slalsd.o \
-   slangb.o slange.o slangt.o slanhs.o slansb.o slansp.o \
-   slansy.o slantb.o slantp.o slantr.o slanv2.o \
-   slapll.o slapmt.o \
-   slaqgb.o slaqge.o slaqp2.o slaqps.o slaqp2rk.o slaqp3rk.o slaqsb.o slaqsp.o slaqsy.o \
-   slaqr0.o slaqr1.o slaqr2.o slaqr3.o slaqr4.o slaqr5.o \
-   slaqtr.o slar1v.o slar2v.o ilaslr.o ilaslc.o \
-   slarf.o  slarfb.o slarfb_gett.o slarfg.o slarfgp.o slarft.o slarfx.o slarfy.o \
-   slargv.o slarmm.o slarrv.o slartv.o \
-   slarz.o  slarzb.o slarzt.o slaswp.o slasy2.o slasyf.o slasyf_rook.o \
+   sbdsvdx.o \
+   spotrf2.o \
+   sgetrf2.o \
+   sgbbrd.o \
+   sgbcon.o \
+   sgbequ.o \
+   sgbrfs.o \
+   sgbsv.o \
+   sgbsvx.o \
+   sgbtf2.o \
+   sgbtrf.o \
+   sgbtrs.o \
+   sgebak.o \
+   sgebal.o \
+   sgebd2.o \
+   sgebrd.o \
+   sgecon.o \
+   sgeequ.o \
+   sgees.o \
+   sgeesx.o \
+   sgeev.o \
+   sgeevx.o \
+   sgehd2.o \
+   sgehrd.o \
+   sgelq2.o \
+   sgelqf.o \
+   sgels.o \
+   sgelst.o \
+   sgelsd.o \
+   sgelss.o \
+   sgelsy.o \
+   sgeql2.o \
+   sgeqlf.o \
+   sgeqp3.o \
+   sgeqp3rk.o \
+   sgeqr2.o \
+   sgeqr2p.o \
+   sgeqrf.o \
+   sgeqrfp.o \
+   sgerfs.o \
+   sgerq2.o \
+   sgerqf.o \
+   sgesc2.o \
+   sgesdd.o \
+   sgesv.o \
+   sgesvd.o \
+   sgesvdx.o \
+   sgesvx.o \
+   sgetc2.o \
+   sgetf2.o \
+   sgetri.o \
+   sggbak.o \
+   sggbal.o \
+   sgges.o \
+   sgges3.o \
+   sggesx.o \
+   sggev.o \
+   sggev3.o \
+   sggevx.o \
+   sggglm.o \
+   sgghrd.o \
+   sgghd3.o \
+   sgglse.o \
+   sggqrf.o \
+   sggrqf.o \
+   sggsvd3.o \
+   sggsvp3.o \
+   sgtcon.o \
+   sgtrfs.o \
+   sgtsv.o \
+   sgtsvx.o \
+   sgttrf.o \
+   sgttrs.o \
+   sgtts2.o \
+   shgeqz.o \
+   slaqz0.o \
+   slaqz1.o \
+   slaqz2.o \
+   slaqz3.o \
+   slaqz4.o \
+   shsein.o \
+   shseqr.o \
+   slabrd.o \
+   slacon.o \
+   slacn2.o \
+   slaein.o \
+   slaexc.o \
+   slag2.o \
+   slags2.o \
+   slagtm.o \
+   slagv2.o \
+   slahqr.o \
+   slahr2.o \
+   slaic1.o \
+   slaln2.o \
+   slals0.o \
+   slalsa.o \
+   slalsd.o \
+   slangb.o \
+   slange.o \
+   slangt.o \
+   slanhs.o \
+   slansb.o \
+   slansp.o \
+   slansy.o \
+   slantb.o \
+   slantp.o \
+   slantr.o \
+   slanv2.o \
+   slapll.o \
+   slapmt.o \
+   slaqgb.o \
+   slaqge.o \
+   slaqp2.o \
+   slaqps.o \
+   slaqp2rk.o \
+   slaqp3rk.o \
+   slaqsb.o \
+   slaqsp.o \
+   slaqsy.o \
+   slaqr0.o \
+   slaqr1.o \
+   slaqr2.o \
+   slaqr3.o \
+   slaqr4.o \
+   slaqr5.o \
+   slaqtr.o \
+   slar1v.o \
+   slar2v.o \
+   ilaslr.o \
+   ilaslc.o \
+   slarf.o \
+   slarfb.o \
+   slarfb_gett.o \
+   slarfg.o \
+   slarfgp.o \
+   slarft.o \
+   slarfx.o \
+   slarfy.o \
+   slargv.o \
+   slarmm.o \
+   slarrv.o \
+   slartv.o \
+   slarz.o \
+   slarzb.o \
+   slarzt.o \
+   slaswp.o \
+   slasy2.o \
+   slasyf.o \
+   slasyf_rook.o \
    slasyf_rk.o \
-   slatbs.o slatdf.o slatps.o slatrd.o slatrs.o slatrs3.o slatrz.o \
-   slauu2.o slauum.o sopgtr.o sopmtr.o sorg2l.o sorg2r.o \
-   sorgbr.o sorghr.o sorgl2.o sorglq.o sorgql.o sorgqr.o sorgr2.o \
-   sorgrq.o sorgtr.o sorgtsqr.o sorgtsqr_row.o sorm2l.o sorm2r.o sorm22.o \
-   sormbr.o sormhr.o sorml2.o sormlq.o sormql.o sormqr.o sormr2.o \
-   sormr3.o sormrq.o sormrz.o sormtr.o spbcon.o spbequ.o spbrfs.o \
-   spbstf.o spbsv.o  spbsvx.o \
-   spbtf2.o spbtrf.o spbtrs.o spocon.o spoequ.o sporfs.o sposv.o \
-   sposvx.o spotf2.o spotri.o spstrf.o spstf2.o \
-   sppcon.o sppequ.o \
-   spprfs.o sppsv.o  sppsvx.o spptrf.o spptri.o spptrs.o sptcon.o \
-   spteqr.o sptrfs.o sptsv.o  sptsvx.o spttrs.o sptts2.o srscl.o \
-   ssbev.o  ssbevd.o ssbevx.o ssbgst.o ssbgv.o  ssbgvd.o ssbgvx.o \
-   ssbtrd.o sspcon.o sspev.o  sspevd.o sspevx.o sspgst.o \
-   sspgv.o  sspgvd.o sspgvx.o ssprfs.o sspsv.o  sspsvx.o ssptrd.o \
-   ssptrf.o ssptri.o ssptrs.o sstegr.o sstein.o sstev.o  sstevd.o sstevr.o \
+   slatbs.o \
+   slatdf.o \
+   slatps.o \
+   slatrd.o \
+   slatrs.o \
+   slatrs3.o \
+   slatrz.o \
+   slauu2.o \
+   slauum.o \
+   sopgtr.o \
+   sopmtr.o \
+   sorg2l.o \
+   sorg2r.o \
+   sorgbr.o \
+   sorghr.o \
+   sorgl2.o \
+   sorglq.o \
+   sorgql.o \
+   sorgqr.o \
+   sorgr2.o \
+   sorgrq.o \
+   sorgtr.o \
+   sorgtsqr.o \
+   sorgtsqr_row.o \
+   sorm2l.o \
+   sorm2r.o \
+   sorm22.o \
+   sormbr.o \
+   sormhr.o \
+   sorml2.o \
+   sormlq.o \
+   sormql.o \
+   sormqr.o \
+   sormr2.o \
+   sormr3.o \
+   sormrq.o \
+   sormrz.o \
+   sormtr.o \
+   spbcon.o \
+   spbequ.o \
+   spbrfs.o \
+   spbstf.o \
+   spbsv.o \
+   spbsvx.o \
+   spbtf2.o \
+   spbtrf.o \
+   spbtrs.o \
+   spocon.o \
+   spoequ.o \
+   sporfs.o \
+   sposv.o \
+   sposvx.o \
+   spotf2.o \
+   spotri.o \
+   spstrf.o \
+   spstf2.o \
+   sppcon.o \
+   sppequ.o \
+   spprfs.o \
+   sppsv.o \
+   sppsvx.o \
+   spptrf.o \
+   spptri.o \
+   spptrs.o \
+   sptcon.o \
+   spteqr.o \
+   sptrfs.o \
+   sptsv.o \
+   sptsvx.o \
+   spttrs.o \
+   sptts2.o \
+   srscl.o \
+   ssbev.o \
+   ssbevd.o \
+   ssbevx.o \
+   ssbgst.o \
+   ssbgv.o \
+   ssbgvd.o \
+   ssbgvx.o \
+   ssbtrd.o \
+   sspcon.o \
+   sspev.o \
+   sspevd.o \
+   sspevx.o \
+   sspgst.o \
+   sspgv.o \
+   sspgvd.o \
+   sspgvx.o \
+   ssprfs.o \
+   sspsv.o \
+   sspsvx.o \
+   ssptrd.o \
+   ssptrf.o \
+   ssptri.o \
+   ssptrs.o \
+   sstegr.o \
+   sstein.o \
+   sstev.o \
+   sstevd.o \
+   sstevr.o \
    sstevx.o \
-   ssycon.o ssyev.o  ssyevd.o ssyevr.o ssyevx.o ssygs2.o \
-   ssygst.o ssygv.o  ssygvd.o ssygvx.o ssyrfs.o ssysv.o  ssysvx.o \
-   ssytd2.o ssytf2.o ssytrd.o ssytrf.o ssytri.o ssytri2.o ssytri2x.o \
-   ssyswapr.o ssytrs.o ssytrs2.o \
-   ssyconv.o ssyconvf.o ssyconvf_rook.o \
-   ssytf2_rook.o ssytrf_rook.o ssytrs_rook.o \
-   ssytri_rook.o ssycon_rook.o ssysv_rook.o \
-   ssytf2_rk.o ssytrf_rk.o ssytrs_3.o \
-   ssytri_3.o ssytri_3x.o ssycon_3.o ssysv_rk.o \
-   slasyf_aa.o ssysv_aa.o ssytrf_aa.o ssytrs_aa.o \
-   ssysv_aa_2stage.o ssytrf_aa_2stage.o ssytrs_aa_2stage.o \
+   ssycon.o \
+   ssyev.o \
+   ssyevd.o \
+   ssyevr.o \
+   ssyevx.o \
+   ssygs2.o \
+   ssygst.o \
+   ssygv.o \
+   ssygvd.o \
+   ssygvx.o \
+   ssyrfs.o \
+   ssysv.o \
+   ssysvx.o \
+   ssytd2.o \
+   ssytf2.o \
+   ssytrd.o \
+   ssytrf.o \
+   ssytri.o \
+   ssytri2.o \
+   ssytri2x.o \
+   ssyswapr.o \
+   ssytrs.o \
+   ssytrs2.o \
+   ssyconv.o \
+   ssyconvf.o \
+   ssyconvf_rook.o \
+   ssytf2_rook.o \
+   ssytrf_rook.o \
+   ssytrs_rook.o \
+   ssytri_rook.o \
+   ssycon_rook.o \
+   ssysv_rook.o \
+   ssytf2_rk.o \
+   ssytrf_rk.o \
+   ssytrs_3.o \
+   ssytri_3.o \
+   ssytri_3x.o \
+   ssycon_3.o \
+   ssysv_rk.o \
+   slasyf_aa.o \
+   ssysv_aa.o \
+   ssytrf_aa.o \
+   ssytrs_aa.o \
+   ssysv_aa_2stage.o \
+   ssytrf_aa_2stage.o \
+   ssytrs_aa_2stage.o \
    stbcon.o \
-   stbrfs.o stbtrs.o stgevc.o stgex2.o stgexc.o stgsen.o \
-   stgsja.o stgsna.o stgsy2.o stgsyl.o stpcon.o stprfs.o stptri.o \
+   stbrfs.o \
+   stbtrs.o \
+   stgevc.o \
+   stgex2.o \
+   stgexc.o \
+   stgsen.o \
+   stgsja.o \
+   stgsna.o \
+   stgsy2.o \
+   stgsyl.o \
+   stpcon.o \
+   stprfs.o \
+   stptri.o \
    stptrs.o \
-   strcon.o strevc.o strevc3.o strexc.o strrfs.o strsen.o strsna.o strsyl.o \
-   strsyl3.o strti2.o strtri.o strtrs.o stzrzf.o sstemr.o \
-   slansf.o spftrf.o spftri.o spftrs.o ssfrk.o stfsm.o stftri.o stfttp.o \
-   stfttr.o stpttf.o stpttr.o strttf.o strttp.o \
-   sgejsv.o sgesvj.o sgsvj0.o sgsvj1.o \
-   sgeequb.o ssyequb.o spoequb.o sgbequb.o \
-   sbbcsd.o slapmr.o sorbdb.o sorbdb1.o sorbdb2.o sorbdb3.o sorbdb4.o \
-   sorbdb5.o sorbdb6.o sorcsd.o sorcsd2by1.o \
-   sgeqrt.o sgeqrt2.o sgeqrt3.o sgemqrt.o \
-   stpqrt.o stpqrt2.o stpmqrt.o stprfb.o \
-   sgelqt.o sgelqt3.o sgemlqt.o \
-   sgetsls.o sgetsqrhrt.o sgeqr.o slatsqr.o slamtsqr.o sgemqr.o \
-   sgelq.o slaswlq.o slamswlq.o sgemlq.o \
-   stplqt.o stplqt2.o stpmlqt.o \
-   sorhr_col.o slaorhr_col_getrfnp.o slaorhr_col_getrfnp2.o \
-   ssytrd_2stage.o ssytrd_sy2sb.o ssytrd_sb2st.o ssb2st_kernels.o \
-   ssyevd_2stage.o ssyev_2stage.o ssyevx_2stage.o ssyevr_2stage.o \
-   ssbev_2stage.o ssbevx_2stage.o ssbevd_2stage.o ssygv_2stage.o \
-   sgesvdq.o sgedmd.o sgedmdq.o
+   strcon.o \
+   strevc.o \
+   strevc3.o \
+   strexc.o \
+   strrfs.o \
+   strsen.o \
+   strsna.o \
+   strsyl.o \
+   strsyl3.o \
+   strti2.o \
+   strtri.o \
+   strtrs.o \
+   stzrzf.o \
+   sstemr.o \
+   slansf.o \
+   spftrf.o \
+   spftri.o \
+   spftrs.o \
+   ssfrk.o \
+   stfsm.o \
+   stftri.o \
+   stfttp.o \
+   stfttr.o \
+   stpttf.o \
+   stpttr.o \
+   strttf.o \
+   strttp.o \
+   sgejsv.o \
+   sgesvj.o \
+   sgsvj0.o \
+   sgsvj1.o \
+   sgeequb.o \
+   ssyequb.o \
+   spoequb.o \
+   sgbequb.o \
+   sbbcsd.o \
+   slapmr.o \
+   sorbdb.o \
+   sorbdb1.o \
+   sorbdb2.o \
+   sorbdb3.o \
+   sorbdb4.o \
+   sorbdb5.o \
+   sorbdb6.o \
+   sorcsd.o \
+   sorcsd2by1.o \
+   sgeqrt.o \
+   sgeqrt2.o \
+   sgeqrt3.o \
+   sgemqrt.o \
+   stpqrt.o \
+   stpqrt2.o \
+   stpmqrt.o \
+   stprfb.o \
+   sgelqt.o \
+   sgelqt3.o \
+   sgemlqt.o \
+   sgetsls.o \
+   sgetsqrhrt.o \
+   sgeqr.o \
+   slatsqr.o \
+   slamtsqr.o \
+   sgemqr.o \
+   sgelq.o \
+   slaswlq.o \
+   slamswlq.o \
+   sgemlq.o \
+   stplqt.o \
+   stplqt2.o \
+   stpmlqt.o \
+   sorhr_col.o \
+   slaorhr_col_getrfnp.o \
+   slaorhr_col_getrfnp2.o \
+   ssytrd_2stage.o \
+   ssytrd_sy2sb.o \
+   ssytrd_sb2st.o \
+   ssb2st_kernels.o \
+   ssyevd_2stage.o \
+   ssyev_2stage.o \
+   ssyevx_2stage.o \
+   ssyevr_2stage.o \
+   ssbev_2stage.o \
+   ssbevx_2stage.o \
+   ssbevd_2stage.o \
+   ssygv_2stage.o \
+   sgesvdq.o \
+   sgedmd.o \
+   sgedmdq.o
 
-DSLASRC = spotrs.o sgetrs.o spotrf.o sgetrf.o
+DSLASRC = \
+   spotrs.o \
+   sgetrs.o \
+   spotrf.o \
+   sgetrf.o
 
 ifdef USEXBLAS
-SXLASRC = sgesvxx.o sgerfsx.o sla_gerfsx_extended.o sla_geamv.o \
-   sla_gercond.o sla_gerpvgrw.o ssysvxx.o ssyrfsx.o \
-   sla_syrfsx_extended.o sla_syamv.o sla_syrcond.o sla_syrpvgrw.o \
-   sposvxx.o sporfsx.o sla_porfsx_extended.o sla_porcond.o \
-   sla_porpvgrw.o sgbsvxx.o sgbrfsx.o sla_gbrfsx_extended.o \
-   sla_gbamv.o sla_gbrcond.o sla_gbrpvgrw.o sla_lin_berr.o slarscl2.o \
-   slascl2.o sla_wwaddw.o
+SXLASRC = \
+   sgesvxx.o \
+   sgerfsx.o \
+   sla_gerfsx_extended.o \
+   sla_geamv.o \
+   sla_gercond.o \
+   sla_gerpvgrw.o \
+   ssysvxx.o \
+   ssyrfsx.o \
+   sla_syrfsx_extended.o \
+   sla_syamv.o \
+   sla_syrcond.o \
+   sla_syrpvgrw.o \
+   sposvxx.o \
+   sporfsx.o \
+   sla_porfsx_extended.o \
+   sla_porcond.o \
+   sla_porpvgrw.o \
+   sgbsvxx.o \
+   sgbrfsx.o \
+   sla_gbrfsx_extended.o \
+   sla_gbamv.o \
+   sla_gbrcond.o \
+   sla_gbrpvgrw.o \
+   sla_lin_berr.o \
+   slarscl2.o \
+   slascl2.o \
+   sla_wwaddw.o
 endif
 
 CLASRC = \
-   cpotrf2.o cgetrf2.o \
-   cbdsqr.o cgbbrd.o cgbcon.o cgbequ.o cgbrfs.o cgbsv.o  cgbsvx.o \
-   cgbtf2.o cgbtrf.o cgbtrs.o cgebak.o cgebal.o cgebd2.o cgebrd.o \
-   cgecon.o cgeequ.o cgees.o  cgeesx.o cgeev.o  cgeevx.o \
-   cgehd2.o cgehrd.o cgelq2.o cgelqf.o \
-   cgels.o  cgelst.o cgelsd.o cgelss.o cgelsy.o cgeql2.o cgeqlf.o \
-   cgeqp3.o cgeqp3rk.o cgeqr2.o cgeqr2p.o cgeqrf.o cgeqrfp.o cgerfs.o \
-   cgerq2.o cgerqf.o cgesc2.o cgesdd.o cgesv.o  cgesvd.o  cgesvdx.o \
-   cgesvj.o cgejsv.o cgsvj0.o cgsvj1.o \
-   cgesvx.o cgetc2.o cgetf2.o cgetri.o \
-   cggbak.o cggbal.o cgges.o  cgges3.o cggesx.o \
-   cggev.o  cggev3.o cggevx.o cggglm.o \
-   cgghrd.o cgghd3.o cgglse.o cggqrf.o cggrqf.o \
-   cggsvd3.o cggsvp3.o \
-   cgtcon.o cgtrfs.o cgtsv.o  cgtsvx.o cgttrf.o cgttrs.o cgtts2.o chbev.o \
-   chbevd.o chbevx.o chbgst.o chbgv.o  chbgvd.o chbgvx.o chbtrd.o \
-   checon.o cheev.o  cheevd.o cheevr.o cheevx.o chegs2.o chegst.o \
-   chegv.o  chegvd.o chegvx.o cherfs.o chesv.o  chesvx.o chetd2.o \
-   chetf2.o chetrd.o \
-   chetrf.o chetri.o chetri2.o chetri2x.o cheswapr.o \
-   chetrs.o chetrs2.o \
-   chetf2_rook.o chetrf_rook.o chetri_rook.o \
-   chetrs_rook.o checon_rook.o chesv_rook.o \
-   chetf2_rk.o chetrf_rk.o chetri_3.o chetri_3x.o \
-   chetrs_3.o checon_3.o chesv_rk.o \
-   chesv_aa.o chetrf_aa.o chetrs_aa.o clahef_aa.o \
-   chesv_aa_2stage.o chetrf_aa_2stage.o chetrs_aa_2stage.o \
-   chgeqz.o chpcon.o chpev.o  chpevd.o \
-   claqz0.o claqz1.o claqz2.o claqz3.o \
-   chpevx.o chpgst.o chpgv.o  chpgvd.o chpgvx.o chprfs.o chpsv.o \
+   cpotrf2.o \
+   cgetrf2.o \
+   cbdsqr.o \
+   cgbbrd.o \
+   cgbcon.o \
+   cgbequ.o \
+   cgbrfs.o \
+   cgbsv.o \
+   cgbsvx.o \
+   cgbtf2.o \
+   cgbtrf.o \
+   cgbtrs.o \
+   cgebak.o \
+   cgebal.o \
+   cgebd2.o \
+   cgebrd.o \
+   cgecon.o \
+   cgeequ.o \
+   cgees.o \
+   cgeesx.o \
+   cgeev.o \
+   cgeevx.o \
+   cgehd2.o \
+   cgehrd.o \
+   cgelq2.o \
+   cgelqf.o \
+   cgels.o \
+   cgelst.o \
+   cgelsd.o \
+   cgelss.o \
+   cgelsy.o \
+   cgeql2.o \
+   cgeqlf.o \
+   cgeqp3.o \
+   cgeqp3rk.o \
+   cgeqr2.o \
+   cgeqr2p.o \
+   cgeqrf.o \
+   cgeqrfp.o \
+   cgerfs.o \
+   cgerq2.o \
+   cgerqf.o \
+   cgesc2.o \
+   cgesdd.o \
+   cgesv.o \
+   cgesvd.o \
+   cgesvdx.o \
+   cgesvj.o \
+   cgejsv.o \
+   cgsvj0.o \
+   cgsvj1.o \
+   cgesvx.o \
+   cgetc2.o \
+   cgetf2.o \
+   cgetri.o \
+   cggbak.o \
+   cggbal.o \
+   cgges.o \
+   cgges3.o \
+   cggesx.o \
+   cggev.o \
+   cggev3.o \
+   cggevx.o \
+   cggglm.o \
+   cgghrd.o \
+   cgghd3.o \
+   cgglse.o \
+   cggqrf.o \
+   cggrqf.o \
+   cggsvd3.o \
+   cggsvp3.o \
+   cgtcon.o \
+   cgtrfs.o \
+   cgtsv.o \
+   cgtsvx.o \
+   cgttrf.o \
+   cgttrs.o \
+   cgtts2.o \
+   chbev.o \
+   chbevd.o \
+   chbevx.o \
+   chbgst.o \
+   chbgv.o \
+   chbgvd.o \
+   chbgvx.o \
+   chbtrd.o \
+   checon.o \
+   cheev.o \
+   cheevd.o \
+   cheevr.o \
+   cheevx.o \
+   chegs2.o \
+   chegst.o \
+   chegv.o \
+   chegvd.o \
+   chegvx.o \
+   cherfs.o \
+   chesv.o \
+   chesvx.o \
+   chetd2.o \
+   chetf2.o \
+   chetrd.o \
+   chetrf.o \
+   chetri.o \
+   chetri2.o \
+   chetri2x.o \
+   cheswapr.o \
+   chetrs.o \
+   chetrs2.o \
+   chetf2_rook.o \
+   chetrf_rook.o \
+   chetri_rook.o \
+   chetrs_rook.o \
+   checon_rook.o \
+   chesv_rook.o \
+   chetf2_rk.o \
+   chetrf_rk.o \
+   chetri_3.o \
+   chetri_3x.o \
+   chetrs_3.o \
+   checon_3.o \
+   chesv_rk.o \
+   chesv_aa.o \
+   chetrf_aa.o \
+   chetrs_aa.o \
+   clahef_aa.o \
+   chesv_aa_2stage.o \
+   chetrf_aa_2stage.o \
+   chetrs_aa_2stage.o \
+   chgeqz.o \
+   chpcon.o \
+   chpev.o \
+   chpevd.o \
+   claqz0.o \
+   claqz1.o \
+   claqz2.o \
+   claqz3.o \
+   chpevx.o \
+   chpgst.o \
+   chpgv.o \
+   chpgvd.o \
+   chpgvx.o \
+   chprfs.o \
+   chpsv.o \
    chpsvx.o \
-   chptrd.o chptrf.o chptri.o chptrs.o chsein.o chseqr.o clabrd.o \
-   clacgv.o clacon.o clacn2.o clacp2.o clacpy.o clacrm.o clacrt.o cladiv.o \
-   claed0.o claed7.o claed8.o \
-   claein.o claesy.o claev2.o clags2.o clagtm.o \
-   clahef.o clahef_rook.o clahef_rk.o clahqr.o \
-   clahr2.o claic1.o clals0.o clalsa.o clalsd.o clangb.o clange.o clangt.o \
-   clanhb.o clanhe.o \
-   clanhp.o clanhs.o clanht.o clansb.o clansp.o clansy.o clantb.o \
-   clantp.o clantr.o clapll.o clapmt.o clarcm.o claqgb.o claqge.o \
-   claqhb.o claqhe.o claqhp.o claqp2.o claqps.o claqp2rk.o claqp3rk.o claqsb.o \
-   claqr0.o claqr1.o claqr2.o claqr3.o claqr4.o claqr5.o \
-   claqsp.o claqsy.o clar1v.o clar2v.o ilaclr.o ilaclc.o \
-   clarf.o  clarfb.o clarfb_gett.o clarfg.o clarft.o clarfgp.o \
-   clarfx.o clarfy.o clargv.o clarnv.o clarrv.o clartg.o clartv.o \
-   clarz.o  clarzb.o clarzt.o clascl.o claset.o clasr.o  classq.o \
-   claswp.o clasyf.o clasyf_rook.o clasyf_rk.o clasyf_aa.o \
-   clatbs.o clatdf.o clatps.o clatrd.o clatrs.o clatrs3.o clatrz.o \
-   clauu2.o clauum.o cpbcon.o cpbequ.o cpbrfs.o cpbstf.o cpbsv.o \
-   cpbsvx.o cpbtf2.o cpbtrf.o cpbtrs.o cpocon.o cpoequ.o cporfs.o \
-   cposv.o  cposvx.o cpotf2.o cpotri.o cpstrf.o cpstf2.o \
-   cppcon.o cppequ.o cpprfs.o cppsv.o  cppsvx.o cpptrf.o cpptri.o cpptrs.o \
-   cptcon.o cpteqr.o cptrfs.o cptsv.o  cptsvx.o cpttrf.o cpttrs.o cptts2.o \
-   crot.o   cspcon.o cspmv.o  cspr.o   csprfs.o cspsv.o \
-   cspsvx.o csptrf.o csptri.o csptrs.o csrscl.o crscl.o cstedc.o \
-   cstegr.o cstein.o csteqr.o \
-   csycon.o csymv.o \
-   csyr.o csyrfs.o csysv.o csysvx.o csytf2.o csytrf.o csytri.o csytri2.o csytri2x.o \
-   csyswapr.o csytrs.o csytrs2.o \
-   csyconv.o csyconvf.o csyconvf_rook.o \
-   csytf2_rook.o csytrf_rook.o csytrs_rook.o \
-   csytri_rook.o csycon_rook.o csysv_rook.o \
-   csytf2_rk.o csytrf_rk.o csytrf_aa.o csytrs_3.o csytrs_aa.o \
-   csytri_3.o csytri_3x.o csycon_3.o csysv_rk.o csysv_aa.o \
-   csysv_aa_2stage.o csytrf_aa_2stage.o csytrs_aa_2stage.o \
-   ctbcon.o ctbrfs.o ctbtrs.o ctgevc.o ctgex2.o \
-   ctgexc.o ctgsen.o ctgsja.o ctgsna.o ctgsy2.o ctgsyl.o ctpcon.o \
-   ctprfs.o ctptri.o \
-   ctptrs.o ctrcon.o ctrevc.o ctrevc3.o ctrexc.o ctrrfs.o ctrsen.o ctrsna.o \
-   ctrsyl.o ctrsyl3.o ctrti2.o ctrtri.o ctrtrs.o ctzrzf.o cung2l.o cung2r.o \
-   cungbr.o cunghr.o cungl2.o cunglq.o cungql.o cungqr.o cungr2.o \
-   cungrq.o cungtr.o cungtsqr.o cungtsqr_row.o cunm2l.o cunm2r.o cunmbr.o cunmhr.o cunml2.o cunm22.o \
-   cunmlq.o cunmql.o cunmqr.o cunmr2.o cunmr3.o cunmrq.o cunmrz.o \
-   cunmtr.o cupgtr.o cupmtr.o icmax1.o scsum1.o cstemr.o \
-   chfrk.o ctfttp.o clanhf.o cpftrf.o cpftri.o cpftrs.o ctfsm.o ctftri.o \
-   ctfttr.o ctpttf.o ctpttr.o ctrttf.o ctrttp.o \
-   cgeequb.o cgbequb.o csyequb.o cpoequb.o cheequb.o \
-   cbbcsd.o clapmr.o cunbdb.o cunbdb1.o cunbdb2.o cunbdb3.o cunbdb4.o \
-   cunbdb5.o cunbdb6.o cuncsd.o cuncsd2by1.o \
-   cgeqrt.o cgeqrt2.o cgeqrt3.o cgemqrt.o \
-   ctpqrt.o ctpqrt2.o ctpmqrt.o ctprfb.o \
-   cgelqt.o cgelqt3.o cgemlqt.o \
-   cgetsls.o cgetsqrhrt.o cgeqr.o clatsqr.o clamtsqr.o cgemqr.o \
-   cgelq.o claswlq.o clamswlq.o cgemlq.o \
-   ctplqt.o ctplqt2.o ctpmlqt.o \
-   cunhr_col.o claunhr_col_getrfnp.o claunhr_col_getrfnp2.o \
-   chetrd_2stage.o chetrd_he2hb.o chetrd_hb2st.o chb2st_kernels.o \
-   cheevd_2stage.o cheev_2stage.o cheevx_2stage.o cheevr_2stage.o \
-   chbev_2stage.o chbevx_2stage.o chbevd_2stage.o chegv_2stage.o \
-   cgesvdq.o cgedmd.o cgedmdq.o
+   chptrd.o \
+   chptrf.o \
+   chptri.o \
+   chptrs.o \
+   chsein.o \
+   chseqr.o \
+   clabrd.o \
+   clacgv.o \
+   clacon.o \
+   clacn2.o \
+   clacp2.o \
+   clacpy.o \
+   clacrm.o \
+   clacrt.o \
+   cladiv.o \
+   claed0.o \
+   claed7.o \
+   claed8.o \
+   claein.o \
+   claesy.o \
+   claev2.o \
+   clags2.o \
+   clagtm.o \
+   clahef.o \
+   clahef_rook.o \
+   clahef_rk.o \
+   clahqr.o \
+   clahr2.o \
+   claic1.o \
+   clals0.o \
+   clalsa.o \
+   clalsd.o \
+   clangb.o \
+   clange.o \
+   clangt.o \
+   clanhb.o \
+   clanhe.o \
+   clanhp.o \
+   clanhs.o \
+   clanht.o \
+   clansb.o \
+   clansp.o \
+   clansy.o \
+   clantb.o \
+   clantp.o \
+   clantr.o \
+   clapll.o \
+   clapmt.o \
+   clarcm.o \
+   claqgb.o \
+   claqge.o \
+   claqhb.o \
+   claqhe.o \
+   claqhp.o \
+   claqp2.o \
+   claqps.o \
+   claqp2rk.o \
+   claqp3rk.o \
+   claqsb.o \
+   claqr0.o \
+   claqr1.o \
+   claqr2.o \
+   claqr3.o \
+   claqr4.o \
+   claqr5.o \
+   claqsp.o \
+   claqsy.o \
+   clar1v.o \
+   clar2v.o \
+   ilaclr.o \
+   ilaclc.o \
+   clarf.o \
+   clarfb.o \
+   clarfb_gett.o \
+   clarfg.o \
+   clarft.o \
+   clarfgp.o \
+   clarfx.o \
+   clarfy.o \
+   clargv.o \
+   clarnv.o \
+   clarrv.o \
+   clartg.o \
+   clartv.o \
+   clarz.o \
+   clarzb.o \
+   clarzt.o \
+   clascl.o \
+   claset.o \
+   clasr.o \
+   classq.o \
+   claswp.o \
+   clasyf.o \
+   clasyf_rook.o \
+   clasyf_rk.o \
+   clasyf_aa.o \
+   clatbs.o \
+   clatdf.o \
+   clatps.o \
+   clatrd.o \
+   clatrs.o \
+   clatrs3.o \
+   clatrz.o \
+   clauu2.o \
+   clauum.o \
+   cpbcon.o \
+   cpbequ.o \
+   cpbrfs.o \
+   cpbstf.o \
+   cpbsv.o \
+   cpbsvx.o \
+   cpbtf2.o \
+   cpbtrf.o \
+   cpbtrs.o \
+   cpocon.o \
+   cpoequ.o \
+   cporfs.o \
+   cposv.o \
+   cposvx.o \
+   cpotf2.o \
+   cpotri.o \
+   cpstrf.o \
+   cpstf2.o \
+   cppcon.o \
+   cppequ.o \
+   cpprfs.o \
+   cppsv.o \
+   cppsvx.o \
+   cpptrf.o \
+   cpptri.o \
+   cpptrs.o \
+   cptcon.o \
+   cpteqr.o \
+   cptrfs.o \
+   cptsv.o \
+   cptsvx.o \
+   cpttrf.o \
+   cpttrs.o \
+   cptts2.o \
+   crot.o \
+   cspcon.o \
+   cspmv.o \
+   cspr.o \
+   csprfs.o \
+   cspsv.o \
+   cspsvx.o \
+   csptrf.o \
+   csptri.o \
+   csptrs.o \
+   csrscl.o \
+   crscl.o \
+   cstedc.o \
+   cstegr.o \
+   cstein.o \
+   csteqr.o \
+   csycon.o \
+   csymv.o \
+   csyr.o \
+   csyrfs.o \
+   csysv.o \
+   csysvx.o \
+   csytf2.o \
+   csytrf.o \
+   csytri.o \
+   csytri2.o \
+   csytri2x.o \
+   csyswapr.o \
+   csytrs.o \
+   csytrs2.o \
+   csyconv.o \
+   csyconvf.o \
+   csyconvf_rook.o \
+   csytf2_rook.o \
+   csytrf_rook.o \
+   csytrs_rook.o \
+   csytri_rook.o \
+   csycon_rook.o \
+   csysv_rook.o \
+   csytf2_rk.o \
+   csytrf_rk.o \
+   csytrf_aa.o \
+   csytrs_3.o \
+   csytrs_aa.o \
+   csytri_3.o \
+   csytri_3x.o \
+   csycon_3.o \
+   csysv_rk.o \
+   csysv_aa.o \
+   csysv_aa_2stage.o \
+   csytrf_aa_2stage.o \
+   csytrs_aa_2stage.o \
+   ctbcon.o \
+   ctbrfs.o \
+   ctbtrs.o \
+   ctgevc.o \
+   ctgex2.o \
+   ctgexc.o \
+   ctgsen.o \
+   ctgsja.o \
+   ctgsna.o \
+   ctgsy2.o \
+   ctgsyl.o \
+   ctpcon.o \
+   ctprfs.o \
+   ctptri.o \
+   ctptrs.o \
+   ctrcon.o \
+   ctrevc.o \
+   ctrevc3.o \
+   ctrexc.o \
+   ctrrfs.o \
+   ctrsen.o \
+   ctrsna.o \
+   ctrsyl.o \
+   ctrsyl3.o \
+   ctrti2.o \
+   ctrtri.o \
+   ctrtrs.o \
+   ctzrzf.o \
+   cung2l.o \
+   cung2r.o \
+   cungbr.o \
+   cunghr.o \
+   cungl2.o \
+   cunglq.o \
+   cungql.o \
+   cungqr.o \
+   cungr2.o \
+   cungrq.o \
+   cungtr.o \
+   cungtsqr.o \
+   cungtsqr_row.o \
+   cunm2l.o \
+   cunm2r.o \
+   cunmbr.o \
+   cunmhr.o \
+   cunml2.o \
+   cunm22.o \
+   cunmlq.o \
+   cunmql.o \
+   cunmqr.o \
+   cunmr2.o \
+   cunmr3.o \
+   cunmrq.o \
+   cunmrz.o \
+   cunmtr.o \
+   cupgtr.o \
+   cupmtr.o \
+   icmax1.o \
+   scsum1.o \
+   cstemr.o \
+   chfrk.o \
+   ctfttp.o \
+   clanhf.o \
+   cpftrf.o \
+   cpftri.o \
+   cpftrs.o \
+   ctfsm.o \
+   ctftri.o \
+   ctfttr.o \
+   ctpttf.o \
+   ctpttr.o \
+   ctrttf.o \
+   ctrttp.o \
+   cgeequb.o \
+   cgbequb.o \
+   csyequb.o \
+   cpoequb.o \
+   cheequb.o \
+   cbbcsd.o \
+   clapmr.o \
+   cunbdb.o \
+   cunbdb1.o \
+   cunbdb2.o \
+   cunbdb3.o \
+   cunbdb4.o \
+   cunbdb5.o \
+   cunbdb6.o \
+   cuncsd.o \
+   cuncsd2by1.o \
+   cgeqrt.o \
+   cgeqrt2.o \
+   cgeqrt3.o \
+   cgemqrt.o \
+   ctpqrt.o \
+   ctpqrt2.o \
+   ctpmqrt.o \
+   ctprfb.o \
+   cgelqt.o \
+   cgelqt3.o \
+   cgemlqt.o \
+   cgetsls.o \
+   cgetsqrhrt.o \
+   cgeqr.o \
+   clatsqr.o \
+   clamtsqr.o \
+   cgemqr.o \
+   cgelq.o \
+   claswlq.o \
+   clamswlq.o \
+   cgemlq.o \
+   ctplqt.o \
+   ctplqt2.o \
+   ctpmlqt.o \
+   cunhr_col.o \
+   claunhr_col_getrfnp.o \
+   claunhr_col_getrfnp2.o \
+   chetrd_2stage.o \
+   chetrd_he2hb.o \
+   chetrd_hb2st.o \
+   chb2st_kernels.o \
+   cheevd_2stage.o \
+   cheev_2stage.o \
+   cheevx_2stage.o \
+   cheevr_2stage.o \
+   chbev_2stage.o \
+   chbevx_2stage.o \
+   chbevd_2stage.o \
+   chegv_2stage.o \
+   cgesvdq.o \
+   cgedmd.o \
+   cgedmdq.o
 
 ifdef USEXBLAS
-CXLASRC = cgesvxx.o cgerfsx.o cla_gerfsx_extended.o cla_geamv.o \
-   cla_gercond_c.o cla_gercond_x.o cla_gerpvgrw.o \
-   csysvxx.o csyrfsx.o cla_syrfsx_extended.o cla_syamv.o \
-   cla_syrcond_c.o cla_syrcond_x.o cla_syrpvgrw.o \
-   cposvxx.o cporfsx.o cla_porfsx_extended.o \
-   cla_porcond_c.o cla_porcond_x.o cla_porpvgrw.o \
-   cgbsvxx.o cgbrfsx.o cla_gbrfsx_extended.o cla_gbamv.o \
-   cla_gbrcond_c.o cla_gbrcond_x.o cla_gbrpvgrw.o \
-   chesvxx.o cherfsx.o cla_herfsx_extended.o cla_heamv.o \
-   cla_hercond_c.o cla_hercond_x.o cla_herpvgrw.o \
-   cla_lin_berr.o clarscl2.o clascl2.o cla_wwaddw.o
+CXLASRC = \
+   cgesvxx.o \
+   cgerfsx.o \
+   cla_gerfsx_extended.o \
+   cla_geamv.o \
+   cla_gercond_c.o \
+   cla_gercond_x.o \
+   cla_gerpvgrw.o \
+   csysvxx.o \
+   csyrfsx.o \
+   cla_syrfsx_extended.o \
+   cla_syamv.o \
+   cla_syrcond_c.o \
+   cla_syrcond_x.o \
+   cla_syrpvgrw.o \
+   cposvxx.o \
+   cporfsx.o \
+   cla_porfsx_extended.o \
+   cla_porcond_c.o \
+   cla_porcond_x.o \
+   cla_porpvgrw.o \
+   cgbsvxx.o \
+   cgbrfsx.o \
+   cla_gbrfsx_extended.o \
+   cla_gbamv.o \
+   cla_gbrcond_c.o \
+   cla_gbrcond_x.o \
+   cla_gbrpvgrw.o \
+   chesvxx.o \
+   cherfsx.o \
+   cla_herfsx_extended.o \
+   cla_heamv.o \
+   cla_hercond_c.o \
+   cla_hercond_x.o \
+   cla_herpvgrw.o \
+   cla_lin_berr.o \
+   clarscl2.o \
+   clascl2.o \
+   cla_wwaddw.o
 endif
 
-ZCLASRC = cpotrs.o cgetrs.o cpotrf.o cgetrf.o
+ZCLASRC = \
+   cpotrs.o \
+   cgetrs.o \
+   cpotrf.o \
+   cgetrf.o
 
 DLASRC = \
-   dpotrf2.o dgetrf2.o \
+   dpotrf2.o \
+   dgetrf2.o \
    dbdsvdx.o \
-   dgbbrd.o dgbcon.o dgbequ.o dgbrfs.o dgbsv.o \
-   dgbsvx.o dgbtf2.o dgbtrf.o dgbtrs.o dgebak.o dgebal.o dgebd2.o \
-   dgebrd.o dgecon.o dgeequ.o dgees.o  dgeesx.o dgeev.o  dgeevx.o \
-   dgehd2.o dgehrd.o dgelq2.o dgelqf.o \
-   dgels.o  dgelst.o dgelsd.o dgelss.o dgelsy.o dgeql2.o dgeqlf.o \
-   dgeqp3.o dgeqp3rk.o dgeqr2.o dgeqr2p.o dgeqrf.o dgeqrfp.o dgerfs.o \
-   dgerq2.o dgerqf.o dgesc2.o dgesdd.o dgesv.o  dgesvd.o dgesvdx.o dgesvx.o \
-   dgetc2.o dgetf2.o dgetrf.o dgetri.o \
-   dgetrs.o dggbak.o dggbal.o dgges.o  dgges3.o dggesx.o \
-   dggev.o  dggev3.o dggevx.o \
-   dggglm.o dgghrd.o dgghd3.o dgglse.o dggqrf.o \
-   dggrqf.o dggsvd3.o dggsvp3.o dgtcon.o dgtrfs.o dgtsv.o \
-   dgtsvx.o dgttrf.o dgttrs.o dgtts2.o dhgeqz.o \
-   dlaqz0.o dlaqz1.o dlaqz2.o dlaqz3.o dlaqz4.o \
-   dhsein.o dhseqr.o dlabrd.o dlacon.o dlacn2.o \
-   dlaein.o dlaexc.o dlag2.o  dlags2.o dlagtm.o dlagv2.o dlahqr.o \
-   dlahr2.o dlaic1.o dlaln2.o dlals0.o dlalsa.o dlalsd.o \
-   dlangb.o dlange.o dlangt.o dlanhs.o dlansb.o dlansp.o \
-   dlansy.o dlantb.o dlantp.o dlantr.o dlanv2.o \
-   dlapll.o dlapmt.o \
-   dlaqgb.o dlaqge.o dlaqp2.o dlaqps.o dlaqp2rk.o dlaqp3rk.o dlaqsb.o dlaqsp.o dlaqsy.o \
-   dlaqr0.o dlaqr1.o dlaqr2.o dlaqr3.o dlaqr4.o dlaqr5.o \
-   dlaqtr.o dlar1v.o dlar2v.o iladlr.o iladlc.o \
-   dlarf.o  dlarfb.o dlarfb_gett.o dlarfg.o dlarfgp.o dlarft.o dlarfx.o dlarfy.o \
-   dlargv.o dlarmm.o dlarrv.o dlartv.o \
-   dlarz.o  dlarzb.o dlarzt.o dlaswp.o dlasy2.o \
-   dlasyf.o dlasyf_rook.o dlasyf_rk.o \
-   dlatbs.o dlatdf.o dlatps.o dlatrd.o dlatrs.o dlatrs3.o dlatrz.o dlauu2.o \
-   dlauum.o dopgtr.o dopmtr.o dorg2l.o dorg2r.o \
-   dorgbr.o dorghr.o dorgl2.o dorglq.o dorgql.o dorgqr.o dorgr2.o \
-   dorgrq.o dorgtr.o dorgtsqr.o dorgtsqr_row.o dorm2l.o dorm2r.o dorm22.o \
-   dormbr.o dormhr.o dorml2.o dormlq.o dormql.o dormqr.o dormr2.o \
-   dormr3.o dormrq.o dormrz.o dormtr.o dpbcon.o dpbequ.o dpbrfs.o \
-   dpbstf.o dpbsv.o  dpbsvx.o \
-   dpbtf2.o dpbtrf.o dpbtrs.o dpocon.o dpoequ.o dporfs.o dposv.o \
-   dposvx.o dpotf2.o dpotrf.o dpotri.o dpotrs.o dpstrf.o dpstf2.o \
-   dppcon.o dppequ.o \
-   dpprfs.o dppsv.o  dppsvx.o dpptrf.o dpptri.o dpptrs.o dptcon.o \
-   dpteqr.o dptrfs.o dptsv.o  dptsvx.o dpttrs.o dptts2.o drscl.o \
-   dsbev.o  dsbevd.o dsbevx.o dsbgst.o dsbgv.o  dsbgvd.o dsbgvx.o \
-   dsbtrd.o dspcon.o dspev.o  dspevd.o dspevx.o dspgst.o \
-   dspgv.o  dspgvd.o dspgvx.o dsprfs.o dspsv.o  dspsvx.o dsptrd.o \
-   dsptrf.o dsptri.o dsptrs.o dstegr.o dstein.o dstev.o  dstevd.o dstevr.o \
+   dgbbrd.o \
+   dgbcon.o \
+   dgbequ.o \
+   dgbrfs.o \
+   dgbsv.o \
+   dgbsvx.o \
+   dgbtf2.o \
+   dgbtrf.o \
+   dgbtrs.o \
+   dgebak.o \
+   dgebal.o \
+   dgebd2.o \
+   dgebrd.o \
+   dgecon.o \
+   dgeequ.o \
+   dgees.o \
+   dgeesx.o \
+   dgeev.o \
+   dgeevx.o \
+   dgehd2.o \
+   dgehrd.o \
+   dgelq2.o \
+   dgelqf.o \
+   dgels.o \
+   dgelst.o \
+   dgelsd.o \
+   dgelss.o \
+   dgelsy.o \
+   dgeql2.o \
+   dgeqlf.o \
+   dgeqp3.o \
+   dgeqp3rk.o \
+   dgeqr2.o \
+   dgeqr2p.o \
+   dgeqrf.o \
+   dgeqrfp.o \
+   dgerfs.o \
+   dgerq2.o \
+   dgerqf.o \
+   dgesc2.o \
+   dgesdd.o \
+   dgesv.o \
+   dgesvd.o \
+   dgesvdx.o \
+   dgesvx.o \
+   dgetc2.o \
+   dgetf2.o \
+   dgetrf.o \
+   dgetri.o \
+   dgetrs.o \
+   dggbak.o \
+   dggbal.o \
+   dgges.o \
+   dgges3.o \
+   dggesx.o \
+   dggev.o \
+   dggev3.o \
+   dggevx.o \
+   dggglm.o \
+   dgghrd.o \
+   dgghd3.o \
+   dgglse.o \
+   dggqrf.o \
+   dggrqf.o \
+   dggsvd3.o \
+   dggsvp3.o \
+   dgtcon.o \
+   dgtrfs.o \
+   dgtsv.o \
+   dgtsvx.o \
+   dgttrf.o \
+   dgttrs.o \
+   dgtts2.o \
+   dhgeqz.o \
+   dlaqz0.o \
+   dlaqz1.o \
+   dlaqz2.o \
+   dlaqz3.o \
+   dlaqz4.o \
+   dhsein.o \
+   dhseqr.o \
+   dlabrd.o \
+   dlacon.o \
+   dlacn2.o \
+   dlaein.o \
+   dlaexc.o \
+   dlag2.o \
+   dlags2.o \
+   dlagtm.o \
+   dlagv2.o \
+   dlahqr.o \
+   dlahr2.o \
+   dlaic1.o \
+   dlaln2.o \
+   dlals0.o \
+   dlalsa.o \
+   dlalsd.o \
+   dlangb.o \
+   dlange.o \
+   dlangt.o \
+   dlanhs.o \
+   dlansb.o \
+   dlansp.o \
+   dlansy.o \
+   dlantb.o \
+   dlantp.o \
+   dlantr.o \
+   dlanv2.o \
+   dlapll.o \
+   dlapmt.o \
+   dlaqgb.o \
+   dlaqge.o \
+   dlaqp2.o \
+   dlaqps.o \
+   dlaqp2rk.o \
+   dlaqp3rk.o \
+   dlaqsb.o \
+   dlaqsp.o \
+   dlaqsy.o \
+   dlaqr0.o \
+   dlaqr1.o \
+   dlaqr2.o \
+   dlaqr3.o \
+   dlaqr4.o \
+   dlaqr5.o \
+   dlaqtr.o \
+   dlar1v.o \
+   dlar2v.o \
+   iladlr.o \
+   iladlc.o \
+   dlarf.o \
+   dlarfb.o \
+   dlarfb_gett.o \
+   dlarfg.o \
+   dlarfgp.o \
+   dlarft.o \
+   dlarfx.o \
+   dlarfy.o \
+   dlargv.o \
+   dlarmm.o \
+   dlarrv.o \
+   dlartv.o \
+   dlarz.o \
+   dlarzb.o \
+   dlarzt.o \
+   dlaswp.o \
+   dlasy2.o \
+   dlasyf.o \
+   dlasyf_rook.o \
+   dlasyf_rk.o \
+   dlatbs.o \
+   dlatdf.o \
+   dlatps.o \
+   dlatrd.o \
+   dlatrs.o \
+   dlatrs3.o \
+   dlatrz.o \
+   dlauu2.o \
+   dlauum.o \
+   dopgtr.o \
+   dopmtr.o \
+   dorg2l.o \
+   dorg2r.o \
+   dorgbr.o \
+   dorghr.o \
+   dorgl2.o \
+   dorglq.o \
+   dorgql.o \
+   dorgqr.o \
+   dorgr2.o \
+   dorgrq.o \
+   dorgtr.o \
+   dorgtsqr.o \
+   dorgtsqr_row.o \
+   dorm2l.o \
+   dorm2r.o \
+   dorm22.o \
+   dormbr.o \
+   dormhr.o \
+   dorml2.o \
+   dormlq.o \
+   dormql.o \
+   dormqr.o \
+   dormr2.o \
+   dormr3.o \
+   dormrq.o \
+   dormrz.o \
+   dormtr.o \
+   dpbcon.o \
+   dpbequ.o \
+   dpbrfs.o \
+   dpbstf.o \
+   dpbsv.o \
+   dpbsvx.o \
+   dpbtf2.o \
+   dpbtrf.o \
+   dpbtrs.o \
+   dpocon.o \
+   dpoequ.o \
+   dporfs.o \
+   dposv.o \
+   dposvx.o \
+   dpotf2.o \
+   dpotrf.o \
+   dpotri.o \
+   dpotrs.o \
+   dpstrf.o \
+   dpstf2.o \
+   dppcon.o \
+   dppequ.o \
+   dpprfs.o \
+   dppsv.o \
+   dppsvx.o \
+   dpptrf.o \
+   dpptri.o \
+   dpptrs.o \
+   dptcon.o \
+   dpteqr.o \
+   dptrfs.o \
+   dptsv.o \
+   dptsvx.o \
+   dpttrs.o \
+   dptts2.o \
+   drscl.o \
+   dsbev.o \
+   dsbevd.o \
+   dsbevx.o \
+   dsbgst.o \
+   dsbgv.o \
+   dsbgvd.o \
+   dsbgvx.o \
+   dsbtrd.o \
+   dspcon.o \
+   dspev.o \
+   dspevd.o \
+   dspevx.o \
+   dspgst.o \
+   dspgv.o \
+   dspgvd.o \
+   dspgvx.o \
+   dsprfs.o \
+   dspsv.o \
+   dspsvx.o \
+   dsptrd.o \
+   dsptrf.o \
+   dsptri.o \
+   dsptrs.o \
+   dstegr.o \
+   dstein.o \
+   dstev.o \
+   dstevd.o \
+   dstevr.o \
    dstevx.o \
-   dsycon.o dsyev.o  dsyevd.o dsyevr.o \
-   dsyevx.o dsygs2.o dsygst.o dsygv.o  dsygvd.o dsygvx.o dsyrfs.o \
-   dsysv.o  dsysvx.o \
-   dsytd2.o dsytf2.o dsytrd.o dsytrf.o dsytri.o dsytri2.o dsytri2x.o \
-   dsyswapr.o dsytrs.o dsytrs2.o \
-   dsyconv.o dsyconvf.o dsyconvf_rook.o \
-   dsytf2_rook.o dsytrf_rook.o dsytrs_rook.o \
-   dsytri_rook.o dsycon_rook.o dsysv_rook.o \
-   dsytf2_rk.o dsytrf_rk.o dsytrs_3.o \
-   dsytri_3.o dsytri_3x.o dsycon_3.o dsysv_rk.o \
-   dlasyf_aa.o dsysv_aa.o dsytrf_aa.o dsytrs_aa.o \
-   dsysv_aa_2stage.o dsytrf_aa_2stage.o dsytrs_aa_2stage.o \
-   dtbcon.o dtbrfs.o dtbtrs.o dtgevc.o dtgex2.o dtgexc.o dtgsen.o \
-   dtgsja.o dtgsna.o dtgsy2.o dtgsyl.o dtpcon.o dtprfs.o dtptri.o \
+   dsycon.o \
+   dsyev.o \
+   dsyevd.o \
+   dsyevr.o \
+   dsyevx.o \
+   dsygs2.o \
+   dsygst.o \
+   dsygv.o \
+   dsygvd.o \
+   dsygvx.o \
+   dsyrfs.o \
+   dsysv.o \
+   dsysvx.o \
+   dsytd2.o \
+   dsytf2.o \
+   dsytrd.o \
+   dsytrf.o \
+   dsytri.o \
+   dsytri2.o \
+   dsytri2x.o \
+   dsyswapr.o \
+   dsytrs.o \
+   dsytrs2.o \
+   dsyconv.o \
+   dsyconvf.o \
+   dsyconvf_rook.o \
+   dsytf2_rook.o \
+   dsytrf_rook.o \
+   dsytrs_rook.o \
+   dsytri_rook.o \
+   dsycon_rook.o \
+   dsysv_rook.o \
+   dsytf2_rk.o \
+   dsytrf_rk.o \
+   dsytrs_3.o \
+   dsytri_3.o \
+   dsytri_3x.o \
+   dsycon_3.o \
+   dsysv_rk.o \
+   dlasyf_aa.o \
+   dsysv_aa.o \
+   dsytrf_aa.o \
+   dsytrs_aa.o \
+   dsysv_aa_2stage.o \
+   dsytrf_aa_2stage.o \
+   dsytrs_aa_2stage.o \
+   dtbcon.o \
+   dtbrfs.o \
+   dtbtrs.o \
+   dtgevc.o \
+   dtgex2.o \
+   dtgexc.o \
+   dtgsen.o \
+   dtgsja.o \
+   dtgsna.o \
+   dtgsy2.o \
+   dtgsyl.o \
+   dtpcon.o \
+   dtprfs.o \
+   dtptri.o \
    dtptrs.o \
-   dtrcon.o dtrevc.o dtrevc3.o dtrexc.o dtrrfs.o dtrsen.o dtrsna.o dtrsyl.o \
-   dtrsyl3.o dtrti2.o dtrtri.o dtrtrs.o dtzrzf.o dstemr.o \
-   dsgesv.o dsposv.o dlag2s.o slag2d.o dlat2s.o \
-   dlansf.o dpftrf.o dpftri.o dpftrs.o dsfrk.o dtfsm.o dtftri.o dtfttp.o \
-   dtfttr.o dtpttf.o dtpttr.o dtrttf.o dtrttp.o \
-   dgejsv.o dgesvj.o dgsvj0.o dgsvj1.o \
-   dgeequb.o dsyequb.o dpoequb.o dgbequb.o \
-   dbbcsd.o dlapmr.o dorbdb.o dorbdb1.o dorbdb2.o dorbdb3.o dorbdb4.o \
-   dorbdb5.o dorbdb6.o dorcsd.o dorcsd2by1.o \
-   dgeqrt.o dgeqrt2.o dgeqrt3.o dgemqrt.o \
-   dtpqrt.o dtpqrt2.o dtpmqrt.o dtprfb.o \
-   dgelqt.o dgelqt3.o dgemlqt.o \
-   dgetsls.o dgetsqrhrt.o dgeqr.o dlatsqr.o dlamtsqr.o dgemqr.o \
-   dgelq.o dlaswlq.o dlamswlq.o dgemlq.o \
-   dtplqt.o dtplqt2.o dtpmlqt.o \
-   dorhr_col.o dlaorhr_col_getrfnp.o dlaorhr_col_getrfnp2.o \
-   dsytrd_2stage.o dsytrd_sy2sb.o dsytrd_sb2st.o dsb2st_kernels.o \
-   dsyevd_2stage.o dsyev_2stage.o dsyevx_2stage.o dsyevr_2stage.o \
-   dsbev_2stage.o dsbevx_2stage.o dsbevd_2stage.o dsygv_2stage.o \
-   dgesvdq.o dgedmd.o dgedmdq.o
+   dtrcon.o \
+   dtrevc.o \
+   dtrevc3.o \
+   dtrexc.o \
+   dtrrfs.o \
+   dtrsen.o \
+   dtrsna.o \
+   dtrsyl.o \
+   dtrsyl3.o \
+   dtrti2.o \
+   dtrtri.o \
+   dtrtrs.o \
+   dtzrzf.o \
+   dstemr.o \
+   dsgesv.o \
+   dsposv.o \
+   dlag2s.o \
+   slag2d.o \
+   dlat2s.o \
+   dlansf.o \
+   dpftrf.o \
+   dpftri.o \
+   dpftrs.o \
+   dsfrk.o \
+   dtfsm.o \
+   dtftri.o \
+   dtfttp.o \
+   dtfttr.o \
+   dtpttf.o \
+   dtpttr.o \
+   dtrttf.o \
+   dtrttp.o \
+   dgejsv.o \
+   dgesvj.o \
+   dgsvj0.o \
+   dgsvj1.o \
+   dgeequb.o \
+   dsyequb.o \
+   dpoequb.o \
+   dgbequb.o \
+   dbbcsd.o \
+   dlapmr.o \
+   dorbdb.o \
+   dorbdb1.o \
+   dorbdb2.o \
+   dorbdb3.o \
+   dorbdb4.o \
+   dorbdb5.o \
+   dorbdb6.o \
+   dorcsd.o \
+   dorcsd2by1.o \
+   dgeqrt.o \
+   dgeqrt2.o \
+   dgeqrt3.o \
+   dgemqrt.o \
+   dtpqrt.o \
+   dtpqrt2.o \
+   dtpmqrt.o \
+   dtprfb.o \
+   dgelqt.o \
+   dgelqt3.o \
+   dgemlqt.o \
+   dgetsls.o \
+   dgetsqrhrt.o \
+   dgeqr.o \
+   dlatsqr.o \
+   dlamtsqr.o \
+   dgemqr.o \
+   dgelq.o \
+   dlaswlq.o \
+   dlamswlq.o \
+   dgemlq.o \
+   dtplqt.o \
+   dtplqt2.o \
+   dtpmlqt.o \
+   dorhr_col.o \
+   dlaorhr_col_getrfnp.o \
+   dlaorhr_col_getrfnp2.o \
+   dsytrd_2stage.o \
+   dsytrd_sy2sb.o \
+   dsytrd_sb2st.o \
+   dsb2st_kernels.o \
+   dsyevd_2stage.o \
+   dsyev_2stage.o \
+   dsyevx_2stage.o \
+   dsyevr_2stage.o \
+   dsbev_2stage.o \
+   dsbevx_2stage.o \
+   dsbevd_2stage.o \
+   dsygv_2stage.o \
+   dgesvdq.o \
+   dgedmd.o \
+   dgedmdq.o
 
 ifdef USEXBLAS
-DXLASRC = dgesvxx.o dgerfsx.o dla_gerfsx_extended.o dla_geamv.o \
-   dla_gercond.o dla_gerpvgrw.o dsysvxx.o dsyrfsx.o \
-   dla_syrfsx_extended.o dla_syamv.o dla_syrcond.o dla_syrpvgrw.o \
-   dposvxx.o dporfsx.o dla_porfsx_extended.o dla_porcond.o \
-   dla_porpvgrw.o dgbsvxx.o dgbrfsx.o dla_gbrfsx_extended.o \
-   dla_gbamv.o dla_gbrcond.o dla_gbrpvgrw.o dla_lin_berr.o dlarscl2.o \
-   dlascl2.o dla_wwaddw.o
+DXLASRC = \
+   dgesvxx.o \
+   dgerfsx.o \
+   dla_gerfsx_extended.o \
+   dla_geamv.o \
+   dla_gercond.o \
+   dla_gerpvgrw.o \
+   dsysvxx.o \
+   dsyrfsx.o \
+   dla_syrfsx_extended.o \
+   dla_syamv.o \
+   dla_syrcond.o \
+   dla_syrpvgrw.o \
+   dposvxx.o \
+   dporfsx.o \
+   dla_porfsx_extended.o \
+   dla_porcond.o \
+   dla_porpvgrw.o \
+   dgbsvxx.o \
+   dgbrfsx.o \
+   dla_gbrfsx_extended.o \
+   dla_gbamv.o \
+   dla_gbrcond.o \
+   dla_gbrpvgrw.o \
+   dla_lin_berr.o \
+   dlarscl2.o \
+   dlascl2.o \
+   dla_wwaddw.o
 endif
 
 ZLASRC = \
-   zpotrf2.o zgetrf2.o \
-   zbdsqr.o zgbbrd.o zgbcon.o zgbequ.o zgbrfs.o zgbsv.o  zgbsvx.o \
-   zgbtf2.o zgbtrf.o zgbtrs.o zgebak.o zgebal.o zgebd2.o zgebrd.o \
-   zgecon.o zgeequ.o zgees.o  zgeesx.o zgeev.o  zgeevx.o \
-   zgehd2.o zgehrd.o zgelq2.o zgelqf.o \
-   zgels.o zgelst.o zgelsd.o zgelss.o zgelsy.o zgeql2.o zgeqlf.o \
-   zgeqp3.o zgeqp3rk.o \
-   zgeqr2.o zgeqr2p.o zgeqrf.o zgeqrfp.o zgerfs.o zgerq2.o zgerqf.o \
-   zgesc2.o zgesdd.o zgesv.o  zgesvd.o zgesvdx.o \
-   zgesvj.o zgejsv.o zgsvj0.o zgsvj1.o \
-   zgesvx.o zgetc2.o zgetf2.o zgetrf.o \
-   zgetri.o zgetrs.o \
-   zggbak.o zggbal.o zgges.o  zgges3.o zggesx.o \
-   zggev.o  zggev3.o zggevx.o zggglm.o \
-   zgghrd.o zgghd3.o zgglse.o zggqrf.o zggrqf.o \
-   zggsvd3.o zggsvp3.o \
-   zgtcon.o zgtrfs.o zgtsv.o  zgtsvx.o zgttrf.o zgttrs.o zgtts2.o zhbev.o \
-   zhbevd.o zhbevx.o zhbgst.o zhbgv.o  zhbgvd.o zhbgvx.o zhbtrd.o \
-   zhecon.o zheev.o  zheevd.o zheevr.o zheevx.o zhegs2.o zhegst.o \
-   zhegv.o  zhegvd.o zhegvx.o zherfs.o zhesv.o  zhesvx.o zhetd2.o \
-   zhetf2.o zhetrd.o \
-   zhetrf.o zhetri.o zhetri2.o zhetri2x.o zheswapr.o \
-   zhetrs.o zhetrs2.o \
-   zhetf2_rook.o zhetrf_rook.o zhetri_rook.o \
-   zhetrs_rook.o zhecon_rook.o zhesv_rook.o \
-   zhetf2_rk.o zhetrf_rk.o zhetri_3.o zhetri_3x.o \
-   zhetrs_3.o zhecon_3.o zhesv_rk.o \
-   zhesv_aa.o zhetrf_aa.o zhetrs_aa.o zlahef_aa.o \
-   zhesv_aa_2stage.o zhetrf_aa_2stage.o zhetrs_aa_2stage.o \
-   zhgeqz.o zhpcon.o zhpev.o  zhpevd.o \
-   zlaqz0.o zlaqz1.o zlaqz2.o zlaqz3.o \
-   zhpevx.o zhpgst.o zhpgv.o  zhpgvd.o zhpgvx.o zhprfs.o zhpsv.o \
+   zpotrf2.o \
+   zgetrf2.o \
+   zbdsqr.o \
+   zgbbrd.o \
+   zgbcon.o \
+   zgbequ.o \
+   zgbrfs.o \
+   zgbsv.o \
+   zgbsvx.o \
+   zgbtf2.o \
+   zgbtrf.o \
+   zgbtrs.o \
+   zgebak.o \
+   zgebal.o \
+   zgebd2.o \
+   zgebrd.o \
+   zgecon.o \
+   zgeequ.o \
+   zgees.o \
+   zgeesx.o \
+   zgeev.o \
+   zgeevx.o \
+   zgehd2.o \
+   zgehrd.o \
+   zgelq2.o \
+   zgelqf.o \
+   zgels.o \
+   zgelst.o \
+   zgelsd.o \
+   zgelss.o \
+   zgelsy.o \
+   zgeql2.o \
+   zgeqlf.o \
+   zgeqp3.o \
+   zgeqp3rk.o \
+   zgeqr2.o \
+   zgeqr2p.o \
+   zgeqrf.o \
+   zgeqrfp.o \
+   zgerfs.o \
+   zgerq2.o \
+   zgerqf.o \
+   zgesc2.o \
+   zgesdd.o \
+   zgesv.o \
+   zgesvd.o \
+   zgesvdx.o \
+   zgesvj.o \
+   zgejsv.o \
+   zgsvj0.o \
+   zgsvj1.o \
+   zgesvx.o \
+   zgetc2.o \
+   zgetf2.o \
+   zgetrf.o \
+   zgetri.o \
+   zgetrs.o \
+   zggbak.o \
+   zggbal.o \
+   zgges.o \
+   zgges3.o \
+   zggesx.o \
+   zggev.o \
+   zggev3.o \
+   zggevx.o \
+   zggglm.o \
+   zgghrd.o \
+   zgghd3.o \
+   zgglse.o \
+   zggqrf.o \
+   zggrqf.o \
+   zggsvd3.o \
+   zggsvp3.o \
+   zgtcon.o \
+   zgtrfs.o \
+   zgtsv.o \
+   zgtsvx.o \
+   zgttrf.o \
+   zgttrs.o \
+   zgtts2.o \
+   zhbev.o \
+   zhbevd.o \
+   zhbevx.o \
+   zhbgst.o \
+   zhbgv.o \
+   zhbgvd.o \
+   zhbgvx.o \
+   zhbtrd.o \
+   zhecon.o \
+   zheev.o \
+   zheevd.o \
+   zheevr.o \
+   zheevx.o \
+   zhegs2.o \
+   zhegst.o \
+   zhegv.o \
+   zhegvd.o \
+   zhegvx.o \
+   zherfs.o \
+   zhesv.o \
+   zhesvx.o \
+   zhetd2.o \
+   zhetf2.o \
+   zhetrd.o \
+   zhetrf.o \
+   zhetri.o \
+   zhetri2.o \
+   zhetri2x.o \
+   zheswapr.o \
+   zhetrs.o \
+   zhetrs2.o \
+   zhetf2_rook.o \
+   zhetrf_rook.o \
+   zhetri_rook.o \
+   zhetrs_rook.o \
+   zhecon_rook.o \
+   zhesv_rook.o \
+   zhetf2_rk.o \
+   zhetrf_rk.o \
+   zhetri_3.o \
+   zhetri_3x.o \
+   zhetrs_3.o \
+   zhecon_3.o \
+   zhesv_rk.o \
+   zhesv_aa.o \
+   zhetrf_aa.o \
+   zhetrs_aa.o \
+   zlahef_aa.o \
+   zhesv_aa_2stage.o \
+   zhetrf_aa_2stage.o \
+   zhetrs_aa_2stage.o \
+   zhgeqz.o \
+   zhpcon.o \
+   zhpev.o \
+   zhpevd.o \
+   zlaqz0.o \
+   zlaqz1.o \
+   zlaqz2.o \
+   zlaqz3.o \
+   zhpevx.o \
+   zhpgst.o \
+   zhpgv.o \
+   zhpgvd.o \
+   zhpgvx.o \
+   zhprfs.o \
+   zhpsv.o \
    zhpsvx.o \
-   zhptrd.o zhptrf.o zhptri.o zhptrs.o zhsein.o zhseqr.o zlabrd.o \
-   zlacgv.o zlacon.o zlacn2.o zlacp2.o zlacpy.o zlacrm.o zlacrt.o zladiv.o \
-   zlaed0.o zlaed7.o zlaed8.o \
-   zlaein.o zlaesy.o zlaev2.o zlags2.o zlagtm.o \
-   zlahef.o zlahef_rook.o zlahef_rk.o zlahqr.o \
-   zlahr2.o zlaic1.o zlals0.o zlalsa.o zlalsd.o zlangb.o zlange.o \
-   zlangt.o zlanhb.o \
+   zhptrd.o \
+   zhptrf.o \
+   zhptri.o \
+   zhptrs.o \
+   zhsein.o \
+   zhseqr.o \
+   zlabrd.o \
+   zlacgv.o \
+   zlacon.o \
+   zlacn2.o \
+   zlacp2.o \
+   zlacpy.o \
+   zlacrm.o \
+   zlacrt.o \
+   zladiv.o \
+   zlaed0.o \
+   zlaed7.o \
+   zlaed8.o \
+   zlaein.o \
+   zlaesy.o \
+   zlaev2.o \
+   zlags2.o \
+   zlagtm.o \
+   zlahef.o \
+   zlahef_rook.o \
+   zlahef_rk.o \
+   zlahqr.o \
+   zlahr2.o \
+   zlaic1.o \
+   zlals0.o \
+   zlalsa.o \
+   zlalsd.o \
+   zlangb.o \
+   zlange.o \
+   zlangt.o \
+   zlanhb.o \
    zlanhe.o \
-   zlanhp.o zlanhs.o zlanht.o zlansb.o zlansp.o zlansy.o zlantb.o \
-   zlantp.o zlantr.o zlapll.o zlapmt.o zlaqgb.o zlaqge.o \
-   zlaqhb.o zlaqhe.o zlaqhp.o zlaqp2.o zlaqps.o zlaqp2rk.o zlaqp3rk.o zlaqsb.o \
-   zlaqr0.o zlaqr1.o zlaqr2.o zlaqr3.o zlaqr4.o zlaqr5.o \
-   zlaqsp.o zlaqsy.o zlar1v.o zlar2v.o ilazlr.o ilazlc.o \
-   zlarcm.o zlarf.o  zlarfb.o zlarfb_gett.o \
-   zlarfg.o zlarft.o zlarfgp.o \
-   zlarfx.o zlarfy.o zlargv.o zlarnv.o zlarrv.o zlartg.o zlartv.o \
-   zlarz.o  zlarzb.o zlarzt.o zlascl.o zlaset.o zlasr.o \
-   zlassq.o zlaswp.o zlasyf.o zlasyf_rook.o zlasyf_rk.o zlasyf_aa.o \
-   zlatbs.o zlatdf.o zlatps.o zlatrd.o zlatrs.o zlatrs3.o zlatrz.o zlauu2.o \
-   zlauum.o zpbcon.o zpbequ.o zpbrfs.o zpbstf.o zpbsv.o \
-   zpbsvx.o zpbtf2.o zpbtrf.o zpbtrs.o zpocon.o zpoequ.o zporfs.o \
-   zposv.o  zposvx.o zpotf2.o zpotrf.o zpotri.o zpotrs.o zpstrf.o zpstf2.o \
-   zppcon.o zppequ.o zpprfs.o zppsv.o  zppsvx.o zpptrf.o zpptri.o zpptrs.o \
-   zptcon.o zpteqr.o zptrfs.o zptsv.o  zptsvx.o zpttrf.o zpttrs.o zptts2.o \
-   zrot.o   zspcon.o zspmv.o  zspr.o   zsprfs.o zspsv.o \
-   zspsvx.o zsptrf.o zsptri.o zsptrs.o zdrscl.o zrscl.o zstedc.o \
-   zstegr.o zstein.o zsteqr.o \
-   zsycon.o zsymv.o \
-   zsyr.o zsyrfs.o zsysv.o zsysvx.o zsytf2.o zsytrf.o zsytri.o zsytri2.o zsytri2x.o \
-   zsyswapr.o zsytrs.o zsytrs2.o \
-   zsyconv.o zsyconvf.o zsyconvf_rook.o \
-   zsytf2_rook.o zsytrf_rook.o zsytrs_rook.o zsytrs_aa.o \
-   zsytri_rook.o zsycon_rook.o zsysv_rook.o \
-   zsysv_aa_2stage.o zsytrf_aa_2stage.o zsytrs_aa_2stage.o \
-   zsytf2_rk.o zsytrf_rk.o zsytrf_aa.o zsytrs_3.o \
-   zsytri_3.o zsytri_3x.o zsycon_3.o zsysv_rk.o zsysv_aa.o \
-   ztbcon.o ztbrfs.o ztbtrs.o ztgevc.o ztgex2.o \
-   ztgexc.o ztgsen.o ztgsja.o ztgsna.o ztgsy2.o ztgsyl.o ztpcon.o \
-   ztprfs.o ztptri.o \
-   ztptrs.o ztrcon.o ztrevc.o ztrevc3.o ztrexc.o ztrrfs.o ztrsen.o ztrsna.o \
-   ztrsyl.o ztrsyl3.o ztrti2.o ztrtri.o ztrtrs.o ztzrzf.o zung2l.o \
-   zung2r.o zungbr.o zunghr.o zungl2.o zunglq.o zungql.o zungqr.o zungr2.o \
-   zungrq.o zungtr.o zungtsqr.o zungtsqr_row.o zunm2l.o zunm2r.o zunmbr.o zunmhr.o zunml2.o zunm22.o \
-   zunmlq.o zunmql.o zunmqr.o zunmr2.o zunmr3.o zunmrq.o zunmrz.o \
-   zunmtr.o zupgtr.o \
-   zupmtr.o izmax1.o dzsum1.o zstemr.o \
-   zcgesv.o zcposv.o zlag2c.o clag2z.o zlat2c.o \
-   zhfrk.o ztfttp.o zlanhf.o zpftrf.o zpftri.o zpftrs.o ztfsm.o ztftri.o \
-   ztfttr.o ztpttf.o ztpttr.o ztrttf.o ztrttp.o \
-   zgeequb.o zgbequb.o zsyequb.o zpoequb.o zheequb.o \
-   zbbcsd.o zlapmr.o zunbdb.o zunbdb1.o zunbdb2.o zunbdb3.o zunbdb4.o \
-   zunbdb5.o zunbdb6.o zuncsd.o zuncsd2by1.o \
-   zgeqrt.o zgeqrt2.o zgeqrt3.o zgemqrt.o \
-   ztpqrt.o ztpqrt2.o ztpmqrt.o ztprfb.o \
-   ztplqt.o ztplqt2.o ztpmlqt.o \
-   zgelqt.o zgelqt3.o zgemlqt.o \
-   zgetsls.o zgetsqrhrt.o zgeqr.o zlatsqr.o zlamtsqr.o zgemqr.o \
-   zgelq.o zlaswlq.o zlamswlq.o zgemlq.o \
-   zunhr_col.o zlaunhr_col_getrfnp.o zlaunhr_col_getrfnp2.o \
-   zhetrd_2stage.o zhetrd_he2hb.o zhetrd_hb2st.o zhb2st_kernels.o \
-   zheevd_2stage.o zheev_2stage.o zheevx_2stage.o zheevr_2stage.o \
-   zhbev_2stage.o zhbevx_2stage.o zhbevd_2stage.o zhegv_2stage.o \
-   zgesvdq.o zgedmd.o zgedmdq.o
+   zlanhp.o \
+   zlanhs.o \
+   zlanht.o \
+   zlansb.o \
+   zlansp.o \
+   zlansy.o \
+   zlantb.o \
+   zlantp.o \
+   zlantr.o \
+   zlapll.o \
+   zlapmt.o \
+   zlaqgb.o \
+   zlaqge.o \
+   zlaqhb.o \
+   zlaqhe.o \
+   zlaqhp.o \
+   zlaqp2.o \
+   zlaqps.o \
+   zlaqp2rk.o \
+   zlaqp3rk.o \
+   zlaqsb.o \
+   zlaqr0.o \
+   zlaqr1.o \
+   zlaqr2.o \
+   zlaqr3.o \
+   zlaqr4.o \
+   zlaqr5.o \
+   zlaqsp.o \
+   zlaqsy.o \
+   zlar1v.o \
+   zlar2v.o \
+   ilazlr.o \
+   ilazlc.o \
+   zlarcm.o \
+   zlarf.o \
+   zlarfb.o \
+   zlarfb_gett.o \
+   zlarfg.o \
+   zlarft.o \
+   zlarfgp.o \
+   zlarfx.o \
+   zlarfy.o \
+   zlargv.o \
+   zlarnv.o \
+   zlarrv.o \
+   zlartg.o \
+   zlartv.o \
+   zlarz.o \
+   zlarzb.o \
+   zlarzt.o \
+   zlascl.o \
+   zlaset.o \
+   zlasr.o \
+   zlassq.o \
+   zlaswp.o \
+   zlasyf.o \
+   zlasyf_rook.o \
+   zlasyf_rk.o \
+   zlasyf_aa.o \
+   zlatbs.o \
+   zlatdf.o \
+   zlatps.o \
+   zlatrd.o \
+   zlatrs.o \
+   zlatrs3.o \
+   zlatrz.o \
+   zlauu2.o \
+   zlauum.o \
+   zpbcon.o \
+   zpbequ.o \
+   zpbrfs.o \
+   zpbstf.o \
+   zpbsv.o \
+   zpbsvx.o \
+   zpbtf2.o \
+   zpbtrf.o \
+   zpbtrs.o \
+   zpocon.o \
+   zpoequ.o \
+   zporfs.o \
+   zposv.o \
+   zposvx.o \
+   zpotf2.o \
+   zpotrf.o \
+   zpotri.o \
+   zpotrs.o \
+   zpstrf.o \
+   zpstf2.o \
+   zppcon.o \
+   zppequ.o \
+   zpprfs.o \
+   zppsv.o \
+   zppsvx.o \
+   zpptrf.o \
+   zpptri.o \
+   zpptrs.o \
+   zptcon.o \
+   zpteqr.o \
+   zptrfs.o \
+   zptsv.o \
+   zptsvx.o \
+   zpttrf.o \
+   zpttrs.o \
+   zptts2.o \
+   zrot.o \
+   zspcon.o \
+   zspmv.o \
+   zspr.o \
+   zsprfs.o \
+   zspsv.o \
+   zspsvx.o \
+   zsptrf.o \
+   zsptri.o \
+   zsptrs.o \
+   zdrscl.o \
+   zrscl.o \
+   zstedc.o \
+   zstegr.o \
+   zstein.o \
+   zsteqr.o \
+   zsycon.o \
+   zsymv.o \
+   zsyr.o \
+   zsyrfs.o \
+   zsysv.o \
+   zsysvx.o \
+   zsytf2.o \
+   zsytrf.o \
+   zsytri.o \
+   zsytri2.o \
+   zsytri2x.o \
+   zsyswapr.o \
+   zsytrs.o \
+   zsytrs2.o \
+   zsyconv.o \
+   zsyconvf.o \
+   zsyconvf_rook.o \
+   zsytf2_rook.o \
+   zsytrf_rook.o \
+   zsytrs_rook.o \
+   zsytrs_aa.o \
+   zsytri_rook.o \
+   zsycon_rook.o \
+   zsysv_rook.o \
+   zsysv_aa_2stage.o \
+   zsytrf_aa_2stage.o \
+   zsytrs_aa_2stage.o \
+   zsytf2_rk.o \
+   zsytrf_rk.o \
+   zsytrf_aa.o \
+   zsytrs_3.o \
+   zsytri_3.o \
+   zsytri_3x.o \
+   zsycon_3.o \
+   zsysv_rk.o \
+   zsysv_aa.o \
+   ztbcon.o \
+   ztbrfs.o \
+   ztbtrs.o \
+   ztgevc.o \
+   ztgex2.o \
+   ztgexc.o \
+   ztgsen.o \
+   ztgsja.o \
+   ztgsna.o \
+   ztgsy2.o \
+   ztgsyl.o \
+   ztpcon.o \
+   ztprfs.o \
+   ztptri.o \
+   ztptrs.o \
+   ztrcon.o \
+   ztrevc.o \
+   ztrevc3.o \
+   ztrexc.o \
+   ztrrfs.o \
+   ztrsen.o \
+   ztrsna.o \
+   ztrsyl.o \
+   ztrsyl3.o \
+   ztrti2.o \
+   ztrtri.o \
+   ztrtrs.o \
+   ztzrzf.o \
+   zung2l.o \
+   zung2r.o \
+   zungbr.o \
+   zunghr.o \
+   zungl2.o \
+   zunglq.o \
+   zungql.o \
+   zungqr.o \
+   zungr2.o \
+   zungrq.o \
+   zungtr.o \
+   zungtsqr.o \
+   zungtsqr_row.o \
+   zunm2l.o \
+   zunm2r.o \
+   zunmbr.o \
+   zunmhr.o \
+   zunml2.o \
+   zunm22.o \
+   zunmlq.o \
+   zunmql.o \
+   zunmqr.o \
+   zunmr2.o \
+   zunmr3.o \
+   zunmrq.o \
+   zunmrz.o \
+   zunmtr.o \
+   zupgtr.o \
+   zupmtr.o \
+   izmax1.o \
+   dzsum1.o \
+   zstemr.o \
+   zcgesv.o \
+   zcposv.o \
+   zlag2c.o \
+   clag2z.o \
+   zlat2c.o \
+   zhfrk.o \
+   ztfttp.o \
+   zlanhf.o \
+   zpftrf.o \
+   zpftri.o \
+   zpftrs.o \
+   ztfsm.o \
+   ztftri.o \
+   ztfttr.o \
+   ztpttf.o \
+   ztpttr.o \
+   ztrttf.o \
+   ztrttp.o \
+   zgeequb.o \
+   zgbequb.o \
+   zsyequb.o \
+   zpoequb.o \
+   zheequb.o \
+   zbbcsd.o \
+   zlapmr.o \
+   zunbdb.o \
+   zunbdb1.o \
+   zunbdb2.o \
+   zunbdb3.o \
+   zunbdb4.o \
+   zunbdb5.o \
+   zunbdb6.o \
+   zuncsd.o \
+   zuncsd2by1.o \
+   zgeqrt.o \
+   zgeqrt2.o \
+   zgeqrt3.o \
+   zgemqrt.o \
+   ztpqrt.o \
+   ztpqrt2.o \
+   ztpmqrt.o \
+   ztprfb.o \
+   ztplqt.o \
+   ztplqt2.o \
+   ztpmlqt.o \
+   zgelqt.o \
+   zgelqt3.o \
+   zgemlqt.o \
+   zgetsls.o \
+   zgetsqrhrt.o \
+   zgeqr.o \
+   zlatsqr.o \
+   zlamtsqr.o \
+   zgemqr.o \
+   zgelq.o \
+   zlaswlq.o \
+   zlamswlq.o \
+   zgemlq.o \
+   zunhr_col.o \
+   zlaunhr_col_getrfnp.o \
+   zlaunhr_col_getrfnp2.o \
+   zhetrd_2stage.o \
+   zhetrd_he2hb.o \
+   zhetrd_hb2st.o \
+   zhb2st_kernels.o \
+   zheevd_2stage.o \
+   zheev_2stage.o \
+   zheevx_2stage.o \
+   zheevr_2stage.o \
+   zhbev_2stage.o \
+   zhbevx_2stage.o \
+   zhbevd_2stage.o \
+   zhegv_2stage.o \
+   zgesvdq.o \
+   zgedmd.o \
+   zgedmdq.o
 
 ifdef USEXBLAS
-ZXLASRC = zgesvxx.o zgerfsx.o zla_gerfsx_extended.o zla_geamv.o \
-   zla_gercond_c.o zla_gercond_x.o zla_gerpvgrw.o zsysvxx.o zsyrfsx.o \
-   zla_syrfsx_extended.o zla_syamv.o zla_syrcond_c.o zla_syrcond_x.o \
-   zla_syrpvgrw.o zposvxx.o zporfsx.o zla_porfsx_extended.o \
-   zla_porcond_c.o zla_porcond_x.o zla_porpvgrw.o zgbsvxx.o zgbrfsx.o \
-   zla_gbrfsx_extended.o zla_gbamv.o zla_gbrcond_c.o zla_gbrcond_x.o \
-   zla_gbrpvgrw.o zhesvxx.o zherfsx.o zla_herfsx_extended.o \
-   zla_heamv.o zla_hercond_c.o zla_hercond_x.o zla_herpvgrw.o \
-   zla_lin_berr.o zlarscl2.o zlascl2.o zla_wwaddw.o
+ZXLASRC = \
+   zgesvxx.o \
+   zgerfsx.o \
+   zla_gerfsx_extended.o \
+   zla_geamv.o \
+   zla_gercond_c.o \
+   zla_gercond_x.o \
+   zla_gerpvgrw.o \
+   zsysvxx.o \
+   zsyrfsx.o \
+   zla_syrfsx_extended.o \
+   zla_syamv.o \
+   zla_syrcond_c.o \
+   zla_syrcond_x.o \
+   zla_syrpvgrw.o \
+   zposvxx.o \
+   zporfsx.o \
+   zla_porfsx_extended.o \
+   zla_porcond_c.o \
+   zla_porcond_x.o \
+   zla_porpvgrw.o \
+   zgbsvxx.o \
+   zgbrfsx.o \
+   zla_gbrfsx_extended.o \
+   zla_gbamv.o \
+   zla_gbrcond_c.o \
+   zla_gbrcond_x.o \
+   zla_gbrpvgrw.o \
+   zhesvxx.o \
+   zherfsx.o \
+   zla_herfsx_extended.o \
+   zla_heamv.o \
+   zla_hercond_c.o \
+   zla_hercond_x.o \
+   zla_herpvgrw.o \
+   zla_lin_berr.o \
+   zlarscl2.o \
+   zlascl2.o \
+   zla_wwaddw.o
 endif
 
-DEPRECSRC = DEPRECATED/cgegs.o DEPRECATED/cgegv.o DEPRECATED/cgelqs.o \
-   DEPRECATED/cgelsx.o DEPRECATED/cgeqpf.o DEPRECATED/cgeqrs.o \
-   DEPRECATED/cggsvd.o DEPRECATED/cggsvp.o DEPRECATED/clahrd.o \
-   DEPRECATED/clatzm.o DEPRECATED/ctzrqf.o \
-   DEPRECATED/dgegs.o  DEPRECATED/dgegv.o  DEPRECATED/dgelqs.o \
-   DEPRECATED/dgelsx.o DEPRECATED/dgeqpf.o DEPRECATED/dgeqrs.o \
-   DEPRECATED/dggsvd.o DEPRECATED/dggsvp.o DEPRECATED/dlahrd.o \
-   DEPRECATED/dlatzm.o DEPRECATED/dtzrqf.o \
-   DEPRECATED/sgegs.o  DEPRECATED/sgegv.o  DEPRECATED/sgelqs.o \
-   DEPRECATED/sgelsx.o DEPRECATED/sgeqpf.o DEPRECATED/sgeqrs.o \
-   DEPRECATED/sggsvd.o DEPRECATED/sggsvp.o DEPRECATED/slahrd.o \
-   DEPRECATED/slatzm.o DEPRECATED/stzrqf.o \
-   DEPRECATED/zgegs.o  DEPRECATED/zgegv.o  DEPRECATED/zgelqs.o \
-   DEPRECATED/zgelsx.o DEPRECATED/zgeqpf.o DEPRECATED/zgeqrs.o \
-   DEPRECATED/zggsvd.o DEPRECATED/zggsvp.o DEPRECATED/zlahrd.o \
-   DEPRECATED/zlatzm.o DEPRECATED/ztzrqf.o
+DEPRECSRC = \
+   DEPRECATED/cgegs.o \
+   DEPRECATED/cgegv.o \
+   DEPRECATED/cgelqs.o \
+   DEPRECATED/cgelsx.o \
+   DEPRECATED/cgeqpf.o \
+   DEPRECATED/cgeqrs.o \
+   DEPRECATED/cggsvd.o \
+   DEPRECATED/cggsvp.o \
+   DEPRECATED/clahrd.o \
+   DEPRECATED/clatzm.o \
+   DEPRECATED/ctzrqf.o \
+   DEPRECATED/dgegs.o \
+   DEPRECATED/dgegv.o \
+   DEPRECATED/dgelqs.o \
+   DEPRECATED/dgelsx.o \
+   DEPRECATED/dgeqpf.o \
+   DEPRECATED/dgeqrs.o \
+   DEPRECATED/dggsvd.o \
+   DEPRECATED/dggsvp.o \
+   DEPRECATED/dlahrd.o \
+   DEPRECATED/dlatzm.o \
+   DEPRECATED/dtzrqf.o \
+   DEPRECATED/sgegs.o \
+   DEPRECATED/sgegv.o \
+   DEPRECATED/sgelqs.o \
+   DEPRECATED/sgelsx.o \
+   DEPRECATED/sgeqpf.o \
+   DEPRECATED/sgeqrs.o \
+   DEPRECATED/sggsvd.o \
+   DEPRECATED/sggsvp.o \
+   DEPRECATED/slahrd.o \
+   DEPRECATED/slatzm.o \
+   DEPRECATED/stzrqf.o \
+   DEPRECATED/zgegs.o \
+   DEPRECATED/zgegv.o \
+   DEPRECATED/zgelqs.o \
+   DEPRECATED/zgelsx.o \
+   DEPRECATED/zgeqpf.o \
+   DEPRECATED/zgeqrs.o \
+   DEPRECATED/zggsvd.o \
+   DEPRECATED/zggsvp.o \
+   DEPRECATED/zlahrd.o \
+   DEPRECATED/zlatzm.o \
+   DEPRECATED/ztzrqf.o
 
 ALLOBJ = $(SLASRC) $(DLASRC) $(DSLASRC) $(CLASRC) $(ZLASRC) $(ZCLASRC) \
    $(SCLAUX) $(DZLAUX) $(ALLAUX)

--- a/TESTING/EIG/CMakeLists.txt
+++ b/TESTING/EIG/CMakeLists.txt
@@ -22,87 +22,381 @@ set(AEIGTST
    xlaenv.f
    chkxer.f)
 
-set(SCIGTST slafts.f slahd2.f slasum.f slatb9.f sstech.f sstect.f
-   ssvdch.f ssvdct.f ssxt1.f)
+set(SCIGTST
+   slafts.f
+   slahd2.f
+   slasum.f
+   slatb9.f
+   sstech.f
+   sstect.f
+   ssvdch.f
+   ssvdct.f
+   ssxt1.f)
 
-set(SEIGTST schkee.F
-   sbdt01.f sbdt02.f sbdt03.f sbdt04.f sbdt05.f
-   schkbb.f schkbd.f schkbk.f schkbl.f schkec.f
-   schkgg.f schkgk.f schkgl.f schkhs.f schksb.f schkst.f schkst2stg.f schksb2stg.f
-   sckcsd.f sckglm.f sckgqr.f sckgsv.f scklse.f scsdts.f
-   sdrges.f sdrgev.f sdrges3.f sdrgev3.f sdrgsx.f sdrgvx.f
-   sdrvbd.f sdrves.f sdrvev.f sdrvsg.f sdrvsg2stg.f
-   sdrvst.f sdrvst2stg.f sdrvsx.f sdrvvx.f
-   serrbd.f serrec.f serred.f serrgg.f serrhs.f serrst.f
-   sget02.f sget10.f sget22.f sget23.f sget24.f sget31.f
-   sget32.f sget33.f sget34.f sget35.f sget36.f
-   sget37.f sget38.f sget39.f sget40.f sget51.f sget52.f sget53.f
-   sget54.f sglmts.f sgqrts.f sgrqts.f sgsvts3.f
-   shst01.f slarfy.f slarhs.f slatm4.f slctes.f slctsx.f slsets.f sort01.f
-   sort03.f ssbt21.f ssgt01.f sslect.f sspt21.f sstt21.f
-   sstt22.f ssyl01.f ssyt21.f ssyt22.f)
+set(SEIGTST
+   schkee.F
+   sbdt01.f
+   sbdt02.f
+   sbdt03.f
+   sbdt04.f
+   sbdt05.f
+   schkbb.f
+   schkbd.f
+   schkbk.f
+   schkbl.f
+   schkec.f
+   schkgg.f
+   schkgk.f
+   schkgl.f
+   schkhs.f
+   schksb.f
+   schkst.f
+   schkst2stg.f
+   schksb2stg.f
+   sckcsd.f
+   sckglm.f
+   sckgqr.f
+   sckgsv.f
+   scklse.f
+   scsdts.f
+   sdrges.f
+   sdrgev.f
+   sdrges3.f
+   sdrgev3.f
+   sdrgsx.f
+   sdrgvx.f
+   sdrvbd.f
+   sdrves.f
+   sdrvev.f
+   sdrvsg.f
+   sdrvsg2stg.f
+   sdrvst.f
+   sdrvst2stg.f
+   sdrvsx.f
+   sdrvvx.f
+   serrbd.f
+   serrec.f
+   serred.f
+   serrgg.f
+   serrhs.f
+   serrst.f
+   sget02.f
+   sget10.f
+   sget22.f
+   sget23.f
+   sget24.f
+   sget31.f
+   sget32.f
+   sget33.f
+   sget34.f
+   sget35.f
+   sget36.f
+   sget37.f
+   sget38.f
+   sget39.f
+   sget40.f
+   sget51.f
+   sget52.f
+   sget53.f
+   sget54.f
+   sglmts.f
+   sgqrts.f
+   sgrqts.f
+   sgsvts3.f
+   shst01.f
+   slarfy.f
+   slarhs.f
+   slatm4.f
+   slctes.f
+   slctsx.f
+   slsets.f
+   sort01.f
+   sort03.f
+   ssbt21.f
+   ssgt01.f
+   sslect.f
+   sspt21.f
+   sstt21.f
+   sstt22.f
+   ssyl01.f
+   ssyt21.f
+   ssyt22.f)
 
-set(SDMDEIGTST schkdmd.f90)
+set(SDMDEIGTST
+   schkdmd.f90)
 
-set(CEIGTST cchkee.F
-   cbdt01.f cbdt02.f cbdt03.f cbdt05.f
-   cchkbb.f cchkbd.f cchkbk.f cchkbl.f cchkec.f
-   cchkgg.f cchkgk.f cchkgl.f cchkhb.f cchkhs.f cchkst.f cchkst2stg.f cchkhb2stg.f
-   cckcsd.f cckglm.f cckgqr.f cckgsv.f ccklse.f ccsdts.f
-   cdrges.f cdrgev.f cdrges3.f cdrgev3.f cdrgsx.f cdrgvx.f
-   cdrvbd.f cdrves.f cdrvev.f cdrvsg.f cdrvsg2stg.f
-   cdrvst.f cdrvst2stg.f cdrvsx.f cdrvvx.f
-   cerrbd.f cerrec.f cerred.f cerrgg.f cerrhs.f cerrst.f
-   cget02.f cget10.f cget22.f cget23.f cget24.f
-   cget35.f cget36.f cget37.f cget38.f cget51.f cget52.f
-   cget54.f cglmts.f cgqrts.f cgrqts.f cgsvts3.f
-   chbt21.f chet21.f chet22.f chpt21.f chst01.f
-   clarfy.f clarhs.f clatm4.f clctes.f clctsx.f clsets.f csbmv.f
-   csgt01.f cslect.f csyl01.f
-   cstt21.f cstt22.f cunt01.f cunt03.f)
+set(CEIGTST
+   cchkee.F
+   cbdt01.f
+   cbdt02.f
+   cbdt03.f
+   cbdt05.f
+   cchkbb.f
+   cchkbd.f
+   cchkbk.f
+   cchkbl.f
+   cchkec.f
+   cchkgg.f
+   cchkgk.f
+   cchkgl.f
+   cchkhb.f
+   cchkhs.f
+   cchkst.f
+   cchkst2stg.f
+   cchkhb2stg.f
+   cckcsd.f
+   cckglm.f
+   cckgqr.f
+   cckgsv.f
+   ccklse.f
+   ccsdts.f
+   cdrges.f
+   cdrgev.f
+   cdrges3.f
+   cdrgev3.f
+   cdrgsx.f
+   cdrgvx.f
+   cdrvbd.f
+   cdrves.f
+   cdrvev.f
+   cdrvsg.f
+   cdrvsg2stg.f
+   cdrvst.f
+   cdrvst2stg.f
+   cdrvsx.f
+   cdrvvx.f
+   cerrbd.f
+   cerrec.f
+   cerred.f
+   cerrgg.f
+   cerrhs.f
+   cerrst.f
+   cget02.f
+   cget10.f
+   cget22.f
+   cget23.f
+   cget24.f
+   cget35.f
+   cget36.f
+   cget37.f
+   cget38.f
+   cget51.f
+   cget52.f
+   cget54.f
+   cglmts.f
+   cgqrts.f
+   cgrqts.f
+   cgsvts3.f
+   chbt21.f
+   chet21.f
+   chet22.f
+   chpt21.f
+   chst01.f
+   clarfy.f
+   clarhs.f
+   clatm4.f
+   clctes.f
+   clctsx.f
+   clsets.f
+   csbmv.f
+   csgt01.f
+   cslect.f
+   csyl01.f
+   cstt21.f
+   cstt22.f
+   cunt01.f
+   cunt03.f)
 
-set(CDMDEIGTST cchkdmd.f90)
+set(CDMDEIGTST
+   cchkdmd.f90)
 
-set(DZIGTST dlafts.f dlahd2.f dlasum.f dlatb9.f dstech.f dstect.f
-   dsvdch.f dsvdct.f dsxt1.f)
+set(DZIGTST
+   dlafts.f
+   dlahd2.f
+   dlasum.f
+   dlatb9.f
+   dstech.f
+   dstect.f
+   dsvdch.f
+   dsvdct.f
+   dsxt1.f)
 
-set(DEIGTST dchkee.F
-   dbdt01.f dbdt02.f dbdt03.f dbdt04.f dbdt05.f
-   dchkbb.f dchkbd.f dchkbk.f dchkbl.f dchkec.f
-   dchkgg.f dchkgk.f dchkgl.f dchkhs.f dchksb.f dchkst.f dchkst2stg.f dchksb2stg.f
-   dckcsd.f dckglm.f dckgqr.f dckgsv.f dcklse.f dcsdts.f
-   ddrges.f ddrgev.f ddrges3.f ddrgev3.f ddrgsx.f ddrgvx.f
-   ddrvbd.f ddrves.f ddrvev.f ddrvsg.f ddrvsg2stg.f
-   ddrvst.f ddrvst2stg.f ddrvsx.f ddrvvx.f
-   derrbd.f derrec.f derred.f derrgg.f derrhs.f derrst.f
-   dget02.f dget10.f dget22.f dget23.f dget24.f dget31.f
-   dget32.f dget33.f dget34.f dget35.f dget36.f
-   dget37.f dget38.f dget39.f dget40.f dget51.f dget52.f dget53.f
-   dget54.f dglmts.f dgqrts.f dgrqts.f dgsvts3.f
-   dhst01.f dlarfy.f dlarhs.f dlatm4.f dlctes.f dlctsx.f dlsets.f dort01.f
-   dort03.f dsbt21.f dsgt01.f dslect.f dspt21.f dstt21.f
-   dstt22.f dsyl01.f dsyt21.f dsyt22.f)
+set(DEIGTST
+   dchkee.F
+   dbdt01.f
+   dbdt02.f
+   dbdt03.f
+   dbdt04.f
+   dbdt05.f
+   dchkbb.f
+   dchkbd.f
+   dchkbk.f
+   dchkbl.f
+   dchkec.f
+   dchkgg.f
+   dchkgk.f
+   dchkgl.f
+   dchkhs.f
+   dchksb.f
+   dchkst.f
+   dchkst2stg.f
+   dchksb2stg.f
+   dckcsd.f
+   dckglm.f
+   dckgqr.f
+   dckgsv.f
+   dcklse.f
+   dcsdts.f
+   ddrges.f
+   ddrgev.f
+   ddrges3.f
+   ddrgev3.f
+   ddrgsx.f
+   ddrgvx.f
+   ddrvbd.f
+   ddrves.f
+   ddrvev.f
+   ddrvsg.f
+   ddrvsg2stg.f
+   ddrvst.f
+   ddrvst2stg.f
+   ddrvsx.f
+   ddrvvx.f
+   derrbd.f
+   derrec.f
+   derred.f
+   derrgg.f
+   derrhs.f
+   derrst.f
+   dget02.f
+   dget10.f
+   dget22.f
+   dget23.f
+   dget24.f
+   dget31.f
+   dget32.f
+   dget33.f
+   dget34.f
+   dget35.f
+   dget36.f
+   dget37.f
+   dget38.f
+   dget39.f
+   dget40.f
+   dget51.f
+   dget52.f
+   dget53.f
+   dget54.f
+   dglmts.f
+   dgqrts.f
+   dgrqts.f
+   dgsvts3.f
+   dhst01.f
+   dlarfy.f
+   dlarhs.f
+   dlatm4.f
+   dlctes.f
+   dlctsx.f
+   dlsets.f
+   dort01.f
+   dort03.f
+   dsbt21.f
+   dsgt01.f
+   dslect.f
+   dspt21.f
+   dstt21.f
+   dstt22.f
+   dsyl01.f
+   dsyt21.f
+   dsyt22.f)
 
-set(DDMDEIGTST dchkdmd.f90)
+set(DDMDEIGTST
+   dchkdmd.f90)
 
-set(ZEIGTST zchkee.F
-   zbdt01.f zbdt02.f zbdt03.f zbdt05.f
-   zchkbb.f zchkbd.f zchkbk.f zchkbl.f zchkec.f
-   zchkgg.f zchkgk.f zchkgl.f zchkhb.f zchkhs.f zchkst.f zchkst2stg.f zchkhb2stg.f
-   zckcsd.f zckglm.f zckgqr.f zckgsv.f zcklse.f zcsdts.f
-   zdrges.f zdrgev.f zdrges3.f zdrgev3.f zdrgsx.f zdrgvx.f
-   zdrvbd.f zdrves.f zdrvev.f zdrvsg.f zdrvsg2stg.f
-   zdrvst.f zdrvst2stg.f zdrvsx.f zdrvvx.f
-   zerrbd.f zerrec.f zerred.f zerrgg.f zerrhs.f zerrst.f
-   zget02.f zget10.f zget22.f zget23.f zget24.f
-   zget35.f zget36.f zget37.f zget38.f zget51.f zget52.f
-   zget54.f zglmts.f zgqrts.f zgrqts.f zgsvts3.f
-   zhbt21.f zhet21.f zhet22.f zhpt21.f zhst01.f
-   zlarfy.f zlarhs.f zlatm4.f zlctes.f zlctsx.f zlsets.f zsbmv.f
-   zsgt01.f zslect.f zsyl01.f
-   zstt21.f zstt22.f zunt01.f zunt03.f)
+set(ZEIGTST
+   zchkee.F
+   zbdt01.f
+   zbdt02.f
+   zbdt03.f
+   zbdt05.f
+   zchkbb.f
+   zchkbd.f
+   zchkbk.f
+   zchkbl.f
+   zchkec.f
+   zchkgg.f
+   zchkgk.f
+   zchkgl.f
+   zchkhb.f
+   zchkhs.f
+   zchkst.f
+   zchkst2stg.f
+   zchkhb2stg.f
+   zckcsd.f
+   zckglm.f
+   zckgqr.f
+   zckgsv.f
+   zcklse.f
+   zcsdts.f
+   zdrges.f
+   zdrgev.f
+   zdrges3.f
+   zdrgev3.f
+   zdrgsx.f
+   zdrgvx.f
+   zdrvbd.f
+   zdrves.f
+   zdrvev.f
+   zdrvsg.f
+   zdrvsg2stg.f
+   zdrvst.f
+   zdrvst2stg.f
+   zdrvsx.f
+   zdrvvx.f
+   zerrbd.f
+   zerrec.f
+   zerred.f
+   zerrgg.f
+   zerrhs.f
+   zerrst.f
+   zget02.f
+   zget10.f
+   zget22.f
+   zget23.f
+   zget24.f
+   zget35.f
+   zget36.f
+   zget37.f
+   zget38.f
+   zget51.f
+   zget52.f
+   zget54.f
+   zglmts.f
+   zgqrts.f
+   zgrqts.f
+   zgsvts3.f
+   zhbt21.f
+   zhet21.f
+   zhet22.f
+   zhpt21.f
+   zhst01.f
+   zlarfy.f
+   zlarhs.f
+   zlatm4.f
+   zlctes.f
+   zlctsx.f
+   zlsets.f
+   zsbmv.f
+   zsgt01.f
+   zslect.f
+   zsyl01.f
+   zstt21.f
+   zstt22.f
+   zunt01.f
+   zunt03.f)
 
-set(ZDMDEIGTST zchkdmd.f90)
+set(ZDMDEIGTST
+   zchkdmd.f90)
 
 macro(add_eig_executable name)
   add_executable(${name} ${ARGN})

--- a/TESTING/EIG/Makefile
+++ b/TESTING/EIG/Makefile
@@ -44,87 +44,381 @@ AEIGTST = \
    xlaenv.o \
    chkxer.o
 
-SCIGTST = slafts.o slahd2.o slasum.o slatb9.o sstech.o sstect.o \
-   ssvdch.o ssvdct.o ssxt1.o
+SCIGTST = \
+   slafts.o \
+   slahd2.o \
+   slasum.o \
+   slatb9.o \
+   sstech.o \
+   sstect.o \
+   ssvdch.o \
+   ssvdct.o \
+   ssxt1.o
 
-SEIGTST = schkee.o \
-   sbdt01.o sbdt02.o sbdt03.o sbdt04.o sbdt05.o \
-   schkbb.o schkbd.o schkbk.o schkbl.o schkec.o \
-   schkgg.o schkgk.o schkgl.o schkhs.o schksb.o schkst.o schkst2stg.o schksb2stg.o \
-   sckcsd.o sckglm.o sckgqr.o sckgsv.o scklse.o scsdts.o \
-   sdrges.o sdrgev.o sdrges3.o sdrgev3.o sdrgsx.o sdrgvx.o \
-   sdrvbd.o sdrves.o sdrvev.o sdrvsg.o sdrvsg2stg.o \
-   sdrvst.o sdrvst2stg.o sdrvsx.o sdrvvx.o \
-   serrbd.o serrec.o serred.o serrgg.o serrhs.o serrst.o \
-   sget02.o sget10.o sget22.o sget23.o sget24.o sget31.o \
-   sget32.o sget33.o sget34.o sget35.o sget36.o \
-   sget37.o sget38.o sget39.o sget40.o sget51.o sget52.o sget53.o \
-   sget54.o sglmts.o sgqrts.o sgrqts.o sgsvts3.o \
-   shst01.o slarfy.o slarhs.o slatm4.o slctes.o slctsx.o slsets.o sort01.o \
-   sort03.o ssbt21.o ssgt01.o sslect.o sspt21.o sstt21.o \
-   sstt22.o ssyl01.o ssyt21.o ssyt22.o
+SEIGTST = \
+   schkee.o \
+   sbdt01.o \
+   sbdt02.o \
+   sbdt03.o \
+   sbdt04.o \
+   sbdt05.o \
+   schkbb.o \
+   schkbd.o \
+   schkbk.o \
+   schkbl.o \
+   schkec.o \
+   schkgg.o \
+   schkgk.o \
+   schkgl.o \
+   schkhs.o \
+   schksb.o \
+   schkst.o \
+   schkst2stg.o \
+   schksb2stg.o \
+   sckcsd.o \
+   sckglm.o \
+   sckgqr.o \
+   sckgsv.o \
+   scklse.o \
+   scsdts.o \
+   sdrges.o \
+   sdrgev.o \
+   sdrges3.o \
+   sdrgev3.o \
+   sdrgsx.o \
+   sdrgvx.o \
+   sdrvbd.o \
+   sdrves.o \
+   sdrvev.o \
+   sdrvsg.o \
+   sdrvsg2stg.o \
+   sdrvst.o \
+   sdrvst2stg.o \
+   sdrvsx.o \
+   sdrvvx.o \
+   serrbd.o \
+   serrec.o \
+   serred.o \
+   serrgg.o \
+   serrhs.o \
+   serrst.o \
+   sget02.o \
+   sget10.o \
+   sget22.o \
+   sget23.o \
+   sget24.o \
+   sget31.o \
+   sget32.o \
+   sget33.o \
+   sget34.o \
+   sget35.o \
+   sget36.o \
+   sget37.o \
+   sget38.o \
+   sget39.o \
+   sget40.o \
+   sget51.o \
+   sget52.o \
+   sget53.o \
+   sget54.o \
+   sglmts.o \
+   sgqrts.o \
+   sgrqts.o \
+   sgsvts3.o \
+   shst01.o \
+   slarfy.o \
+   slarhs.o \
+   slatm4.o \
+   slctes.o \
+   slctsx.o \
+   slsets.o \
+   sort01.o \
+   sort03.o \
+   ssbt21.o \
+   ssgt01.o \
+   sslect.o \
+   sspt21.o \
+   sstt21.o \
+   sstt22.o \
+   ssyl01.o \
+   ssyt21.o \
+   ssyt22.o
 
-SDMDEIGTST = schkdmd.o
+SDMDEIGTST = \
+   schkdmd.o
 
-CEIGTST = cchkee.o \
-   cbdt01.o cbdt02.o cbdt03.o cbdt05.o \
-   cchkbb.o cchkbd.o cchkbk.o cchkbl.o cchkec.o \
-   cchkgg.o cchkgk.o cchkgl.o cchkhb.o cchkhs.o cchkst.o cchkst2stg.o cchkhb2stg.o \
-   cckcsd.o cckglm.o cckgqr.o cckgsv.o ccklse.o ccsdts.o \
-   cdrges.o cdrgev.o cdrges3.o cdrgev3.o cdrgsx.o cdrgvx.o \
-   cdrvbd.o cdrves.o cdrvev.o cdrvsg.o cdrvsg2stg.o \
-   cdrvst.o cdrvst2stg.o cdrvsx.o cdrvvx.o \
-   cerrbd.o cerrec.o cerred.o cerrgg.o cerrhs.o cerrst.o \
-   cget02.o cget10.o cget22.o cget23.o cget24.o \
-   cget35.o cget36.o cget37.o cget38.o cget51.o cget52.o \
-   cget54.o cglmts.o cgqrts.o cgrqts.o cgsvts3.o \
-   chbt21.o chet21.o chet22.o chpt21.o chst01.o \
-   clarfy.o clarhs.o clatm4.o clctes.o clctsx.o clsets.o csbmv.o \
-   csgt01.o cslect.o csyl01.o\
-   cstt21.o cstt22.o cunt01.o cunt03.o
+CEIGTST = \
+   cchkee.o \
+   cbdt01.o \
+   cbdt02.o \
+   cbdt03.o \
+   cbdt05.o \
+   cchkbb.o \
+   cchkbd.o \
+   cchkbk.o \
+   cchkbl.o \
+   cchkec.o \
+   cchkgg.o \
+   cchkgk.o \
+   cchkgl.o \
+   cchkhb.o \
+   cchkhs.o \
+   cchkst.o \
+   cchkst2stg.o \
+   cchkhb2stg.o \
+   cckcsd.o \
+   cckglm.o \
+   cckgqr.o \
+   cckgsv.o \
+   ccklse.o \
+   ccsdts.o \
+   cdrges.o \
+   cdrgev.o \
+   cdrges3.o \
+   cdrgev3.o \
+   cdrgsx.o \
+   cdrgvx.o \
+   cdrvbd.o \
+   cdrves.o \
+   cdrvev.o \
+   cdrvsg.o \
+   cdrvsg2stg.o \
+   cdrvst.o \
+   cdrvst2stg.o \
+   cdrvsx.o \
+   cdrvvx.o \
+   cerrbd.o \
+   cerrec.o \
+   cerred.o \
+   cerrgg.o \
+   cerrhs.o \
+   cerrst.o \
+   cget02.o \
+   cget10.o \
+   cget22.o \
+   cget23.o \
+   cget24.o \
+   cget35.o \
+   cget36.o \
+   cget37.o \
+   cget38.o \
+   cget51.o \
+   cget52.o \
+   cget54.o \
+   cglmts.o \
+   cgqrts.o \
+   cgrqts.o \
+   cgsvts3.o \
+   chbt21.o \
+   chet21.o \
+   chet22.o \
+   chpt21.o \
+   chst01.o \
+   clarfy.o \
+   clarhs.o \
+   clatm4.o \
+   clctes.o \
+   clctsx.o \
+   clsets.o \
+   csbmv.o \
+   csgt01.o \
+   cslect.o \
+   csyl01.o \
+   cstt21.o \
+   cstt22.o \
+   cunt01.o \
+   cunt03.o
 
-CDMDEIGTST = cchkdmd.o
+CDMDEIGTST = \
+   cchkdmd.o
 
-DZIGTST = dlafts.o dlahd2.o dlasum.o dlatb9.o dstech.o dstect.o \
-   dsvdch.o dsvdct.o dsxt1.o
+DZIGTST = \
+   dlafts.o \
+   dlahd2.o \
+   dlasum.o \
+   dlatb9.o \
+   dstech.o \
+   dstect.o \
+   dsvdch.o \
+   dsvdct.o \
+   dsxt1.o
 
-DEIGTST = dchkee.o \
-   dbdt01.o dbdt02.o dbdt03.o dbdt04.o dbdt05.o \
-   dchkbb.o dchkbd.o dchkbk.o dchkbl.o dchkec.o \
-   dchkgg.o dchkgk.o dchkgl.o dchkhs.o dchksb.o dchkst.o dchkst2stg.o dchksb2stg.o \
-   dckcsd.o dckglm.o dckgqr.o dckgsv.o dcklse.o dcsdts.o \
-   ddrges.o ddrgev.o ddrges3.o ddrgev3.o ddrgsx.o ddrgvx.o \
-   ddrvbd.o ddrves.o ddrvev.o ddrvsg.o ddrvsg2stg.o \
-   ddrvst.o ddrvst2stg.o ddrvsx.o ddrvvx.o \
-   derrbd.o derrec.o derred.o derrgg.o derrhs.o derrst.o \
-   dget02.o dget10.o dget22.o dget23.o dget24.o dget31.o \
-   dget32.o dget33.o dget34.o dget35.o dget36.o \
-   dget37.o dget38.o dget39.o dget40.o dget51.o dget52.o dget53.o \
-   dget54.o dglmts.o dgqrts.o dgrqts.o dgsvts3.o \
-   dhst01.o dlarfy.o dlarhs.o dlatm4.o dlctes.o dlctsx.o dlsets.o dort01.o \
-   dort03.o dsbt21.o dsgt01.o dslect.o dspt21.o dstt21.o \
-   dstt22.o dsyl01.o dsyt21.o dsyt22.o
+DEIGTST = \
+   dchkee.o \
+   dbdt01.o \
+   dbdt02.o \
+   dbdt03.o \
+   dbdt04.o \
+   dbdt05.o \
+   dchkbb.o \
+   dchkbd.o \
+   dchkbk.o \
+   dchkbl.o \
+   dchkec.o \
+   dchkgg.o \
+   dchkgk.o \
+   dchkgl.o \
+   dchkhs.o \
+   dchksb.o \
+   dchkst.o \
+   dchkst2stg.o \
+   dchksb2stg.o \
+   dckcsd.o \
+   dckglm.o \
+   dckgqr.o \
+   dckgsv.o \
+   dcklse.o \
+   dcsdts.o \
+   ddrges.o \
+   ddrgev.o \
+   ddrges3.o \
+   ddrgev3.o \
+   ddrgsx.o \
+   ddrgvx.o \
+   ddrvbd.o \
+   ddrves.o \
+   ddrvev.o \
+   ddrvsg.o \
+   ddrvsg2stg.o \
+   ddrvst.o \
+   ddrvst2stg.o \
+   ddrvsx.o \
+   ddrvvx.o \
+   derrbd.o \
+   derrec.o \
+   derred.o \
+   derrgg.o \
+   derrhs.o \
+   derrst.o \
+   dget02.o \
+   dget10.o \
+   dget22.o \
+   dget23.o \
+   dget24.o \
+   dget31.o \
+   dget32.o \
+   dget33.o \
+   dget34.o \
+   dget35.o \
+   dget36.o \
+   dget37.o \
+   dget38.o \
+   dget39.o \
+   dget40.o \
+   dget51.o \
+   dget52.o \
+   dget53.o \
+   dget54.o \
+   dglmts.o \
+   dgqrts.o \
+   dgrqts.o \
+   dgsvts3.o \
+   dhst01.o \
+   dlarfy.o \
+   dlarhs.o \
+   dlatm4.o \
+   dlctes.o \
+   dlctsx.o \
+   dlsets.o \
+   dort01.o \
+   dort03.o \
+   dsbt21.o \
+   dsgt01.o \
+   dslect.o \
+   dspt21.o \
+   dstt21.o \
+   dstt22.o \
+   dsyl01.o \
+   dsyt21.o \
+   dsyt22.o
 
-DDMDEIGTST = dchkdmd.o
+DDMDEIGTST = \
+   dchkdmd.o
 
-ZEIGTST = zchkee.o \
-   zbdt01.o zbdt02.o zbdt03.o zbdt05.o \
-   zchkbb.o zchkbd.o zchkbk.o zchkbl.o zchkec.o \
-   zchkgg.o zchkgk.o zchkgl.o zchkhb.o zchkhs.o zchkst.o zchkst2stg.o zchkhb2stg.o \
-   zckcsd.o zckglm.o zckgqr.o zckgsv.o zcklse.o zcsdts.o \
-   zdrges.o zdrgev.o zdrges3.o zdrgev3.o zdrgsx.o zdrgvx.o \
-   zdrvbd.o zdrves.o zdrvev.o zdrvsg.o zdrvsg2stg.o \
-   zdrvst.o zdrvst2stg.o zdrvsx.o zdrvvx.o \
-   zerrbd.o zerrec.o zerred.o zerrgg.o zerrhs.o zerrst.o \
-   zget02.o zget10.o zget22.o zget23.o zget24.o \
-   zget35.o zget36.o zget37.o zget38.o zget51.o zget52.o \
-   zget54.o zglmts.o zgqrts.o zgrqts.o zgsvts3.o \
-   zhbt21.o zhet21.o zhet22.o zhpt21.o zhst01.o \
-   zlarfy.o zlarhs.o zlatm4.o zlctes.o zlctsx.o zlsets.o zsbmv.o \
-   zsgt01.o zslect.o zsyl01.o\
-   zstt21.o zstt22.o zunt01.o zunt03.o
+ZEIGTST = \
+   zchkee.o \
+   zbdt01.o \
+   zbdt02.o \
+   zbdt03.o \
+   zbdt05.o \
+   zchkbb.o \
+   zchkbd.o \
+   zchkbk.o \
+   zchkbl.o \
+   zchkec.o \
+   zchkgg.o \
+   zchkgk.o \
+   zchkgl.o \
+   zchkhb.o \
+   zchkhs.o \
+   zchkst.o \
+   zchkst2stg.o \
+   zchkhb2stg.o \
+   zckcsd.o \
+   zckglm.o \
+   zckgqr.o \
+   zckgsv.o \
+   zcklse.o \
+   zcsdts.o \
+   zdrges.o \
+   zdrgev.o \
+   zdrges3.o \
+   zdrgev3.o \
+   zdrgsx.o \
+   zdrgvx.o \
+   zdrvbd.o \
+   zdrves.o \
+   zdrvev.o \
+   zdrvsg.o \
+   zdrvsg2stg.o \
+   zdrvst.o \
+   zdrvst2stg.o \
+   zdrvsx.o \
+   zdrvvx.o \
+   zerrbd.o \
+   zerrec.o \
+   zerred.o \
+   zerrgg.o \
+   zerrhs.o \
+   zerrst.o \
+   zget02.o \
+   zget10.o \
+   zget22.o \
+   zget23.o \
+   zget24.o \
+   zget35.o \
+   zget36.o \
+   zget37.o \
+   zget38.o \
+   zget51.o \
+   zget52.o \
+   zget54.o \
+   zglmts.o \
+   zgqrts.o \
+   zgrqts.o \
+   zgsvts3.o \
+   zhbt21.o \
+   zhet21.o \
+   zhet22.o \
+   zhpt21.o \
+   zhst01.o \
+   zlarfy.o \
+   zlarhs.o \
+   zlatm4.o \
+   zlctes.o \
+   zlctsx.o \
+   zlsets.o \
+   zsbmv.o \
+   zsgt01.o \
+   zslect.o \
+   zsyl01.o \
+   zstt21.o \
+   zstt22.o \
+   zunt01.o \
+   zunt03.o
 
-ZDMDEIGTST = zchkdmd.o
+ZDMDEIGTST = \
+   zchkdmd.o
 
 .PHONY: all
 all: single complex double complex16

--- a/TESTING/LIN/CMakeLists.txt
+++ b/TESTING/LIN/CMakeLists.txt
@@ -228,7 +228,6 @@ set(CLINTST
    cdrvhe_rk.f
    cdrvhe_aa.f
    cdrvhe_aa_2stage.f
-   cdrvsy_aa_2stage.f
    cdrvhp.f
    cdrvls.f
    cdrvpb.f
@@ -238,6 +237,7 @@ set(CLINTST
    cdrvsy_rook.f
    cdrvsy_rk.f
    cdrvsy_aa.f
+   cdrvsy_aa_2stage.f
    cerrgt.f
    cerrlq.f
    cerrls.f

--- a/TESTING/LIN/CMakeLists.txt
+++ b/TESTING/LIN/CMakeLists.txt
@@ -1,241 +1,899 @@
 set(ALINTST
-   aladhd.f alaerh.f alaesm.f alahd.f alareq.f
-   alasum.f alasvm.f chkxer.f icopy.f ilaenv.f xlaenv.f xerbla.f)
+   aladhd.f
+   alaerh.f
+   alaesm.f
+   alahd.f
+   alareq.f
+   alasum.f
+   alasvm.f
+   chkxer.f
+   icopy.f
+   ilaenv.f
+   xlaenv.f
+   xerbla.f)
 
-set(SCLNTST slaord.f)
+set(SCLNTST
+   slaord.f)
 
-set(DZLNTST dlaord.f)
+set(DZLNTST
+   dlaord.f)
 
-set(SLINTST schkaa.F
-   schkeq.f schkgb.f schkge.f schkgt.f
-   schklq.f schkpb.f schkpo.f schkps.f schkpp.f
-   schkpt.f schkq3.f schkqp3rk.f schkql.f schkqr.f schkrq.f
-   schksp.f schksy.f schksy_rook.f schksy_rk.f 
-   schksy_aa.f schksy_aa_2stage.f 
-   schktb.f schktp.f schktr.f
+set(SLINTST
+   schkaa.F
+   schkeq.f
+   schkgb.f
+   schkge.f
+   schkgt.f
+   schklq.f
+   schkpb.f
+   schkpo.f
+   schkps.f
+   schkpp.f
+   schkpt.f
+   schkq3.f
+   schkqp3rk.f
+   schkql.f
+   schkqr.f
+   schkrq.f
+   schksp.f
+   schksy.f
+   schksy_rook.f
+   schksy_rk.f
+   schksy_aa.f
+   schksy_aa_2stage.f
+   schktb.f
+   schktp.f
+   schktr.f
    schktz.f
-   sdrvgt.f sdrvls.f sdrvpb.f
-   sdrvpp.f sdrvpt.f sdrvsp.f sdrvsy_rook.f sdrvsy_rk.f 
-   sdrvsy_aa.f sdrvsy_aa_2stage.f
-   serrgt.f serrlq.f serrls.f
-   serrps.f serrql.f serrqp.f serrqr.f
-   serrrq.f serrtr.f serrtz.f
-   sgbt01.f sgbt02.f sgbt05.f sgeqls.f
-   sgerqs.f sget01.f sget02.f
-   sget03.f sget04.f sget06.f sget07.f sgtt01.f sgtt02.f
-   sgtt05.f slaptm.f slarhs.f slatb4.f slatb5.f slattb.f slattp.f
-   slattr.f slavsp.f slavsy.f slavsy_rook.f slqt01.f slqt02.f
-   slqt03.f spbt01.f spbt02.f spbt05.f spot01.f
-   spot02.f spot03.f spot05.f spst01.f sppt01.f
-   sppt02.f sppt03.f sppt05.f sptt01.f sptt02.f
-   sptt05.f sqlt01.f sqlt02.f sqlt03.f sqpt01.f
-   sqrt01.f sqrt01p.f sqrt02.f sqrt03.f sqrt11.f sqrt12.f
-   sqrt13.f sqrt14.f sqrt15.f sqrt16.f sqrt17.f
-   srqt01.f srqt02.f srqt03.f srzt01.f srzt02.f
-   sspt01.f ssyt01.f ssyt01_rook.f ssyt01_3.f 
+   sdrvgt.f
+   sdrvls.f
+   sdrvpb.f
+   sdrvpp.f
+   sdrvpt.f
+   sdrvsp.f
+   sdrvsy_rook.f
+   sdrvsy_rk.f
+   sdrvsy_aa.f
+   sdrvsy_aa_2stage.f
+   serrgt.f
+   serrlq.f
+   serrls.f
+   serrps.f
+   serrql.f
+   serrqp.f
+   serrqr.f
+   serrrq.f
+   serrtr.f
+   serrtz.f
+   sgbt01.f
+   sgbt02.f
+   sgbt05.f
+   sgeqls.f
+   sgerqs.f
+   sget01.f
+   sget02.f
+   sget03.f
+   sget04.f
+   sget06.f
+   sget07.f
+   sgtt01.f
+   sgtt02.f
+   sgtt05.f
+   slaptm.f
+   slarhs.f
+   slatb4.f
+   slatb5.f
+   slattb.f
+   slattp.f
+   slattr.f
+   slavsp.f
+   slavsy.f
+   slavsy_rook.f
+   slqt01.f
+   slqt02.f
+   slqt03.f
+   spbt01.f
+   spbt02.f
+   spbt05.f
+   spot01.f
+   spot02.f
+   spot03.f
+   spot05.f
+   spst01.f
+   sppt01.f
+   sppt02.f
+   sppt03.f
+   sppt05.f
+   sptt01.f
+   sptt02.f
+   sptt05.f
+   sqlt01.f
+   sqlt02.f
+   sqlt03.f
+   sqpt01.f
+   sqrt01.f
+   sqrt01p.f
+   sqrt02.f
+   sqrt03.f
+   sqrt11.f
+   sqrt12.f
+   sqrt13.f
+   sqrt14.f
+   sqrt15.f
+   sqrt16.f
+   sqrt17.f
+   srqt01.f
+   srqt02.f
+   srqt03.f
+   srzt01.f
+   srzt02.f
+   sspt01.f
+   ssyt01.f
+   ssyt01_rook.f
+   ssyt01_3.f
    ssyt01_aa.f
-   stbt02.f stbt03.f stbt05.f stbt06.f stpt01.f
-   stpt02.f stpt03.f stpt05.f stpt06.f strt01.f
-   strt02.f strt03.f strt05.f strt06.f
-   sgennd.f sqrt04.f sqrt05.f schkqrt.f serrqrt.f schkqrtp.f serrqrtp.f
-   schklqt.f schklqtp.f schktsqr.f
-   serrlqt.f serrlqtp.f serrtsqr.f stsqr01.f slqt04.f slqt05.f
-   schkorhr_col.f serrorhr_col.f sorhr_col01.f sorhr_col02.f)
+   stbt02.f
+   stbt03.f
+   stbt05.f
+   stbt06.f
+   stpt01.f
+   stpt02.f
+   stpt03.f
+   stpt05.f
+   stpt06.f
+   strt01.f
+   strt02.f
+   strt03.f
+   strt05.f
+   strt06.f
+   sgennd.f
+   sqrt04.f
+   sqrt05.f
+   schkqrt.f
+   serrqrt.f
+   schkqrtp.f
+   serrqrtp.f
+   schklqt.f
+   schklqtp.f
+   schktsqr.f
+   serrlqt.f
+   serrlqtp.f
+   serrtsqr.f
+   stsqr01.f
+   slqt04.f
+   slqt05.f
+   schkorhr_col.f
+   serrorhr_col.f
+   sorhr_col01.f
+   sorhr_col02.f)
 
 if(USE_XBLAS)
-  list(APPEND SLINTST sdrvgbx.f sdrvgex.f sdrvsyx.f sdrvpox.f
-                      serrvxx.f serrgex.f serrsyx.f serrpox.f
-                      sebchvxx.f)
+  list(APPEND SLINTST
+    sdrvgbx.f
+    sdrvgex.f
+    sdrvsyx.f
+    sdrvpox.f
+    serrvxx.f
+    serrgex.f
+    serrsyx.f
+    serrpox.f
+    sebchvxx.f)
 else()
-  list(APPEND SLINTST sdrvgb.f sdrvge.f sdrvsy.f sdrvpo.f
-                      serrvx.f serrge.f serrsy.f serrpo.f)
+  list(APPEND SLINTST
+    sdrvgb.f
+    sdrvge.f
+    sdrvsy.f
+    sdrvpo.f
+    serrvx.f
+    serrge.f
+    serrsy.f
+    serrpo.f)
 endif()
 
-set(CLINTST cchkaa.F
-   cchkeq.f cchkgb.f cchkge.f cchkgt.f
-   cchkhe.f cchkhe_rook.f cchkhe_rk.f 
-   cchkhe_aa.f cchkhe_aa_2stage.f
-   cchkhp.f cchklq.f cchkpb.f
-   cchkpo.f cchkps.f cchkpp.f cchkpt.f cchkq3.f cchkqp3rk.f cchkql.f
-   cchkqr.f cchkrq.f cchksp.f cchksy.f cchksy_rook.f cchksy_rk.f
-   cchksy_aa.f cchksy_aa_2stage.f
+set(CLINTST
+   cchkaa.F
+   cchkeq.f
+   cchkgb.f
+   cchkge.f
+   cchkgt.f
+   cchkhe.f
+   cchkhe_rook.f
+   cchkhe_rk.f
+   cchkhe_aa.f
+   cchkhe_aa_2stage.f
+   cchkhp.f
+   cchklq.f
+   cchkpb.f
+   cchkpo.f
+   cchkps.f
+   cchkpp.f
+   cchkpt.f
+   cchkq3.f
+   cchkqp3rk.f
+   cchkql.f
+   cchkqr.f
+   cchkrq.f
+   cchksp.f
+   cchksy.f
+   cchksy_rook.f
+   cchksy_rk.f
+   cchksy_aa.f
+   cchksy_aa_2stage.f
    cchktb.f
-   cchktp.f cchktr.f cchktz.f
-   cdrvgt.f cdrvhe_rook.f cdrvhe_rk.f 
-   cdrvhe_aa.f cdrvhe_aa_2stage.f cdrvsy_aa_2stage.f
+   cchktp.f
+   cchktr.f
+   cchktz.f
+   cdrvgt.f
+   cdrvhe_rook.f
+   cdrvhe_rk.f
+   cdrvhe_aa.f
+   cdrvhe_aa_2stage.f
+   cdrvsy_aa_2stage.f
    cdrvhp.f
-   cdrvls.f cdrvpb.f cdrvpp.f cdrvpt.f
-   cdrvsp.f cdrvsy_rook.f cdrvsy_rk.f 
-   cdrvsy_aa.f 
-   cerrgt.f cerrlq.f
-   cerrls.f cerrps.f cerrql.f cerrqp.f
-   cerrqr.f cerrrq.f cerrtr.f cerrtz.f
-   cgbt01.f cgbt02.f cgbt05.f cgeqls.f
-   cgerqs.f cget01.f cget02.f
-   cget03.f cget04.f cget07.f cgtt01.f cgtt02.f
-   cgtt05.f chet01.f chet01_rook.f chet01_3.f
+   cdrvls.f
+   cdrvpb.f
+   cdrvpp.f
+   cdrvpt.f
+   cdrvsp.f
+   cdrvsy_rook.f
+   cdrvsy_rk.f
+   cdrvsy_aa.f
+   cerrgt.f
+   cerrlq.f
+   cerrls.f
+   cerrps.f
+   cerrql.f
+   cerrqp.f
+   cerrqr.f
+   cerrrq.f
+   cerrtr.f
+   cerrtz.f
+   cgbt01.f
+   cgbt02.f
+   cgbt05.f
+   cgeqls.f
+   cgerqs.f
+   cget01.f
+   cget02.f
+   cget03.f
+   cget04.f
+   cget07.f
+   cgtt01.f
+   cgtt02.f
+   cgtt05.f
+   chet01.f
+   chet01_rook.f
+   chet01_3.f
    chet01_aa.f
-   chpt01.f claipd.f claptm.f clarhs.f clatb4.f clatb5.f
-   clatsp.f clatsy.f clattb.f clattp.f clattr.f
-   clavhe.f clavhe_rook.f clavhp.f clavsp.f clavsy.f clavsy_rook.f clqt01.f
-   clqt02.f clqt03.f cpbt01.f cpbt02.f cpbt05.f
-   cpot01.f cpot02.f cpot03.f cpot05.f cpst01.f
-   cppt01.f cppt02.f cppt03.f cppt05.f cptt01.f
-   cptt02.f cptt05.f cqlt01.f cqlt02.f cqlt03.f
-   cqpt01.f cqrt01.f cqrt01p.f cqrt02.f cqrt03.f cqrt11.f
-   cqrt12.f cqrt13.f cqrt14.f cqrt15.f cqrt16.f
-   cqrt17.f crqt01.f crqt02.f crqt03.f crzt01.f crzt02.f
-   csbmv.f  cspt01.f
-   cspt02.f cspt03.f csyt01.f csyt01_rook.f csyt01_3.f
-   csyt01_aa.f 
-   csyt02.f csyt03.f
-   ctbt02.f ctbt03.f ctbt05.f ctbt06.f ctpt01.f
-   ctpt02.f ctpt03.f ctpt05.f ctpt06.f ctrt01.f
-   ctrt02.f ctrt03.f ctrt05.f ctrt06.f
-   sget06.f cgennd.f
-   cqrt04.f cqrt05.f cchkqrt.f cerrqrt.f cchkqrtp.f cerrqrtp.f
-   cchklqt.f cchklqtp.f cchktsqr.f
-   cerrlqt.f cerrlqtp.f cerrtsqr.f ctsqr01.f clqt04.f clqt05.f
-   cchkunhr_col.f cerrunhr_col.f cunhr_col01.f cunhr_col02.f)
+   chpt01.f
+   claipd.f
+   claptm.f
+   clarhs.f
+   clatb4.f
+   clatb5.f
+   clatsp.f
+   clatsy.f
+   clattb.f
+   clattp.f
+   clattr.f
+   clavhe.f
+   clavhe_rook.f
+   clavhp.f
+   clavsp.f
+   clavsy.f
+   clavsy_rook.f
+   clqt01.f
+   clqt02.f
+   clqt03.f
+   cpbt01.f
+   cpbt02.f
+   cpbt05.f
+   cpot01.f
+   cpot02.f
+   cpot03.f
+   cpot05.f
+   cpst01.f
+   cppt01.f
+   cppt02.f
+   cppt03.f
+   cppt05.f
+   cptt01.f
+   cptt02.f
+   cptt05.f
+   cqlt01.f
+   cqlt02.f
+   cqlt03.f
+   cqpt01.f
+   cqrt01.f
+   cqrt01p.f
+   cqrt02.f
+   cqrt03.f
+   cqrt11.f
+   cqrt12.f
+   cqrt13.f
+   cqrt14.f
+   cqrt15.f
+   cqrt16.f
+   cqrt17.f
+   crqt01.f
+   crqt02.f
+   crqt03.f
+   crzt01.f
+   crzt02.f
+   csbmv.f
+   cspt01.f
+   cspt02.f
+   cspt03.f
+   csyt01.f
+   csyt01_rook.f
+   csyt01_3.f
+   csyt01_aa.f
+   csyt02.f
+   csyt03.f
+   ctbt02.f
+   ctbt03.f
+   ctbt05.f
+   ctbt06.f
+   ctpt01.f
+   ctpt02.f
+   ctpt03.f
+   ctpt05.f
+   ctpt06.f
+   ctrt01.f
+   ctrt02.f
+   ctrt03.f
+   ctrt05.f
+   ctrt06.f
+   sget06.f
+   cgennd.f
+   cqrt04.f
+   cqrt05.f
+   cchkqrt.f
+   cerrqrt.f
+   cchkqrtp.f
+   cerrqrtp.f
+   cchklqt.f
+   cchklqtp.f
+   cchktsqr.f
+   cerrlqt.f
+   cerrlqtp.f
+   cerrtsqr.f
+   ctsqr01.f
+   clqt04.f
+   clqt05.f
+   cchkunhr_col.f
+   cerrunhr_col.f
+   cunhr_col01.f
+   cunhr_col02.f)
 
 if(USE_XBLAS)
-  list(APPEND CLINTST cdrvgbx.f cdrvgex.f cdrvhex.f cdrvsyx.f cdrvpox.f
-                      cerrvxx.f cerrgex.f cerrhex.f cerrsyx.f cerrpox.f
-                      cebchvxx.f)
+  list(APPEND CLINTST
+    cdrvgbx.f
+    cdrvgex.f
+    cdrvhex.f
+    cdrvsyx.f
+    cdrvpox.f
+    cerrvxx.f
+    cerrgex.f
+    cerrhex.f
+    cerrsyx.f
+    cerrpox.f
+    cebchvxx.f)
 else()
-  list(APPEND CLINTST cdrvgb.f cdrvge.f cdrvhe.f cdrvsy.f cdrvpo.f
-                      cerrvx.f cerrge.f cerrhe.f cerrsy.f cerrpo.f)
+  list(APPEND CLINTST
+    cdrvgb.f
+    cdrvge.f
+    cdrvhe.f
+    cdrvsy.f
+    cdrvpo.f
+    cerrvx.f
+    cerrge.f
+    cerrhe.f
+    cerrsy.f
+    cerrpo.f)
 endif()
 
-set(DLINTST dchkaa.F
-   dchkeq.f dchkgb.f dchkge.f dchkgt.f
-   dchklq.f dchkpb.f dchkpo.f dchkps.f dchkpp.f
-   dchkpt.f dchkq3.f dchkqp3rk.f dchkql.f dchkqr.f dchkrq.f
-   dchksp.f dchksy.f dchksy_rook.f dchksy_rk.f 
-   dchksy_aa.f dchksy_aa_2stage.f
-   dchktb.f dchktp.f dchktr.f
+set(DLINTST
+   dchkaa.F
+   dchkeq.f
+   dchkgb.f
+   dchkge.f
+   dchkgt.f
+   dchklq.f
+   dchkpb.f
+   dchkpo.f
+   dchkps.f
+   dchkpp.f
+   dchkpt.f
+   dchkq3.f
+   dchkqp3rk.f
+   dchkql.f
+   dchkqr.f
+   dchkrq.f
+   dchksp.f
+   dchksy.f
+   dchksy_rook.f
+   dchksy_rk.f
+   dchksy_aa.f
+   dchksy_aa_2stage.f
+   dchktb.f
+   dchktp.f
+   dchktr.f
    dchktz.f
-   ddrvgt.f ddrvls.f ddrvpb.f
-   ddrvpp.f ddrvpt.f ddrvsp.f ddrvsy_rook.f ddrvsy_rk.f 
-   ddrvsy_aa.f ddrvsy_aa_2stage.f
-   derrgt.f derrlq.f derrls.f
-   derrps.f derrql.f derrqp.f derrqr.f
-   derrrq.f derrtr.f derrtz.f
-   dgbt01.f dgbt02.f dgbt05.f dgeqls.f
-   dgerqs.f dget01.f dget02.f
-   dget03.f dget04.f dget06.f dget07.f dgtt01.f dgtt02.f
-   dgtt05.f dlaptm.f dlarhs.f dlatb4.f dlatb5.f dlattb.f dlattp.f
-   dlattr.f dlavsp.f dlavsy.f dlavsy_rook.f dlqt01.f dlqt02.f
-   dlqt03.f dpbt01.f dpbt02.f dpbt05.f dpot01.f
-   dpot02.f dpot03.f dpot05.f dpst01.f dppt01.f
-   dppt02.f dppt03.f dppt05.f dptt01.f dptt02.f
-   dptt05.f dqlt01.f dqlt02.f dqlt03.f dqpt01.f
-   dqrt01.f dqrt01p.f dqrt02.f dqrt03.f dqrt11.f dqrt12.f
-   dqrt13.f dqrt14.f dqrt15.f dqrt16.f dqrt17.f
-   drqt01.f drqt02.f drqt03.f drzt01.f drzt02.f
-   dspt01.f dsyt01.f dsyt01_rook.f dsyt01_3.f
+   ddrvgt.f
+   ddrvls.f
+   ddrvpb.f
+   ddrvpp.f
+   ddrvpt.f
+   ddrvsp.f
+   ddrvsy_rook.f
+   ddrvsy_rk.f
+   ddrvsy_aa.f
+   ddrvsy_aa_2stage.f
+   derrgt.f
+   derrlq.f
+   derrls.f
+   derrps.f
+   derrql.f
+   derrqp.f
+   derrqr.f
+   derrrq.f
+   derrtr.f
+   derrtz.f
+   dgbt01.f
+   dgbt02.f
+   dgbt05.f
+   dgeqls.f
+   dgerqs.f
+   dget01.f
+   dget02.f
+   dget03.f
+   dget04.f
+   dget06.f
+   dget07.f
+   dgtt01.f
+   dgtt02.f
+   dgtt05.f
+   dlaptm.f
+   dlarhs.f
+   dlatb4.f
+   dlatb5.f
+   dlattb.f
+   dlattp.f
+   dlattr.f
+   dlavsp.f
+   dlavsy.f
+   dlavsy_rook.f
+   dlqt01.f
+   dlqt02.f
+   dlqt03.f
+   dpbt01.f
+   dpbt02.f
+   dpbt05.f
+   dpot01.f
+   dpot02.f
+   dpot03.f
+   dpot05.f
+   dpst01.f
+   dppt01.f
+   dppt02.f
+   dppt03.f
+   dppt05.f
+   dptt01.f
+   dptt02.f
+   dptt05.f
+   dqlt01.f
+   dqlt02.f
+   dqlt03.f
+   dqpt01.f
+   dqrt01.f
+   dqrt01p.f
+   dqrt02.f
+   dqrt03.f
+   dqrt11.f
+   dqrt12.f
+   dqrt13.f
+   dqrt14.f
+   dqrt15.f
+   dqrt16.f
+   dqrt17.f
+   drqt01.f
+   drqt02.f
+   drqt03.f
+   drzt01.f
+   drzt02.f
+   dspt01.f
+   dsyt01.f
+   dsyt01_rook.f
+   dsyt01_3.f
    dsyt01_aa.f
-   dtbt02.f dtbt03.f dtbt05.f dtbt06.f dtpt01.f
-   dtpt02.f dtpt03.f dtpt05.f dtpt06.f dtrt01.f
-   dtrt02.f dtrt03.f dtrt05.f dtrt06.f
+   dtbt02.f
+   dtbt03.f
+   dtbt05.f
+   dtbt06.f
+   dtpt01.f
+   dtpt02.f
+   dtpt03.f
+   dtpt05.f
+   dtpt06.f
+   dtrt01.f
+   dtrt02.f
+   dtrt03.f
+   dtrt05.f
+   dtrt06.f
    dgennd.f
-   dqrt04.f dqrt05.f dchkqrt.f derrqrt.f dchkqrtp.f derrqrtp.f
-   dchklq.f dchklqt.f dchklqtp.f dchktsqr.f
-   derrlqt.f derrlqtp.f derrtsqr.f dtsqr01.f dlqt04.f dlqt05.f
-   dchkorhr_col.f derrorhr_col.f dorhr_col01.f dorhr_col02.f)
+   dqrt04.f
+   dqrt05.f
+   dchkqrt.f
+   derrqrt.f
+   dchkqrtp.f
+   derrqrtp.f
+   dchklq.f
+   dchklqt.f
+   dchklqtp.f
+   dchktsqr.f
+   derrlqt.f
+   derrlqtp.f
+   derrtsqr.f
+   dtsqr01.f
+   dlqt04.f
+   dlqt05.f
+   dchkorhr_col.f
+   derrorhr_col.f
+   dorhr_col01.f
+   dorhr_col02.f)
 
 if(USE_XBLAS)
-  list(APPEND DLINTST ddrvgbx.f ddrvgex.f ddrvsyx.f ddrvpox.f
-                      derrvxx.f derrgex.f derrsyx.f derrpox.f
-                      debchvxx.f)
+  list(APPEND DLINTST
+    ddrvgbx.f
+    ddrvgex.f
+    ddrvsyx.f
+    ddrvpox.f
+    derrvxx.f
+    derrgex.f
+    derrsyx.f
+    derrpox.f
+    debchvxx.f)
 else()
-  list(APPEND DLINTST ddrvgb.f ddrvge.f ddrvsy.f ddrvpo.f
-                      derrvx.f derrge.f derrsy.f derrpo.f)
+  list(APPEND DLINTST
+    ddrvgb.f
+    ddrvge.f
+    ddrvsy.f
+    ddrvpo.f
+    derrvx.f
+    derrge.f
+    derrsy.f
+    derrpo.f)
 endif()
 
-set(ZLINTST zchkaa.F
-   zchkeq.f zchkgb.f zchkge.f zchkgt.f
-   zchkhe.f zchkhe_rook.f zchkhe_rk.f 
-   zchkhe_aa.f zchkhe_aa_2stage.f
-   zchkhp.f zchklq.f zchkpb.f
-   zchkpo.f zchkps.f zchkpp.f zchkpt.f zchkq3.f zchkqp3rk.f zchkql.f
-   zchkqr.f zchkrq.f zchksp.f zchksy.f zchksy_rook.f zchksy_rk.f
-   zchksy_aa.f  zchksy_aa_2stage.f
+set(ZLINTST
+   zchkaa.F
+   zchkeq.f
+   zchkgb.f
+   zchkge.f
+   zchkgt.f
+   zchkhe.f
+   zchkhe_rook.f
+   zchkhe_rk.f
+   zchkhe_aa.f
+   zchkhe_aa_2stage.f
+   zchkhp.f
+   zchklq.f
+   zchkpb.f
+   zchkpo.f
+   zchkps.f
+   zchkpp.f
+   zchkpt.f
+   zchkq3.f
+   zchkqp3rk.f
+   zchkql.f
+   zchkqr.f
+   zchkrq.f
+   zchksp.f
+   zchksy.f
+   zchksy_rook.f
+   zchksy_rk.f
+   zchksy_aa.f
+   zchksy_aa_2stage.f
    zchktb.f
-   zchktp.f zchktr.f zchktz.f
-   zdrvgt.f zdrvhe_rook.f zdrvhe_rk.f 
-   zdrvhe_aa.f  zdrvhe_aa_2stage.f
+   zchktp.f
+   zchktr.f
+   zchktz.f
+   zdrvgt.f
+   zdrvhe_rook.f
+   zdrvhe_rk.f
+   zdrvhe_aa.f
+   zdrvhe_aa_2stage.f
    zdrvhp.f
-   zdrvls.f zdrvpb.f zdrvpp.f zdrvpt.f
-   zdrvsp.f zdrvsy_rook.f zdrvsy_rk.f 
-   zdrvsy_aa.f zdrvsy_aa_2stage.f 
-   zerrgt.f zerrlq.f
-   zerrls.f zerrps.f zerrql.f zerrqp.f
-   zerrqr.f zerrrq.f zerrtr.f zerrtz.f
-   zgbt01.f zgbt02.f zgbt05.f zgeqls.f
-   zgerqs.f zget01.f zget02.f
-   zget03.f zget04.f zget07.f zgtt01.f zgtt02.f
-   zgtt05.f zhet01.f zhet01_rook.f zhet01_3.f
+   zdrvls.f
+   zdrvpb.f
+   zdrvpp.f
+   zdrvpt.f
+   zdrvsp.f
+   zdrvsy_rook.f
+   zdrvsy_rk.f
+   zdrvsy_aa.f
+   zdrvsy_aa_2stage.f
+   zerrgt.f
+   zerrlq.f
+   zerrls.f
+   zerrps.f
+   zerrql.f
+   zerrqp.f
+   zerrqr.f
+   zerrrq.f
+   zerrtr.f
+   zerrtz.f
+   zgbt01.f
+   zgbt02.f
+   zgbt05.f
+   zgeqls.f
+   zgerqs.f
+   zget01.f
+   zget02.f
+   zget03.f
+   zget04.f
+   zget07.f
+   zgtt01.f
+   zgtt02.f
+   zgtt05.f
+   zhet01.f
+   zhet01_rook.f
+   zhet01_3.f
    zhet01_aa.f
-   zhpt01.f zlaipd.f zlaptm.f zlarhs.f zlatb4.f zlatb5.f
-   zlatsp.f zlatsy.f zlattb.f zlattp.f zlattr.f
-   zlavhe.f zlavhe_rook.f zlavhp.f zlavsp.f zlavsy.f zlavsy_rook.f zlqt01.f
-   zlqt02.f zlqt03.f zpbt01.f zpbt02.f zpbt05.f
-   zpot01.f zpot02.f zpot03.f zpot05.f zpst01.f
-   zppt01.f zppt02.f zppt03.f zppt05.f zptt01.f
-   zptt02.f zptt05.f zqlt01.f zqlt02.f zqlt03.f
-   zqpt01.f zqrt01.f zqrt01p.f zqrt02.f zqrt03.f zqrt11.f
-   zqrt12.f zqrt13.f zqrt14.f zqrt15.f zqrt16.f
-   zqrt17.f zrqt01.f zrqt02.f zrqt03.f zrzt01.f zrzt02.f
-   zsbmv.f  zspt01.f
-   zspt02.f zspt03.f zsyt01.f zsyt01_rook.f zsyt01_3.f
+   zhpt01.f
+   zlaipd.f
+   zlaptm.f
+   zlarhs.f
+   zlatb4.f
+   zlatb5.f
+   zlatsp.f
+   zlatsy.f
+   zlattb.f
+   zlattp.f
+   zlattr.f
+   zlavhe.f
+   zlavhe_rook.f
+   zlavhp.f
+   zlavsp.f
+   zlavsy.f
+   zlavsy_rook.f
+   zlqt01.f
+   zlqt02.f
+   zlqt03.f
+   zpbt01.f
+   zpbt02.f
+   zpbt05.f
+   zpot01.f
+   zpot02.f
+   zpot03.f
+   zpot05.f
+   zpst01.f
+   zppt01.f
+   zppt02.f
+   zppt03.f
+   zppt05.f
+   zptt01.f
+   zptt02.f
+   zptt05.f
+   zqlt01.f
+   zqlt02.f
+   zqlt03.f
+   zqpt01.f
+   zqrt01.f
+   zqrt01p.f
+   zqrt02.f
+   zqrt03.f
+   zqrt11.f
+   zqrt12.f
+   zqrt13.f
+   zqrt14.f
+   zqrt15.f
+   zqrt16.f
+   zqrt17.f
+   zrqt01.f
+   zrqt02.f
+   zrqt03.f
+   zrzt01.f
+   zrzt02.f
+   zsbmv.f
+   zspt01.f
+   zspt02.f
+   zspt03.f
+   zsyt01.f
+   zsyt01_rook.f
+   zsyt01_3.f
    zsyt01_aa.f
-   zsyt02.f zsyt03.f
-   ztbt02.f ztbt03.f ztbt05.f ztbt06.f ztpt01.f
-   ztpt02.f ztpt03.f ztpt05.f ztpt06.f ztrt01.f
-   ztrt02.f ztrt03.f ztrt05.f ztrt06.f
-   dget06.f zgennd.f
-   zqrt04.f zqrt05.f zchkqrt.f zerrqrt.f zchkqrtp.f zerrqrtp.f
-   zchklqt.f zchklqtp.f zchktsqr.f
-   zerrlqt.f zerrlqtp.f zerrtsqr.f ztsqr01.f zlqt04.f zlqt05.f
-   zchkunhr_col.f zerrunhr_col.f zunhr_col01.f zunhr_col02.f)
+   zsyt02.f
+   zsyt03.f
+   ztbt02.f
+   ztbt03.f
+   ztbt05.f
+   ztbt06.f
+   ztpt01.f
+   ztpt02.f
+   ztpt03.f
+   ztpt05.f
+   ztpt06.f
+   ztrt01.f
+   ztrt02.f
+   ztrt03.f
+   ztrt05.f
+   ztrt06.f
+   dget06.f
+   zgennd.f
+   zqrt04.f
+   zqrt05.f
+   zchkqrt.f
+   zerrqrt.f
+   zchkqrtp.f
+   zerrqrtp.f
+   zchklqt.f
+   zchklqtp.f
+   zchktsqr.f
+   zerrlqt.f
+   zerrlqtp.f
+   zerrtsqr.f
+   ztsqr01.f
+   zlqt04.f
+   zlqt05.f
+   zchkunhr_col.f
+   zerrunhr_col.f
+   zunhr_col01.f
+   zunhr_col02.f)
 
 if(USE_XBLAS)
-  list(APPEND ZLINTST zdrvgbx.f zdrvgex.f zdrvhex.f zdrvsyx.f zdrvpox.f
-                      zerrvxx.f zerrgex.f zerrhex.f zerrsyx.f zerrpox.f
-                      zebchvxx.f)
+  list(APPEND ZLINTST
+    zdrvgbx.f
+    zdrvgex.f
+    zdrvhex.f
+    zdrvsyx.f
+    zdrvpox.f
+    zerrvxx.f
+    zerrgex.f
+    zerrhex.f
+    zerrsyx.f
+    zerrpox.f
+    zebchvxx.f)
 else()
-  list(APPEND ZLINTST zdrvgb.f zdrvge.f zdrvhe.f zdrvsy.f zdrvpo.f
-                      zerrvx.f zerrge.f zerrhe.f zerrsy.f zerrpo.f)
+  list(APPEND ZLINTST
+    zdrvgb.f
+    zdrvge.f
+    zdrvhe.f
+    zdrvsy.f
+    zdrvpo.f
+    zerrvx.f
+    zerrge.f
+    zerrhe.f
+    zerrsy.f
+    zerrpo.f)
 endif()
 
-set(DSLINTST dchkab.f
-	ddrvab.f ddrvac.f derrab.f derrac.f dget08.f
-	alaerh.f alahd.f  aladhd.f alareq.f
-	chkxer.f dlarhs.f dlatb4.f xerbla.f
-	dget02.f dpot06.f)
+set(DSLINTST
+   dchkab.f
+   ddrvab.f
+   ddrvac.f
+   derrab.f
+   derrac.f
+   dget08.f
+   alaerh.f
+   alahd.f
+   aladhd.f
+   alareq.f
+   chkxer.f
+   dlarhs.f
+   dlatb4.f
+   xerbla.f
+   dget02.f
+   dpot06.f)
 
-set(ZCLINTST zchkab.f
-	zdrvab.f zdrvac.f zerrab.f zerrac.f zget08.f
-	alaerh.f alahd.f  aladhd.f alareq.f
-	chkxer.f zget02.f zlarhs.f zlatb4.f
-	zsbmv.f  xerbla.f zpot06.f zlaipd.f)
+set(ZCLINTST
+   zchkab.f
+   zdrvab.f
+   zdrvac.f
+   zerrab.f
+   zerrac.f
+   zget08.f
+   alaerh.f
+   alahd.f
+   aladhd.f
+   alareq.f
+   chkxer.f
+   zget02.f
+   zlarhs.f
+   zlatb4.f
+   zsbmv.f
+   xerbla.f
+   zpot06.f
+   zlaipd.f)
 
-set(SLINTSTRFP schkrfp.f sdrvrfp.f sdrvrf1.f sdrvrf2.f sdrvrf3.f sdrvrf4.f serrrfp.f
-	slatb4.f slarhs.f sget04.f spot01.f spot03.f spot02.f
-	chkxer.f xerbla.f alaerh.f aladhd.f alahd.f alasvm.f)
+set(SLINTSTRFP
+   schkrfp.f
+   sdrvrfp.f
+   sdrvrf1.f
+   sdrvrf2.f
+   sdrvrf3.f
+   sdrvrf4.f
+   serrrfp.f
+   slatb4.f
+   slarhs.f
+   sget04.f
+   spot01.f
+   spot03.f
+   spot02.f
+   chkxer.f
+   xerbla.f
+   alaerh.f
+   aladhd.f
+   alahd.f
+   alasvm.f)
 
-set(DLINTSTRFP dchkrfp.f ddrvrfp.f ddrvrf1.f ddrvrf2.f ddrvrf3.f ddrvrf4.f derrrfp.f
-	dlatb4.f dlarhs.f dget04.f dpot01.f dpot03.f dpot02.f
-	chkxer.f xerbla.f alaerh.f aladhd.f alahd.f alasvm.f)
+set(DLINTSTRFP
+   dchkrfp.f
+   ddrvrfp.f
+   ddrvrf1.f
+   ddrvrf2.f
+   ddrvrf3.f
+   ddrvrf4.f
+   derrrfp.f
+   dlatb4.f
+   dlarhs.f
+   dget04.f
+   dpot01.f
+   dpot03.f
+   dpot02.f
+   chkxer.f
+   xerbla.f
+   alaerh.f
+   aladhd.f
+   alahd.f
+   alasvm.f)
 
-set(CLINTSTRFP cchkrfp.f cdrvrfp.f cdrvrf1.f cdrvrf2.f cdrvrf3.f cdrvrf4.f cerrrfp.f
-  claipd.f clatb4.f clarhs.f csbmv.f cget04.f cpot01.f cpot03.f cpot02.f
-  chkxer.f xerbla.f alaerh.f aladhd.f alahd.f alasvm.f)
+set(CLINTSTRFP
+   cchkrfp.f
+   cdrvrfp.f
+   cdrvrf1.f
+   cdrvrf2.f
+   cdrvrf3.f
+   cdrvrf4.f
+   cerrrfp.f
+   claipd.f
+   clatb4.f
+   clarhs.f
+   csbmv.f
+   cget04.f
+   cpot01.f
+   cpot03.f
+   cpot02.f
+   chkxer.f
+   xerbla.f
+   alaerh.f
+   aladhd.f
+   alahd.f
+   alasvm.f)
 
-set(ZLINTSTRFP zchkrfp.f zdrvrfp.f zdrvrf1.f zdrvrf2.f zdrvrf3.f zdrvrf4.f zerrrfp.f
-  zlatb4.f zlaipd.f zlarhs.f zsbmv.f zget04.f zpot01.f zpot03.f zpot02.f
-  chkxer.f xerbla.f alaerh.f aladhd.f alahd.f alasvm.f)
+set(ZLINTSTRFP
+   zchkrfp.f
+   zdrvrfp.f
+   zdrvrf1.f
+   zdrvrf2.f
+   zdrvrf3.f
+   zdrvrf4.f
+   zerrrfp.f
+   zlatb4.f
+   zlaipd.f
+   zlarhs.f
+   zsbmv.f
+   zget04.f
+   zpot01.f
+   zpot03.f
+   zpot02.f
+   chkxer.f
+   xerbla.f
+   alaerh.f
+   aladhd.f
+   alahd.f
+   alasvm.f)
 
 macro(add_lin_executable name)
   add_executable(${name} ${ARGN})

--- a/TESTING/LIN/Makefile
+++ b/TESTING/LIN/Makefile
@@ -263,8 +263,8 @@ CLINTST = \
    cdrvhe_rook.o \
    cdrvhe_rk.o \
    cdrvhe_aa.o \
-   cdrvhp.o \
    cdrvhe_aa_2stage.o \
+   cdrvhp.o \
    cdrvls.o \
    cdrvpb.o \
    cdrvpp.o \

--- a/TESTING/LIN/Makefile
+++ b/TESTING/LIN/Makefile
@@ -35,224 +35,901 @@ TOPSRCDIR = ../..
 include $(TOPSRCDIR)/make.inc
 
 ALINTST = \
-   aladhd.o alaerh.o alaesm.o alahd.o alareq.o \
-   alasum.o alasvm.o chkxer.o icopy.o ilaenv.o xlaenv.o xerbla.o
+   aladhd.o \
+   alaerh.o \
+   alaesm.o \
+   alahd.o \
+   alareq.o \
+   alasum.o \
+   alasvm.o \
+   chkxer.o \
+   icopy.o \
+   ilaenv.o \
+   xlaenv.o \
+   xerbla.o
 
-SCLNTST = slaord.o
+SCLNTST = \
+   slaord.o
 
-DZLNTST = dlaord.o
+DZLNTST = \
+   dlaord.o
 
-SLINTST = schkaa.o \
-   schkeq.o schkgb.o schkge.o schkgt.o \
-   schklq.o schkpb.o schkpo.o schkps.o schkpp.o \
-   schkpt.o schkq3.o schkqp3rk.o schkql.o schkqr.o schkrq.o \
-   schksp.o schksy.o schksy_rook.o schksy_rk.o  \
-   schksy_aa.o schksy_aa_2stage.o schktb.o schktp.o schktr.o \
+SLINTST = \
+   schkaa.o \
+   schkeq.o \
+   schkgb.o \
+   schkge.o \
+   schkgt.o \
+   schklq.o \
+   schkpb.o \
+   schkpo.o \
+   schkps.o \
+   schkpp.o \
+   schkpt.o \
+   schkq3.o \
+   schkqp3rk.o \
+   schkql.o \
+   schkqr.o \
+   schkrq.o \
+   schksp.o \
+   schksy.o \
+   schksy_rook.o \
+   schksy_rk.o \
+   schksy_aa.o \
+   schksy_aa_2stage.o \
+   schktb.o \
+   schktp.o \
+   schktr.o \
    schktz.o \
-   sdrvgt.o sdrvls.o sdrvpb.o \
-   sdrvpp.o sdrvpt.o sdrvsp.o sdrvsy_rook.o sdrvsy_rk.o \
-   sdrvsy_aa.o sdrvsy_aa_2stage.o \
-   serrgt.o serrlq.o serrls.o \
-   serrps.o serrql.o serrqp.o serrqr.o \
-   serrrq.o serrtr.o serrtz.o \
-   sgbt01.o sgbt02.o sgbt05.o sgeqls.o \
-   sgerqs.o sget01.o sget02.o \
-   sget03.o sget04.o sget06.o sget07.o sgtt01.o sgtt02.o \
-   sgtt05.o slaptm.o slarhs.o slatb4.o slatb5.o slattb.o slattp.o \
-   slattr.o slavsp.o slavsy.o slavsy_rook.o slqt01.o slqt02.o \
-   slqt03.o spbt01.o spbt02.o spbt05.o spot01.o \
-   spot02.o spot03.o spot05.o spst01.o sppt01.o \
-   sppt02.o sppt03.o sppt05.o sptt01.o sptt02.o \
-   sptt05.o sqlt01.o sqlt02.o sqlt03.o sqpt01.o \
-   sqrt01.o sqrt01p.o sqrt02.o sqrt03.o sqrt11.o sqrt12.o \
-   sqrt13.o sqrt14.o sqrt15.o sqrt16.o sqrt17.o \
-   srqt01.o srqt02.o srqt03.o srzt01.o srzt02.o \
-   sspt01.o ssyt01.o ssyt01_rook.o ssyt01_3.o ssyt01_aa.o \
-   stbt02.o stbt03.o stbt05.o stbt06.o stpt01.o \
-   stpt02.o stpt03.o stpt05.o stpt06.o strt01.o \
-   strt02.o strt03.o strt05.o strt06.o \
-   sgennd.o sqrt04.o sqrt05.o schkqrt.o serrqrt.o schkqrtp.o serrqrtp.o \
-   schklqt.o schklqtp.o schktsqr.o \
-   serrlqt.o serrlqtp.o serrtsqr.o stsqr01.o slqt04.o slqt05.o \
-   schkorhr_col.o serrorhr_col.o sorhr_col01.o sorhr_col02.o
+   sdrvgt.o \
+   sdrvls.o \
+   sdrvpb.o \
+   sdrvpp.o \
+   sdrvpt.o \
+   sdrvsp.o \
+   sdrvsy_rook.o \
+   sdrvsy_rk.o \
+   sdrvsy_aa.o \
+   sdrvsy_aa_2stage.o \
+   serrgt.o \
+   serrlq.o \
+   serrls.o \
+   serrps.o \
+   serrql.o \
+   serrqp.o \
+   serrqr.o \
+   serrrq.o \
+   serrtr.o \
+   serrtz.o \
+   sgbt01.o \
+   sgbt02.o \
+   sgbt05.o \
+   sgeqls.o \
+   sgerqs.o \
+   sget01.o \
+   sget02.o \
+   sget03.o \
+   sget04.o \
+   sget06.o \
+   sget07.o \
+   sgtt01.o \
+   sgtt02.o \
+   sgtt05.o \
+   slaptm.o \
+   slarhs.o \
+   slatb4.o \
+   slatb5.o \
+   slattb.o \
+   slattp.o \
+   slattr.o \
+   slavsp.o \
+   slavsy.o \
+   slavsy_rook.o \
+   slqt01.o \
+   slqt02.o \
+   slqt03.o \
+   spbt01.o \
+   spbt02.o \
+   spbt05.o \
+   spot01.o \
+   spot02.o \
+   spot03.o \
+   spot05.o \
+   spst01.o \
+   sppt01.o \
+   sppt02.o \
+   sppt03.o \
+   sppt05.o \
+   sptt01.o \
+   sptt02.o \
+   sptt05.o \
+   sqlt01.o \
+   sqlt02.o \
+   sqlt03.o \
+   sqpt01.o \
+   sqrt01.o \
+   sqrt01p.o \
+   sqrt02.o \
+   sqrt03.o \
+   sqrt11.o \
+   sqrt12.o \
+   sqrt13.o \
+   sqrt14.o \
+   sqrt15.o \
+   sqrt16.o \
+   sqrt17.o \
+   srqt01.o \
+   srqt02.o \
+   srqt03.o \
+   srzt01.o \
+   srzt02.o \
+   sspt01.o \
+   ssyt01.o \
+   ssyt01_rook.o \
+   ssyt01_3.o \
+   ssyt01_aa.o \
+   stbt02.o \
+   stbt03.o \
+   stbt05.o \
+   stbt06.o \
+   stpt01.o \
+   stpt02.o \
+   stpt03.o \
+   stpt05.o \
+   stpt06.o \
+   strt01.o \
+   strt02.o \
+   strt03.o \
+   strt05.o \
+   strt06.o \
+   sgennd.o \
+   sqrt04.o \
+   sqrt05.o \
+   schkqrt.o \
+   serrqrt.o \
+   schkqrtp.o \
+   serrqrtp.o \
+   schklqt.o \
+   schklqtp.o \
+   schktsqr.o \
+   serrlqt.o \
+   serrlqtp.o \
+   serrtsqr.o \
+   stsqr01.o \
+   slqt04.o \
+   slqt05.o \
+   schkorhr_col.o \
+   serrorhr_col.o \
+   sorhr_col01.o \
+   sorhr_col02.o
 
 ifdef USEXBLAS
-SLINTST += sdrvgbx.o sdrvgex.o sdrvsyx.o sdrvpox.o \
-           serrvxx.o serrgex.o serrsyx.o serrpox.o \
-           sebchvxx.o
+SLINTST += \
+   sdrvgbx.o \
+   sdrvgex.o \
+   sdrvsyx.o \
+   sdrvpox.o \
+   serrvxx.o \
+   serrgex.o \
+   serrsyx.o \
+   serrpox.o \
+   sebchvxx.o
 else
-SLINTST += sdrvgb.o sdrvge.o sdrvsy.o sdrvpo.o \
-           serrvx.o serrge.o serrsy.o serrpo.o
+SLINTST += \
+   sdrvgb.o \
+   sdrvge.o \
+   sdrvsy.o \
+   sdrvpo.o \
+   serrvx.o \
+   serrge.o \
+   serrsy.o \
+   serrpo.o
 endif
 
-CLINTST = cchkaa.o \
-   cchkeq.o cchkgb.o cchkge.o cchkgt.o \
-   cchkhe.o cchkhe_rook.o cchkhe_rk.o  \
-   cchkhe_aa.o cchkhe_aa_2stage.o cchkhp.o cchklq.o cchkpb.o \
-   cchkpo.o cchkps.o cchkpp.o cchkpt.o cchkq3.o cchkqp3rk.o cchkql.o \
-   cchkqr.o cchkrq.o cchksp.o cchksy.o cchksy_rook.o cchksy_rk.o \
-   cchksy_aa.o cchksy_aa_2stage.o cchktb.o \
-   cchktp.o cchktr.o cchktz.o \
-   cdrvgt.o cdrvhe_rook.o cdrvhe_rk.o cdrvhe_aa.o cdrvhp.o \
+CLINTST = \
+   cchkaa.o \
+   cchkeq.o \
+   cchkgb.o \
+   cchkge.o \
+   cchkgt.o \
+   cchkhe.o \
+   cchkhe_rook.o \
+   cchkhe_rk.o \
+   cchkhe_aa.o \
+   cchkhe_aa_2stage.o \
+   cchkhp.o \
+   cchklq.o \
+   cchkpb.o \
+   cchkpo.o \
+   cchkps.o \
+   cchkpp.o \
+   cchkpt.o \
+   cchkq3.o \
+   cchkqp3rk.o \
+   cchkql.o \
+   cchkqr.o \
+   cchkrq.o \
+   cchksp.o \
+   cchksy.o \
+   cchksy_rook.o \
+   cchksy_rk.o \
+   cchksy_aa.o \
+   cchksy_aa_2stage.o \
+   cchktb.o \
+   cchktp.o \
+   cchktr.o \
+   cchktz.o \
+   cdrvgt.o \
+   cdrvhe_rook.o \
+   cdrvhe_rk.o \
+   cdrvhe_aa.o \
+   cdrvhp.o \
    cdrvhe_aa_2stage.o \
-   cdrvls.o cdrvpb.o cdrvpp.o cdrvpt.o \
-   cdrvsp.o cdrvsy_rook.o cdrvsy_rk.o cdrvsy_aa.o cdrvsy_aa_2stage.o \
-   cerrgt.o cerrlq.o \
-   cerrls.o cerrps.o cerrql.o cerrqp.o \
-   cerrqr.o cerrrq.o cerrtr.o cerrtz.o \
-   cgbt01.o cgbt02.o cgbt05.o cgeqls.o \
-   cgerqs.o cget01.o cget02.o \
-   cget03.o cget04.o cget07.o cgtt01.o cgtt02.o \
-   cgtt05.o chet01.o chet01_rook.o chet01_3.o chet01_aa.o \
-   chpt01.o claipd.o claptm.o clarhs.o clatb4.o clatb5.o \
-   clatsp.o clatsy.o clattb.o clattp.o clattr.o \
-   clavhe.o clavhe_rook.o clavhp.o clavsp.o clavsy.o clavsy_rook.o clqt01.o \
-   clqt02.o clqt03.o cpbt01.o cpbt02.o cpbt05.o \
-   cpot01.o cpot02.o cpot03.o cpot05.o cpst01.o \
-   cppt01.o cppt02.o cppt03.o cppt05.o cptt01.o \
-   cptt02.o cptt05.o cqlt01.o cqlt02.o cqlt03.o \
-   cqpt01.o cqrt01.o cqrt01p.o cqrt02.o cqrt03.o cqrt11.o \
-   cqrt12.o cqrt13.o cqrt14.o cqrt15.o cqrt16.o \
-   cqrt17.o crqt01.o crqt02.o crqt03.o crzt01.o crzt02.o \
-   csbmv.o  cspt01.o \
-   cspt02.o cspt03.o csyt01.o csyt01_rook.o csyt01_3.o csyt01_aa.o csyt02.o csyt03.o \
-   ctbt02.o ctbt03.o ctbt05.o ctbt06.o ctpt01.o \
-   ctpt02.o ctpt03.o ctpt05.o ctpt06.o ctrt01.o \
-   ctrt02.o ctrt03.o ctrt05.o ctrt06.o \
-   sget06.o cgennd.o \
-   cqrt04.o cqrt05.o cchkqrt.o cerrqrt.o cchkqrtp.o cerrqrtp.o \
-   cchklqt.o cchklqtp.o cchktsqr.o \
-   cerrlqt.o cerrlqtp.o cerrtsqr.o ctsqr01.o clqt04.o clqt05.o \
-   cchkunhr_col.o cerrunhr_col.o cunhr_col01.o cunhr_col02.o
+   cdrvls.o \
+   cdrvpb.o \
+   cdrvpp.o \
+   cdrvpt.o \
+   cdrvsp.o \
+   cdrvsy_rook.o \
+   cdrvsy_rk.o \
+   cdrvsy_aa.o \
+   cdrvsy_aa_2stage.o \
+   cerrgt.o \
+   cerrlq.o \
+   cerrls.o \
+   cerrps.o \
+   cerrql.o \
+   cerrqp.o \
+   cerrqr.o \
+   cerrrq.o \
+   cerrtr.o \
+   cerrtz.o \
+   cgbt01.o \
+   cgbt02.o \
+   cgbt05.o \
+   cgeqls.o \
+   cgerqs.o \
+   cget01.o \
+   cget02.o \
+   cget03.o \
+   cget04.o \
+   cget07.o \
+   cgtt01.o \
+   cgtt02.o \
+   cgtt05.o \
+   chet01.o \
+   chet01_rook.o \
+   chet01_3.o \
+   chet01_aa.o \
+   chpt01.o \
+   claipd.o \
+   claptm.o \
+   clarhs.o \
+   clatb4.o \
+   clatb5.o \
+   clatsp.o \
+   clatsy.o \
+   clattb.o \
+   clattp.o \
+   clattr.o \
+   clavhe.o \
+   clavhe_rook.o \
+   clavhp.o \
+   clavsp.o \
+   clavsy.o \
+   clavsy_rook.o \
+   clqt01.o \
+   clqt02.o \
+   clqt03.o \
+   cpbt01.o \
+   cpbt02.o \
+   cpbt05.o \
+   cpot01.o \
+   cpot02.o \
+   cpot03.o \
+   cpot05.o \
+   cpst01.o \
+   cppt01.o \
+   cppt02.o \
+   cppt03.o \
+   cppt05.o \
+   cptt01.o \
+   cptt02.o \
+   cptt05.o \
+   cqlt01.o \
+   cqlt02.o \
+   cqlt03.o \
+   cqpt01.o \
+   cqrt01.o \
+   cqrt01p.o \
+   cqrt02.o \
+   cqrt03.o \
+   cqrt11.o \
+   cqrt12.o \
+   cqrt13.o \
+   cqrt14.o \
+   cqrt15.o \
+   cqrt16.o \
+   cqrt17.o \
+   crqt01.o \
+   crqt02.o \
+   crqt03.o \
+   crzt01.o \
+   crzt02.o \
+   csbmv.o \
+   cspt01.o \
+   cspt02.o \
+   cspt03.o \
+   csyt01.o \
+   csyt01_rook.o \
+   csyt01_3.o \
+   csyt01_aa.o \
+   csyt02.o \
+   csyt03.o \
+   ctbt02.o \
+   ctbt03.o \
+   ctbt05.o \
+   ctbt06.o \
+   ctpt01.o \
+   ctpt02.o \
+   ctpt03.o \
+   ctpt05.o \
+   ctpt06.o \
+   ctrt01.o \
+   ctrt02.o \
+   ctrt03.o \
+   ctrt05.o \
+   ctrt06.o \
+   sget06.o \
+   cgennd.o \
+   cqrt04.o \
+   cqrt05.o \
+   cchkqrt.o \
+   cerrqrt.o \
+   cchkqrtp.o \
+   cerrqrtp.o \
+   cchklqt.o \
+   cchklqtp.o \
+   cchktsqr.o \
+   cerrlqt.o \
+   cerrlqtp.o \
+   cerrtsqr.o \
+   ctsqr01.o \
+   clqt04.o \
+   clqt05.o \
+   cchkunhr_col.o \
+   cerrunhr_col.o \
+   cunhr_col01.o \
+   cunhr_col02.o
 
 ifdef USEXBLAS
-CLINTST += cdrvgbx.o cdrvgex.o cdrvhex.o cdrvsyx.o cdrvpox.o \
-           cerrvxx.o cerrgex.o cerrhex.o cerrsyx.o cerrpox.o \
-           cebchvxx.o
+CLINTST += \
+   cdrvgbx.o \
+   cdrvgex.o \
+   cdrvhex.o \
+   cdrvsyx.o \
+   cdrvpox.o \
+   cerrvxx.o \
+   cerrgex.o \
+   cerrhex.o \
+   cerrsyx.o \
+   cerrpox.o \
+   cebchvxx.o
 else
-CLINTST += cdrvgb.o cdrvge.o cdrvhe.o cdrvsy.o cdrvpo.o \
-           cerrvx.o cerrge.o cerrhe.o cerrsy.o cerrpo.o
+CLINTST += \
+   cdrvgb.o \
+   cdrvge.o \
+   cdrvhe.o \
+   cdrvsy.o \
+   cdrvpo.o \
+   cerrvx.o \
+   cerrge.o \
+   cerrhe.o \
+   cerrsy.o \
+   cerrpo.o
 endif
 
-DLINTST = dchkaa.o \
-   dchkeq.o dchkgb.o dchkge.o dchkgt.o \
-   dchklq.o dchkpb.o dchkpo.o dchkps.o dchkpp.o \
-   dchkpt.o dchkq3.o dchkqp3rk.o dchkql.o dchkqr.o dchkrq.o \
-   dchksp.o dchksy.o dchksy_rook.o dchksy_rk.o  \
-   dchksy_aa.o dchksy_aa_2stage.o dchktb.o dchktp.o dchktr.o \
+DLINTST = \
+   dchkaa.o \
+   dchkeq.o \
+   dchkgb.o \
+   dchkge.o \
+   dchkgt.o \
+   dchklq.o \
+   dchkpb.o \
+   dchkpo.o \
+   dchkps.o \
+   dchkpp.o \
+   dchkpt.o \
+   dchkq3.o \
+   dchkqp3rk.o \
+   dchkql.o \
+   dchkqr.o \
+   dchkrq.o \
+   dchksp.o \
+   dchksy.o \
+   dchksy_rook.o \
+   dchksy_rk.o \
+   dchksy_aa.o \
+   dchksy_aa_2stage.o \
+   dchktb.o \
+   dchktp.o \
+   dchktr.o \
    dchktz.o \
-   ddrvgt.o ddrvls.o ddrvpb.o \
-   ddrvpp.o ddrvpt.o ddrvsp.o ddrvsy_rook.o ddrvsy_rk.o \
-   ddrvsy_aa.o ddrvsy_aa_2stage.o \
-   derrgt.o derrlq.o derrls.o \
-   derrps.o derrql.o derrqp.o derrqr.o \
-   derrrq.o derrtr.o derrtz.o \
-   dgbt01.o dgbt02.o dgbt05.o dgeqls.o \
-   dgerqs.o dget01.o dget02.o \
-   dget03.o dget04.o dget06.o dget07.o dgtt01.o dgtt02.o \
-   dgtt05.o dlaptm.o dlarhs.o dlatb4.o dlatb5.o dlattb.o dlattp.o \
-   dlattr.o dlavsp.o dlavsy.o dlavsy_rook.o dlqt01.o dlqt02.o \
-   dlqt03.o dpbt01.o dpbt02.o dpbt05.o dpot01.o \
-   dpot02.o dpot03.o dpot05.o dpst01.o dppt01.o \
-   dppt02.o dppt03.o dppt05.o dptt01.o dptt02.o \
-   dptt05.o dqlt01.o dqlt02.o dqlt03.o dqpt01.o \
-   dqrt01.o dqrt01p.o dqrt02.o dqrt03.o dqrt11.o dqrt12.o \
-   dqrt13.o dqrt14.o dqrt15.o dqrt16.o dqrt17.o \
-   drqt01.o drqt02.o drqt03.o drzt01.o drzt02.o \
-   dspt01.o dsyt01.o dsyt01_rook.o dsyt01_3.o dsyt01_aa.o \
-   dtbt02.o dtbt03.o dtbt05.o dtbt06.o dtpt01.o \
-   dtpt02.o dtpt03.o dtpt05.o dtpt06.o dtrt01.o \
-   dtrt02.o dtrt03.o dtrt05.o dtrt06.o \
+   ddrvgt.o \
+   ddrvls.o \
+   ddrvpb.o \
+   ddrvpp.o \
+   ddrvpt.o \
+   ddrvsp.o \
+   ddrvsy_rook.o \
+   ddrvsy_rk.o \
+   ddrvsy_aa.o \
+   ddrvsy_aa_2stage.o \
+   derrgt.o \
+   derrlq.o \
+   derrls.o \
+   derrps.o \
+   derrql.o \
+   derrqp.o \
+   derrqr.o \
+   derrrq.o \
+   derrtr.o \
+   derrtz.o \
+   dgbt01.o \
+   dgbt02.o \
+   dgbt05.o \
+   dgeqls.o \
+   dgerqs.o \
+   dget01.o \
+   dget02.o \
+   dget03.o \
+   dget04.o \
+   dget06.o \
+   dget07.o \
+   dgtt01.o \
+   dgtt02.o \
+   dgtt05.o \
+   dlaptm.o \
+   dlarhs.o \
+   dlatb4.o \
+   dlatb5.o \
+   dlattb.o \
+   dlattp.o \
+   dlattr.o \
+   dlavsp.o \
+   dlavsy.o \
+   dlavsy_rook.o \
+   dlqt01.o \
+   dlqt02.o \
+   dlqt03.o \
+   dpbt01.o \
+   dpbt02.o \
+   dpbt05.o \
+   dpot01.o \
+   dpot02.o \
+   dpot03.o \
+   dpot05.o \
+   dpst01.o \
+   dppt01.o \
+   dppt02.o \
+   dppt03.o \
+   dppt05.o \
+   dptt01.o \
+   dptt02.o \
+   dptt05.o \
+   dqlt01.o \
+   dqlt02.o \
+   dqlt03.o \
+   dqpt01.o \
+   dqrt01.o \
+   dqrt01p.o \
+   dqrt02.o \
+   dqrt03.o \
+   dqrt11.o \
+   dqrt12.o \
+   dqrt13.o \
+   dqrt14.o \
+   dqrt15.o \
+   dqrt16.o \
+   dqrt17.o \
+   drqt01.o \
+   drqt02.o \
+   drqt03.o \
+   drzt01.o \
+   drzt02.o \
+   dspt01.o \
+   dsyt01.o \
+   dsyt01_rook.o \
+   dsyt01_3.o \
+   dsyt01_aa.o \
+   dtbt02.o \
+   dtbt03.o \
+   dtbt05.o \
+   dtbt06.o \
+   dtpt01.o \
+   dtpt02.o \
+   dtpt03.o \
+   dtpt05.o \
+   dtpt06.o \
+   dtrt01.o \
+   dtrt02.o \
+   dtrt03.o \
+   dtrt05.o \
+   dtrt06.o \
    dgennd.o \
-   dqrt04.o dqrt05.o dchkqrt.o derrqrt.o dchkqrtp.o derrqrtp.o \
-   dchklq.o dchklqt.o dchklqtp.o dchktsqr.o \
-   derrlqt.o derrlqtp.o derrtsqr.o dtsqr01.o dlqt04.o dlqt05.o \
-   dchkorhr_col.o derrorhr_col.o dorhr_col01.o dorhr_col02.o
+   dqrt04.o \
+   dqrt05.o \
+   dchkqrt.o \
+   derrqrt.o \
+   dchkqrtp.o \
+   derrqrtp.o \
+   dchklq.o \
+   dchklqt.o \
+   dchklqtp.o \
+   dchktsqr.o \
+   derrlqt.o \
+   derrlqtp.o \
+   derrtsqr.o \
+   dtsqr01.o \
+   dlqt04.o \
+   dlqt05.o \
+   dchkorhr_col.o \
+   derrorhr_col.o \
+   dorhr_col01.o \
+   dorhr_col02.o
 
 ifdef USEXBLAS
-DLINTST += ddrvgbx.o ddrvgex.o ddrvsyx.o ddrvpox.o \
-           derrvxx.o derrgex.o derrsyx.o derrpox.o \
-           debchvxx.o
+DLINTST += \
+   ddrvgbx.o \
+   ddrvgex.o \
+   ddrvsyx.o \
+   ddrvpox.o \
+   derrvxx.o \
+   derrgex.o \
+   derrsyx.o \
+   derrpox.o \
+   debchvxx.o
 else
-DLINTST += ddrvgb.o ddrvge.o ddrvsy.o ddrvpo.o \
-           derrvx.o derrge.o derrsy.o derrpo.o
+DLINTST += \
+   ddrvgb.o \
+   ddrvge.o \
+   ddrvsy.o \
+   ddrvpo.o \
+   derrvx.o \
+   derrge.o \
+   derrsy.o \
+   derrpo.o
 endif
 
-ZLINTST = zchkaa.o \
-   zchkeq.o zchkgb.o zchkge.o zchkgt.o \
-   zchkhe.o zchkhe_rook.o zchkhe_rk.o zchkhe_aa.o zchkhe_aa_2stage.o \
-   zchkhp.o zchklq.o zchkpb.o \
-   zchkpo.o zchkps.o zchkpp.o zchkpt.o zchkq3.o zchkqp3rk.o zchkql.o \
-   zchkqr.o zchkrq.o zchksp.o zchksy.o zchksy_rook.o zchksy_rk.o \
-   zchksy_aa.o zchksy_aa_2stage.o zchktb.o \
-   zchktp.o zchktr.o zchktz.o \
-   zdrvgt.o zdrvhe_rook.o zdrvhe_rk.o zdrvhe_aa.o zdrvhe_aa_2stage.o zdrvhp.o \
-   zdrvls.o zdrvpb.o zdrvpp.o zdrvpt.o \
-   zdrvsp.o zdrvsy_rook.o zdrvsy_rk.o zdrvsy_aa.o zdrvsy_aa_2stage.o \
-   zerrgt.o zerrlq.o \
-   zerrls.o zerrps.o zerrql.o zerrqp.o \
-   zerrqr.o zerrrq.o zerrtr.o zerrtz.o \
-   zgbt01.o zgbt02.o zgbt05.o zgeqls.o \
-   zgerqs.o zget01.o zget02.o \
-   zget03.o zget04.o zget07.o zgtt01.o zgtt02.o \
-   zgtt05.o zhet01.o zhet01_rook.o zhet01_3.o zhet01_aa.o \
-   zhpt01.o zlaipd.o zlaptm.o zlarhs.o zlatb4.o zlatb5.o \
-   zlatsp.o zlatsy.o zlattb.o zlattp.o zlattr.o \
-   zlavhe.o zlavhe_rook.o zlavhp.o zlavsp.o zlavsy.o zlavsy_rook.o zlqt01.o \
-   zlqt02.o zlqt03.o zpbt01.o zpbt02.o zpbt05.o \
-   zpot01.o zpot02.o zpot03.o zpot05.o zpst01.o \
-   zppt01.o zppt02.o zppt03.o zppt05.o zptt01.o \
-   zptt02.o zptt05.o zqlt01.o zqlt02.o zqlt03.o \
-   zqpt01.o zqrt01.o zqrt01p.o zqrt02.o zqrt03.o zqrt11.o \
-   zqrt12.o zqrt13.o zqrt14.o zqrt15.o zqrt16.o \
-   zqrt17.o zrqt01.o zrqt02.o zrqt03.o zrzt01.o zrzt02.o \
-   zsbmv.o  zspt01.o \
-   zspt02.o zspt03.o zsyt01.o zsyt01_rook.o zsyt01_3.o zsyt01_aa.o zsyt02.o zsyt03.o \
-   ztbt02.o ztbt03.o ztbt05.o ztbt06.o ztpt01.o \
-   ztpt02.o ztpt03.o ztpt05.o ztpt06.o ztrt01.o \
-   ztrt02.o ztrt03.o ztrt05.o ztrt06.o \
-   dget06.o zgennd.o \
-   zqrt04.o zqrt05.o zchkqrt.o zerrqrt.o zchkqrtp.o zerrqrtp.o \
-   zchklqt.o zchklqtp.o zchktsqr.o \
-   zerrlqt.o zerrlqtp.o zerrtsqr.o ztsqr01.o zlqt04.o zlqt05.o \
-   zchkunhr_col.o zerrunhr_col.o zunhr_col01.o zunhr_col02.o
+ZLINTST = \
+   zchkaa.o \
+   zchkeq.o \
+   zchkgb.o \
+   zchkge.o \
+   zchkgt.o \
+   zchkhe.o \
+   zchkhe_rook.o \
+   zchkhe_rk.o \
+   zchkhe_aa.o \
+   zchkhe_aa_2stage.o \
+   zchkhp.o \
+   zchklq.o \
+   zchkpb.o \
+   zchkpo.o \
+   zchkps.o \
+   zchkpp.o \
+   zchkpt.o \
+   zchkq3.o \
+   zchkqp3rk.o \
+   zchkql.o \
+   zchkqr.o \
+   zchkrq.o \
+   zchksp.o \
+   zchksy.o \
+   zchksy_rook.o \
+   zchksy_rk.o \
+   zchksy_aa.o \
+   zchksy_aa_2stage.o \
+   zchktb.o \
+   zchktp.o \
+   zchktr.o \
+   zchktz.o \
+   zdrvgt.o \
+   zdrvhe_rook.o \
+   zdrvhe_rk.o \
+   zdrvhe_aa.o \
+   zdrvhe_aa_2stage.o \
+   zdrvhp.o \
+   zdrvls.o \
+   zdrvpb.o \
+   zdrvpp.o \
+   zdrvpt.o \
+   zdrvsp.o \
+   zdrvsy_rook.o \
+   zdrvsy_rk.o \
+   zdrvsy_aa.o \
+   zdrvsy_aa_2stage.o \
+   zerrgt.o \
+   zerrlq.o \
+   zerrls.o \
+   zerrps.o \
+   zerrql.o \
+   zerrqp.o \
+   zerrqr.o \
+   zerrrq.o \
+   zerrtr.o \
+   zerrtz.o \
+   zgbt01.o \
+   zgbt02.o \
+   zgbt05.o \
+   zgeqls.o \
+   zgerqs.o \
+   zget01.o \
+   zget02.o \
+   zget03.o \
+   zget04.o \
+   zget07.o \
+   zgtt01.o \
+   zgtt02.o \
+   zgtt05.o \
+   zhet01.o \
+   zhet01_rook.o \
+   zhet01_3.o \
+   zhet01_aa.o \
+   zhpt01.o \
+   zlaipd.o \
+   zlaptm.o \
+   zlarhs.o \
+   zlatb4.o \
+   zlatb5.o \
+   zlatsp.o \
+   zlatsy.o \
+   zlattb.o \
+   zlattp.o \
+   zlattr.o \
+   zlavhe.o \
+   zlavhe_rook.o \
+   zlavhp.o \
+   zlavsp.o \
+   zlavsy.o \
+   zlavsy_rook.o \
+   zlqt01.o \
+   zlqt02.o \
+   zlqt03.o \
+   zpbt01.o \
+   zpbt02.o \
+   zpbt05.o \
+   zpot01.o \
+   zpot02.o \
+   zpot03.o \
+   zpot05.o \
+   zpst01.o \
+   zppt01.o \
+   zppt02.o \
+   zppt03.o \
+   zppt05.o \
+   zptt01.o \
+   zptt02.o \
+   zptt05.o \
+   zqlt01.o \
+   zqlt02.o \
+   zqlt03.o \
+   zqpt01.o \
+   zqrt01.o \
+   zqrt01p.o \
+   zqrt02.o \
+   zqrt03.o \
+   zqrt11.o \
+   zqrt12.o \
+   zqrt13.o \
+   zqrt14.o \
+   zqrt15.o \
+   zqrt16.o \
+   zqrt17.o \
+   zrqt01.o \
+   zrqt02.o \
+   zrqt03.o \
+   zrzt01.o \
+   zrzt02.o \
+   zsbmv.o \
+   zspt01.o \
+   zspt02.o \
+   zspt03.o \
+   zsyt01.o \
+   zsyt01_rook.o \
+   zsyt01_3.o \
+   zsyt01_aa.o \
+   zsyt02.o \
+   zsyt03.o \
+   ztbt02.o \
+   ztbt03.o \
+   ztbt05.o \
+   ztbt06.o \
+   ztpt01.o \
+   ztpt02.o \
+   ztpt03.o \
+   ztpt05.o \
+   ztpt06.o \
+   ztrt01.o \
+   ztrt02.o \
+   ztrt03.o \
+   ztrt05.o \
+   ztrt06.o \
+   dget06.o \
+   zgennd.o \
+   zqrt04.o \
+   zqrt05.o \
+   zchkqrt.o \
+   zerrqrt.o \
+   zchkqrtp.o \
+   zerrqrtp.o \
+   zchklqt.o \
+   zchklqtp.o \
+   zchktsqr.o \
+   zerrlqt.o \
+   zerrlqtp.o \
+   zerrtsqr.o \
+   ztsqr01.o \
+   zlqt04.o \
+   zlqt05.o \
+   zchkunhr_col.o \
+   zerrunhr_col.o \
+   zunhr_col01.o \
+   zunhr_col02.o
 
 ifdef USEXBLAS
-ZLINTST += zdrvgbx.o zdrvgex.o zdrvhex.o zdrvsyx.o zdrvpox.o \
-           zerrvxx.o zerrgex.o zerrhex.o zerrsyx.o zerrpox.o \
-           zebchvxx.o
+ZLINTST += \
+   zdrvgbx.o \
+   zdrvgex.o \
+   zdrvhex.o \
+   zdrvsyx.o \
+   zdrvpox.o \
+   zerrvxx.o \
+   zerrgex.o \
+   zerrhex.o \
+   zerrsyx.o \
+   zerrpox.o \
+   zebchvxx.o
 else
-ZLINTST += zdrvgb.o zdrvge.o zdrvhe.o zdrvsy.o zdrvpo.o \
-           zerrvx.o zerrge.o zerrhe.o zerrsy.o zerrpo.o
+ZLINTST += \
+   zdrvgb.o \
+   zdrvge.o \
+   zdrvhe.o \
+   zdrvsy.o \
+   zdrvpo.o \
+   zerrvx.o \
+   zerrge.o \
+   zerrhe.o \
+   zerrsy.o \
+   zerrpo.o
 endif
 
-DSLINTST = dchkab.o \
-	ddrvab.o ddrvac.o derrab.o derrac.o dget08.o \
-	alaerh.o alahd.o  aladhd.o alareq.o \
-	chkxer.o dlarhs.o dlatb4.o xerbla.o \
-	dget02.o dpot06.o
+DSLINTST = \
+   dchkab.o \
+   ddrvab.o \
+   ddrvac.o \
+   derrab.o \
+   derrac.o \
+   dget08.o \
+   alaerh.o \
+   alahd.o \
+   aladhd.o \
+   alareq.o \
+   chkxer.o \
+   dlarhs.o \
+   dlatb4.o \
+   xerbla.o \
+   dget02.o \
+   dpot06.o
 
-ZCLINTST = zchkab.o \
-	zdrvab.o zdrvac.o zerrab.o zerrac.o zget08.o \
-	alaerh.o alahd.o  aladhd.o alareq.o \
-	chkxer.o zget02.o zlarhs.o zlatb4.o \
-	zsbmv.o  xerbla.o zpot06.o zlaipd.o
+ZCLINTST = \
+   zchkab.o \
+   zdrvab.o \
+   zdrvac.o \
+   zerrab.o \
+   zerrac.o \
+   zget08.o \
+   alaerh.o \
+   alahd.o \
+   aladhd.o \
+   alareq.o \
+   chkxer.o \
+   zget02.o \
+   zlarhs.o \
+   zlatb4.o \
+   zsbmv.o \
+   xerbla.o \
+   zpot06.o \
+   zlaipd.o
 
-SLINTSTRFP = schkrfp.o sdrvrfp.o sdrvrf1.o sdrvrf2.o sdrvrf3.o sdrvrf4.o serrrfp.o \
-	slatb4.o slarhs.o sget04.o spot01.o spot03.o spot02.o \
-	chkxer.o xerbla.o alaerh.o aladhd.o alahd.o alasvm.o
+SLINTSTRFP = \
+   schkrfp.o \
+   sdrvrfp.o \
+   sdrvrf1.o \
+   sdrvrf2.o \
+   sdrvrf3.o \
+   sdrvrf4.o \
+   serrrfp.o \
+   slatb4.o \
+   slarhs.o \
+   sget04.o \
+   spot01.o \
+   spot03.o \
+   spot02.o \
+   chkxer.o \
+   xerbla.o \
+   alaerh.o \
+   aladhd.o \
+   alahd.o \
+   alasvm.o
 
-DLINTSTRFP = dchkrfp.o ddrvrfp.o ddrvrf1.o ddrvrf2.o ddrvrf3.o ddrvrf4.o derrrfp.o \
-	dlatb4.o dlarhs.o dget04.o dpot01.o dpot03.o dpot02.o \
-	chkxer.o xerbla.o alaerh.o aladhd.o alahd.o alasvm.o
+DLINTSTRFP = \
+   dchkrfp.o \
+   ddrvrfp.o \
+   ddrvrf1.o \
+   ddrvrf2.o \
+   ddrvrf3.o \
+   ddrvrf4.o \
+   derrrfp.o \
+   dlatb4.o \
+   dlarhs.o \
+   dget04.o \
+   dpot01.o \
+   dpot03.o \
+   dpot02.o \
+   chkxer.o \
+   xerbla.o \
+   alaerh.o \
+   aladhd.o \
+   alahd.o \
+   alasvm.o
 
-CLINTSTRFP = cchkrfp.o cdrvrfp.o cdrvrf1.o cdrvrf2.o cdrvrf3.o cdrvrf4.o cerrrfp.o \
-	claipd.o clatb4.o clarhs.o csbmv.o cget04.o cpot01.o cpot03.o cpot02.o \
-	chkxer.o xerbla.o alaerh.o aladhd.o alahd.o alasvm.o
+CLINTSTRFP = \
+   cchkrfp.o \
+   cdrvrfp.o \
+   cdrvrf1.o \
+   cdrvrf2.o \
+   cdrvrf3.o \
+   cdrvrf4.o \
+   cerrrfp.o \
+   claipd.o \
+   clatb4.o \
+   clarhs.o \
+   csbmv.o \
+   cget04.o \
+   cpot01.o \
+   cpot03.o \
+   cpot02.o \
+   chkxer.o \
+   xerbla.o \
+   alaerh.o \
+   aladhd.o \
+   alahd.o \
+   alasvm.o
 
-ZLINTSTRFP = zchkrfp.o zdrvrfp.o zdrvrf1.o zdrvrf2.o zdrvrf3.o zdrvrf4.o zerrrfp.o \
-	zlatb4.o zlaipd.o zlarhs.o zsbmv.o zget04.o zpot01.o zpot03.o zpot02.o \
-	chkxer.o xerbla.o alaerh.o aladhd.o alahd.o alasvm.o
+ZLINTSTRFP = \
+   zchkrfp.o \
+   zdrvrfp.o \
+   zdrvrf1.o \
+   zdrvrf2.o \
+   zdrvrf3.o \
+   zdrvrf4.o \
+   zerrrfp.o \
+   zlatb4.o \
+   zlaipd.o \
+   zlarhs.o \
+   zsbmv.o \
+   zget04.o \
+   zpot01.o \
+   zpot03.o \
+   zpot02.o \
+   chkxer.o \
+   xerbla.o \
+   alaerh.o \
+   aladhd.o \
+   alahd.o \
+   alasvm.o
 
 .PHONY: all
 all: single double complex complex16 proto-single proto-double proto-complex proto-complex16

--- a/TESTING/MATGEN/CMakeLists.txt
+++ b/TESTING/MATGEN/CMakeLists.txt
@@ -11,25 +11,91 @@
 #
 #######################################################################
 
-set(SCATGEN slatm1.f slatm7.f slaran.f slarnd.f)
+set(SCATGEN
+   slatm1.f
+   slatm7.f
+   slaran.f
+   slarnd.f)
 
-set(SMATGEN slatms.f slatme.f slatmr.f slatmt.f
-   slagge.f slagsy.f slakf2.f slarge.f slaror.f slarot.f slatm2.f
-   slatm3.f slatm5.f slatm6.f slahilb.f)
+set(SMATGEN
+   slatms.f
+   slatme.f
+   slatmr.f
+   slatmt.f
+   slagge.f
+   slagsy.f
+   slakf2.f
+   slarge.f
+   slaror.f
+   slarot.f
+   slatm2.f
+   slatm3.f
+   slatm5.f
+   slatm6.f
+   slahilb.f)
 
-set(CMATGEN clatms.f clatme.f clatmr.f clatmt.f
-   clagge.f claghe.f clagsy.f clakf2.f clarge.f claror.f clarot.f
-   clatm1.f clarnd.f clatm2.f clatm3.f clatm5.f clatm6.f clahilb.f)
+set(CMATGEN
+   clatms.f
+   clatme.f
+   clatmr.f
+   clatmt.f
+   clagge.f
+   claghe.f
+   clagsy.f
+   clakf2.f
+   clarge.f
+   claror.f
+   clarot.f
+   clatm1.f
+   clarnd.f
+   clatm2.f
+   clatm3.f
+   clatm5.f
+   clatm6.f
+   clahilb.f)
 
-set(DZATGEN dlatm1.f dlatm7.f dlaran.f dlarnd.f)
+set(DZATGEN
+   dlatm1.f
+   dlatm7.f
+   dlaran.f
+   dlarnd.f)
 
-set(DMATGEN dlatms.f dlatme.f dlatmr.f dlatmt.f
-   dlagge.f dlagsy.f dlakf2.f dlarge.f dlaror.f dlarot.f dlatm2.f
-   dlatm3.f dlatm5.f dlatm6.f dlahilb.f)
+set(DMATGEN
+   dlatms.f
+   dlatme.f
+   dlatmr.f
+   dlatmt.f
+   dlagge.f
+   dlagsy.f
+   dlakf2.f
+   dlarge.f
+   dlaror.f
+   dlarot.f
+   dlatm2.f
+   dlatm3.f
+   dlatm5.f
+   dlatm6.f
+   dlahilb.f)
 
-set(ZMATGEN zlatms.f zlatme.f zlatmr.f zlatmt.f
-  zlagge.f zlaghe.f zlagsy.f zlakf2.f zlarge.f zlaror.f zlarot.f
-  zlatm1.f zlarnd.f zlatm2.f zlatm3.f zlatm5.f zlatm6.f zlahilb.f)
+set(ZMATGEN
+   zlatms.f
+   zlatme.f
+   zlatmr.f
+   zlatmt.f
+   zlagge.f
+   zlaghe.f
+   zlagsy.f
+   zlakf2.f
+   zlarge.f
+   zlaror.f
+   zlarot.f
+   zlatm1.f
+   zlarnd.f
+   zlatm2.f
+   zlatm3.f
+   zlatm5.f
+   zlatm6.f
+   zlahilb.f)
 
 
 set(SOURCES)

--- a/TESTING/MATGEN/Makefile
+++ b/TESTING/MATGEN/Makefile
@@ -33,25 +33,91 @@
 TOPSRCDIR = ../..
 include $(TOPSRCDIR)/make.inc
 
-SCATGEN = slatm1.o slatm7.o slaran.o slarnd.o
+SCATGEN = \
+   slatm1.o \
+   slatm7.o \
+   slaran.o \
+   slarnd.o
 
-SMATGEN = slatms.o slatme.o slatmr.o slatmt.o \
-   slagge.o slagsy.o slakf2.o slarge.o slaror.o slarot.o slatm2.o \
-   slatm3.o slatm5.o slatm6.o slahilb.o
+SMATGEN = \
+   slatms.o \
+   slatme.o \
+   slatmr.o \
+   slatmt.o \
+   slagge.o \
+   slagsy.o \
+   slakf2.o \
+   slarge.o \
+   slaror.o \
+   slarot.o \
+   slatm2.o \
+   slatm3.o \
+   slatm5.o \
+   slatm6.o \
+   slahilb.o
 
-CMATGEN = clatms.o clatme.o clatmr.o clatmt.o \
-   clagge.o claghe.o clagsy.o clakf2.o clarge.o claror.o clarot.o \
-   clatm1.o clarnd.o clatm2.o clatm3.o clatm5.o clatm6.o clahilb.o
+CMATGEN = \
+   clatms.o \
+   clatme.o \
+   clatmr.o \
+   clatmt.o \
+   clagge.o \
+   claghe.o \
+   clagsy.o \
+   clakf2.o \
+   clarge.o \
+   claror.o \
+   clarot.o \
+   clatm1.o \
+   clarnd.o \
+   clatm2.o \
+   clatm3.o \
+   clatm5.o \
+   clatm6.o \
+   clahilb.o
 
-DZATGEN = dlatm1.o dlatm7.o dlaran.o dlarnd.o
+DZATGEN = \
+   dlatm1.o \
+   dlatm7.o \
+   dlaran.o \
+   dlarnd.o
 
-DMATGEN = dlatms.o dlatme.o dlatmr.o dlatmt.o \
-   dlagge.o dlagsy.o dlakf2.o dlarge.o dlaror.o dlarot.o dlatm2.o \
-   dlatm3.o dlatm5.o dlatm6.o dlahilb.o
+DMATGEN = \
+   dlatms.o \
+   dlatme.o \
+   dlatmr.o \
+   dlatmt.o \
+   dlagge.o \
+   dlagsy.o \
+   dlakf2.o \
+   dlarge.o \
+   dlaror.o \
+   dlarot.o \
+   dlatm2.o \
+   dlatm3.o \
+   dlatm5.o \
+   dlatm6.o \
+   dlahilb.o
 
-ZMATGEN = zlatms.o zlatme.o zlatmr.o zlatmt.o \
-   zlagge.o zlaghe.o zlagsy.o zlakf2.o zlarge.o zlaror.o zlarot.o \
-   zlatm1.o zlarnd.o zlatm2.o zlatm3.o zlatm5.o zlatm6.o zlahilb.o
+ZMATGEN = \
+   zlatms.o \
+   zlatme.o \
+   zlatmr.o \
+   zlatmt.o \
+   zlagge.o \
+   zlaghe.o \
+   zlagsy.o \
+   zlakf2.o \
+   zlarge.o \
+   zlaror.o \
+   zlarot.o \
+   zlatm1.o \
+   zlarnd.o \
+   zlatm2.o \
+   zlatm3.o \
+   zlatm5.o \
+   zlatm6.o \
+   zlahilb.o
 
 .PHONY: all
 all: $(TMGLIB)


### PR DESCRIPTION
The list of source files listed in the Makefile vs. CMakeLists.txt has gotten out-of-sync.  Doing a selective build using the Makefiles will give different results than CMake.  (Just to be clear, building all precisions should be OK.)  This set of changes fixes most of the differences.

Comparing the two was challenging due to how the lists of source files are formatted/organized, and I wanted to make this process easier in case we need to check it again later.  The first commit changes the formatting to one source file per line; there shouldn't be any change to the order of files (see the last commit for that).  I'm doing a side-by-side diff after stripping off the .f/.o file suffixes to compare the two.

All of the differences I found (other than differences in the order of files) were introduced in #637.  That PR didn't update the Makefile to match CMake, so I've done it here with a few fix-ups.  That change was to fix missing dependencies when building only one precision, basically rearranging some needed files to different source groups so they'll get built.

(That PR also adds some differences to the BLAS build scripts which I'm not going to touch in this PR.  From what I can tell, LAPACK built for one precision might need BLAS routines from another precision, so it's now building at least the needed files from BLAS.  So now if you want to build only BLAS and only specific precisions of it, you might get more than you asked for.  I think the proper fix is that BLAS may need to be built for all precisions even if LAPACK is built with only one.)