### PR TITLE
Introduce cpp (and also adds lasr3, which applies a sequence of rotations efficiently)

### DIFF
--- a/LAPACK_CPP/Makefile
+++ b/LAPACK_CPP/Makefile
@@ -14,11 +14,19 @@ HEADERS = $(wildcard lapack_c/include/*.h) \
 		  $(wildcard lapack_cpp/include/*/*.hpp) \
 		  $(wildcard lapack_cpp/include/*/*/*.hpp)
 
-OBJFILES = src/lapack_c/rot_c.o \
+OBJFILES = src/lapack_cpp/rot_cpp.o \
+		   src/lapack_cpp/lartg_cpp.o \
+		   src/lapack_c/rot_c.o \
 		   src/lapack_c/lartg_c.o \
 		   src/lapack_c/lasr3_c.o \
-		   src/lapack_cpp/rot_cpp.o \
-		   src/lapack_cpp/lartg_cpp.o \
+		   src/lapack_fortran/slasr3.o \
+		   src/lapack_fortran/dlasr3.o \
+		   src/lapack_fortran/clasr3.o \
+		   src/lapack_fortran/zlasr3.o \
+
+# Fortran files
+src/lapack_fortran/%.o: src/lapack_fortran/%.f90
+	$(FC) $(FFLAGS) -cpp -c -o $@ $<
 
 # C files
 

--- a/LAPACK_CPP/Makefile
+++ b/LAPACK_CPP/Makefile
@@ -1,0 +1,43 @@
+CXX=g++
+# CXXFLAGS=-std=c++17 -Wall -Wextra -pedantic -g -Og
+CXXFLAGS=-std=c++17 -O3 -march=native -ffast-math -g -DNDEBUG
+
+FC=gfortran
+FFLAGS=-Wall -Wextra -pedantic -g
+
+all: ./example/test_lasr3 ./example/profile_lasr3
+
+HEADERS = $(wildcard lapack_c/include/*.h) \
+		  $(wildcard lapack_c/include/*/*.h) \
+		  $(wildcard lapack_c/include/*/*/*.h) \
+		  $(wildcard lapack_cpp/include/*.hpp) \
+		  $(wildcard lapack_cpp/include/*/*.hpp) \
+		  $(wildcard lapack_cpp/include/*/*/*.hpp)
+
+OBJFILES = src/lapack_c/rot_c.o \
+		   src/lapack_c/lartg_c.o \
+		   src/lapack_c/lasr3_c.o \
+		   src/lapack_cpp/rot_cpp.o \
+		   src/lapack_cpp/lartg_cpp.o \
+
+# C files
+
+src/lapack_c/%.o: src/lapack_c/%.cpp
+	$(CXX) $(CXXFLAGS) -I./include -c -o $@ $<
+
+src/lapack_c/%.o: src/lapack_c/%.f90
+	$(FC) $(FFLAGS) -c -o $@ $<
+
+# C++ files
+src/lapack_cpp/%.o: src/lapack_cpp/%.cpp $(HEADERS)
+	$(CXX) $(CXXFLAGS) -I./include -c -o $@ $<
+
+# Test files
+example/test_lasr3: example/test_lasr3.cpp $(OBJFILES) $(HEADERS)
+	$(CXX) $(CXXFLAGS) -o $@ $< $(OBJFILES) -I./include -lstdc++ -lgfortran -lblas -llapack
+
+example/profile_lasr3: example/profile_lasr3.cpp $(OBJFILES) $(HEADERS)
+	$(CXX) $(CXXFLAGS) -o $@ $< $(OBJFILES) -I./include -lstdc++ -lgfortran -lblas -llapack
+
+clean:
+	find . -type f -name '*.o' -delete

--- a/LAPACK_CPP/example/.gitignore
+++ b/LAPACK_CPP/example/.gitignore
@@ -1,0 +1,2 @@
+test_lasr3
+profile_lasr3

--- a/LAPACK_CPP/example/profile_lasr3.cpp
+++ b/LAPACK_CPP/example/profile_lasr3.cpp
@@ -1,0 +1,99 @@
+
+#include <chrono>  // for high_resolution_clock
+#include <complex>
+#include <iostream>
+
+#include "lapack_cpp.hpp"
+
+using namespace lapack_cpp;
+
+template <typename T,
+          Layout layout = Layout::ColMajor,
+          typename idx_t = lapack_idx_t>
+void profile_lasr3(idx_t m, idx_t n, idx_t k, Side side, Direction direction)
+{
+    idx_t n_rot = side == Side::Left ? m - 1 : n - 1;
+
+    MemoryBlock<T, idx_t> A_(m, n, layout);
+    Matrix<T, layout, idx_t> A(m, n, A_);
+
+    MemoryBlock<real_t<T>, idx_t> C_(n_rot, k, layout);
+    Matrix<real_t<T>, layout, idx_t> C(n_rot, k, C_);
+
+    MemoryBlock<T, idx_t> S_(n_rot, k, layout);
+    Matrix<T, layout, idx_t> S(n_rot, k, S_);
+
+    randomize(A);
+
+    // Generate random, but valid rotations
+    randomize(C);
+    randomize(S);
+    for (idx_t i = 0; i < n_rot; ++i) {
+        for (idx_t j = 0; j < k; ++j) {
+            T f = C(i, j);
+            T g = S(i, j);
+            T r;
+            lartg(f, g, C(i, j), S(i, j), r);
+        }
+    }
+
+    MemoryBlock<T, idx_t> A_copy_(m, n, layout);
+    Matrix<T, layout, idx_t> A_copy(m, n, A_copy_);
+
+    A_copy = A;
+
+    MemoryBlock<T, idx_t> work(
+        lasr3_workquery(side, direction, C.as_const(), S.as_const(), A));
+
+    const idx_t n_timings = 100;
+    const idx_t n_warmup = 20;
+    std::vector<float> timings(n_timings);
+
+    for (idx_t i = 0; i < n_timings; ++i) {
+        A = A_copy;
+        auto start = std::chrono::high_resolution_clock::now();
+        lasr3(side, direction, C.as_const(), S.as_const(), A, work);
+        auto end = std::chrono::high_resolution_clock::now();
+        timings[i] = std::chrono::duration<float>(end - start).count();
+    }
+
+    float mean = 0;
+    for (idx_t i = n_warmup; i < n_timings; ++i)
+        mean += timings[i];
+    mean /= n_timings - n_warmup;
+
+    long nflops =
+        side == Side::Left ? 6. * (m - 1) * n * k : 6. * (n - 1) * m * k;
+
+    std::cout << "m = " << m << ", n = " << n << ", k = " << k
+              << ", side = " << (char)side
+              << ", direction = " << (char)direction << ", mean time = " << mean
+              << " s"
+              << ", flop rate = " << nflops / mean * 1.0e-9 << " GFlops"
+              << std::endl;
+}
+
+int main()
+{
+    typedef lapack_idx_t idx_t;
+    typedef double T;
+
+    const idx_t nb = 1000;
+    const idx_t k = 64;
+
+    for (int s = 0; s < 2; ++s) {
+        Side side = s == 0 ? Side::Left : Side::Right;
+        for (int d = 0; d < 2; ++d) {
+            Direction direction =
+                d == 0 ? Direction::Forward : Direction::Backward;
+            for (idx_t n_rot = 99; n_rot <= 1600; n_rot += 100) {
+                idx_t m = side == Side::Left ? n_rot + 1 : nb;
+                idx_t n = side == Side::Left ? nb : n_rot + 1;
+
+                profile_lasr3<T, Layout::ColMajor, lapack_idx_t>(m, n, k, side,
+                                                                 direction);
+            }
+        }
+    }
+    return 0;
+}

--- a/LAPACK_CPP/example/test_lasr3.cpp
+++ b/LAPACK_CPP/example/test_lasr3.cpp
@@ -1,0 +1,115 @@
+
+#include <complex>
+#include <iostream>
+
+#include "lapack_cpp.hpp"
+
+using namespace lapack_cpp;
+
+template <typename T,
+          Layout layout = Layout::ColMajor,
+          typename idx_t = lapack_idx_t>
+void test_lasr3(idx_t m, idx_t n, idx_t k, Side side, Direction direction)
+{
+    idx_t n_rot = side == Side::Left ? m - 1 : n - 1;
+
+    MemoryBlock<T, idx_t> A_(m, n, layout);
+    Matrix<T, layout, idx_t> A(m, n, A_);
+
+    MemoryBlock<real_t<T>, idx_t> C_(n_rot, k, layout);
+    Matrix<real_t<T>, layout, idx_t> C(n_rot, k, C_);
+
+    MemoryBlock<T, idx_t> S_(n_rot, k, layout);
+    Matrix<T, layout, idx_t> S(n_rot, k, S_);
+
+    randomize(A);
+
+    // Generate random, but valid rotations
+    randomize(C);
+    randomize(S);
+    for (idx_t i = 0; i < n_rot; ++i) {
+        for (idx_t j = 0; j < k; ++j) {
+            T f = C(i, j);
+            T g = S(i, j);
+            T r;
+            lartg(f, g, C(i, j), S(i, j), r);
+        }
+    }
+
+    MemoryBlock<T, idx_t> A_copy_(m, n, layout);
+    Matrix<T, layout, idx_t> A_copy(m, n, A_copy_);
+
+    A_copy = A;
+
+    // Apply rotations using simple loops as test
+    if (side == Side::Left) {
+        if (direction == Direction::Forward) {
+            for (idx_t i = 0; i < k; ++i)
+                for (idx_t j = 0; j < n_rot; ++j)
+                    rot(A_copy.row(j), A_copy.row(j + 1), C(j, i), S(j, i));
+        }
+        else {
+            for (idx_t i = 0; i < k; ++i)
+                for (idx_t j = n_rot - 1; j >= 0; --j)
+                    rot(A_copy.row(j), A_copy.row(j + 1), C(j, i), S(j, i));
+        }
+    }
+    else {
+        if (direction == Direction::Forward) {
+            for (idx_t i = 0; i < k; ++i)
+                for (idx_t j = 0; j < n_rot; ++j)
+                    rot(A_copy.column(j), A_copy.column(j + 1), C(j, i),
+                        conj(S(j, i)));
+        }
+        else {
+            for (idx_t i = 0; i < k; ++i)
+                for (idx_t j = n_rot - 1; j >= 0; --j)
+                    rot(A_copy.column(j), A_copy.column(j + 1), C(j, i),
+                        conj(S(j, i)));
+        }
+    }
+
+    lasr3(side, direction, C.as_const(), S.as_const(), A);
+
+    // Check that the result is the same
+    for (idx_t i = 0; i < m; ++i)
+        for (idx_t j = 0; j < n; ++j)
+            A_copy(i, j) -= A(i, j);
+
+    real_t<T> err = 0.;
+    for (idx_t i = 0; i < m; ++i)
+        for (idx_t j = 0; j < n; ++j)
+            err = std::max(err, abs(A_copy(i, j)));
+
+    // This test should really be relative
+    if( err > 1e-5 ){
+        std::cout << "Failed test_lasr3 with parameters: " << m << ", " << n << ", " << k << ", " << (char)side << ", " << (char)direction << std::endl;
+        std::cout << "Error: " << err << std::endl;
+    } else {
+        std::cout << "Passed test_lasr3 with parameters: " << m << ", " << n << ", " << k << ", " << (char)side << ", " << (char)direction << std::endl;
+    }
+
+    // print(A_copy);
+}
+
+int main()
+{
+    typedef lapack_idx_t idx_t;
+    typedef std::complex<float> T;
+
+    for (idx_t nb = 64; nb <= 2000; nb *= 2) {
+        for (idx_t n_rot = 2; n_rot <= 2000; n_rot*=2) {
+            for (idx_t k = 32; k <= 128; k+=32) {
+                test_lasr3<T, Layout::ColMajor, lapack_idx_t>(
+                    n_rot + 1, nb, k, Side::Left, Direction::Forward);
+                test_lasr3<T, Layout::ColMajor, lapack_idx_t>(
+                    nb, n_rot + 1, k, Side::Right, Direction::Forward);
+                test_lasr3<T, Layout::ColMajor, lapack_idx_t>(
+                    n_rot + 1, nb, k, Side::Left, Direction::Backward);
+                test_lasr3<T, Layout::ColMajor, lapack_idx_t>(
+                    nb, n_rot + 1, k, Side::Right, Direction::Backward);
+            }
+        }
+    }
+    return 0;
+}

--- a/LAPACK_CPP/include/lapack_c.h
+++ b/LAPACK_CPP/include/lapack_c.h
@@ -1,0 +1,13 @@
+#ifndef LAPACK_C_HPP
+#define LAPACK_C_HPP
+
+#include "lapack_c/util.h"
+
+// BLAS
+#include "lapack_c/rot.h"
+
+// LAPACK
+#include "lapack_c/lartg.h"
+
+
+#endif

--- a/LAPACK_CPP/include/lapack_c/lartg.h
+++ b/LAPACK_CPP/include/lapack_c/lartg.h
@@ -1,0 +1,22 @@
+#ifndef LAPACK_C_LARTG_HPP
+#define LAPACK_C_LARTG_HPP
+
+#include "lapack_c/util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+void lapack_c_slartg(float f, float g, float* cs, float* sn, float* r);
+
+void lapack_c_dlartg(double f, double g, double* cs, double* sn, double* r);
+
+void lapack_c_clartg(lapack_float_complex f, lapack_float_complex g, float* cs, lapack_float_complex* sn, lapack_float_complex* r);
+
+void lapack_c_zlartg(lapack_double_complex f, lapack_double_complex g, double* cs, lapack_double_complex* sn, lapack_double_complex* r);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif

--- a/LAPACK_CPP/include/lapack_c/lasr3.h
+++ b/LAPACK_CPP/include/lapack_c/lasr3.h
@@ -1,0 +1,94 @@
+#ifndef LAPACK_C_ROT_HPP
+#define LAPACK_C_ROT_HPP
+
+#include "lapack_c/util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+void lapack_c_slasr3(char side,
+                     char direct,
+                     lapack_idx m,
+                     lapack_idx n,
+                     lapack_idx k,
+                     const float* C,
+                     lapack_idx ldc,
+                     const float* S,
+                     lapack_idx lds,
+                     float* A,
+                     lapack_idx lda,
+                     float* work,
+                     lapack_idx lwork);
+
+void lapack_c_dlasr3(char side,
+                     char direct,
+                     lapack_idx m,
+                     lapack_idx n,
+                     lapack_idx k,
+                     const double* C,
+                     lapack_idx ldc,
+                     const double* S,
+                     lapack_idx lds,
+                     double* A,
+                     lapack_idx lda,
+                     double* work,
+                     lapack_idx lwork);
+
+void lapack_c_clasr3(char side,
+                     char direct,
+                     lapack_idx m,
+                     lapack_idx n,
+                     lapack_idx k,
+                     const float* C,
+                     lapack_idx ldc,
+                     const lapack_float_complex* S,
+                     lapack_idx lds,
+                     lapack_float_complex* A,
+                     lapack_idx lda,
+                     lapack_float_complex* work,
+                     lapack_idx lwork);
+
+void lapack_c_sclasr3(char side,
+                      char direct,
+                      lapack_idx m,
+                      lapack_idx n,
+                      lapack_idx k,
+                      const float* C,
+                      lapack_idx ldc,
+                      const float* S,
+                      lapack_idx lds,
+                      lapack_float_complex* A,
+                      lapack_idx lda,
+                      lapack_float_complex* work,
+                      lapack_idx lwork);
+
+void lapack_c_zlasr3(lapack_idx m,
+                     lapack_idx n,
+                     lapack_idx k,
+                     const double* C,
+                     lapack_idx ldc,
+                     const lapack_double_complex* S,
+                     lapack_idx lds,
+                     lapack_double_complex* A,
+                     lapack_idx lda,
+                     lapack_double_complex* work,
+                     lapack_idx lwork);
+
+void lapack_c_dzlasr3(lapack_idx m,
+                      lapack_idx n,
+                      lapack_idx k,
+                      const double* C,
+                      lapack_idx ldc,
+                      const double* S,
+                      lapack_idx lds,
+                      lapack_double_complex* A,
+                      lapack_idx lda,
+                      lapack_double_complex* work,
+                      lapack_idx lwork);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif

