### PR TITLE
Two small fixes of bdsqr

### DIFF
--- a/SRC/cbdsqr.f
+++ b/SRC/cbdsqr.f
@@ -166,7 +166,7 @@
 *>
 *> \param[out] RWORK
 *> \verbatim
-*>          RWORK is REAL array, dimension (4*N)
+*>          RWORK is REAL array, dimension (4*(N-1))
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/cbdsqr.f
+++ b/SRC/cbdsqr.f
@@ -809,6 +809,12 @@
 *
   160 CONTINUE
       DO 170 I = 1, N
+         IF( D( I ).EQ.ZERO ) THEN
+*
+*           Avoid -ZERO
+*
+            D( I ) = ZERO
+         END IF
          IF( D( I ).LT.ZERO ) THEN
             D( I ) = -D( I )
 *

--- a/SRC/dbdsqr.f
+++ b/SRC/dbdsqr.f
@@ -817,6 +817,12 @@
 *
   160 CONTINUE
       DO 170 I = 1, N
+         IF( D( I ).EQ.ZERO ) THEN
+*
+*           Avoid -ZERO
+*
+            D( I ) = ZERO
+         END IF
          IF( D( I ).LT.ZERO ) THEN
             D( I ) = -D( I )
 *

--- a/SRC/sbdsqr.f
+++ b/SRC/sbdsqr.f
@@ -166,7 +166,7 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension (4*N)
+*>          WORK is REAL array, dimension (4*(N-1))
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/sbdsqr.f
+++ b/SRC/sbdsqr.f
@@ -817,7 +817,14 @@
 *
   160 CONTINUE
       DO 170 I = 1, N
+         IF( D( I ).EQ.ZERO ) THEN
+*
+*           Avoid -ZERO
+*
+            D( I ) = ZERO
+         END IF
          IF( D( I ).LT.ZERO ) THEN
+
             D( I ) = -D( I )
 *
 *           Change sign of singular vectors, if desired

--- a/SRC/zbdsqr.f
+++ b/SRC/zbdsqr.f
@@ -807,6 +807,12 @@
 *
   160 CONTINUE
       DO 170 I = 1, N
+         IF( D( I ).EQ.ZERO ) THEN
+*
+*           Avoid -ZERO
+*
+            D( I ) = ZERO
+         END IF
          IF( D( I ).LT.ZERO ) THEN
             D( I ) = -D( I )
 *

--- a/SRC/zbdsqr.f
+++ b/SRC/zbdsqr.f
@@ -166,7 +166,7 @@
 *>
 *> \param[out] RWORK
 *> \verbatim
-*>          RWORK is DOUBLE PRECISION array, dimension (4*N)
+*>          RWORK is DOUBLE PRECISION array, dimension (4*(N-1))
 *> \endverbatim
 *>
 *> \param[out] INFO


### PR DESCRIPTION
Two small fixes of bdsqr:

1) In https://github.com/Reference-LAPACK/lapack/pull/234 only the documentation of `dbdsqr` was updated. This  updates the documentation of the remaining precisions.

2) `bdsqr` can return `-ZERO` as a singular value. For example, `[d,z]bdsqr` on

```
D = [ -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
E = [ 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
```
returns `D(10) = -ZERO`. This adds a branch enforcing that all singular values follow the definition and are non-negative, i.e., `-ZERO` is converted into `+ZERO`. Note that this is already enforced in `lasq1` (used for the singular-values-only path).

