### PR TITLE
fix fails of tests for QR/LQ factorizations

### DIFF
--- a/TESTING/LIN/cchklq.f
+++ b/TESTING/LIN/cchklq.f
@@ -237,7 +237,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, CERRLQ, CGELS, CGET02,
      $                   CLACPY, CLARHS, CLATB4, CLATMS, CLQT01, CLQT02,
-     $                   CLQT03, XLAENV
+     $                   CLQT03, CGELQF, XLAENV
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -355,16 +355,18 @@
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      ELSE IF( M.LE.N ) THEN
 *
-*                       Test CUNGLQ, using factorization
-*                       returned by CLQT01
+*                       Test CUNGLQ
+*
+                        CALL CLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL CGELQF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL CLQT02( M, N, K, A, AF, AQ, AL, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test CUNMLQ, using factorization returned
-*                       by CLQT01
+*                       Test CUNMLQ
 *
                         CALL CLQT03( M, N, K, AF, AC, AL, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )

--- a/TESTING/LIN/cchkqr.f
+++ b/TESTING/LIN/cchkqr.f
@@ -246,7 +246,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, CERRQR, CGELS, CGET02,
      $                   CLACPY, CLARHS, CLATB4, CLATMS, CQRT01,
-     $                   CQRT01P, CQRT02, CQRT03, XLAENV
+     $                   CQRT01P, CQRT02, CQRT03, CGEQRF, XLAENV
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -373,16 +373,18 @@
                         NT = NT + 1
                      ELSE IF( M.GE.N ) THEN
 *
-*                       Test CUNGQR, using factorization
-*                       returned by CQRT01
+*                       Test CUNGQR
+*
+                        CALL CLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL CGEQRF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL CQRT02( M, N, K, A, AF, AQ, AR, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test CUNMQR, using factorization returned
-*                       by CQRT01
+*                       Test CUNMQR
 *
                         CALL CQRT03( M, N, K, AF, AC, AR, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )

--- a/TESTING/LIN/dchklq.f
+++ b/TESTING/LIN/dchklq.f
@@ -237,7 +237,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, DERRLQ, DGELS, DGET02,
      $                   DLACPY, DLARHS, DLATB4, DLATMS, DLQT01, DLQT02,
-     $                   DLQT03, XLAENV
+     $                   DLQT03, DGELQF, XLAENV
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -355,8 +355,11 @@
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      ELSE IF( M.LE.N ) THEN
 *
-*                       Test DORGLQ, using factorization
-*                       returned by DLQT01
+*                       Test DORGLQ
+*
+                        CALL DLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL DGELQF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL DLQT02( M, N, K, A, AF, AQ, AL, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
@@ -366,8 +369,7 @@
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test DORMLQ, using factorization returned
-*                       by DLQT01
+*                       Test DORMLQ
 *
                         CALL DLQT03( M, N, K, AF, AC, AL, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )

--- a/TESTING/LIN/dchkqr.f
+++ b/TESTING/LIN/dchkqr.f
@@ -246,7 +246,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, DERRQR, DGELS, DGET02,
      $                   DLACPY, DLARHS, DLATB4, DLATMS, DQRT01,
-     $                   DQRT01P, DQRT02, DQRT03, XLAENV
+     $                   DQRT01P, DQRT02, DQRT03, DGEQRF, XLAENV
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -374,16 +374,18 @@
                         NT = NT + 1
                      ELSE IF( M.GE.N ) THEN
 *
-*                       Test DORGQR, using factorization
-*                       returned by DQRT01
+*                       Test DORGQR
+*
+                        CALL DLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL DGEQRF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL DQRT02( M, N, K, A, AF, AQ, AR, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test DORMQR, using factorization returned
-*                       by DQRT01
+*                       Test DORMQR
 *
                         CALL DQRT03( M, N, K, AF, AC, AR, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )

--- a/TESTING/LIN/schklq.f
+++ b/TESTING/LIN/schklq.f
@@ -237,7 +237,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, SERRLQ, SGET02,
      $                   SLACPY, SLARHS, SLATB4, SLATMS, SLQT01, SLQT02,
-     $                   SLQT03, XLAENV
+     $                   SLQT03, SGELQF, XLAENV
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -355,16 +355,18 @@
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      ELSE IF( M.LE.N ) THEN
 *
-*                       Test SORGLQ, using factorization
-*                       returned by SLQT01
+*                       Test SORGLQ
+*
+                        CALL SLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL SGELQF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL SLQT02( M, N, K, A, AF, AQ, AL, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test SORMLQ, using factorization returned
-*                       by SLQT01
+*                       Test SORMLQ
 *
                         CALL SLQT03( M, N, K, AF, AC, AL, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )

--- a/TESTING/LIN/schkqr.f
+++ b/TESTING/LIN/schkqr.f
@@ -246,7 +246,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, SERRQR, SGELS, SGET02,
      $                   SLACPY, SLARHS, SLATB4, SLATMS, SQRT01,
-     $                   SQRT01P, SQRT02, SQRT03, XLAENV
+     $                   SQRT01P, SQRT02, SQRT03, SGEQRF, XLAENV
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -373,16 +373,18 @@
                          NT = NT + 1
                      ELSE IF( M.GE.N ) THEN
 *
-*                       Test SORGQR, using factorization
-*                       returned by SQRT01
+*                       Test SORGQR
+*
+                        CALL SLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL SGEQRF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL SQRT02( M, N, K, A, AF, AQ, AR, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test SORMQR, using factorization returned
-*                       by SQRT01
+*                       Test SORMQR
 *
                         CALL SQRT03( M, N, K, AF, AC, AR, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )

--- a/TESTING/LIN/zchklq.f
+++ b/TESTING/LIN/zchklq.f
@@ -237,7 +237,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, XLAENV, ZERRLQ, ZGELS,
      $                   ZGET02, ZLACPY, ZLARHS, ZLATB4, ZLATMS, ZLQT01,
-     $                   ZLQT02, ZLQT03
+     $                   ZLQT02, ZLQT03, ZGELQF
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -355,16 +355,18 @@
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      ELSE IF( M.LE.N ) THEN
 *
-*                       Test ZUNGLQ, using factorization
-*                       returned by ZLQT01
+*                       Test ZUNGLQ
+*
+                        CALL ZLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL ZGELQF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL ZLQT02( M, N, K, A, AF, AQ, AL, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test ZUNMLQ, using factorization returned
-*                       by ZLQT01
+*                       Test ZUNMLQ
 *
                         CALL ZLQT03( M, N, K, AF, AC, AL, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )

--- a/TESTING/LIN/zchkqr.f
+++ b/TESTING/LIN/zchkqr.f
@@ -246,7 +246,7 @@
 *     .. External Subroutines ..
       EXTERNAL           ALAERH, ALAHD, ALASUM, XLAENV, ZERRQR, ZGELS,
      $                   ZGET02, ZLACPY, ZLARHS, ZLATB4, ZLATMS, ZQRT01,
-     $                   ZQRT01P, ZQRT02, ZQRT03
+     $                   ZQRT01P, ZQRT02, ZQRT03, ZGEQRF
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
@@ -373,16 +373,18 @@
                         NT = NT + 1
                      ELSE IF( M.GE.N ) THEN
 *
-*                       Test ZUNGQR, using factorization
-*                       returned by ZQRT01
+*                       Test ZUNGQR
 *
                         CALL ZQRT02( M, N, K, A, AF, AQ, AR, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 1 ) )
                      END IF
                      IF( M.GE.K ) THEN
 *
-*                       Test ZUNMQR, using factorization returned
-*                       by ZQRT01
+*                       Test ZUNMQR
+*
+                        CALL ZLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                        CALL ZGEQRF( M, N, AF, LDA, TAU, WORK, LWORK,
+     $                               INFO )
 *
                         CALL ZQRT03( M, N, K, AF, AC, AR, AQ, LDA, TAU,
      $                               WORK, LWORK, RWORK, RESULT( 3 ) )


### PR DESCRIPTION
**Fix fails of tests for QR/LQ factorizations**

Hello! This PR is willing to close issue #973.

Briefly speaking, there are some problems, recently appeared after Release 3.12. Functions `GELQS/GEQRS` were made DEPRECATED and have been replaced by `GELS`  in tests of QR/LQ factorizations. But,

1. `GELS` calls specific factorization depending on input size: `QR` for `m >= n` and `LQ` for `m < n`. Test does not take into account this knowledge and wrong factorization can be called for specific parameters `m` and `n`.
2. Even if parameters, passed to `GELS` are correct, test can be also failed for matrices near overflow/underflow. I believe, that it happens, since `GELS` calls scaling routines inside, but previous version `GELQS/GEQRS` does not. Behavior is also changed in that way.

It is important to point out, that test is failed on the **next** iteration of parameter `K` while data is improperly changed on the **first** iteration. That's why fails are reproduced only on fixed input file.

Thinking of solution, I suggest to call the correct factorization on each iteration of inner loop for parameter `K`. It will solve any problems, related to occasionally changed data inside the test. Maybe this solution is not fully optimal, since it does not restrict any inputs into `GELS`, but it can be discussed.

- [x] If the PR solves a specific issue, it is set to be closed on merge.