--- a/LAPACK_CPP/include/lapack_c/lasr3.h
+++ b/LAPACK_CPP/include/lapack_c/lasr3.h
@@ -4,91 +4,96 @@
 #include "lapack_c/util.h"
 
 #ifdef __cplusplus
-extern "C" {
-#endif  // __cplusplus
+extern "C"
+{
+#endif // __cplusplus
 
-void lapack_c_slasr3(char side,
-                     char direct,
-                     lapack_idx m,
-                     lapack_idx n,
-                     lapack_idx k,
-                     const float* C,
-                     lapack_idx ldc,
-                     const float* S,
-                     lapack_idx lds,
-                     float* A,
-                     lapack_idx lda,
-                     float* work,
-                     lapack_idx lwork);
+    void lapack_c_slasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const float *C,
+                         lapack_idx ldc,
+                         const float *S,
+                         lapack_idx lds,
+                         float *A,
+                         lapack_idx lda,
+                         float *work,
+                         lapack_idx lwork);
 
-void lapack_c_dlasr3(char side,
-                     char direct,
-                     lapack_idx m,
-                     lapack_idx n,
-                     lapack_idx k,
-                     const double* C,
-                     lapack_idx ldc,
-                     const double* S,
-                     lapack_idx lds,
-                     double* A,
-                     lapack_idx lda,
-                     double* work,
-                     lapack_idx lwork);
+    void lapack_c_dlasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const double *C,
+                         lapack_idx ldc,
+                         const double *S,
+                         lapack_idx lds,
+                         double *A,
+                         lapack_idx lda,
+                         double *work,
+                         lapack_idx lwork);
 
-void lapack_c_clasr3(char side,
-                     char direct,
-                     lapack_idx m,
-                     lapack_idx n,
-                     lapack_idx k,
-                     const float* C,
-                     lapack_idx ldc,
-                     const lapack_float_complex* S,
-                     lapack_idx lds,
-                     lapack_float_complex* A,
-                     lapack_idx lda,
-                     lapack_float_complex* work,
-                     lapack_idx lwork);
+    void lapack_c_clasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const float *C,
+                         lapack_idx ldc,
+                         const lapack_float_complex *S,
+                         lapack_idx lds,
+                         lapack_float_complex *A,
+                         lapack_idx lda,
+                         lapack_float_complex *work,
+                         lapack_idx lwork);
 
-void lapack_c_sclasr3(char side,
-                      char direct,
-                      lapack_idx m,
-                      lapack_idx n,
-                      lapack_idx k,
-                      const float* C,
-                      lapack_idx ldc,
-                      const float* S,
-                      lapack_idx lds,
-                      lapack_float_complex* A,
-                      lapack_idx lda,
-                      lapack_float_complex* work,
-                      lapack_idx lwork);
+    void lapack_c_sclasr3(char side,
+                          char direct,
+                          lapack_idx m,
+                          lapack_idx n,
+                          lapack_idx k,
+                          const float *C,
+                          lapack_idx ldc,
+                          const float *S,
+                          lapack_idx lds,
+                          lapack_float_complex *A,
+                          lapack_idx lda,
+                          lapack_float_complex *work,
+                          lapack_idx lwork);
 
-void lapack_c_zlasr3(lapack_idx m,
-                     lapack_idx n,
-                     lapack_idx k,
-                     const double* C,
-                     lapack_idx ldc,
-                     const lapack_double_complex* S,
-                     lapack_idx lds,
-                     lapack_double_complex* A,
-                     lapack_idx lda,
-                     lapack_double_complex* work,
-                     lapack_idx lwork);
+    void lapack_c_zlasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const double *C,
+                         lapack_idx ldc,
+                         const lapack_double_complex *S,
+                         lapack_idx lds,
+                         lapack_double_complex *A,
+                         lapack_idx lda,
+                         lapack_double_complex *work,
+                         lapack_idx lwork);
 
-void lapack_c_dzlasr3(lapack_idx m,
-                      lapack_idx n,
-                      lapack_idx k,
-                      const double* C,
-                      lapack_idx ldc,
-                      const double* S,
-                      lapack_idx lds,
-                      lapack_double_complex* A,
-                      lapack_idx lda,
-                      lapack_double_complex* work,
-                      lapack_idx lwork);
+    void lapack_c_dzlasr3(char side,
+                          char direct, 
+                          lapack_idx m,
+                          lapack_idx n,
+                          lapack_idx k,
+                          const double *C,
+                          lapack_idx ldc,
+                          const double *S,
+                          lapack_idx lds,
+                          lapack_double_complex *A,
+                          lapack_idx lda,
+                          lapack_double_complex *work,
+                          lapack_idx lwork);
 
 #ifdef __cplusplus
 }
-#endif  // __cplusplus
+#endif // __cplusplus
 
 #endif

--- a/LAPACK_CPP/include/lapack_c/rot.h
+++ b/LAPACK_CPP/include/lapack_c/rot.h
@@ -1,0 +1,46 @@
+#ifndef LAPACK_C_ROT_HPP
+#define LAPACK_C_ROT_HPP
+
+#include "lapack_c/util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+void lapack_c_drot(lapack_idx n,
+                    double* x,
+                    lapack_idx incx,
+                    double* y,
+                    lapack_idx incy,
+                    double c,
+                    double s);
+
+void lapack_c_srot(lapack_idx n,
+                    float* x,
+                    lapack_idx incx,
+                    float* y,
+                    lapack_idx incy,
+                    float c,
+                    float s);
+
+void lapack_c_crot(lapack_idx n,
+                    lapack_float_complex* x,
+                    lapack_idx incx,
+                    lapack_float_complex* y,
+                    lapack_idx incy,
+                    float c,
+                    lapack_float_complex s);
+
+void lapack_c_zrot(lapack_idx n,
+                    lapack_double_complex* x,
+                    lapack_idx incx,
+                    lapack_double_complex* y,
+                    lapack_idx incy,
+                    double c,
+                    lapack_double_complex s);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif

--- a/LAPACK_CPP/include/lapack_c/util.h
+++ b/LAPACK_CPP/include/lapack_c/util.h
@@ -1,0 +1,19 @@
+#ifndef LAPACK_C_UTIL_H
+#define LAPACK_C_UTIL_H
+
+// Define types for complex number
+#ifdef __cplusplus
+#include <complex>
+#define lapack_float_complex std::complex<float>
+#define lapack_double_complex std::complex<double>
+#else
+#define lapack_float_complex float _Complex
+#define lapack_double_complex double _Complex
+#endif // __cplusplus
+
+// Default to 32 bit integer if not yet defined
+#ifndef lapack_idx
+#define lapack_idx int
+#endif // lapack_idx
+
+#endif

--- a/LAPACK_CPP/include/lapack_cpp.hpp
+++ b/LAPACK_CPP/include/lapack_cpp.hpp
@@ -1,0 +1,9 @@
+#ifndef LAPACK_CPP_HPP
+#define LAPACK_CPP_HPP
+
+#include "lapack_cpp/base.hpp"
+#include "lapack_cpp/blas.hpp"
+#include "lapack_cpp/lapack.hpp"
+#include "lapack_cpp/utils.hpp"
+
+#endif // LAPACK_CPP_HPP

--- a/LAPACK_CPP/include/lapack_cpp/base.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/base.hpp
@@ -1,0 +1,10 @@
+#ifndef LAPACK_CPP_BASE_HPP
+#define LAPACK_CPP_BASE_HPP
+
+#include "lapack_cpp/base/types.hpp"
+#include "lapack_cpp/base/enums.hpp"
+#include "lapack_cpp/base/matrix.hpp"
+#include "lapack_cpp/base/memory_block.hpp"
+#include "lapack_cpp/base/vector.hpp"
+
+#endif // LAPACK_CPP_BASE_HPP

--- a/LAPACK_CPP/include/lapack_cpp/base/enums.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/base/enums.hpp
@@ -1,0 +1,84 @@
+#ifndef LAPACK_CPP_ENUMP_HPP
+#define LAPACK_CPP_ENUMP_HPP
+
+#include <cassert>
+
+namespace lapack_cpp {
+
+enum class Layout : char { RowMajor = 'R', ColMajor = 'C' };
+
+enum class Op : char { NoTrans = 'N', Trans = 'T', ConjTrans = 'C' };
+
+inline constexpr Op char2op(char t)
+{
+    switch (t) {
+        case 'N':
+            return Op::NoTrans;
+        case 'T':
+            return Op::Trans;
+        case 'C':
+            return Op::ConjTrans;
+        default:
+            assert(false);
+    }
+}
+
+enum class Side : char { Left = 'L', Right = 'R' };
+
+inline constexpr Side char2side(char t)
+{
+    switch (t) {
+        case 'L':
+            return Side::Left;
+        case 'R':
+            return Side::Right;
+        default:
+            assert(false);
+    }
+}
+
+enum class Uplo : char { Upper = 'U', Lower = 'L' };
+
+inline constexpr Uplo char2uplo(char t)
+{
+    switch (t) {
+        case 'U':
+            return Uplo::Upper;
+        case 'R':
+            return Uplo::Lower;
+        default:
+            assert(false);
+    }
+}
+
+enum class Diag : char { Unit = 'U', NonUnit = 'N' };
+
+inline constexpr Diag char2diag(char t)
+{
+    switch (t) {
+        case 'U':
+            return Diag::Unit;
+        case 'N':
+            return Diag::NonUnit;
+        default:
+            assert(false);
+    }
+}
+
+enum class Direction : char { Forward = 'F', Backward = 'B' };
+
+inline constexpr Direction char2direct(char t)
+{
+    switch (t) {
+        case 'F':
+            return Direction::Forward;
+        case 'N':
+            return Direction::Backward;
+        default:
+            assert(false);
+    }
+}
+
+}  // namespace lapack_cpp
+
+#endif  // LAPACK_CPP_ENUMP_HPP

