### PR TITLE
CMake build: Add -DLAPACK option, un-break CBLAS+BLAS build, do not require C++ if unnecessary

### DIFF
--- a/BLAS/CMakeLists.txt
+++ b/BLAS/CMakeLists.txt
@@ -14,3 +14,8 @@ install(FILES
   DESTINATION ${PKG_CONFIG_DIR}
   COMPONENT Development
   )
+
+install(EXPORT ${BLASLIB}-targets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${BLASLIB}-${LAPACK_VERSION}
+  COMPONENT Development
+  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 
-project(LAPACK)
+project(LAPACK Fortran C)
 
 set(LAPACK_MAJOR_VERSION 3)
 set(LAPACK_MINOR_VERSION 12)
@@ -424,6 +424,7 @@ function(_display_cpp_implementation_msg name)
   message(STATUS "----------------")
 endfunction()
 if (BLAS++)
+  enable_language(CXX)
   _display_cpp_implementation_msg("BLAS")
   include(ExternalProject)
   ExternalProject_Add(blaspp
@@ -435,6 +436,7 @@ if (BLAS++)
   ExternalProject_Add_StepDependencies(blaspp build ${BLAS_LIBRARIES})
 endif()
 if (LAPACK++)
+  enable_language(CXX)
 	message (STATUS "linking lapack++ against ${LAPACK_LIBRARIES}")
   _display_cpp_implementation_msg("LAPACK")
   include(ExternalProject)
@@ -583,6 +585,7 @@ if (LAPACK++)
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     FILES_MATCHING REGEX "\\.(h|hh)$"
   )
+  include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     "lapackppConfigVersion.cmake"
     VERSION 2020.10.02
@@ -596,6 +599,7 @@ if (LAPACK++)
 
 endif()
 if (BLAS++)
+  include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     "blasppConfigVersion.cmake"
     VERSION 2020.10.02

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,10 @@ endif()
 
 option(USE_OPTIMIZED_LAPACK "Whether or not to use an optimized LAPACK library instead of included netlib LAPACK" OFF)
 
+option(LAPACK "Whether to build or use LAPACK (to enable a BLAS-only build)")
+
+if(LAPACK)
+
 # --------------------------------------------------
 # LAPACK
 # User did not provide a LAPACK Library but specified to search for one
@@ -347,6 +351,8 @@ else()
   set(CMAKE_SHARED_LINKER_FLAGS
     "${CMAKE_SHARED_LINKER_FLAGS} ${LAPACK_LINKER_FLAGS}"
     CACHE STRING "Linker flags for shared libs" FORCE)
+endif()
+
 endif()
 
 if(BUILD_TESTING)
@@ -483,10 +489,14 @@ if(NOT BLAS_FOUND)
   set(ALL_TARGETS ${ALL_TARGETS} ${BLASLIB})
 endif()
 
+if(LAPACK)
 if(NOT LATESTLAPACK_FOUND)
   set(ALL_TARGETS ${ALL_TARGETS} ${LAPACKLIB})
+  set(BUILD_LAPACK ON)
+endif()
 endif()
 
+if(LAPACK)
 # Export lapack targets, not including lapacke, from the
 # install tree, if any.
 set(_lapack_config_install_guard_target "")
@@ -499,6 +509,7 @@ if(ALL_TARGETS)
   # Choose one of the lapack targets to use as a guard for
   # lapack-config.cmake to load targets from the install tree.
   list(GET ALL_TARGETS 0 _lapack_config_install_guard_target)
+endif()
 endif()
 
 # Include cblas in targets exported from the build tree.
@@ -514,6 +525,8 @@ endif()
 if(NOT LAPACK_WITH_TMGLIB_FOUND AND LAPACKE_WITH_TMG)
   set(ALL_TARGETS ${ALL_TARGETS} ${TMGLIB})
 endif()
+
+if(BUILD_LAPACK)
 
 # Export lapack and lapacke targets from the build tree, if any.
 set(_lapack_config_build_guard_target "")
@@ -552,6 +565,9 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LAPACKLIB}-${LAPACK_VERSION}
   COMPONENT Development
   )
+
+endif() # BUILD_LAPACK
+
 if (LAPACK++)
   install(
   DIRECTORY "${LAPACK_BINARY_DIR}/lib/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,8 +245,12 @@ endif()
 # Neither user specified or optimized BLAS libraries can be used
 if(NOT BLAS_FOUND)
   message(STATUS "Using supplied NETLIB BLAS implementation")
+  set(LAPACK_INSTALL_EXPORT_NAME_CACHE ${LAPACK_INSTALL_EXPORT_NAME})
+  set(LAPACK_INSTALL_EXPORT_NAME ${BLASLIB}-targets)
   add_subdirectory(BLAS)
   set(BLAS_LIBRARIES ${BLASLIB})
+  set(LAPACK_INSTALL_EXPORT_NAME ${LAPACK_INSTALL_EXPORT_NAME_CACHE})
+  unset(LAPACK_INSTALL_EXPORT_NAME_CACHE)
 else()
   set(CMAKE_EXE_LINKER_FLAGS
     "${CMAKE_EXE_LINKER_FLAGS} ${BLAS_LINKER_FLAGS}"


### PR DESCRIPTION
This fixes some build issues I face when packaging for pkgsrc using the CMake build.

- Adds option to build without LAPACK, so that any of BLAS, LAPACK, CBLAS, LAPACKE can be built as individual library from source.
- Fixes CBLAS build missing blas-targets for CMake by adding that. Note that I do not use those cmake files and scrub them from the install. Would like an option to avoid that machinery, as we use pkg-config also for CMake to locate BLAS deps (BLA_PREFER_PKGCONFIG in FindBLAS).
- Avoids requiring a C++ compiler when not needed.
- Also fixes macro usage for BLAS++ / LAPACK++.

I hope that can be merged in one go. Though, I have to admit that I am no CMake expert and someone might find further errors. But this works for me at least.