### PR TITLE
xGEDMD(Q): silence warning with 64-bit integers

### DIFF
--- a/SRC/cgedmd.f90
+++ b/SRC/cgedmd.f90
@@ -11,7 +11,7 @@
 !                        W, LDW,  S, LDS, ZWORK,  LZWORK,   &
 !                        RWORK, LRWORK, IWORK, LIWORK, INFO )
 !.....
-!     USE                   iso_fortran_env
+!     USE, INTRINSIC :: iso_fortran_env, only: real32
 !     IMPLICIT NONE
 !     INTEGER, PARAMETER :: WP = real32
 !
@@ -506,7 +506,7 @@
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real32
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real32
 !

--- a/SRC/cgedmdq.f90
+++ b/SRC/cgedmdq.f90
@@ -12,7 +12,7 @@
 !                   S, LDS, ZWORK, LZWORK, WORK,  LWORK,   &
 !                   IWORK, LIWORK, INFO )
 !.....
-!     USE                   iso_fortran_env
+!     USE, INTRINSIC :: iso_fortran_env, only: real32
 !     IMPLICIT NONE
 !     INTEGER, PARAMETER :: WP = real32
 !.....
@@ -563,7 +563,7 @@ SUBROUTINE CGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real32
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real32
 !

--- a/SRC/dgedmd.f90
+++ b/SRC/dgedmd.f90
@@ -10,9 +10,8 @@
 !                        K, REIG,  IMEIG,   Z, LDZ,  RES,  &
 !                        B, LDB, W,  LDW,   S, LDS,        &
 !                        WORK, LWORK, IWORK, LIWORK, INFO )
-!
 !.....
-!     USE                   iso_fortran_env
+!     USE, INTRINSIC :: iso_fortran_env, only: real64
 !     IMPLICIT NONE
 !     INTEGER, PARAMETER :: WP = real64
 !.....
@@ -541,7 +540,7 @@
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real64
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real64
 !

--- a/SRC/dgedmdq.f90
+++ b/SRC/dgedmdq.f90
@@ -11,7 +11,7 @@
 !                         Z, LDZ, RES,  B,     LDB,   V, LDV,    &
 !                         S, LDS, WORK, LWORK, IWORK, LIWORK, INFO )
 !.....
-!     USE                   iso_fortran_env
+!     USE, INTRINSIC :: iso_fortran_env, only: real64
 !     IMPLICIT NONE
 !     INTEGER, PARAMETER :: WP = real64
 !.....
@@ -581,7 +581,7 @@ SUBROUTINE DGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real64
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real64
 !

--- a/SRC/sgedmd.f90
+++ b/SRC/sgedmd.f90
@@ -11,7 +11,7 @@
 !                        B, LDB, W,  LDW,   S, LDS,        &
 !                        WORK, LWORK, IWORK, LIWORK, INFO )
 !.....
-!     USE                   iso_fortran_env
+!     USE, INTRINSIC :: iso_fortran_env, only: real32
 !     IMPLICIT NONE
 !     INTEGER, PARAMETER :: WP = real32
 !.....
@@ -540,7 +540,7 @@
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real32
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real32
 !

--- a/SRC/sgedmdq.f90
+++ b/SRC/sgedmdq.f90
@@ -11,7 +11,7 @@
 !                         Z, LDZ, RES,  B,     LDB,   V, LDV,    &
 !                         S, LDS, WORK, LWORK, IWORK, LIWORK, INFO )
 !.....
-!     USE                   iso_fortran_env
+!     USE, INTRINSIC :: iso_fortran_env, only: real32
 !     IMPLICIT NONE
 !     INTEGER, PARAMETER :: WP = real32
 !.....
@@ -581,7 +581,7 @@ SUBROUTINE SGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real32
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real32
 !

--- a/SRC/zgedmd.f90
+++ b/SRC/zgedmd.f90
@@ -11,7 +11,7 @@
 !                         W, LDW,  S, LDS, ZWORK,  LZWORK,   &
 !                         RWORK, LRWORK, IWORK, LIWORK, INFO )
 !......
-!      USE                   iso_fortran_env
+!      USE, INTRINSIC :: iso_fortran_env, only: real64
 !      IMPLICIT NONE
 !      INTEGER, PARAMETER :: WP = real64
 !
@@ -506,7 +506,7 @@
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real64
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real64
 !

--- a/SRC/zgedmdq.f90
+++ b/SRC/zgedmdq.f90
@@ -12,7 +12,7 @@
 !                         S, LDS, ZWORK, LZWORK, WORK,  LWORK,   &
 !                         IWORK, LIWORK, INFO )
 !.....
-!     USE                   iso_fortran_env
+!     USE, INTRINSIC :: iso_fortran_env, only: real64
 !     IMPLICIT NONE
 !     INTEGER, PARAMETER :: WP = real64
 !.....
@@ -562,7 +562,7 @@ SUBROUTINE ZGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
 !  -- Colorado Denver and NAG Ltd..                                   --
 !
 !.....
-      USE                   iso_fortran_env
+      USE, INTRINSIC :: iso_fortran_env, only: real64
       IMPLICIT NONE
       INTEGER, PARAMETER :: WP = real64
 !


### PR DESCRIPTION
Fix the following warning by GCC 12.2.0 when building with 64-bit integers (e.g., when `BUILD_INDEX64_EXT_API=ON`):
```
Warning: Use of the NUMERIC_STORAGE_SIZE named constant from intrinsic module ISO_FORTRAN_ENV at (1) is incompatible with option -fdefault-integer-8
```

References:
* [Stack Overflow thread _ISO_FORTRAN_ENV or -fdefault-real-8 to promote reals to double precision_](https://stackoverflow.com/questions/49588914/iso-fortran-env-or-fdefault-real-8-to-promote-reals-to-double-precision)


**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.