--- a/LAPACK_CPP/include/lapack_cpp/base/matrix.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/base/matrix.hpp
@@ -1,0 +1,334 @@
+
+#ifndef LAPACK_CPP_MATRIX_HPP
+#define LAPACK_CPP_MATRIX_HPP
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <random>
+
+#include "lapack_cpp/base/types.hpp"
+#include "lapack_cpp/base/enums.hpp"
+#include "lapack_cpp/base/memory_block.hpp"
+#include "lapack_cpp/base/vector.hpp"
+
+namespace lapack_cpp {
+
+// Forward declaration of ConstMatrix
+template <typename T, Layout layout = Layout::ColMajor, typename idx_t = lapack_idx_t>
+class ConstMatrix;
+
+/**
+ * A matrix class that can be used to store matrices of arbitrary size.
+ *
+ * The elements of the matrix are stored in column-major order
+ *
+ * @tparam T this is a template parameter that specifies the type of the
+ *           elements of the vector.
+ */
+template <typename T, Layout layout = Layout::ColMajor, typename idx_t = lapack_idx_t>
+class Matrix {
+   public:
+    typedef T value_type;
+    typedef idx_t index_type;
+    // Constructor for a matrix of size m x n
+    template <bool aligned>
+    Matrix(const idx_t m,
+           const idx_t n,
+           const MemoryBlock<T, idx_t, aligned>& m_block)
+        : m_(m),
+          n_(n),
+          ldim_(calc_ld<T, idx_t, aligned>(layout == Layout::ColMajor ? m_ : n_)),
+          data_(m_block.ptr())
+    {
+        assert(m_block.size() >=
+               ldim_ * (layout == Layout::ColMajor ? n_ : m_));
+    }
+
+    // Constructor for a matrix of size m x n
+    template <bool aligned>
+    Matrix(const idx_t m,
+           const idx_t n,
+           const MemoryBlock<T, idx_t, aligned>& m_block,
+           const idx_t ldim)
+        : m_(m), n_(n), ldim_(ldim), data_(m_block.ptr())
+    {
+        assert(m_block.size() >=
+               ldim_ * (layout == Layout::ColMajor ? n_ : m_));
+    }
+
+    // Constructor for a matrix of size m x n
+    Matrix(const idx_t m, const idx_t n, T* ptr, const idx_t ldim)
+        : m_(m), n_(n), ldim_(ldim), data_(ptr)
+    {
+        assert(ldim >= (layout == Layout::ColMajor ? m : n));
+    }
+
+    // Copy constructor
+    Matrix(const Matrix& m)
+        : m_(m.num_rows()), n_(m.num_columns()), ldim_(m.ldim()), data_(m.ptr())
+    {}
+
+    // Make a const promotion of the matrix
+    ConstMatrix<T, layout, idx_t> as_const() const
+    {
+        return ConstMatrix<T, layout, idx_t>(m_, n_, data_, ldim_);
+    }
+
+    // Assignment operator
+    void operator=(const Matrix& m)
+    {
+        assert(m.num_rows() == m_);
+        assert(m.num_columns() == n_);
+        for (idx_t i = 0; i < m_; ++i) {
+            for (idx_t j = 0; j < n_; ++j) {
+                (*this)(i,j) = m(i, j);
+            }
+        }
+    }
+
+    // Returns the number of rows of the matrix
+    inline idx_t num_rows() const { return m_; }
+
+    // Returns the number of columns of the matrix
+    inline idx_t num_columns() const { return n_; }
+
+    // Returns the leading dimension of the matrix
+    inline idx_t ldim() const { return ldim_; }
+
+    // Returns the size of the matrix (i.e. the number of elements m * n)
+    inline idx_t size() const { return n_ * m_; }
+
+    // Returns the ij-th element of the matrix
+    inline T& operator()(idx_t i, idx_t j) const
+    {
+        assert(i < m_);
+        assert(j < n_);
+        if (layout == Layout::ColMajor)
+            return data_[i + j * ldim_];
+        else
+            return data_[i * ldim_ + j];
+    }
+
+    /**
+     * Return a submatrix of the matrix.
+     *
+     * @param i1 index of the first row of the submatrix
+     * @param i2 index of the last row of the submatrix (not inclusive)
+     * @param j1 index of the first column of the submatrix
+     * @param j2 index of the last column of the submatrix (not inclusive)
+     *
+     * @example
+     * Matrix<float> A(5,5);
+     * auto B = A.submatrix(1, 4, 1, 4); // B is a 3x3 submatrix of A
+     */
+    inline Matrix submatrix(idx_t i1, idx_t i2, idx_t j1, idx_t j2) const
+    {
+        assert(i1 >= 0);
+        assert(i2 <= m_);
+        assert(j1 >= 0);
+        assert(j2 <= n_);
+        assert(i1 < i2);
+        assert(j1 < j2);
+        if (layout == Layout::ColMajor)
+            return Matrix(i2 - i1, j2 - j1, &data_[i1 + j1 * ldim_], ldim_);
+        else
+            return Matrix(i2 - i1, j2 - j1, &data_[i1 * ldim_ + j1], ldim_);
+    }
+
+    /**
+     * Return a column of the matrix as a vector
+     *
+     * @param i index of the column
+     */
+    inline Vector<T, idx_t> column(idx_t i) const
+    {
+        assert(i >= 0);
+        assert(i < n_);
+        if (layout == Layout::ColMajor)
+            return Vector<T, idx_t>(m_, &data_[i * ldim_], 1);
+        else
+            return Vector<T, idx_t>(m_, &data_[i], ldim_);
+    }
+
+    /**
+     * Return a row of the matrix as a vector
+     *
+     * @param i index of the row
+     */
+    inline Vector<T, idx_t> row(idx_t i) const
+    {
+        assert(i >= 0);
+        assert(i < m_);
+        if (layout == Layout::ColMajor)
+            return Vector<T, idx_t>(n_, &data_[i], ldim_);
+        else
+            return Vector<T, idx_t>(n_, &data_[i * ldim_], 1);
+    }
+
+    /**
+     * Return a pointer to the data of the matrix.
+     */
+    inline T* ptr() const { return data_; }
+
+   private:
+    // Number of rows of the matrix
+    const idx_t m_;
+    // Number of columns of the matrix
+    const idx_t n_;
+    // Leading dimension of the matrix
+    const idx_t ldim_;
+    // Pointer to the data
+    T* data_;
+};
+
+template <typename T, Layout layout, typename idx_t >
+class ConstMatrix {
+   public:
+    typedef T value_type;
+    typedef idx_t index_type;
+    // Constructor for a matrix of size m x n
+    template <bool aligned>
+    ConstMatrix(const idx_t m,
+                const idx_t n,
+                const MemoryBlock<T, idx_t, aligned>& m_block)
+        : m_(m),
+          n_(n),
+          ldim_(calc_ld<T, idx_t, aligned>(layout == Layout::ColMajor ? m_ : n_)),
+          data_(m_block.ptr())
+    {
+        assert(m_block.size() >=
+               ldim_ * (layout == Layout::ColMajor ? n_ : m_));
+    }
+
+    // Constructor for a matrix of size m x n
+    template <bool aligned>
+    ConstMatrix(const idx_t m,
+                const idx_t n,
+                const MemoryBlock<T, idx_t, aligned>& m_block,
+                const idx_t ldim)
+        : m_(m), n_(n), ldim_(ldim), data_(m_block.ptr())
+    {
+        assert(m_block.size() >=
+               ldim_ * (layout == Layout::ColMajor ? n_ : m_));
+    }
+
+    // Constructor for a matrix of size m x n
+    ConstMatrix(const idx_t m, const idx_t n, const T* ptr, const idx_t ldim)
+        : m_(m), n_(n), ldim_(ldim), data_(ptr)
+    {
+        assert(ldim >= (layout == Layout::ColMajor ? m : n));
+    }
+
+    // Copy constructor
+    ConstMatrix(const ConstMatrix& m)
+        : m_(m.num_rows()), n_(m.num_columns()), ldim_(m.ldim()), data_(m.ptr())
+    {}
+
+    // Const promotion constructor
+    ConstMatrix(const Matrix<T, layout, idx_t>& m)
+        : m_(m.num_rows()), n_(m.num_columns()), ldim_(m.ldim()), data_(m.ptr())
+    {}
+
+    // Returns the number of rows of the matrix
+    inline idx_t num_rows() const { return m_; }
+
+    // Returns the number of columns of the matrix
+    inline idx_t num_columns() const { return n_; }
+
+    // Returns the leading dimension of the matrix
+    inline idx_t ldim() const { return ldim_; }
+
+    // Returns the size of the matrix (i.e. the number of elements m * n)
+    inline idx_t size() const { return n_ * m_; }
+
+    // Returns the ij-th element of the matrix
+    inline T operator()(idx_t i, idx_t j) const
+    {
+        assert(i < m_);
+        assert(j < n_);
+        if (layout == Layout::ColMajor)
+            return data_[i + j * ldim_];
+        else
+            return data_[i * ldim_ + j];
+    }
+
+    /**
+     * Return a submatrix of the matrix.
+     *
+     * @param i1 index of the first row of the submatrix
+     * @param i2 index of the last row of the submatrix (not inclusive)
+     * @param j1 index of the first column of the submatrix
+     * @param j2 index of the last column of the submatrix (not inclusive)
+     *
+     * @example
+     * Matrix<float> A(5,5);
+     * auto B = A.submatrix(1, 4, 1, 4); // B is a 3x3 submatrix of A
+     */
+    inline ConstMatrix submatrix(idx_t i1, idx_t i2, idx_t j1, idx_t j2) const
+    {
+        assert(i1 >= 0);
+        assert(i2 <= m_);
+        assert(j1 >= 0);
+        assert(j2 <= n_);
+        assert(i1 < i2);
+        assert(j1 < j2);
+        if (layout == Layout::ColMajor)
+            return ConstMatrix(i2 - i1, j2 - j1, &data_[i1 + j1 * ldim_],
+                               ldim_);
+        else
+            return ConstMatrix(i2 - i1, j2 - j1, &data_[i1 * ldim_ + j1],
+                               ldim_);
+    }
+
+    /**
+     * Return a column of matrix as a vector
+     *
+     * @param i index of the column
+     */
+    inline ConstVector<T, idx_t> column(idx_t i) const
+    {
+        assert(i >= 0);
+        assert(i < n_);
+        if (layout == Layout::ColMajor)
+            return ConstVector<T, idx_t>(m_, &data_[i * ldim_], 1);
+        else
+            return ConstVector<T, idx_t>(m_, &data_[i], ldim_);
+    }
+
+    /**
+     * Return a row of matrix as a vector
+     *
+     * @param i index of the row
+     */
+    inline ConstVector<T, idx_t> row(idx_t i) const
+    {
+        assert(i >= 0);
+        assert(i < m_);
+        if (layout == Layout::ColMajor)
+            return ConstVector<T, idx_t>(n_, &data_[i], ldim_);
+        else
+            return ConstVector<T, idx_t>(n_, &data_[i * ldim_], 1);
+    }
+
+    /**
+     * Return a pointer to the data of the matrix.
+     */
+    inline const T* ptr() const { return data_; }
+
+   private:
+    // Number of rows of the matrix
+    const idx_t m_;
+    // Number of columns of the matrix
+    const idx_t n_;
+    // Leading dimension of the matrix
+    const idx_t ldim_;
+    // Pointer to the data
+    const T* data_;
+};
+
+}  // namespace lapack_cpp
+
+#endif  // LAPACK_CPP_MATRIX_HPP

--- a/LAPACK_CPP/include/lapack_cpp/base/memory_block.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/base/memory_block.hpp
@@ -1,0 +1,136 @@
+
+#ifndef LAPACK_CPP_MEMORY_BLOCK_HPP
+#define LAPACK_CPP_MEMORY_BLOCK_HPP
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <type_traits>
+
+#include "lapack_cpp/base/types.hpp"
+
+namespace lapack_cpp {
+
+/**
+ * Calculate the leading dimension of a matrix, given the number of rows.
+ * Normally, the leading dimension can just be equal to to the number of rows,
+ * but for performance reasons, we want to make sure that the leading dimension
+ * is a multiple of 64 bytes. That way, if the first column is aligned, they all
+ * are.
+ *
+ * @tparam T
+ * @param m
+ * @return int
+ */
+template <typename T, typename idx_t, bool aligned = true>
+inline constexpr idx_t calc_ld(const idx_t m)
+{
+    if (aligned)
+        return ((m - 1 + (64 / sizeof(T))) / (64 / sizeof(T))) *
+               (64 / sizeof(T));
+    else
+        return m;
+}
+
+/**
+ * A class representing a contiguous block of memory of fixed size.
+ *
+ * This class owns the data. It is responsible for allocating and deallocating
+ * the memory.
+ *
+ * A special note about const. Declaring a Memory block as const does not make
+ * the data const. For example:
+ * const MemoryBlock<double> A(10);
+ * double* data = A.ptr();
+ * data[0] = 1.0; // This is allowed
+ */
+template <typename T, typename idx_t = lapack_idx_t, bool aligned = true>
+class MemoryBlock {
+   public:
+    // Constructor for a block of size n
+    MemoryBlock(idx_t n)
+        : n_(n),
+          data_(aligned ? (T*)aligned_alloc(64, n_ * sizeof(T))
+                        : (T*)malloc(n_ * sizeof(T)))
+    {
+        assert(n >= 0);
+        #ifndef NDEBUG
+            // When debugging, fill the memory with NaNs
+            // This makes it easier to spot uninitialized memory
+            std::fill(data_, data_ + n_, NAN);
+        #endif
+    }
+
+    // Constructor for a block of sufficient size to store a matrix of size m x
+    // n
+    MemoryBlock(idx_t m, idx_t n, Layout layout = Layout::ColMajor)
+        : n_(layout == Layout::ColMajor ? (calc_ld<T, idx_t, aligned>(m) * n) : (calc_ld<T, idx_t, aligned>(n) * m)),
+          data_(aligned ? (T*)aligned_alloc(64, n_ * sizeof(T))
+                        : (T*)malloc(n_ * sizeof(T)))
+    {
+        assert(m >= 0);
+        assert(n >= 0);
+        #ifndef NDEBUG
+            // When debugging, fill the memory with NaNs
+            // This makes it easier to spot uninitialized memory
+            std::fill(data_, data_ + n_, NAN);
+        #endif
+    }
+
+    // Non-owning constructor
+    MemoryBlock(idx_t n, T* data) : n_(n), data_(data), owns_data_(false)
+    {
+        assert(n >= 0);
+    }
+
+    // Destructor
+    ~MemoryBlock()
+    {
+        if (owns_data_) free((std::remove_const_t<T>*)data_);
+    }
+
+    // Copy constructor
+    MemoryBlock(const MemoryBlock& other)
+        : n_(other.n_), data_(other.data_), owns_data_(false)
+    {}
+
+    // Assignment operator
+    void operator=(const MemoryBlock& other)
+    {
+        assert(other.size() == this->size());
+        std::copy(other.data_, other.data_ + n_, data_);
+    }
+
+    // Memory block that remains after creating a vector of size n
+    MemoryBlock remainder(idx_t n) const
+    {
+        idx_t size = calc_ld<T, idx_t, aligned>(n);
+        assert(size <= n_);
+        return MemoryBlock(n_ - n, data_ + n);
+    }
+
+    // Memory block that remains after creating a vector of size n
+    MemoryBlock remainder(idx_t m, idx_t n) const
+    {
+        idx_t size = calc_ld<T, idx_t, aligned>(calc_ld<T, idx_t, aligned>(m) * n);
+        assert(size <= n_);
+        return MemoryBlock(n_ - size, data_ + size);
+    }
+
+    // Returns the size of the memory block
+    inline idx_t size() const { return n_; }
+
+    /**
+     * Return a pointer to the data of the vector.
+     */
+    inline T* ptr() const { return data_; }
+
+   private:
+    const idx_t n_;
+    T* data_;
+    const bool owns_data_ = true;
+};
+
+}  // namespace lapack_cpp
+
+#endif

--- a/LAPACK_CPP/include/lapack_cpp/base/types.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/base/types.hpp
@@ -1,0 +1,33 @@
+#ifndef LAPACK_CPP_BASE_TYPES_HPP
+#define LAPACK_CPP_BASE_TYPES_HPP
+
+#include <complex>
+#include <cstdint>
+#include <type_traits>
+
+// While the library is templated and can handle different integers,
+// this is the default integer type used by the library.
+typedef int64_t lapack_idx_t;
+
+// declare conj for real types
+template <typename T,
+          std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+inline T conj(const T& x)
+{
+    return x;
+}
+
+template <typename T>
+struct real_type_struct {
+    typedef T type;
+};
+
+template <typename T>
+struct real_type_struct<std::complex<T>> {
+    typedef T type;
+};
+
+template <typename T>
+using real_t = typename real_type_struct<T>::type;
+
+#endif  // LAPACK_CPP_BASE_TYPES_HPP

--- a/LAPACK_CPP/include/lapack_cpp/base/vector.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/base/vector.hpp
@@ -1,0 +1,203 @@
+
+#ifndef LAPACK_CPP_VECTOR_HPP
+#define LAPACK_CPP_VECTOR_HPP
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+
+#include "lapack_cpp/base/types.hpp"
+#include "lapack_cpp/base/enums.hpp"
+#include "lapack_cpp/base/memory_block.hpp"
+
+namespace lapack_cpp {
+
+// Forward declaration of ConstVector
+template <typename T, typename idx_t = lapack_idx_t>
+class ConstVector;
+
+/**
+ * A vector class that can be used to store vectors of arbitrary size.
+ *
+ * @tparam T this is a template parameter that specifies the type of the
+ *           elements of the vector.
+ */
+template <typename T, typename idx_t = lapack_idx_t>
+class Vector {
+   public:
+    typedef T value_type;
+    typedef idx_t index_type;
+
+    // Constructor for a vector of size n
+    template <bool aligned>
+    Vector(idx_t n,
+           const MemoryBlock<T, idx_t, aligned>& m_block,
+           idx_t stride = 1)
+        : n_(n), stride_(stride), data_(m_block.ptr())
+    {
+        assert(n >= 0);
+        assert(m_block.size() >= n);
+    }
+
+    // Constructor for a vector of size n
+    Vector(idx_t n, T* data, idx_t stride = 1)
+        : n_(n), stride_(stride), data_(data)
+    {
+        assert(n >= 0);
+    }
+
+    // Copy constructor
+    // Note: the default copy constructor would probably work, but we want to
+    // emphasize that we are doing a shallow copy here.
+    Vector(const Vector<T>& v) : n_(v.n_), stride_(v.stride_), data_(v.data_) {}
+
+    // Assignment operator
+    void operator=(const Vector<T>& v)
+    {
+        assert(v.size() == this->size());
+        for (int i = 0; i < this->size(); ++i) {
+            (*this)[i] = v[i];
+        }
+    }
+
+    // Make a const promotion of the vector
+    inline ConstVector<T, idx_t> as_const() const
+    {
+        return ConstVector<T, idx_t>(n_, data_, stride_);
+    }
+
+    // Returns the size of the vector
+    inline idx_t size() const { return n_; }
+
+    inline idx_t stride() const { return stride_; }
+
+    // Returns the i-th element of the vector
+    // Note: this function will only be called when the vector is not const
+    // therefore, we return the element by reference.
+    inline T& operator[](const idx_t i) const
+    {
+        assert(i < n_);
+        return data_[i * stride_];
+    }
+
+    /**
+     * The subvector starts at index start and ends at index end - 1.
+     * The stride is the step size between two elements of the subvector.
+     */
+    inline Vector subvector(idx_t start, idx_t end, idx_t stride = 1) const
+    {
+        assert(start >= 0);
+        assert(end <= n_);
+        assert(start < end);
+        assert(stride > 0);
+        return Vector((end - start) / stride, &data_[start * stride_],
+                      stride * stride_);
+    }
+
+    /**
+     * Return a pointer to the data of the vector.
+     */
+    inline T* ptr() const { return data_; }
+
+   private:
+    const idx_t n_;
+    const idx_t stride_;
+    T* data_;
+};
+
+/**
+ * A vector class that can be used to store vectors of arbitrary size.
+ *
+ * @tparam T this is a template parameter that specifies the type of the
+ *           elements of the vector.
+ */
+template <typename T, typename idx_t>
+class ConstVector {
+   public:
+    typedef T value_type;
+    typedef idx_t index_type;
+    // Constructor for a vector of size n
+    template <bool aligned>
+    ConstVector(idx_t n,
+                const MemoryBlock<T, idx_t, aligned>& m_block,
+                idx_t stride = 1)
+        : n_(n), stride_(stride), data_(m_block.ptr())
+    {
+        assert(n >= 0);
+        assert(m_block.size() >= n);
+    }
+
+    // Constructor for a vector of size n
+    ConstVector(idx_t n, const T* data, idx_t stride = 1)
+        : n_(n), stride_(stride), data_(data)
+    {
+        assert(n >= 0);
+    }
+
+    // Copy constructor
+    // Note: the default copy constructor would probably work, but we want to
+    // emphasize that we are doing a shallow copy here.
+    ConstVector(const ConstVector<T, idx_t>& v)
+        : n_(v.n_), stride_(v.stride_), data_(v.data_)
+    {}
+
+    // Const promotion constructor
+    ConstVector(const Vector<T, idx_t>& v)
+        : n_(v.size()), stride_(v.stride()), data_(v.ptr())
+    {}
+
+    // Assignment operator
+    void operator=(const Vector<T>& v)
+    {
+        assert(v.size() == this->size());
+        for (int i = 0; i < this->size(); ++i) {
+            (*this)[i] = v[i];
+        }
+    }
+
+    // Returns the size of the vector
+    inline idx_t size() const { return n_; }
+
+    inline idx_t stride() const { return stride_; }
+
+    // Returns the i-th element of the vector
+    // Note: this function will only be called when the vector is not const
+    // therefore, we return the element by reference.
+    inline T operator[](const idx_t i) const
+    {
+        assert(i < n_);
+        return data_[i * stride_];
+    }
+
+    /**
+     * The subvector starts at index start and ends at index end - 1.
+     * The stride is the step size between two elements of the subvector.
+     *
+     * Note: this function will also be called if the matrix is const, even
+     * though the returned object is not const. Solving this problem would
+     * require either an inefficient or a more complex design.
+     */
+    inline ConstVector subvector(idx_t start, idx_t end, idx_t stride = 1) const
+    {
+        assert(start >= 0);
+        assert(end <= n_);
+        assert(start < end);
+        assert(stride > 0);
+        return ConstVector((end - start) / stride, &data_[start * stride_],
+                           stride * stride_);
+    }
+
+    /**
+     * Return a pointer to the data of the vector.
+     */
+    inline const T* ptr() const { return data_; }
+
+   private:
+    const idx_t n_;
+    const idx_t stride_;
+    const T* data_;
+};
+
+}  // namespace lapack_cpp
+
+#endif

--- a/LAPACK_CPP/include/lapack_cpp/blas.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/blas.hpp
@@ -1,0 +1,6 @@
+#ifndef LAPACK_CPP_BLAS_HPP
+#define LAPACK_CPP_BLAS_HPP
+
+#include "lapack_cpp/blas/rot.hpp"
+
+#endif // LAPACK_CPP_BLAS_HPP

--- a/LAPACK_CPP/include/lapack_cpp/blas/rot.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/blas/rot.hpp
@@ -1,0 +1,24 @@
+#ifndef LAPACK_CPP_ROT_HPP
+#define LAPACK_CPP_ROT_HPP
+
+#include "lapack_cpp/base.hpp"
+#include "lapack_cpp/utils.hpp"
+namespace lapack_cpp {
+
+/**
+ * Apply a plane rotation to a pair of vectors.
+ */
+template <typename T, typename TS, typename idx_t>
+void rot(const Vector<T, idx_t>& x, const Vector<T, idx_t>& y, real_t<T> c, TS s){
+    assert(x.size() == y.size());
+    const idx_t n = x.size();
+    for (idx_t i = 0; i < n; ++i) {
+        T temp = -conj(s) * x[i] + c * y[i];
+        x[i] = c * x[i] + s * y[i];
+        y[i] = temp;
+    }
+}
+
+}  // namespace lapack_cpp
+
+#endif  // LAPACK_CPP_GEMV_HPP

--- a/LAPACK_CPP/include/lapack_cpp/lapack.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/lapack.hpp
@@ -1,0 +1,7 @@
+#ifndef LAPACK_CPP_LAPACK_HPP
+#define LAPACK_CPP_LAPACK_HPP
+
+#include "lapack_cpp/lapack/lartg.hpp"
+#include "lapack_cpp/lapack/lasr3.hpp"
+
+#endif // LAPACK_CPP_LAPACK_HPP

--- a/LAPACK_CPP/include/lapack_cpp/lapack/lartg.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/lapack/lartg.hpp
@@ -1,0 +1,16 @@
+#ifndef LAPACK_CPP_LARTG_HPP
+#define LAPACK_CPP_LARTG_HPP
+
+#include "lapack_cpp/base.hpp"
+#include "lapack_cpp/utils.hpp"
+namespace lapack_cpp {
+
+/**
+ * Generate a plane rotation.
+ */
+template <typename T>
+void lartg(T f, T g, real_t<T>& c, T& s, T& r);
+
+}  // namespace lapack_cpp
+
+#endif  // LAPACK_CPP_GEMV_HPP

--- a/LAPACK_CPP/include/lapack_cpp/lapack/lasr3.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/lapack/lasr3.hpp
@@ -1,0 +1,815 @@
+#ifndef LAPACK_CPP_LASR3_HPP
+#define LAPACK_CPP_LASR3_HPP
+
+#include "lapack_cpp/base.hpp"
+#include "lapack_cpp/blas/rot.hpp"
+#include "lapack_cpp/utils.hpp"
+
+namespace lapack_cpp {
+
+/**
+ * Applies a sequence of plane rotations to a general rectangular matrix.
+ *
+ * @param side   Specifies whether the plane rotations are applied to A on the
+ *               left or right.
+ *
+ * @param direct Specifies whether the sequence is applied in forward or
+ *               backward order.
+ *
+ * @param C      The cosines of the rotations
+ *               If side == Side::Left, C is an array of dimension m-1 x k
+ *               If side == Side::Right, C is an array of dimension n-1 x k
+ *
+ * @param S      The sines of the rotations
+ *               If side == Side::Left, S is an array of dimension m-1 x k
+ *               If side == Side::Right, S is an array of dimension n-1 x k
+ *
+ * @param A      m x n matrix to which the rotations are to be applied.
+ *
+ * @param work   A workspace array, its dimension is specified by lasr3_work.
+ *               Note, because we use the work array to align the data for
+ *               efficient vectorization, this routine only support aligned
+ *               work arrays.
+ *
+ * @tparam T     The type of the elements of the matrix A.
+ *
+ * @tparam TC    The type of the elements of the matrix C.
+ *
+ * @tparam TS    The type of the elements of the matrix S.
+ *
+ * @tparam layout The layout of the matrices A, C, and S.
+ *
+ * @tparam idx_t  The type of the indices.
+ *
+ * @note if either TC or TS is a complex type, then T must also be a complex
+ * type.
+ *
+ */
+template <typename T, typename TC, typename TS, Layout layout, typename idx_t>
+void lasr3(Side side,
+           Direction direct,
+           ConstMatrix<TC, layout, idx_t> C,
+           ConstMatrix<TS, layout, idx_t> S,
+           Matrix<T, layout, idx_t> A,
+           MemoryBlock<T, idx_t, true> work);
+
+/**
+ * Workspace query for lasr3.
+ */
+template <typename T, typename TC, typename TS, Layout layout, typename idx_t>
+idx_t lasr3_workquery(Side side,
+                      Direction direct,
+                      ConstMatrix<TC, layout, idx_t> C,
+                      ConstMatrix<TS, layout, idx_t> S,
+                      Matrix<T, layout, idx_t> A)
+{
+    const idx_t m = A.num_rows();
+    const idx_t n = A.num_columns();
+    const idx_t k = C.num_columns();
+    const idx_t num_rot = C.num_rows();
+
+    assert(side == Side::Left || side == Side::Right);
+    assert(direct == Direction::Forward || direct == Direction::Backward);
+    assert(C.num_rows() == S.num_rows());
+    assert(C.num_columns() == S.num_columns());
+    assert(side == Side::Left ? m : n == C.num_rows() + 1);
+
+    // Blocksize for the number of rows/columns of A to be processed at once
+    const idx_t block_mn = 256;
+    // Blocksize for the number of rotation sequences to be processed at once
+    const idx_t block_k = 64;
+    const idx_t block_k2 = std::min(num_rot - 3, block_k);
+
+    const idx_t nm2 = std::min(block_mn, side == Side::Left ? n : m);
+    const idx_t k2 = std::min(block_k2, k);
+
+    return calc_ld<T, idx_t>(nm2) * (k2 + 2);
+}
+
+/**
+ * @copydoc lasr3
+ */
+template <typename T, typename TC, typename TS, Layout layout, typename idx_t>
+void lasr3(Side side,
+           Direction direct,
+           ConstMatrix<TC, layout, idx_t> C,
+           ConstMatrix<TS, layout, idx_t> S,
+           Matrix<T, layout, idx_t> A)
+{
+    idx_t lwork = lasr3_workquery(side, direct, C, S, A);
+    MemoryBlock<T, idx_t, true> work(lwork);
+    lasr3(side, direct, C, S, A, work);
+}
+
+namespace internal {
+
+    /** Applies two plane rotations to three vectors.
+     *
+     * [x1]   [1 0   0  ]   [c1  s1 0]   [x1]
+     * [x2] = [0 c2  s2 ] * [-s1 c1 0] * [x2]
+     * [x3]   [0 -s2 c2 ]   [0   0  1]   [x3]
+     *
+     * @param x1  The first vector.
+     * @param x2  The second vector.
+     * @param x3  The third vector.
+     * @param c1  The cosine of the first rotation.
+     * @param s1  The sine of the first rotation.
+     * @param c2  The cosine of the second rotation.
+     * @param s2  The sine of the second rotation.
+     */
+    template <typename T, typename TC, typename TS, typename idx_t>
+    void rot_fuse2x1(Vector<T, idx_t> x1,
+                     Vector<T, idx_t> x2,
+                     Vector<T, idx_t> x3,
+                     TC c1,
+                     TS s1,
+                     TC c2,
+                     TS s2)
+    {
+        assert(x1.size() == x2.size() && x2.size() == x3.size());
+        const idx_t n = x1.size();
+        for (idx_t i = 0; i < n; ++i) {
+            T x2_g1 = -conj(s1) * x1[i] + c1 * x2[i];
+            x1[i] = c1 * x1[i] + s1 * x2[i];
+            x2[i] = c2 * x2_g1 + s2 * x3[i];
+            x3[i] = -conj(s2) * x2_g1 + c2 * x3[i];
+        }
+    }
+
+    /** Applies two plane rotations to three vectors.
+     *
+     * [x1]   [c2  s2 0]   [1 0   0  ]   [x1]
+     * [x2] = [-s2 c2 0] * [0 c1  s1 ] * [x2]
+     * [x3]   [0   0  1]   [0 -s1 c1 ]   [x3]
+     *
+     * @param x1  The first vector.
+     * @param x2  The second vector.
+     * @param x3  The third vector.
+     * @param c1  The cosine of the first rotation.
+     * @param s1  The sine of the first rotation.
+     * @param c2  The cosine of the second rotation.
+     * @param s2  The sine of the second rotation.
+     */
+    template <typename T, typename TC, typename TS, typename idx_t>
+    void rot_fuse1x2(Vector<T, idx_t> x1,
+                     Vector<T, idx_t> x2,
+                     Vector<T, idx_t> x3,
+                     TC c1,
+                     TS s1,
+                     TC c2,
+                     TS s2)
+    {
+        assert(x1.size() == x2.size() && x2.size() == x3.size());
+        const idx_t n = x1.size();
+        for (idx_t i = 0; i < n; ++i) {
+            T x2_g1 = c1 * x2[i] + s1 * x3[i];
+            x3[i] = -conj(s1) * x2[i] + c1 * x3[i];
+            x2[i] = -conj(s2) * x1[i] + c2 * x2_g1;
+            x1[i] = c2 * x1[i] + s2 * x2_g1;
+        }
+    }
+
+    /** Applies four plane rotations to four vectors.
+     *
+     * [x1]   [1 0   0  0]   [1 0 0   0 ]   [c2  s2 0 0]   [1 0   0  0]   [x1]
+     * [x2] = [0 c4  s4 0] * [0 1 0   0 ] * [-s2 c2 0 0] * [0 c1  s1 0] * [x2]
+     * [x3]   [0 -s4 c4 0]   [0 0 c3  s3]   [0   0  1 0]   [0 -s1 c1 0]   [x3]
+     * [x4]   [0 0   0  1]   [0 0 -s3 c3]   [0   0  0 1]   [0 0   0  0]   [x4]
+     *
+     * Note: the rotations are applied in the order G1, G2, G3, G4,
+     * but the order G1, G3, G2, G4 is also possible.
+     *
+     * @param x1  The first vector.
+     * @param x2  The second vector.
+     * @param x3  The third vector.
+     * @param x4  The fourth vector.
+     * @param c1  The cosine of the first rotation.
+     * @param s1  The sine of the first rotation.
+     * @param c2  The cosine of the second rotation.
+     * @param s2  The sine of the second rotation.
+     * @param c3  The cosine of the third rotation.
+     * @param s3  The sine of the third rotation.
+     * @param c4  The cosine of the fourth rotation.
+     * @param s4  The sine of the fourth rotation.
+     */
+    template <typename T, typename TC, typename TS, typename idx_t>
+    void rot_fuse2x2(Vector<T, idx_t> x1,
+                     Vector<T, idx_t> x2,
+                     Vector<T, idx_t> x3,
+                     Vector<T, idx_t> x4,
+                     TC c1,
+                     TS s1,
+                     TC c2,
+                     TS s2,
+                     TC c3,
+                     TS s3,
+                     TC c4,
+                     TS s4)
+    {
+        assert(x1.size() == x2.size() && x1.size() == x3.size() &&
+               x1.size() == x4.size());
+        const idx_t n = x1.size();
+        for (idx_t i = 0; i < n; ++i) {
+            T x2_g1 = c1 * x2[i] + s1 * x3[i];
+            T x3_g1 = -conj(s1) * x2[i] + c1 * x3[i];
+            T x2_g2 = -conj(s2) * x1[i] + c2 * x2_g1;
+            x1[i] = c2 * x1[i] + s2 * x2_g1;
+            T x3_g3 = c3 * x3_g1 + s3 * x4[i];
+            x4[i] = -conj(s3) * x3_g1 + c3 * x4[i];
+            x2[i] = c4 * x2_g2 + s4 * x3_g3;
+            x3[i] = -conj(s4) * x2_g2 + c4 * x3_g3;
+        }
+    }
+
+    // Kernel for lasr3, forward left variant
+    template <typename T,
+              typename TC,
+              typename TS,
+              Layout layout,
+              typename idx_t>
+    void lasr3_kernel_forward_left(ConstMatrix<TC, layout, idx_t> C,
+                                   ConstMatrix<TS, layout, idx_t> S,
+                                   Matrix<T, layout, idx_t> A,
+                                   MemoryBlock<T, idx_t, true> work)
+    {
+        idx_t m = A.num_rows();
+        idx_t n = A.num_columns();
+        idx_t k = C.num_columns();
+
+        assert(C.num_rows() == S.num_rows());
+        assert(C.num_columns() == S.num_columns());
+        assert(m == C.num_rows() + 1);
+        assert(m > k + 1);
+
+        // Number of rows that will be stored in the packed workspace matrix
+        const idx_t np = k + 2;
+        // During the algorithm, instead of applying the rotations directly to
+        // the matrix A, we will apply them to a packed version of A. This is
+        // done to allow for efficient vectorization of the rotations. The
+        // packed matrix is stored in the workspace array. Since we apply the
+        // rotations from the left, this packed matrix is always row-major
+        // regardless of the layout of A.
+        Matrix<T, Layout::RowMajor, idx_t> A_pack(np, n, work);
+        // A_pack will store np rows of A.
+        // To avoid having to shuffle rows in A, we keep track of two indices
+        // For i = i_pack2, ..., i_pack2 + np - 1, row (i_pack + i - i_pack2 +
+        // np) % np of A_pack corresponds to row i of A.
+        idx_t i_pack = 0;
+        idx_t i_pack2 = 0;
+
+        // Copy the first np rows of A to A_pack
+        for (idx_t i = 0; i < np; ++i) {
+            for (idx_t j = 0; j < n; ++j) {
+                A_pack(i, j) = A(i, j);
+            }
+        }
+
+        // Startup phase
+        for (idx_t j = 0; j + 1 < k; ++j) {
+            for (idx_t i = 0, g = j; i < j + 1; ++i, --g) {
+                rot(A_pack.row(g), A_pack.row(g + 1), C(g, i), S(g, i));
+            }
+        }
+
+        // Pipeline phase
+        for (idx_t j = k - 1; j + 1 < m - 1; j += 2) {
+            for (idx_t i = 0, g = j; i + 1 < k; i += 2, g -= 2) {
+                auto a1 = A_pack.row((g - 1 + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.row((g + i_pack - i_pack2 + np) % np);
+                auto a3 = A_pack.row((g + 1 + i_pack - i_pack2 + np) % np);
+                auto a4 = A_pack.row((g + 2 + i_pack - i_pack2 + np) % np);
+
+                rot_fuse2x2(a1, a2, a3, a4, C(g, i), S(g, i), C(g - 1, i + 1),
+                            S(g - 1, i + 1), C(g + 1, i), S(g + 1, i),
+                            C(g, i + 1), S(g, i + 1));
+            }
+            if (k % 2 == 1) {
+                // k is odd, so there are two more rotations to apply
+                idx_t i = k - 1;
+                idx_t g = j - i;
+
+                auto a1 = A_pack.row((g + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.row((g + 1 + i_pack - i_pack2 + np) % np);
+                auto a3 = A_pack.row((g + 2 + i_pack - i_pack2 + np) % np);
+
+                rot_fuse2x1(a1, a2, a3, C(g, i), S(g, i), C(g + 1, i),
+                            S(g + 1, i));
+            }
+            // rows i_pack and i_pack+1 of A_pack are finished, copy them back
+            // to A
+            for (idx_t i = 0; i < n; i++) {
+                A(i_pack2, i) = A_pack(i_pack, i);
+                A(i_pack2 + 1, i) = A_pack((i_pack + 1) % np, i);
+            }
+            // Pack next rows and update i_pack and i_pack2
+            if (j + 4 < m) {
+                for (idx_t i = 0; i < n; i++) {
+                    A_pack(i_pack, i) = A(j + 3, i);
+                    A_pack((i_pack + 1) % np, i) = A(j + 4, i);
+                }
+                i_pack = (i_pack + 2) % np;
+                i_pack2 += 2;
+            }
+            else if (j + 3 < m) {
+                for (idx_t i = 0; i < n; i++) {
+                    A_pack(i_pack, i) = A(j + 3, i);
+                }
+                i_pack = (i_pack + 1) % np;
+                i_pack2 += 1;
+            }
+        }
+
+        // Shutdown phase
+        for (idx_t j = (m - k + 1) % 2; j < k; ++j) {
+            for (idx_t i = j, g = m - 2; i < k; ++i, --g) {
+                auto a1 = A_pack.row((g + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.row((g + 1 + i_pack - i_pack2 + np) % np);
+                rot(a1, a2, C(g, i), S(g, i));
+            }
+        }
+
+        // Copy the last np rows of A_pack back to A
+        for (idx_t i = 0; i < std::min(np, m - i_pack2); ++i) {
+            for (idx_t j = 0; j < n; ++j) {
+                A(i_pack2 + i, j) = A_pack((i_pack + i) % np, j);
+            }
+        }
+    }
+
+    // Kernel for lasr3, backward left variant
+    template <typename T,
+              typename TC,
+              typename TS,
+              Layout layout,
+              typename idx_t>
+    void lasr3_kernel_backward_left(ConstMatrix<TC, layout, idx_t> C,
+                                    ConstMatrix<TS, layout, idx_t> S,
+                                    Matrix<T, layout, idx_t> A,
+                                    MemoryBlock<T, idx_t, true> work)
+    {
+        idx_t m = A.num_rows();
+        idx_t n = A.num_columns();
+        idx_t k = C.num_columns();
+
+        assert(C.num_rows() == S.num_rows());
+        assert(C.num_columns() == S.num_columns());
+        assert(m == C.num_rows() + 1);
+        assert(m > k + 1);
+
+        // Number of rows that will be stored in the packed workspace matrix
+        const idx_t np = k + 2;
+        // During the algorithm, instead of applying the rotations directly to
+        // the matrix A, we will apply them to a packed version of A. This is
+        // done to allow for efficient vectorization of the rotations. The
+        // packed matrix is stored in the workspace array. Since we apply the
+        // rotations from the left, this packed matrix is always row-major
+        // regardless of the layout of A.
+        Matrix<T, Layout::RowMajor, idx_t> A_pack(np, n, work);
+        // A_pack will store np rows of A.
+        // To avoid having to shuffle rows in A, we keep track of two indices
+        // For i = i_pack2, ..., i_pack2 + np - 1, row (i_pack + i - i_pack2 +
+        // np) % np of A_pack corresponds to row i of A.
+        idx_t i_pack = 0;
+        idx_t i_pack2 = m - np;
+
+        // Copy the last np rows of A to A_pack
+        for (idx_t i = 0; i < np; ++i) {
+            for (idx_t j = 0; j < n; ++j) {
+                A_pack(i, j) = A(m - np + i, j);
+            }
+        }
+
+        // Startup phase
+        for (idx_t j = 0; j + 1 < k; ++j) {
+            for (idx_t i = 0, g = m - 2 - j; i < j + 1; ++i, ++g) {
+                rot(A_pack.row((g - i_pack2) % np),
+                    A_pack.row((g + 1 - i_pack2) % np), C(g, i), S(g, i));
+            }
+        }
+
+        // Pipeline phase
+        for (idx_t j = k - 1; j + 1 < m - 1; j += 2) {
+            for (idx_t i = 0, g = m - 2 - j; i + 1 < k; i += 2, g += 2) {
+                auto a1 = A_pack.row((g - 1 + i_pack - i_pack2) % np);
+                auto a2 = A_pack.row((g + i_pack - i_pack2) % np);
+                auto a3 = A_pack.row((g + 1 + i_pack - i_pack2) % np);
+                auto a4 = A_pack.row((g + 2 + i_pack - i_pack2) % np);
+
+                rot_fuse2x2(a1, a2, a3, a4, C(g, i), S(g, i), C(g - 1, i),
+                            S(g - 1, i), C(g + 1, i + 1), S(g + 1, i + 1),
+                            C(g, i + 1), S(g, i + 1));
+            }
+            if (k % 2 == 1) {
+                // k is odd, so there are two more rotations to apply
+                idx_t i = k - 1;
+                idx_t g = m - 2 - j + i;
+
+                auto a1 = A_pack.row((g - 1 + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.row((g + i_pack - i_pack2 + np) % np);
+                auto a3 = A_pack.row((g + 1 + i_pack - i_pack2 + np) % np);
+
+                rot_fuse1x2(a1, a2, a3, C(g, i), S(g, i), C(g - 1, i),
+                            S(g - 1, i));
+            }
+            // rows i_pack+np-2 and i_pack+np-1 are finished, copy them back to
+            // A
+            for (idx_t i = 0; i < n; i++) {
+                A(i_pack2 + np - 2, i) = A_pack((i_pack + np - 2) % np, i);
+                A(i_pack2 + np - 1, i) = A_pack((i_pack + np - 1) % np, i);
+            }
+            // Pack next rows and update i_pack and i_pack2
+            if (i_pack2 > 1) {
+                for (idx_t i = 0; i < n; i++) {
+                    A_pack((i_pack + np - 2) % np, i) = A(i_pack2 - 2, i);
+                    A_pack((i_pack + np - 1) % np, i) = A(i_pack2 - 1, i);
+                }
+                i_pack = (i_pack + np - 2) % np;
+                i_pack2 -= 2;
+            }
+            else if (i_pack2 > 0) {
+                for (idx_t i = 0; i < n; i++) {
+                    A_pack((i_pack + np - 1) % np, i) = A(i_pack2 - 1, i);
+                }
+                i_pack = (i_pack + np - 1) % np;
+                i_pack2 -= 1;
+            }
+        }
+
+        // By now, i_pack2 should point to the start of the matrix.
+        assert(i_pack2 == 0);
+
+        // Shutdown phase
+        for (idx_t j = (m - k + 1) % 2; j < k; ++j) {
+            for (idx_t i = j, g = 0; i < k; ++i, ++g) {
+                auto a1 = A_pack.row((g + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.row((g + 1 + i_pack - i_pack2 + np) % np);
+                rot(a1, a2, C(g, i), S(g, i));
+            }
+        }
+
+        // Copy the first np rows of A_pack back to A
+        for (idx_t i = 0; i < np; ++i) {
+            for (idx_t j = 0; j < n; ++j) {
+                A(i, j) = A_pack((i_pack + i) % np, j);
+            }
+        }
+    }
+
+    // Kernel for lasr3, forward right variant
+    template <typename T,
+              typename TC,
+              typename TS,
+              Layout layout,
+              typename idx_t>
+    void lasr3_kernel_forward_right(ConstMatrix<TC, layout, idx_t> C,
+                                    ConstMatrix<TS, layout, idx_t> S,
+                                    Matrix<T, layout, idx_t> A,
+                                    MemoryBlock<T, idx_t, true> work)
+    {
+        idx_t m = A.num_rows();
+        idx_t n = A.num_columns();
+        idx_t k = C.num_columns();
+
+        assert(C.num_rows() == S.num_rows());
+        assert(C.num_columns() == S.num_columns());
+        assert(n == C.num_rows() + 1);
+        assert(n > k + 1);
+
+        // Number of columns that will be stored in the packed workspace matrix
+        const idx_t np = k + 2;
+        // During the algorithm, instead of applying the rotations directly to
+        // the matrix A, we will apply them to a packed version of A. This is
+        // done to allow for efficient vectorization of the rotations. The
+        // packed matrix is stored in the workspace array. Since we apply the
+        // rotations from the right, this packed matrix is always column-major
+        // regardless of the layout of A.
+        Matrix<T, Layout::ColMajor, idx_t> A_pack(m, np, work);
+        // A_pack will store np columns of A.
+        // To avoid having to shuffle columns in A, we keep track of two indices
+        // For i = i_pack2, ..., i_pack2 + np - 1, column (i_pack + i - i_pack2
+        // + np) % np of A_pack corresponds to column i of A.
+        idx_t i_pack = 0;
+        idx_t i_pack2 = 0;
+
+        // Copy the first np columns of A to A_pack
+        for (idx_t j = 0; j < np; ++j) {
+            for (idx_t i = 0; i < m; ++i) {
+                A_pack(i, j) = A(i, j);
+            }
+        }
+
+        // Startup phase
+        for (idx_t j = 0; j + 1 < k; ++j) {
+            for (idx_t i = 0, g = j; i < j + 1; ++i, --g) {
+                rot(A_pack.column(g), A_pack.column(g + 1), C(g, i),
+                    conj(S(g, i)));
+            }
+        }
+
+        // Pipeline phase
+        for (idx_t j = k - 1; j + 1 < n - 1; j += 2) {
+            for (idx_t i = 0, g = j; i + 1 < k; i += 2, g -= 2) {
+                auto a1 = A_pack.column((g - 1 + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.column((g + i_pack - i_pack2 + np) % np);
+                auto a3 = A_pack.column((g + 1 + i_pack - i_pack2 + np) % np);
+                auto a4 = A_pack.column((g + 2 + i_pack - i_pack2 + np) % np);
+
+                rot_fuse2x2(a1, a2, a3, a4, C(g, i), conj(S(g, i)),
+                            C(g - 1, i + 1), conj(S(g - 1, i + 1)), C(g + 1, i),
+                            conj(S(g + 1, i)), C(g, i + 1), conj(S(g, i + 1)));
+            }
+            if (k % 2 == 1) {
+                // k is odd, so there are two more rotations to apply
+                idx_t i = k - 1;
+                idx_t g = j - i;
+
+                auto a1 = A_pack.column((g + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.column((g + 1 + i_pack - i_pack2 + np) % np);
+                auto a3 = A_pack.column((g + 2 + i_pack - i_pack2 + np) % np);
+
+                rot_fuse2x1(a1, a2, a3, C(g, i), conj(S(g, i)), C(g + 1, i),
+                            conj(S(g + 1, i)));
+            }
+            // columns i_pack and i_pack+1 of A_pack are finished, copy them
+            // back to A
+            for (idx_t i = 0; i < m; i++) {
+                A(i, i_pack2) = A_pack(i, i_pack);
+                A(i, i_pack2 + 1) = A_pack(i, (i_pack + 1) % np);
+            }
+            // Pack next columns and update i_pack and i_pack2
+            if (j + 4 < n) {
+                for (idx_t i = 0; i < m; i++) {
+                    A_pack(i, i_pack) = A(i, j + 3);
+                    A_pack(i, (i_pack + 1) % np) = A(i, j + 4);
+                }
+                i_pack = (i_pack + 2) % np;
+                i_pack2 += 2;
+            }
+            else if (j + 3 < n) {
+                for (idx_t i = 0; i < m; i++) {
+                    A_pack(i, i_pack) = A(i, j + 3);
+                }
+                i_pack = (i_pack + 1) % np;
+                i_pack2 += 1;
+            }
+        }
+
+        // Shutdown phase
+        for (idx_t j = (n - k + 1) % 2; j < k; ++j) {
+            for (idx_t i = j, g = n - 2; i < k; ++i, --g) {
+                auto a1 = A_pack.column((g + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.column((g + 1 + i_pack - i_pack2 + np) % np);
+                rot(a1, a2, C(g, i), conj(S(g, i)));
+            }
+        }
+
+        // Copy the last np columns of A_pack back to A
+        for (idx_t i = 0; i < std::min(np, n - i_pack2); ++i) {
+            for (idx_t j = 0; j < m; ++j) {
+                A(j, i_pack2 + i) = A_pack(j, (i_pack + i) % np);
+            }
+        }
+    }
+
+    // Kernel for lasr3, backward right variant
+    template <typename T,
+              typename TC,
+              typename TS,
+              Layout layout,
+              typename idx_t>
+    void lasr3_kernel_backward_right(ConstMatrix<TC, layout, idx_t> C,
+                                     ConstMatrix<TS, layout, idx_t> S,
+                                     Matrix<T, layout, idx_t> A,
+                                     MemoryBlock<T, idx_t, true> work)
+    {
+        idx_t m = A.num_rows();
+        idx_t n = A.num_columns();
+        idx_t k = C.num_columns();
+
+        assert(C.num_rows() == S.num_rows());
+        assert(C.num_columns() == S.num_columns());
+        assert(n == C.num_rows() + 1);
+        assert(n > k + 1);
+
+        // Number of columns that will be stored in the packed workspace matrix
+        const idx_t np = k + 2;
+        // During the algorithm, instead of applying the rotations directly to
+        // the matrix A, we will apply them to a packed version of A. This is
+        // done to allow for efficient vectorization of the rotations. The
+        // packed matrix is stored in the workspace array. Since we apply the
+        // rotations from the right, this packed matrix is always column-major
+        // regardless of the layout of A.
+        Matrix<T, Layout::ColMajor, idx_t> A_pack(m, np, work);
+        // A_pack will store np columns of A.
+        // To avoid having to shuffle columns in A, we keep track of two indices
+        // For i = i_pack2, ..., i_pack2 + np - 1, column (i_pack + i - i_pack2
+        // + np) % np of A_pack corresponds to column i of A.
+        idx_t i_pack = 0;
+        idx_t i_pack2 = n - np;
+
+        // Copy the last np columns of A to A_pack
+        for (idx_t i = 0; i < m; ++i) {
+            for (idx_t j = 0; j < np; ++j) {
+                A_pack(i, j) = A(i, n - np + j);
+            }
+        }
+
+        // Startup phase
+        for (idx_t j = 0; j + 1 < k; ++j) {
+            for (idx_t i = 0, g = n - 2 - j; i < j + 1; ++i, ++g) {
+                rot(A_pack.column((g - i_pack2) % np),
+                    A_pack.column((g + 1 - i_pack2) % np), C(g, i),
+                    conj(S(g, i)));
+            }
+        }
+
+        // Pipeline phase
+        for (idx_t j = k - 1; j + 1 < n - 1; j += 2) {
+            for (idx_t i = 0, g = n - 2 - j; i + 1 < k; i += 2, g += 2) {
+                auto a1 = A_pack.column((g - 1 + i_pack - i_pack2) % np);
+                auto a2 = A_pack.column((g + i_pack - i_pack2) % np);
+                auto a3 = A_pack.column((g + 1 + i_pack - i_pack2) % np);
+                auto a4 = A_pack.column((g + 2 + i_pack - i_pack2) % np);
+
+                rot_fuse2x2(a1, a2, a3, a4, C(g, i), conj(S(g, i)), C(g - 1, i),
+                            conj(S(g - 1, i)), C(g + 1, i + 1),
+                            conj(S(g + 1, i + 1)), C(g, i + 1),
+                            conj(S(g, i + 1)));
+            }
+            if (k % 2 == 1) {
+                // k is odd, so there are two more rotations to apply
+                idx_t i = k - 1;
+                idx_t g = n - 2 - j + i;
+
+                auto a1 = A_pack.column((g - 1 + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.column((g + i_pack - i_pack2 + np) % np);
+                auto a3 = A_pack.column((g + 1 + i_pack - i_pack2 + np) % np);
+
+                rot_fuse1x2(a1, a2, a3, C(g, i), conj(S(g, i)), C(g - 1, i),
+                            conj(S(g - 1, i)));
+            }
+            // columns i_pack+np-2 and i_pack+np-1 are finished, copy them back
+            // to A
+            for (idx_t i = 0; i < m; i++) {
+                A(i, i_pack2 + np - 2) = A_pack(i, (i_pack + np - 2) % np);
+                A(i, i_pack2 + np - 1) = A_pack(i, (i_pack + np - 1) % np);
+            }
+            // Pack next rows and update i_pack and i_pack2
+            if (i_pack2 > 1) {
+                for (idx_t i = 0; i < m; i++) {
+                    A_pack(i, (i_pack + np - 2) % np) = A(i, i_pack2 - 2);
+                    A_pack(i, (i_pack + np - 1) % np) = A(i, i_pack2 - 1);
+                }
+                i_pack = (i_pack + np - 2) % np;
+                i_pack2 -= 2;
+            }
+            else if (i_pack2 > 0) {
+                for (idx_t i = 0; i < m; i++) {
+                    A_pack(i, (i_pack + np - 1) % np) = A(i, i_pack2 - 1);
+                }
+                i_pack = (i_pack + np - 1) % np;
+                i_pack2 -= 1;
+            }
+        }
+
+        // By now, i_pack2 should point to the start of the matrix.
+        assert(i_pack2 == 0);
+
+        // Shutdown phase
+        for (idx_t j = (n - k + 1) % 2; j < k; ++j) {
+            for (idx_t i = j, g = 0; i < k; ++i, ++g) {
+                auto a1 = A_pack.column((g + i_pack - i_pack2 + np) % np);
+                auto a2 = A_pack.column((g + 1 + i_pack - i_pack2 + np) % np);
+                rot(a1, a2, C(g, i), conj(S(g, i)));
+            }
+        }
+
+        // Copy the first np columns of A_pack back to A
+        for (idx_t i = 0; i < m; ++i) {
+            for (idx_t j = 0; j < np; ++j) {
+                A(i, j) = A_pack(i, (i_pack + j) % np);
+            }
+        }
+    }
+}  // namespace internal
+
+/**
+ * @copydoc lasr3
+ */
+template <typename T, typename TC, typename TS, Layout layout, typename idx_t>
+void lasr3(Side side,
+           Direction direct,
+           ConstMatrix<TC, layout, idx_t> C,
+           ConstMatrix<TS, layout, idx_t> S,
+           Matrix<T, layout, idx_t> A,
+           MemoryBlock<T, idx_t, true> work)
+{
+    const idx_t m = A.num_rows();
+    const idx_t n = A.num_columns();
+    const idx_t k = C.num_columns();
+    const idx_t num_rot = C.num_rows();
+
+    assert(side == Side::Left || side == Side::Right);
+    assert(direct == Direction::Forward || direct == Direction::Backward);
+    assert(C.num_rows() == S.num_rows());
+    assert(C.num_columns() == S.num_columns());
+    assert(side == Side::Left ? m : n == C.num_rows() + 1);
+    assert(work.size() >= lasr3_workquery(side, direct, C, S, A));
+
+    // Blocksize for the number of rows/columns of A to be processed at once
+    const idx_t block_mn = 256;
+    // Blocksize for the number of rotation sequences to be processed at once
+    const idx_t block_k = 64;
+
+    if (num_rot < 4) {
+        // If there are less than 4 rotations, we can't really pipeline,
+        // just use standard loops
+        if (side == Side::Left) {
+            if (direct == Direction::Forward) {
+                for (idx_t i = 0; i < k; ++i)
+                    for (idx_t j = 0; j < num_rot; ++j)
+                        rot(A.row(j), A.row(j + 1), C(j, i), S(j, i));
+            }
+            else {
+                for (idx_t i = 0; i < k; ++i)
+                    for (idx_t j = num_rot - 1; j >= 0; --j)
+                        rot(A.row(j), A.row(j + 1), C(j, i), S(j, i));
+            }
+        }
+        else {
+            if (direct == Direction::Forward) {
+                for (idx_t i = 0; i < k; ++i)
+                    for (idx_t j = 0; j < num_rot; ++j)
+                        rot(A.column(j), A.column(j + 1), C(j, i),
+                            conj(S(j, i)));
+            }
+            else {
+                for (idx_t i = 0; i < k; ++i)
+                    for (idx_t j = num_rot - 1; j >= 0; --j)
+                        rot(A.column(j), A.column(j + 1), C(j, i),
+                            conj(S(j, i)));
+            }
+        }
+        return;
+    }
+
+    // We can only pipeline if num_rot > k + 2
+    // And for good performance, we want an even larger ratio
+    const idx_t block_k2 = std::min(num_rot - 3, block_k);
+
+    if (side == Side::Left and direct == Direction::Forward) {
+        for (idx_t n_b = 0; n_b < n; n_b += block_mn) {
+            auto A2 = A.submatrix(0, m, n_b, std::min(n, n_b + block_mn));
+            for (idx_t k_b = 0; k_b < k; k_b += block_k2) {
+                auto C2 = C.submatrix(0, C.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                auto S2 = S.submatrix(0, S.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                internal::lasr3_kernel_forward_left(C2, S2, A2, work);
+            }
+        }
+    }
+
+    if (side == Side::Left and direct == Direction::Backward) {
+        for (idx_t n_b = 0; n_b < n; n_b += block_mn) {
+            auto A2 = A.submatrix(0, m, n_b, std::min(n, n_b + block_mn));
+            for (idx_t k_b = 0; k_b < k; k_b += block_k2) {
+                auto C2 = C.submatrix(0, C.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                auto S2 = S.submatrix(0, S.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                internal::lasr3_kernel_backward_left(C2, S2, A2, work);
+            }
+        }
+    }
+
+    if (side == Side::Right and direct == Direction::Forward) {
+        for (idx_t m_b = 0; m_b < m; m_b += block_mn) {
+            auto A2 = A.submatrix(m_b, std::min(m, m_b + block_mn), 0, n);
+            for (idx_t k_b = 0; k_b < k; k_b += block_k2) {
+                auto C2 = C.submatrix(0, C.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                auto S2 = S.submatrix(0, S.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                internal::lasr3_kernel_forward_right(C2, S2, A2, work);
+            }
+        }
+    }
+
+    if (side == Side::Right and direct == Direction::Backward) {
+        for (idx_t m_b = 0; m_b < m; m_b += block_mn) {
+            auto A2 = A.submatrix(m_b, std::min(m, m_b + block_mn), 0, n);
+            for (idx_t k_b = 0; k_b < k; k_b += block_k2) {
+                auto C2 = C.submatrix(0, C.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                auto S2 = S.submatrix(0, S.num_rows(), k_b,
+                                      std::min(k, k_b + block_k2));
+                internal::lasr3_kernel_backward_right(C2, S2, A2, work);
+            }
+        }
+    }
+}
+
+}  // namespace lapack_cpp
+
+#endif  // LAPACK_CPP_LASR3_HPP

--- a/LAPACK_CPP/include/lapack_cpp/utils.hpp
+++ b/LAPACK_CPP/include/lapack_cpp/utils.hpp
@@ -1,0 +1,87 @@
+#ifndef LAPACK_CPP_UTILS_HPP
+#define LAPACK_CPP_UTILS_HPP
+
+#include <iostream>
+#include <type_traits>
+
+#include "lapack_cpp/base.hpp"
+
+namespace lapack_cpp {
+
+// Code for printing
+template <typename T, typename idx_t>
+void print(const Vector<T, idx_t>& v)
+{
+    std::cout << "(" << v.size() << ")[" << std::endl;
+    for (idx_t i = 0; i < v.size(); ++i) {
+        std::cout << v[i] << std::endl;
+    }
+    std::cout << "]" << std::endl;
+}
+
+// Code for printing
+template <typename T, Layout layout, typename idx_t>
+void print(const Matrix<T, layout, idx_t>& m)
+{
+    std::cout << "(" << m.num_rows() << "," << m.num_columns() << ")["
+              << std::endl;
+    for (idx_t i = 0; i < m.num_rows(); ++i) {
+        std::cout << "[";
+        for (idx_t j = 0; j < m.num_columns() - 1; ++j) {
+            std::cout << m(i, j) << ",";
+        }
+        std::cout << m(i, m.num_columns() - 1) << "]" << std::endl;
+    }
+    std::cout << "]" << std::endl;
+}
+
+// Code for printing
+template <typename T, Layout layout, typename idx_t>
+void print(const ConstMatrix<T, layout, idx_t>& m)
+{
+    std::cout << "(" << m.num_rows() << "," << m.num_columns() << ")["
+              << std::endl;
+    for (idx_t i = 0; i < m.num_rows(); ++i) {
+        std::cout << "[";
+        for (idx_t j = 0; j < m.num_columns() - 1; ++j) {
+            std::cout << m(i, j) << ",";
+        }
+        std::cout << m(i, m.num_columns() - 1) << "]" << std::endl;
+    }
+    std::cout << "]" << std::endl;
+}
+
+// Initialize a matrix with random values
+template <typename T, Layout layout, typename idx_t>
+void randomize(Matrix<T, layout, idx_t>& m)
+{
+    for (idx_t j = 0; j < m.num_columns(); ++j) {
+        for (idx_t i = 0; i < m.num_rows(); ++i) {
+            m(i, j) = (T)rand() / (T)RAND_MAX;
+        }
+    }
+}
+
+template <typename T, Layout layout, typename idx_t>
+void randomize(Matrix<std::complex<T>, layout, idx_t>& m)
+{
+    for (idx_t j = 0; j < m.num_columns(); ++j) {
+        for (idx_t i = 0; i < m.num_rows(); ++i) {
+            m(i, j) = std::complex<T>((T)rand() / (T)RAND_MAX,
+                                      (T)rand() / (T)RAND_MAX);
+        }
+    }
+}
+
+// Initialize a vector with random values
+template <typename T, typename idx_t>
+void randomize(Vector<T, idx_t>& v)
+{
+    for (idx_t i = 0; i < v.size(); ++i) {
+        v[i] = (T)rand() / (T)RAND_MAX;
+    }
+}
+
+}  // namespace lapack_cpp
+
+#endif

--- a/LAPACK_CPP/src/lapack_c/lartg_c.f90
+++ b/LAPACK_CPP/src/lapack_c/lartg_c.f90
@@ -1,0 +1,53 @@
+subroutine lapack_c_slartg(f, g, c, s, r) bind(c, name='lapack_c_slartg')
+    use iso_c_binding
+    implicit none
+    real(kind=c_float), intent(in), value :: f, g
+    real(kind=c_float), intent(out) :: c, s, r
+
+    external slartg
+
+    ! Forward call to fortran implementation
+    call slartg( f, g, c, s, r )
+
+end subroutine lapack_c_slartg
+
+subroutine lapack_c_dlartg(f, g, c, s, r) bind(c, name='lapack_c_dlartg')
+    use iso_c_binding
+    implicit none
+    real(kind=c_double), intent(in), value :: f, g
+    real(kind=c_double), intent(out) :: c, s, r
+
+    external dlartg
+
+    ! Forward call to fortran implementation
+    call dlartg( f, g, c, s, r )
+
+end subroutine lapack_c_dlartg
+
+subroutine lapack_c_clartg(f, g, c, s, r) bind(c, name='lapack_c_clartg')
+    use iso_c_binding
+    implicit none
+    complex(kind=c_float_complex), intent(in), value :: f, g
+    complex(kind=c_float_complex), intent(out) :: s, r
+    real(kind=c_float), intent(out) :: c
+
+    external clartg
+
+    ! Forward call to fortran implementation
+    call clartg( f, g, c, s, r )
+
+end subroutine lapack_c_clartg
+
+subroutine lapack_c_zlartg(f, g, c, s, r) bind(c, name='lapack_c_zlartg')
+    use iso_c_binding
+    implicit none
+    complex(kind=c_double_complex), intent(in), value :: f, g
+    complex(kind=c_double_complex), intent(out) :: s, r
+    real(kind=c_double), intent(out) :: c
+
+    external zlartg
+
+    ! Forward call to fortran implementation
+    call zlartg( f, g, c, s, r )
+
+end subroutine lapack_c_zlartg

--- a/LAPACK_CPP/src/lapack_c/lasr3_c.cpp
+++ b/LAPACK_CPP/src/lapack_c/lasr3_c.cpp
@@ -1,0 +1,206 @@
+#include "lapack_c/lasr3.h"
+#include "lapack_cpp/base.hpp"
+#include "lapack_cpp/lapack/lasr3.hpp"
+
+using namespace lapack_cpp;
+
+// Actual definitions
+extern "C" {
+
+void slasr3(char side,
+            char direct,
+            lapack_idx m,
+            lapack_idx n,
+            lapack_idx k,
+            const float* C,
+            lapack_idx ldc,
+            const float* S,
+            lapack_idx lds,
+            float* A,
+            lapack_idx lda,
+            float* work,
+            lapack_idx lwork)
+{
+    Side side_ = char2side(side);
+    Direction direct_ = char2direct(direct);
+    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+
+    ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+    ConstMatrix<float, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+    Matrix<float, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+
+    if (lwork == -1) {
+        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+        *work = lwork_;
+        return;
+    }
+
+    MemoryBlock<float, lapack_idx> work_(lwork, work);
+    lasr3(side_, direct_, C_, S_, A_, work_);
+}
+
+void dlasr3(char side,
+            char direct,
+            lapack_idx m,
+            lapack_idx n,
+            lapack_idx k,
+            const double* C,
+            lapack_idx ldc,
+            const double* S,
+            lapack_idx lds,
+            double* A,
+            lapack_idx lda,
+            double* work,
+            lapack_idx lwork)
+{
+    Side side_ = char2side(side);
+    Direction direct_ = char2direct(direct);
+    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+
+    ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+    ConstMatrix<double, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+    Matrix<double, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+
+    if (lwork == -1) {
+        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+        *work = lwork_;
+        return;
+    }
+
+    MemoryBlock<double, lapack_idx> work_(lwork, work);
+    lasr3(side_, direct_, C_, S_, A_, work_);
+}
+
+void clasr3(char side,
+            char direct,
+            lapack_idx m,
+            lapack_idx n,
+            lapack_idx k,
+            const float* C,
+            lapack_idx ldc,
+            const lapack_float_complex* S,
+            lapack_idx lds,
+            lapack_float_complex* A,
+            lapack_idx lda,
+            lapack_float_complex* work,
+            lapack_idx lwork)
+{
+    Side side_ = char2side(side);
+    Direction direct_ = char2direct(direct);
+    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+
+    ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+    ConstMatrix<lapack_float_complex, Layout::ColMajor, lapack_idx> S_(n_rot, k,
+                                                                       S, lds);
+    Matrix<lapack_float_complex, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+
+    if (lwork == -1) {
+        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+        *work = lwork_;
+        return;
+    }
+
+    MemoryBlock<lapack_float_complex, lapack_idx> work_(lwork, work);
+    lasr3(side_, direct_, C_, S_, A_, work_);
+}
+
+void zlasr3(char side,
+            char direct,
+            lapack_idx m,
+            lapack_idx n,
+            lapack_idx k,
+            const double* C,
+            lapack_idx ldc,
+            const lapack_double_complex* S,
+            lapack_idx lds,
+            lapack_double_complex* A,
+            lapack_idx lda,
+            lapack_double_complex* work,
+            lapack_idx lwork)
+{
+    Side side_ = char2side(side);
+    Direction direct_ = char2direct(direct);
+    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+
+    ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+    ConstMatrix<lapack_double_complex, Layout::ColMajor, lapack_idx> S_(
+        n_rot, k, S, lds);
+    Matrix<lapack_double_complex, Layout::ColMajor, lapack_idx> A_(m, n, A,
+                                                                   lda);
+
+    if (lwork == -1) {
+        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+        *work = lwork_;
+        return;
+    }
+
+    MemoryBlock<lapack_double_complex, lapack_idx> work_(lwork, work);
+    lasr3(side_, direct_, C_, S_, A_, work_);
+}
+
+void cslasr3(char side,
+             char direct,
+             lapack_idx m,
+             lapack_idx n,
+             lapack_idx k,
+             const float* C,
+             lapack_idx ldc,
+             const float* S,
+             lapack_idx lds,
+             lapack_float_complex* A,
+             lapack_idx lda,
+             lapack_float_complex* work,
+             lapack_idx lwork)
+{
+    Side side_ = char2side(side);
+    Direction direct_ = char2direct(direct);
+    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+
+    ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+    ConstMatrix<float, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+    Matrix<lapack_float_complex, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+
+    if (lwork == -1) {
+        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+        *work = lwork_;
+        return;
+    }
+
+    MemoryBlock<lapack_float_complex, lapack_idx> work_(lwork, work);
+    lasr3(side_, direct_, C_, S_, A_, work_);
+}
+
+void zdlasr3(char side,
+             char direct,
+             lapack_idx m,
+             lapack_idx n,
+             lapack_idx k,
+             const double* C,
+             lapack_idx ldc,
+             const double* S,
+             lapack_idx lds,
+             lapack_double_complex* A,
+             lapack_idx lda,
+             lapack_double_complex* work,
+             lapack_idx lwork)
+{
+    Side side_ = char2side(side);
+    Direction direct_ = char2direct(direct);
+    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+
+    ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+    ConstMatrix<double, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+    Matrix<lapack_double_complex, Layout::ColMajor, lapack_idx> A_(m, n, A,
+                                                                   lda);
+
+    if (lwork == -1) {
+        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+        *work = lwork_;
+        return;
+    }
+
+    MemoryBlock<lapack_double_complex, lapack_idx> work_(lwork, work);
+    lasr3(side_, direct_, C_, S_, A_, work_);
+}
+
+}  // extern "C"

--- a/LAPACK_CPP/src/lapack_c/lasr3_c.cpp
+++ b/LAPACK_CPP/src/lapack_c/lasr3_c.cpp
@@ -5,202 +5,209 @@
 using namespace lapack_cpp;
 
 // Actual definitions
-extern "C" {
-
-void slasr3(char side,
-            char direct,
-            lapack_idx m,
-            lapack_idx n,
-            lapack_idx k,
-            const float* C,
-            lapack_idx ldc,
-            const float* S,
-            lapack_idx lds,
-            float* A,
-            lapack_idx lda,
-            float* work,
-            lapack_idx lwork)
+extern "C"
 {
-    Side side_ = char2side(side);
-    Direction direct_ = char2direct(direct);
-    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
 
-    ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
-    ConstMatrix<float, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
-    Matrix<float, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+    void lapack_c_slasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const float *C,
+                         lapack_idx ldc,
+                         const float *S,
+                         lapack_idx lds,
+                         float *A,
+                         lapack_idx lda,
+                         float *work,
+                         lapack_idx lwork)
+    {
+        Side side_ = char2side(side);
+        Direction direct_ = char2direct(direct);
+        const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
 
-    if (lwork == -1) {
-        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
-        *work = lwork_;
-        return;
+        ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+        ConstMatrix<float, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+        Matrix<float, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+
+        if (lwork == -1)
+        {
+            lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+            *work = lwork_;
+            return;
+        }
+
+        MemoryBlock<float, lapack_idx> work_(lwork, work);
+        lasr3(side_, direct_, C_, S_, A_, work_);
     }
 
-    MemoryBlock<float, lapack_idx> work_(lwork, work);
-    lasr3(side_, direct_, C_, S_, A_, work_);
-}
+    void lapack_c_dlasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const double *C,
+                         lapack_idx ldc,
+                         const double *S,
+                         lapack_idx lds,
+                         double *A,
+                         lapack_idx lda,
+                         double *work,
+                         lapack_idx lwork)
+    {
+        Side side_ = char2side(side);
+        Direction direct_ = char2direct(direct);
+        const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
 
-void dlasr3(char side,
-            char direct,
-            lapack_idx m,
-            lapack_idx n,
-            lapack_idx k,
-            const double* C,
-            lapack_idx ldc,
-            const double* S,
-            lapack_idx lds,
-            double* A,
-            lapack_idx lda,
-            double* work,
-            lapack_idx lwork)
-{
-    Side side_ = char2side(side);
-    Direction direct_ = char2direct(direct);
-    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+        ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+        ConstMatrix<double, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+        Matrix<double, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
 
-    ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
-    ConstMatrix<double, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
-    Matrix<double, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+        if (lwork == -1)
+        {
+            lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+            *work = lwork_;
+            return;
+        }
 
-    if (lwork == -1) {
-        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
-        *work = lwork_;
-        return;
+        MemoryBlock<double, lapack_idx> work_(lwork, work);
+        lasr3(side_, direct_, C_, S_, A_, work_);
     }
 
-    MemoryBlock<double, lapack_idx> work_(lwork, work);
-    lasr3(side_, direct_, C_, S_, A_, work_);
-}
+    void lapack_c_clasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const float *C,
+                         lapack_idx ldc,
+                         const lapack_float_complex *S,
+                         lapack_idx lds,
+                         lapack_float_complex *A,
+                         lapack_idx lda,
+                         lapack_float_complex *work,
+                         lapack_idx lwork)
+    {
+        Side side_ = char2side(side);
+        Direction direct_ = char2direct(direct);
+        const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
 
-void clasr3(char side,
-            char direct,
-            lapack_idx m,
-            lapack_idx n,
-            lapack_idx k,
-            const float* C,
-            lapack_idx ldc,
-            const lapack_float_complex* S,
-            lapack_idx lds,
-            lapack_float_complex* A,
-            lapack_idx lda,
-            lapack_float_complex* work,
-            lapack_idx lwork)
-{
-    Side side_ = char2side(side);
-    Direction direct_ = char2direct(direct);
-    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+        ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+        ConstMatrix<lapack_float_complex, Layout::ColMajor, lapack_idx> S_(n_rot, k,
+                                                                           S, lds);
+        Matrix<lapack_float_complex, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
 
-    ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
-    ConstMatrix<lapack_float_complex, Layout::ColMajor, lapack_idx> S_(n_rot, k,
-                                                                       S, lds);
-    Matrix<lapack_float_complex, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+        if (lwork == -1)
+        {
+            lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+            *work = lwork_;
+            return;
+        }
 
-    if (lwork == -1) {
-        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
-        *work = lwork_;
-        return;
+        MemoryBlock<lapack_float_complex, lapack_idx> work_(lwork, work);
+        lasr3(side_, direct_, C_, S_, A_, work_);
     }
 
-    MemoryBlock<lapack_float_complex, lapack_idx> work_(lwork, work);
-    lasr3(side_, direct_, C_, S_, A_, work_);
-}
+    void lapack_c_zlasr3(char side,
+                         char direct,
+                         lapack_idx m,
+                         lapack_idx n,
+                         lapack_idx k,
+                         const double *C,
+                         lapack_idx ldc,
+                         const lapack_double_complex *S,
+                         lapack_idx lds,
+                         lapack_double_complex *A,
+                         lapack_idx lda,
+                         lapack_double_complex *work,
+                         lapack_idx lwork)
+    {
+        Side side_ = char2side(side);
+        Direction direct_ = char2direct(direct);
+        const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
 
-void zlasr3(char side,
-            char direct,
-            lapack_idx m,
-            lapack_idx n,
-            lapack_idx k,
-            const double* C,
-            lapack_idx ldc,
-            const lapack_double_complex* S,
-            lapack_idx lds,
-            lapack_double_complex* A,
-            lapack_idx lda,
-            lapack_double_complex* work,
-            lapack_idx lwork)
-{
-    Side side_ = char2side(side);
-    Direction direct_ = char2direct(direct);
-    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+        ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+        ConstMatrix<lapack_double_complex, Layout::ColMajor, lapack_idx> S_(
+            n_rot, k, S, lds);
+        Matrix<lapack_double_complex, Layout::ColMajor, lapack_idx> A_(m, n, A,
+                                                                       lda);
 
-    ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
-    ConstMatrix<lapack_double_complex, Layout::ColMajor, lapack_idx> S_(
-        n_rot, k, S, lds);
-    Matrix<lapack_double_complex, Layout::ColMajor, lapack_idx> A_(m, n, A,
-                                                                   lda);
+        if (lwork == -1)
+        {
+            lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+            *work = lwork_;
+            return;
+        }
 
-    if (lwork == -1) {
-        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
-        *work = lwork_;
-        return;
+        MemoryBlock<lapack_double_complex, lapack_idx> work_(lwork, work);
+        lasr3(side_, direct_, C_, S_, A_, work_);
     }
 
-    MemoryBlock<lapack_double_complex, lapack_idx> work_(lwork, work);
-    lasr3(side_, direct_, C_, S_, A_, work_);
-}
+    void lapack_c_sclasr3(char side,
+                          char direct,
+                          lapack_idx m,
+                          lapack_idx n,
+                          lapack_idx k,
+                          const float *C,
+                          lapack_idx ldc,
+                          const float *S,
+                          lapack_idx lds,
+                          lapack_float_complex *A,
+                          lapack_idx lda,
+                          lapack_float_complex *work,
+                          lapack_idx lwork)
+    {
+        Side side_ = char2side(side);
+        Direction direct_ = char2direct(direct);
+        const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
 
-void cslasr3(char side,
-             char direct,
-             lapack_idx m,
-             lapack_idx n,
-             lapack_idx k,
-             const float* C,
-             lapack_idx ldc,
-             const float* S,
-             lapack_idx lds,
-             lapack_float_complex* A,
-             lapack_idx lda,
-             lapack_float_complex* work,
-             lapack_idx lwork)
-{
-    Side side_ = char2side(side);
-    Direction direct_ = char2direct(direct);
-    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+        ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+        ConstMatrix<float, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+        Matrix<lapack_float_complex, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
 
-    ConstMatrix<float, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
-    ConstMatrix<float, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
-    Matrix<lapack_float_complex, Layout::ColMajor, lapack_idx> A_(m, n, A, lda);
+        if (lwork == -1)
+        {
+            lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+            *work = lwork_;
+            return;
+        }
 
-    if (lwork == -1) {
-        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
-        *work = lwork_;
-        return;
+        MemoryBlock<lapack_float_complex, lapack_idx> work_(lwork, work);
+        lasr3(side_, direct_, C_, S_, A_, work_);
     }
 
-    MemoryBlock<lapack_float_complex, lapack_idx> work_(lwork, work);
-    lasr3(side_, direct_, C_, S_, A_, work_);
-}
+    void lapack_c_dzlasr3(char side,
+                          char direct,
+                          lapack_idx m,
+                          lapack_idx n,
+                          lapack_idx k,
+                          const double *C,
+                          lapack_idx ldc,
+                          const double *S,
+                          lapack_idx lds,
+                          lapack_double_complex *A,
+                          lapack_idx lda,
+                          lapack_double_complex *work,
+                          lapack_idx lwork)
+    {
+        Side side_ = char2side(side);
+        Direction direct_ = char2direct(direct);
+        const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
 
-void zdlasr3(char side,
-             char direct,
-             lapack_idx m,
-             lapack_idx n,
-             lapack_idx k,
-             const double* C,
-             lapack_idx ldc,
-             const double* S,
-             lapack_idx lds,
-             lapack_double_complex* A,
-             lapack_idx lda,
-             lapack_double_complex* work,
-             lapack_idx lwork)
-{
-    Side side_ = char2side(side);
-    Direction direct_ = char2direct(direct);
-    const lapack_idx n_rot = side_ == Side::Left ? m - 1 : n - 1;
+        ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
+        ConstMatrix<double, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
+        Matrix<lapack_double_complex, Layout::ColMajor, lapack_idx> A_(m, n, A,
+                                                                       lda);
 
-    ConstMatrix<double, Layout::ColMajor, lapack_idx> C_(n_rot, k, C, ldc);
-    ConstMatrix<double, Layout::ColMajor, lapack_idx> S_(n_rot, k, S, lds);
-    Matrix<lapack_double_complex, Layout::ColMajor, lapack_idx> A_(m, n, A,
-                                                                   lda);
+        if (lwork == -1)
+        {
+            lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
+            *work = lwork_;
+            return;
+        }
 
-    if (lwork == -1) {
-        lapack_idx lwork_ = lasr3_workquery(side_, direct_, C_, S_, A_);
-        *work = lwork_;
-        return;
+        MemoryBlock<lapack_double_complex, lapack_idx> work_(lwork, work);
+        lasr3(side_, direct_, C_, S_, A_, work_);
     }
 
-    MemoryBlock<lapack_double_complex, lapack_idx> work_(lwork, work);
-    lasr3(side_, direct_, C_, S_, A_, work_);
-}
-
-}  // extern "C"
+} // extern "C"

--- a/LAPACK_CPP/src/lapack_c/rot_c.f90
+++ b/LAPACK_CPP/src/lapack_c/rot_c.f90
@@ -1,0 +1,57 @@
+subroutine lapack_c_drot(n, dx ,incx, dy, incy, c, s) bind(c, name='lapack_c_drot')
+    use iso_c_binding
+    implicit none
+    integer(kind=c_int), value, intent(in) :: n, incx, incy
+    real(kind=c_double), value, intent(in) :: c, s
+    real(kind=c_double), dimension(*), intent(inout) :: dx, dy
+
+    external drot
+
+    ! Forward call to fortran implementation
+    call drot( n, dx ,incx, dy, incy, c, s )
+
+end subroutine lapack_c_drot
+
+subroutine lapack_c_srot(n, dx ,incx, dy, incy, c, s) bind(c, name='lapack_c_srot')
+    use iso_c_binding
+    implicit none
+    integer(kind=c_int), value, intent(in) :: n, incx, incy
+    real(kind=c_float), value, intent(in) :: c, s
+    real(kind=c_float), dimension(*), intent(inout) :: dx, dy
+
+    external srot
+
+    ! Forward call to fortran implementation
+    call srot( n, dx ,incx, dy, incy, c, s )
+
+end subroutine lapack_c_srot
+
+subroutine lapack_c_crot(n, dx ,incx, dy, incy, c, s) bind(c, name='lapack_c_crot')
+    use iso_c_binding
+    implicit none
+    integer(kind=c_int), value, intent(in) :: n, incx, incy
+    real(kind=c_float), value, intent(in) :: c
+    complex(kind=c_float_complex), value, intent(in) :: s
+    complex(kind=c_float_complex), dimension(*), intent(inout) :: dx, dy
+
+    external crot
+
+    ! Forward call to fortran implementation
+    call crot( n, dx ,incx, dy, incy, c, s )
+
+end subroutine lapack_c_crot
+
+subroutine lapack_c_zrot(n, dx ,incx, dy, incy, c, s) bind(c, name='lapack_c_zrot')
+    use iso_c_binding
+    implicit none
+    integer(kind=c_int), value, intent(in) :: n, incx, incy
+    real(kind=c_double), value, intent(in) :: c
+    complex(kind=c_double_complex), value, intent(in) :: s
+    complex(kind=c_double_complex), dimension(*), intent(inout) :: dx, dy
+
+    external zrot
+
+    ! Forward call to fortran implementation
+    call zrot( n, dx ,incx, dy, incy, c, s )
+
+end subroutine lapack_c_zrot

--- a/LAPACK_CPP/src/lapack_cpp/lartg_cpp.cpp
+++ b/LAPACK_CPP/src/lapack_cpp/lartg_cpp.cpp
@@ -1,0 +1,43 @@
+#include <cassert>
+#include <complex>
+#include <type_traits>
+
+#include "lapack_c.h"
+#include "lapack_cpp/base.hpp"
+#include "lapack_cpp/lapack/lartg.hpp"
+
+namespace lapack_cpp {
+
+template <>
+void lartg<float>(float f, float g, float& c, float& s, float& r)
+{
+    lapack_c_slartg(f, g, &c, &s, &r);
+}
+
+template <>
+void lartg<double>(double f, double g, double& c, double& s, double& r)
+{
+    lapack_c_dlartg(f, g, &c, &s, &r);
+}
+
+template <>
+void lartg<std::complex<float>>(std::complex<float> f,
+                                std::complex<float> g,
+                                float& c,
+                                std::complex<float>& s,
+                                std::complex<float>& r)
+{
+    lapack_c_clartg(f, g, &c, &s, &r);
+}
+
+template <>
+void lartg<std::complex<double>>(std::complex<double> f,
+                                 std::complex<double> g,
+                                 double& c,
+                                 std::complex<double>& s,
+                                 std::complex<double>& r)
+{
+    lapack_c_zlartg(f, g, &c, &s, &r);
+}
+
+}  // namespace lapack_cpp

--- a/LAPACK_CPP/src/lapack_cpp/rot_cpp.cpp
+++ b/LAPACK_CPP/src/lapack_cpp/rot_cpp.cpp
@@ -1,0 +1,67 @@
+#ifdef USE_FORTRAN_BLAS
+    #include <cassert>
+    #include <complex>
+    #include <type_traits>
+
+    #include "lapack_c.h"
+    #include "lapack_cpp/base.hpp"
+    #include "lapack_cpp/blas/rot.hpp"
+
+namespace lapack_cpp {
+
+/**
+ * Templated wrapper around c functions, will be instantiated for each type.
+ *
+ * @tparam T
+ * @param A
+ * @param B
+ * @param C
+ */
+template <typename T, typename TC, typename TS, typename idx_t>
+inline void rot_c_wrapper(const Vector<T, idx_t>& x,
+                          const Vector<T, idx_t>& y,
+                          TC c,
+                          TS s)
+{
+    assert(x.size() == y.size());
+
+    if constexpr (std::is_same<T, double>::value) {
+        lapack_c_drot(x.size(), x.ptr(), x.stride(), y.ptr(), y.stride(), c, s);
+    }
+    else if constexpr (std::is_same<T, float>::value) {
+        lapack_c_srot(x.size(), x.ptr(), x.stride(), y.ptr(), y.stride(), c, s);
+    }
+    else if constexpr (std::is_same<T, std::complex<float>>::value) {
+        lapack_c_crot(x.size(), x.ptr(), x.stride(), y.ptr(), y.stride(), c, s);
+    }
+    else if constexpr (std::is_same<T, std::complex<double>>::value) {
+        lapack_c_zrot(x.size(), x.ptr(), x.stride(), y.ptr(), y.stride(), c, s);
+    }
+    else {
+        assert(false);
+    }
+}
+
+    // We have a lot of types to instantiate for, so we use a macro to avoid
+    // repetition.
+    #define INSTANTIATE_ROT(T, TC, idx_t)                                    \
+        template <>                                                          \
+        void rot(const Vector<T, idx_t>& x, const Vector<T, idx_t>& y, TC c, \
+                 T s)                                                        \
+        {                                                                    \
+            rot_c_wrapper(x, y, c, s);                                       \
+        }
+
+INSTANTIATE_ROT(float, float, lapack_idx_t)
+INSTANTIATE_ROT(double, double, lapack_idx_t)
+INSTANTIATE_ROT(std::complex<float>, float, lapack_idx_t)
+INSTANTIATE_ROT(std::complex<double>, double, lapack_idx_t)
+INSTANTIATE_ROT(float, float, int)
+INSTANTIATE_ROT(double, double, int)
+INSTANTIATE_ROT(std::complex<float>, float, int)
+INSTANTIATE_ROT(std::complex<double>, double, int)
+
+    #undef INSTANTIATE_ROT
+
+}  // namespace lapack_cpp
+#endif  // USE_FORTRAN_BLAS

--- a/LAPACK_CPP/src/lapack_fortran/clasr3.f90
+++ b/LAPACK_CPP/src/lapack_fortran/clasr3.f90
@@ -1,0 +1,32 @@
+subroutine clasr3 ( side, direct, m, n, k, C, ldc, S, lds, A, lda, work, lwork )
+    use iso_c_binding, only: c_char
+    implicit none
+    ! Interface to C
+    interface
+        subroutine lapack_c_clasr3(side_c, direct_c, m_c, n_c, k_c, C_c,&
+             ldc_c, S_c, lds_c, A_c, lda_c, work_c, lwork_c) bind(c, name="lapack_c_clasr3")
+            use iso_c_binding, only: c_char, c_float, c_float_complex, c_int
+            implicit none
+            integer(c_int), intent(in) :: m_c,n_c,k_c,ldc_c, lds_c, lda_c, lwork_c
+            character(c_char), intent(in) :: side_c, direct_c
+            real(c_float), intent(in) :: C_c(ldc_c,*)
+            complex(c_float_complex), intent(in) :: S_c(lds_c,*)
+            complex(c_float_complex), intent(inout) :: A_c(lda_c,*), work_c(*)
+        end subroutine lapack_c_clasr3
+    end interface
+
+    ! Arguments
+    integer, intent(in) :: m,n,k,ldc, lds, lda, lwork
+    character, intent(in) :: side, direct
+    real, intent(in) :: C(ldc,*)
+    complex, intent(in) :: S(lds,*)
+    complex, intent(inout) :: A(lda,*), work(*)
+    character(c_char) :: side_to_c, direct_to_c
+
+    ! Convert characters to C characters
+    side_to_c = side
+    direct_to_c = direct
+
+    ! Call C function
+    call lapack_c_clasr3(side_to_c, direct_to_c, m, n, k, C, ldc, S, lds, A, lda, work, lwork)
+end subroutine clasr3

--- a/LAPACK_CPP/src/lapack_fortran/dlasr3.f90
+++ b/LAPACK_CPP/src/lapack_fortran/dlasr3.f90
@@ -1,0 +1,30 @@
+subroutine dlasr3 ( side, direct, m, n, k, C, ldc, S, lds, A, lda, work, lwork )
+    use iso_c_binding, only: c_char
+    implicit none
+    ! Interface to C
+    interface
+        subroutine lapack_c_dlasr3(side_c, direct_c, m_c, n_c, k_c, C_c,&
+             ldc_c, S_c, lds_c, A_c, lda_c, work_c, lwork_c) bind(c, name="lapack_c_dlasr3")
+            use iso_c_binding, only: c_char, c_double, c_int
+            implicit none
+            integer(c_int), intent(in) :: m_c,n_c,k_c,ldc_c, lds_c, lda_c, lwork_c
+            character(c_char), intent(in) :: side_c, direct_c
+            real(c_double), intent(in) :: C_c(ldc_c,*),S_c(lds_c,*)
+            real(c_double), intent(inout) :: A_c(lda_c,*), work_c(*)
+        end subroutine lapack_c_dlasr3
+    end interface
+
+    ! Arguments
+    integer, intent(in) :: m,n,k,ldc, lds, lda, lwork
+    character, intent(in) :: side, direct
+    double precision, intent(in) :: C(ldc,*),S(lds,*)
+    double precision, intent(inout) :: A(lda,*), work(*)
+    character(c_char) :: side_to_c, direct_to_c
+
+    ! Convert characters to C characters
+    side_to_c = side
+    direct_to_c = direct
+
+    ! Call C function
+    call lapack_c_dlasr3(side_to_c, direct_to_c, m, n, k, C, ldc, S, lds, A, lda, work, lwork)
+end subroutine dlasr3

--- a/LAPACK_CPP/src/lapack_fortran/slasr3.f90
+++ b/LAPACK_CPP/src/lapack_fortran/slasr3.f90
@@ -1,0 +1,30 @@
+subroutine slasr3 ( side, direct, m, n, k, C, ldc, S, lds, A, lda, work, lwork )
+    use iso_c_binding, only: c_char
+    implicit none
+    ! Interface to C
+    interface
+        subroutine lapack_c_slasr3(side_c, direct_c, m_c, n_c, k_c, C_c,&
+             ldc_c, S_c, lds_c, A_c, lda_c, work_c, lwork_c) bind(c, name="lapack_c_slasr3")
+            use iso_c_binding, only: c_char, c_float, c_int
+            implicit none
+            integer(c_int), intent(in) :: m_c,n_c,k_c,ldc_c, lds_c, lda_c, lwork_c
+            character(c_char), intent(in) :: side_c, direct_c
+            real(c_float), intent(in) :: C_c(ldc_c,*),S_c(lds_c,*)
+            real(c_float), intent(inout) :: A_c(lda_c,*), work_c(*)
+        end subroutine lapack_c_slasr3
+    end interface
+
+    ! Arguments
+    integer, intent(in) :: m,n,k,ldc, lds, lda, lwork
+    character, intent(in) :: side, direct
+    real, intent(in) :: C(ldc,*),S(lds,*)
+    real, intent(inout) :: A(lda,*), work(*)
+    character(c_char) :: side_to_c, direct_to_c
+
+    ! Convert characters to C characters
+    side_to_c = side
+    direct_to_c = direct
+
+    ! Call C function
+    call lapack_c_slasr3(side_to_c, direct_to_c, m, n, k, C, ldc, S, lds, A, lda, work, lwork)
+end subroutine slasr3

--- a/LAPACK_CPP/src/lapack_fortran/zlasr3.f90
+++ b/LAPACK_CPP/src/lapack_fortran/zlasr3.f90
@@ -1,0 +1,32 @@
+subroutine zlasr3 ( side, direct, m, n, k, C, ldc, S, lds, A, lda, work, lwork )
+    use iso_c_binding, only: c_char
+    implicit none
+    ! Interface to C
+    interface
+        subroutine lapack_c_zlasr3(side_c, direct_c, m_c, n_c, k_c, C_c,&
+             ldc_c, S_c, lds_c, A_c, lda_c, work_c, lwork_c) bind(c, name="lapack_c_zlasr3")
+            use iso_c_binding, only: c_char, c_double, c_double_complex, c_int
+            implicit none
+            integer(c_int), intent(in) :: m_c,n_c,k_c,ldc_c, lds_c, lda_c, lwork_c
+            character(c_char), intent(in) :: side_c, direct_c
+            real(c_double), intent(in) :: C_c(ldc_c,*)
+            complex(c_double_complex), intent(in) :: S_c(lds_c,*)
+            complex(c_double_complex), intent(inout) :: A_c(lda_c,*), work_c(*)
+        end subroutine lapack_c_zlasr3
+    end interface
+
+    ! Arguments
+    integer, intent(in) :: m,n,k,ldc, lds, lda, lwork
+    character, intent(in) :: side, direct
+    double precision, intent(in) :: C(ldc,*)
+    double complex, intent(in) :: S(lds,*)
+    double complex, intent(inout) :: A(lda,*), work(*)
+    character(c_char) :: side_to_c, direct_to_c
+
+    ! Convert characters to C characters
+    side_to_c = side
+    direct_to_c = direct
+
+    ! Call C function
+    call lapack_c_zlasr3(side_to_c, direct_to_c, m, n, k, C, ldc, S, lds, A, lda, work, lwork)
+end subroutine zlasr3


### PR DESCRIPTION
related to issue #988

This PR introduces some C++ code to LAPACK.

The general design for the C++ code is:
- C wrappers on top of existing fortran code
- C++ wrappers on top of those C wrappers
- C++ code for the new algorithm and its tests (note, those tests are not automated, so definitely need improving)
- C wrappers around the new C++ code
- Fortran wrappers around those C wrappers so current users can still use a familiar API.

A lot of things are introduced in this PR:
- Vector and Matrix classes, these are thin wrappers around a pointer and a size, allowing things like verbose selection of submatrices, columns, ..., all with bounds checks for every step.
- LASR3, an algorithm which efficiently applies a sequence of plane rotations to a matrix. (Note, this applies multiple sequences, making is more a level 3 routine than lasr, which is more a level 2 routine, hence the name) This algorithm is described in the paper: "Restructuring the Tridiagonal and Bidiagonal QR Algorithms for Performance" F. G. Van Zee et al. I have made a modification of this algorithm which packs the matrix A into an aligned workspace for efficiency. This means we also achieve high performance for matrices that are not aligned and even for access patterns that are normally not efficient (applying a sequence from the left on a column major matrix).

I expect (or hope) a lot of people will have comments on whether we should use C++ and on my implementation. To keep the discussions easy to follow, I suggest that conceptual comments on whether or not we should use C++ are direction to issue #998, comments on the specific way I introduced C++ and my implementation of the algorithm should be posted here.