### PR TITLE
Configurable type of hidden Fortran strlen arguments

### DIFF
--- a/CBLAS/include/cblas_f77.h
+++ b/CBLAS/include/cblas_f77.h
@@ -17,6 +17,10 @@
 *  or make the str argument into a struct. */
 #define BLAS_FORTRAN_STRLEN_END
 
+#ifndef FORTRAN_STRLEN
+  #define FORTRAN_STRLEN size_t
+#endif
+
 #ifdef CRAY
    #include <fortran.h>
    #define F77_CHAR _fcd
@@ -569,7 +573,7 @@ __attribute__((weak))
 #endif
 F77_xerbla_base(FCHAR, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 
@@ -652,78 +656,78 @@ void F77_dcabs1_sub_base(const void *, double *);
 
 void F77_sgemv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_sgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const float *,  const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_ssymv_base(FCHAR, FINT, const float *, const float *, FINT, const float *,  FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_ssbmv_base(FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_sspmv_base(FCHAR, FINT, const float *, const float *, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_strmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_stbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_strsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_stbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_stpmv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_stpsv_base(FCHAR, FCHAR, FCHAR, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_sger_base(FINT, FINT, const float *, const float *, FINT, const float *, FINT, float *, FINT);
 void F77_ssyr_base(FCHAR, FINT, const float *, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_sspr_base(FCHAR, FINT, const float *, const float *, FINT, float *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_sspr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_ssyr2_base(FCHAR, FINT, const float *, const float *, FINT, const float *, FINT,  float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 
@@ -731,78 +735,78 @@ void F77_ssyr2_base(FCHAR, FINT, const float *, const float *, FINT, const float
 
 void F77_dgemv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const double *,  const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dsymv_base(FCHAR, FINT, const double *, const double *, FINT, const double *,  FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dsbmv_base(FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dspmv_base(FCHAR, FINT, const double *, const double *, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dtrmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dtbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dtrsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dtbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dtpmv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dtpsv_base(FCHAR, FCHAR, FCHAR, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dger_base(FINT, FINT, const double *, const double *, FINT, const double *, FINT, double *, FINT);
 void F77_dsyr_base(FCHAR, FINT, const double *, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dspr_base(FCHAR, FINT, const double *, const double *, FINT, double *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dspr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_dsyr2_base(FCHAR, FINT, const double *, const double *, FINT, const double *, FINT,  double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 
@@ -810,79 +814,79 @@ void F77_dsyr2_base(FCHAR, FINT, const double *, const double *, FINT, const dou
 
 void F77_cgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_cgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_chemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_chbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_chpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_ctrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ctbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ctpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ctrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ctbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ctpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_cgerc_base(FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
 void F77_cgeru_base(FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
 void F77_cher_base(FCHAR, FINT, const float *, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_cher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_chpr_base(FCHAR, FINT, const float *, const void *, FINT, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_chpr2_base(FCHAR, FINT, const float *, const void *, FINT, const void *, FINT, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 
@@ -890,79 +894,79 @@ void F77_chpr2_base(FCHAR, FINT, const float *, const void *, FINT, const void *
 
 void F77_zgemv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_zgbmv_base(FCHAR, FINT, FINT, FINT, FINT, const void *,  const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_zhemv_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_zhbmv_base(FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_zhpmv_base(FCHAR, FINT, const void *, const void *, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_ztrmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ztbmv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ztpmv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ztrsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ztbsv_base(FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ztpsv_base(FCHAR, FCHAR, FCHAR, FINT, const void *, void *,FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_zgerc_base(FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT);
 void F77_zgeru_base(FINT, FINT, const void *, const void *, FINT, const void *, FINT, void *,  FINT);
 void F77_zher_base(FCHAR, FINT, const double *, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_zher2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_zhpr_base(FCHAR, FINT, const double *, const void *, FINT, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 void F77_zhpr2_base(FCHAR, FINT, const double *, const void *, FINT, const void *, FINT, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t
+   , FORTRAN_STRLEN
 #endif
 );
 
@@ -974,32 +978,32 @@ void F77_zhpr2_base(FCHAR, FINT, const double *, const void *, FINT, const void 
 
 void F77_sgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ssymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ssyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ssyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_strmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_strsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 
@@ -1007,32 +1011,32 @@ void F77_strsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const
 
 void F77_dgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dtrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_dtrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 
@@ -1040,47 +1044,47 @@ void F77_dtrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, cons
 
 void F77_cgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_csymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_chemm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_csyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_cherk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_csyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_cher2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ctrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 
@@ -1088,47 +1092,47 @@ void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const
 
 void F77_zgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_zsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_zhemm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_zsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_zherk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_zsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_zher2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ztrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 void F77_ztrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
-   , size_t, size_t, size_t, size_t
+   , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 

--- a/CBLAS/src/xerbla.c
+++ b/CBLAS/src/xerbla.c
@@ -17,7 +17,7 @@ F77_xerbla_base
 (char *srname, void *vinfo
 #endif
 #ifdef BLAS_FORTRAN_STRLEN_END
-, size_t len
+, FORTRAN_STRLEN len
 #endif
 )
 {

--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -55,6 +55,10 @@ macro(CheckLAPACKCompilerFlags)
 
     add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-frecursive>")
 
+    if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "8")
+      add_compile_definitions("$<$<COMPILE_LANGUAGE:C>:FORTRAN_STRLEN=int>")
+    endif()
+
   # Intel Fortran
   elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     set(FPE_EXIT_FLAG "[-/]fpe(-all=|)0")
@@ -112,6 +116,20 @@ macro(CheckLAPACKCompilerFlags)
     add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-thread_safe>")
     add_link_options("$<$<COMPILE_LANGUAGE:Fortran>:-thread_safe>")
     add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-recursive>")
+
+    # By default NAG Fortran uses 32bit integers as hidden STRLEN arguments
+    if(UNIX)
+      if(APPLE)
+        add_compile_definitions("$<$<COMPILE_LANGUAGE:C>:FORTRAN_STRLEN=int>")
+      else()
+        # Get all flags added via `add_compile_options(...)`
+        get_directory_property(COMP_OPTIONS COMPILE_OPTIONS)
+
+        if(NOT("${CMAKE_Fortran_FLAGS};${COMP_OPTIONS}" MATCHES "-abi=64c"))
+          add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:FORTRAN_STRLEN=int>")
+        endif()
+      endif()
+    endif()
 
     # Disable warnings
     add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-w=obs>")

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -19,6 +19,10 @@
 *  or make the str argument into a struct. */
 #define LAPACK_FORTRAN_STRLEN_END
 
+#ifndef FORTRAN_STRLEN
+  #define FORTRAN_STRLEN size_t
+#endif
+
 /* Complex types are structures equivalent to the
 * Fortran complex types COMPLEX(4) and COMPLEX(8).
 *
@@ -134,7 +138,7 @@ typedef lapack_logical (*LAPACK_Z_SELECT2)
 lapack_logical LAPACK_lsame_base( const char* ca,  const char* cb,
                               lapack_int lca, lapack_int lcb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -182,7 +186,7 @@ void LAPACK_cbbcsd_base(
     float* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -212,7 +216,7 @@ void LAPACK_dbbcsd_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -242,7 +246,7 @@ void LAPACK_sbbcsd_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -272,7 +276,7 @@ void LAPACK_zbbcsd_base(
     double* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -294,7 +298,7 @@ void LAPACK_dbdsdc_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -316,7 +320,7 @@ void LAPACK_sbdsdc_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -337,7 +341,7 @@ void LAPACK_cbdsqr_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -358,7 +362,7 @@ void LAPACK_dbdsqr_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -379,7 +383,7 @@ void LAPACK_sbdsqr_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -400,7 +404,7 @@ void LAPACK_zbdsqr_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -423,7 +427,7 @@ void LAPACK_dbdsvdx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -446,7 +450,7 @@ void LAPACK_sbdsvdx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -463,7 +467,7 @@ void LAPACK_ddisna_base(
     double* SEP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -480,7 +484,7 @@ void LAPACK_sdisna_base(
     float* SEP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -503,7 +507,7 @@ void LAPACK_cgbbrd_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -525,7 +529,7 @@ void LAPACK_dgbbrd_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -547,7 +551,7 @@ void LAPACK_sgbbrd_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -570,7 +574,7 @@ void LAPACK_zgbbrd_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -590,7 +594,7 @@ void LAPACK_cgbcon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -610,7 +614,7 @@ void LAPACK_dgbcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -630,7 +634,7 @@ void LAPACK_sgbcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -650,7 +654,7 @@ void LAPACK_zgbcon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -761,7 +765,7 @@ void LAPACK_cgbrfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -784,7 +788,7 @@ void LAPACK_dgbrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -807,7 +811,7 @@ void LAPACK_sgbrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -830,7 +834,7 @@ void LAPACK_zgbrfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -858,7 +862,7 @@ void LAPACK_cgbrfsx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -886,7 +890,7 @@ void LAPACK_dgbrfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -914,7 +918,7 @@ void LAPACK_sgbrfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -942,7 +946,7 @@ void LAPACK_zgbrfsx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -997,7 +1001,7 @@ void LAPACK_cgbsvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1024,7 +1028,7 @@ void LAPACK_dgbsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1051,7 +1055,7 @@ void LAPACK_sgbsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1078,7 +1082,7 @@ void LAPACK_zgbsvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1108,7 +1112,7 @@ void LAPACK_cgbsvxx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1138,7 +1142,7 @@ void LAPACK_dgbsvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1168,7 +1172,7 @@ void LAPACK_sgbsvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1198,7 +1202,7 @@ void LAPACK_zgbsvxx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1239,7 +1243,7 @@ void LAPACK_cgbtrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1256,7 +1260,7 @@ void LAPACK_dgbtrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1273,7 +1277,7 @@ void LAPACK_sgbtrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1290,7 +1294,7 @@ void LAPACK_zgbtrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1307,7 +1311,7 @@ void LAPACK_cgebak_base(
     lapack_complex_float* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1324,7 +1328,7 @@ void LAPACK_dgebak_base(
     double* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1341,7 +1345,7 @@ void LAPACK_sgebak_base(
     float* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1358,7 +1362,7 @@ void LAPACK_zgebak_base(
     lapack_complex_double* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1375,7 +1379,7 @@ void LAPACK_cgebal_base(
     float* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1392,7 +1396,7 @@ void LAPACK_dgebal_base(
     double* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1409,7 +1413,7 @@ void LAPACK_sgebal_base(
     float* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1426,7 +1430,7 @@ void LAPACK_zgebal_base(
     double* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1490,7 +1494,7 @@ void LAPACK_cgecon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1510,7 +1514,7 @@ void LAPACK_dgecon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1530,7 +1534,7 @@ void LAPACK_sgecon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1550,7 +1554,7 @@ void LAPACK_zgecon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1658,7 +1662,7 @@ void LAPACK_cgees_base(
     float* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1678,7 +1682,7 @@ void LAPACK_dgees_base(
     double* work, lapack_int const* lwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1698,7 +1702,7 @@ void LAPACK_sgees_base(
     float* work, lapack_int const* lwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1718,7 +1722,7 @@ void LAPACK_zgees_base(
     double* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1740,7 +1744,7 @@ void LAPACK_cgeesx_base(
     float* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1763,7 +1767,7 @@ void LAPACK_dgeesx_base(
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1786,7 +1790,7 @@ void LAPACK_sgeesx_base(
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1808,7 +1812,7 @@ void LAPACK_zgeesx_base(
     double* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1829,7 +1833,7 @@ void LAPACK_cgeev_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1850,7 +1854,7 @@ void LAPACK_dgeev_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1871,7 +1875,7 @@ void LAPACK_sgeev_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1892,7 +1896,7 @@ void LAPACK_zgeev_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1917,7 +1921,7 @@ void LAPACK_cgeevx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1943,7 +1947,7 @@ void LAPACK_dgeevx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1969,7 +1973,7 @@ void LAPACK_sgeevx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -1994,7 +1998,7 @@ void LAPACK_zgeevx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2048,7 +2052,7 @@ void LAPACK_cgejsv_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2069,7 +2073,7 @@ void LAPACK_dgejsv_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2090,7 +2094,7 @@ void LAPACK_sgejsv_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2112,7 +2116,7 @@ void LAPACK_zgejsv_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2226,7 +2230,7 @@ void LAPACK_cgels_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2244,7 +2248,7 @@ void LAPACK_dgels_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2262,7 +2266,7 @@ void LAPACK_sgels_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2280,7 +2284,7 @@ void LAPACK_zgels_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2425,7 +2429,7 @@ void LAPACK_cgemlq_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2444,7 +2448,7 @@ void LAPACK_dgemlq_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2463,7 +2467,7 @@ void LAPACK_sgemlq_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2482,7 +2486,7 @@ void LAPACK_zgemlq_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2501,7 +2505,7 @@ void LAPACK_cgemqr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2520,7 +2524,7 @@ void LAPACK_dgemqr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2539,7 +2543,7 @@ void LAPACK_sgemqr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2558,7 +2562,7 @@ void LAPACK_zgemqr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2577,7 +2581,7 @@ void LAPACK_cgemqrt_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2596,7 +2600,7 @@ void LAPACK_dgemqrt_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2615,7 +2619,7 @@ void LAPACK_sgemqrt_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2634,7 +2638,7 @@ void LAPACK_zgemqrt_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -2993,7 +2997,7 @@ void LAPACK_cgerfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3016,7 +3020,7 @@ void LAPACK_dgerfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3039,7 +3043,7 @@ void LAPACK_sgerfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3062,7 +3066,7 @@ void LAPACK_zgerfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3090,7 +3094,7 @@ void LAPACK_cgerfsx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3118,7 +3122,7 @@ void LAPACK_dgerfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3146,7 +3150,7 @@ void LAPACK_sgerfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3174,7 +3178,7 @@ void LAPACK_zgerfsx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3260,7 +3264,7 @@ void LAPACK_cgesdd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3281,7 +3285,7 @@ void LAPACK_dgesdd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3302,7 +3306,7 @@ void LAPACK_sgesdd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3324,7 +3328,7 @@ void LAPACK_zgesdd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3349,7 +3353,7 @@ void LAPACK_cgedmd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3374,7 +3378,7 @@ void LAPACK_dgedmd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3398,7 +3402,7 @@ void LAPACK_sgedmd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3423,7 +3427,7 @@ void LAPACK_zgedmd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3451,7 +3455,7 @@ void LAPACK_cgedmdq_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3478,7 +3482,7 @@ void LAPACK_dgedmdq_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3505,7 +3509,7 @@ void LAPACK_sgedmdq_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3534,7 +3538,7 @@ void LAPACK_zgedmdq_base(
     lapack_int* info
 
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3604,7 +3608,7 @@ void LAPACK_cgesvd_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3624,7 +3628,7 @@ void LAPACK_dgesvd_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3644,7 +3648,7 @@ void LAPACK_sgesvd_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3665,7 +3669,7 @@ void LAPACK_zgesvd_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3687,7 +3691,7 @@ void LAPACK_cgesvdq_base(
     float* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3709,7 +3713,7 @@ void LAPACK_dgesvdq_base(
     double* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3731,7 +3735,7 @@ void LAPACK_sgesvdq_base(
     float* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3753,7 +3757,7 @@ void LAPACK_zgesvdq_base(
     double* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3777,7 +3781,7 @@ void LAPACK_cgesvdx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3801,7 +3805,7 @@ void LAPACK_dgesvdx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3824,7 +3828,7 @@ void LAPACK_sgesvdx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3848,7 +3852,7 @@ void LAPACK_zgesvdx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3868,7 +3872,7 @@ void LAPACK_cgesvj_base(
     float* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3887,7 +3891,7 @@ void LAPACK_dgesvj_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3906,7 +3910,7 @@ void LAPACK_sgesvj_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3926,7 +3930,7 @@ void LAPACK_zgesvj_base(
     double* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3953,7 +3957,7 @@ void LAPACK_cgesvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -3980,7 +3984,7 @@ void LAPACK_dgesvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4007,7 +4011,7 @@ void LAPACK_sgesvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4034,7 +4038,7 @@ void LAPACK_zgesvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4064,7 +4068,7 @@ void LAPACK_cgesvxx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4094,7 +4098,7 @@ void LAPACK_dgesvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4124,7 +4128,7 @@ void LAPACK_sgesvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4154,7 +4158,7 @@ void LAPACK_zgesvxx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4271,7 +4275,7 @@ void LAPACK_cgetrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4288,7 +4292,7 @@ void LAPACK_dgetrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4305,7 +4309,7 @@ void LAPACK_sgetrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4322,7 +4326,7 @@ void LAPACK_zgetrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4340,7 +4344,7 @@ void LAPACK_cgetsls_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4358,7 +4362,7 @@ void LAPACK_dgetsls_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4376,7 +4380,7 @@ void LAPACK_sgetsls_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4394,7 +4398,7 @@ void LAPACK_zgetsls_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4448,7 +4452,7 @@ void LAPACK_cggbak_base(
     lapack_complex_float* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4466,7 +4470,7 @@ void LAPACK_dggbak_base(
     double* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4484,7 +4488,7 @@ void LAPACK_sggbak_base(
     float* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4502,7 +4506,7 @@ void LAPACK_zggbak_base(
     lapack_complex_double* V, lapack_int const* ldv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4522,7 +4526,7 @@ void LAPACK_cggbal_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4542,7 +4546,7 @@ void LAPACK_dggbal_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4562,7 +4566,7 @@ void LAPACK_sggbal_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4582,7 +4586,7 @@ void LAPACK_zggbal_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4605,7 +4609,7 @@ void LAPACK_cgges_base(
     float* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4628,7 +4632,7 @@ void LAPACK_dgges_base(
     double* work, lapack_int const* lwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4651,7 +4655,7 @@ void LAPACK_sgges_base(
     float* work, lapack_int const* lwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4674,7 +4678,7 @@ void LAPACK_zgges_base(
     double* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4697,7 +4701,7 @@ void LAPACK_cgges3_base(
     float* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4720,7 +4724,7 @@ void LAPACK_dgges3_base(
     double* work, lapack_int const* lwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4743,7 +4747,7 @@ void LAPACK_sgges3_base(
     float* work, lapack_int const* lwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4766,7 +4770,7 @@ void LAPACK_zgges3_base(
     double* rwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4792,7 +4796,7 @@ void LAPACK_cggesx_base(
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4818,7 +4822,7 @@ void LAPACK_dggesx_base(
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4844,7 +4848,7 @@ void LAPACK_sggesx_base(
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4870,7 +4874,7 @@ void LAPACK_zggesx_base(
     lapack_int* iwork, lapack_int const* liwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4893,7 +4897,7 @@ void LAPACK_cggev_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4916,7 +4920,7 @@ void LAPACK_dggev_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4939,7 +4943,7 @@ void LAPACK_sggev_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4962,7 +4966,7 @@ void LAPACK_zggev_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -4985,7 +4989,7 @@ void LAPACK_cggev3_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5008,7 +5012,7 @@ void LAPACK_dggev3_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5031,7 +5035,7 @@ void LAPACK_sggev3_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5054,7 +5058,7 @@ void LAPACK_zggev3_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5084,7 +5088,7 @@ void LAPACK_cggevx_base(
     lapack_int* iwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5114,7 +5118,7 @@ void LAPACK_dggevx_base(
     lapack_int* iwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5144,7 +5148,7 @@ void LAPACK_sggevx_base(
     lapack_int* iwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5174,7 +5178,7 @@ void LAPACK_zggevx_base(
     lapack_int* iwork, lapack_logical* BWORK,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5238,7 +5242,7 @@ void LAPACK_cgghd3_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5258,7 +5262,7 @@ void LAPACK_dgghd3_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5278,7 +5282,7 @@ void LAPACK_sgghd3_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5298,7 +5302,7 @@ void LAPACK_zgghd3_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5317,7 +5321,7 @@ void LAPACK_cgghrd_base(
     lapack_complex_float* Z, lapack_int const* ldz,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5336,7 +5340,7 @@ void LAPACK_dgghrd_base(
     double* Z, lapack_int const* ldz,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5355,7 +5359,7 @@ void LAPACK_sgghrd_base(
     float* Z, lapack_int const* ldz,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5374,7 +5378,7 @@ void LAPACK_zgghrd_base(
     lapack_complex_double* Z, lapack_int const* ldz,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5521,7 +5525,7 @@ lapack_int LAPACK_cggsvd_base(
     lapack_complex_float* work, float* rwork,
     lapack_int* iwork, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5543,7 +5547,7 @@ lapack_int LAPACK_sggsvd_base(
     float* q, lapack_int const* ldq,
     float* work, lapack_int* iwork, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5565,7 +5569,7 @@ lapack_int LAPACK_dggsvd_base(
     double* q, lapack_int const* ldq,
     double* work, lapack_int* iwork, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5588,7 +5592,7 @@ lapack_int LAPACK_zggsvd_base(
     lapack_complex_double* work, double* rwork,
     lapack_int* iwork, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5613,7 +5617,7 @@ void LAPACK_cggsvd3_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5637,7 +5641,7 @@ void LAPACK_dggsvd3_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5661,7 +5665,7 @@ void LAPACK_sggsvd3_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5686,7 +5690,7 @@ void LAPACK_zggsvd3_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5709,7 +5713,7 @@ lapack_int LAPACK_sggsvp_base(
     lapack_int* iwork, float* tau,
     float* work, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5732,7 +5736,7 @@ lapack_int LAPACK_dggsvp_base(
     lapack_int* iwork, double* tau,
     double* work, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5754,7 +5758,7 @@ lapack_int LAPACK_cggsvp_base(
     lapack_int* iwork, float* rwork, lapack_complex_float* tau,
     lapack_complex_float* work, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5776,7 +5780,7 @@ lapack_int LAPACK_zggsvp_base(
     lapack_int* iwork, double* rwork, lapack_complex_double* tau,
     lapack_complex_double* work, lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5802,7 +5806,7 @@ void LAPACK_cggsvp3_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5827,7 +5831,7 @@ void LAPACK_dggsvp3_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5852,7 +5856,7 @@ void LAPACK_sggsvp3_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5878,7 +5882,7 @@ void LAPACK_zggsvp3_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5900,7 +5904,7 @@ void LAPACK_cgtcon_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5923,7 +5927,7 @@ void LAPACK_dgtcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5946,7 +5950,7 @@ void LAPACK_sgtcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5968,7 +5972,7 @@ void LAPACK_zgtcon_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -5996,7 +6000,7 @@ void LAPACK_cgtrfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6024,7 +6028,7 @@ void LAPACK_dgtrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6052,7 +6056,7 @@ void LAPACK_sgtrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6080,7 +6084,7 @@ void LAPACK_zgtrfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6145,7 +6149,7 @@ void LAPACK_cgtsvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6174,7 +6178,7 @@ void LAPACK_dgtsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6203,7 +6207,7 @@ void LAPACK_sgtsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6232,7 +6236,7 @@ void LAPACK_zgtsvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6288,7 +6292,7 @@ void LAPACK_cgttrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6308,7 +6312,7 @@ void LAPACK_dgttrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6328,7 +6332,7 @@ void LAPACK_sgttrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6348,7 +6352,7 @@ void LAPACK_zgttrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6368,7 +6372,7 @@ void LAPACK_chbev_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6388,7 +6392,7 @@ void LAPACK_zhbev_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6408,7 +6412,7 @@ void LAPACK_chbev_2stage_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6428,7 +6432,7 @@ void LAPACK_zhbev_2stage_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6449,7 +6453,7 @@ void LAPACK_chbevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6470,7 +6474,7 @@ void LAPACK_zhbevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6491,7 +6495,7 @@ void LAPACK_chbevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6512,7 +6516,7 @@ void LAPACK_zhbevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6537,7 +6541,7 @@ void LAPACK_chbevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6562,7 +6566,7 @@ void LAPACK_zhbevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6587,7 +6591,7 @@ void LAPACK_chbevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6612,7 +6616,7 @@ void LAPACK_zhbevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6632,7 +6636,7 @@ void LAPACK_chbgst_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6652,7 +6656,7 @@ void LAPACK_zhbgst_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6673,7 +6677,7 @@ void LAPACK_chbgv_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6694,7 +6698,7 @@ void LAPACK_zhbgv_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6716,7 +6720,7 @@ void LAPACK_chbgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6738,7 +6742,7 @@ void LAPACK_zhbgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6764,7 +6768,7 @@ void LAPACK_chbgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6790,7 +6794,7 @@ void LAPACK_zhbgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6810,7 +6814,7 @@ void LAPACK_chbtrd_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6830,7 +6834,7 @@ void LAPACK_zhbtrd_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6849,7 +6853,7 @@ void LAPACK_checon_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6868,7 +6872,7 @@ void LAPACK_zhecon_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6888,7 +6892,7 @@ void LAPACK_checon_3_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6908,7 +6912,7 @@ void LAPACK_zhecon_3_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6928,7 +6932,7 @@ void LAPACK_cheequb_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6948,7 +6952,7 @@ void LAPACK_zheequb_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6967,7 +6971,7 @@ void LAPACK_cheev_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -6986,7 +6990,7 @@ void LAPACK_zheev_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7005,7 +7009,7 @@ void LAPACK_cheev_2stage_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7024,7 +7028,7 @@ void LAPACK_zheev_2stage_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7044,7 +7048,7 @@ void LAPACK_cheevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7064,7 +7068,7 @@ void LAPACK_zheevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7084,7 +7088,7 @@ void LAPACK_cheevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7104,7 +7108,7 @@ void LAPACK_zheevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7128,7 +7132,7 @@ void LAPACK_cheevr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7152,7 +7156,7 @@ void LAPACK_zheevr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7176,7 +7180,7 @@ void LAPACK_cheevr_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7200,7 +7204,7 @@ void LAPACK_zheevr_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7224,7 +7228,7 @@ void LAPACK_cheevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7248,7 +7252,7 @@ void LAPACK_zheevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7272,7 +7276,7 @@ void LAPACK_cheevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7296,7 +7300,7 @@ void LAPACK_zheevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7313,7 +7317,7 @@ void LAPACK_chegst_base(
     const lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7330,7 +7334,7 @@ void LAPACK_zhegst_base(
     const lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7350,7 +7354,7 @@ void LAPACK_chegv_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7370,7 +7374,7 @@ void LAPACK_zhegv_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7390,7 +7394,7 @@ void LAPACK_chegv_2stage_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7410,7 +7414,7 @@ void LAPACK_zhegv_2stage_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7431,7 +7435,7 @@ void LAPACK_chegvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7452,7 +7456,7 @@ void LAPACK_zhegvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7477,7 +7481,7 @@ void LAPACK_chegvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7502,7 +7506,7 @@ void LAPACK_zhegvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7525,7 +7529,7 @@ void LAPACK_cherfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7548,7 +7552,7 @@ void LAPACK_zherfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7575,7 +7579,7 @@ void LAPACK_cherfsx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7602,7 +7606,7 @@ void LAPACK_zherfsx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7620,7 +7624,7 @@ void LAPACK_chesv_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7638,7 +7642,7 @@ void LAPACK_zhesv_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7656,7 +7660,7 @@ void LAPACK_chesv_aa_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7674,7 +7678,7 @@ void LAPACK_zhesv_aa_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7693,7 +7697,7 @@ void LAPACK_chesv_aa_2stage_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7712,7 +7716,7 @@ void LAPACK_zhesv_aa_2stage_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7731,7 +7735,7 @@ void LAPACK_chesv_rk_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7750,7 +7754,7 @@ void LAPACK_zhesv_rk_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7768,7 +7772,7 @@ void LAPACK_chesv_rook_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7786,7 +7790,7 @@ void LAPACK_zhesv_rook_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7810,7 +7814,7 @@ void LAPACK_chesvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7834,7 +7838,7 @@ void LAPACK_zhesvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7863,7 +7867,7 @@ void LAPACK_chesvxx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7892,7 +7896,7 @@ void LAPACK_zhesvxx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7907,7 +7911,7 @@ void LAPACK_cheswapr_base(
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7922,7 +7926,7 @@ void LAPACK_zheswapr_base(
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7942,7 +7946,7 @@ void LAPACK_chetrd_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7962,7 +7966,7 @@ void LAPACK_zhetrd_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -7983,7 +7987,7 @@ void LAPACK_chetrd_2stage_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8004,7 +8008,7 @@ void LAPACK_zhetrd_2stage_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8021,7 +8025,7 @@ void LAPACK_chetrf_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8038,7 +8042,7 @@ void LAPACK_zhetrf_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8055,7 +8059,7 @@ void LAPACK_chetrf_aa_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8072,7 +8076,7 @@ void LAPACK_zhetrf_aa_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8090,7 +8094,7 @@ void LAPACK_chetrf_aa_2stage_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8108,7 +8112,7 @@ void LAPACK_zhetrf_aa_2stage_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8126,7 +8130,7 @@ void LAPACK_chetrf_rk_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8144,7 +8148,7 @@ void LAPACK_zhetrf_rk_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8161,7 +8165,7 @@ void LAPACK_chetrf_rook_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8178,7 +8182,7 @@ void LAPACK_zhetrf_rook_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8195,7 +8199,7 @@ void LAPACK_chetri_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8212,7 +8216,7 @@ void LAPACK_zhetri_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8229,7 +8233,7 @@ void LAPACK_chetri2_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8246,7 +8250,7 @@ void LAPACK_zhetri2_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8263,7 +8267,7 @@ void LAPACK_chetri2x_base(
     lapack_complex_float* work, lapack_int const* nb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8280,7 +8284,7 @@ void LAPACK_zhetri2x_base(
     lapack_complex_double* work, lapack_int const* nb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8298,7 +8302,7 @@ void LAPACK_chetri_3_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8316,7 +8320,7 @@ void LAPACK_zhetri_3_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8333,7 +8337,7 @@ void LAPACK_chetrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8350,7 +8354,7 @@ void LAPACK_zhetrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8368,7 +8372,7 @@ void LAPACK_chetrs2_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8386,7 +8390,7 @@ void LAPACK_zhetrs2_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8404,7 +8408,7 @@ void LAPACK_chetrs_3_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8422,7 +8426,7 @@ void LAPACK_zhetrs_3_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8440,7 +8444,7 @@ void LAPACK_chetrs_aa_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8458,7 +8462,7 @@ void LAPACK_zhetrs_aa_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8476,7 +8480,7 @@ void LAPACK_chetrs_aa_2stage_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8494,7 +8498,7 @@ void LAPACK_zhetrs_aa_2stage_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8511,7 +8515,7 @@ void LAPACK_chetrs_rook_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8528,7 +8532,7 @@ void LAPACK_zhetrs_rook_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8546,7 +8550,7 @@ void LAPACK_chfrk_base(
     float const* beta,
     lapack_complex_float* C
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8564,7 +8568,7 @@ void LAPACK_zhfrk_base(
     double const* beta,
     lapack_complex_double* C
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8587,7 +8591,7 @@ void LAPACK_chgeqz_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8610,7 +8614,7 @@ void LAPACK_dhgeqz_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8633,7 +8637,7 @@ void LAPACK_shgeqz_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8656,7 +8660,7 @@ void LAPACK_zhgeqz_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8675,7 +8679,7 @@ void LAPACK_chpcon_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8694,7 +8698,7 @@ void LAPACK_zhpcon_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8714,7 +8718,7 @@ void LAPACK_chpev_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8734,7 +8738,7 @@ void LAPACK_zhpev_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8755,7 +8759,7 @@ void LAPACK_chpevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8776,7 +8780,7 @@ void LAPACK_zhpevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8800,7 +8804,7 @@ void LAPACK_chpevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8824,7 +8828,7 @@ void LAPACK_zhpevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8841,7 +8845,7 @@ void LAPACK_chpgst_base(
     lapack_complex_float const* BP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8858,7 +8862,7 @@ void LAPACK_zhpgst_base(
     lapack_complex_double const* BP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8879,7 +8883,7 @@ void LAPACK_chpgv_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8900,7 +8904,7 @@ void LAPACK_zhpgv_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8922,7 +8926,7 @@ void LAPACK_chpgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8944,7 +8948,7 @@ void LAPACK_zhpgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8969,7 +8973,7 @@ void LAPACK_chpgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -8994,7 +8998,7 @@ void LAPACK_zhpgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9017,7 +9021,7 @@ void LAPACK_chprfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9040,7 +9044,7 @@ void LAPACK_zhprfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9057,7 +9061,7 @@ void LAPACK_chpsv_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9074,7 +9078,7 @@ void LAPACK_zhpsv_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9098,7 +9102,7 @@ void LAPACK_chpsvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9122,7 +9126,7 @@ void LAPACK_zhpsvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9141,7 +9145,7 @@ void LAPACK_chptrd_base(
     lapack_complex_float* tau,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9160,7 +9164,7 @@ void LAPACK_zhptrd_base(
     lapack_complex_double* tau,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9176,7 +9180,7 @@ void LAPACK_chptrf_base(
     lapack_complex_float* AP, lapack_int* ipiv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9192,7 +9196,7 @@ void LAPACK_zhptrf_base(
     lapack_complex_double* AP, lapack_int* ipiv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9209,7 +9213,7 @@ void LAPACK_chptri_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9226,7 +9230,7 @@ void LAPACK_zhptri_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9243,7 +9247,7 @@ void LAPACK_chptrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9260,7 +9264,7 @@ void LAPACK_zhptrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9282,7 +9286,7 @@ void LAPACK_chsein_base(
     float* rwork, lapack_int* IFAILL, lapack_int* IFAILR,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9304,7 +9308,7 @@ void LAPACK_dhsein_base(
     double* work, lapack_int* IFAILL, lapack_int* IFAILR,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9326,7 +9330,7 @@ void LAPACK_shsein_base(
     float* work, lapack_int* IFAILL, lapack_int* IFAILR,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9348,7 +9352,7 @@ void LAPACK_zhsein_base(
     double* rwork, lapack_int* IFAILL, lapack_int* IFAILR,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9367,7 +9371,7 @@ void LAPACK_chseqr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9387,7 +9391,7 @@ void LAPACK_dhseqr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9407,7 +9411,7 @@ void LAPACK_shseqr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9426,7 +9430,7 @@ void LAPACK_zhseqr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9480,7 +9484,7 @@ void LAPACK_clacp2_base(
     float const* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9496,7 +9500,7 @@ void LAPACK_zlacp2_base(
     double const* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9512,7 +9516,7 @@ void LAPACK_clacpy_base(
     lapack_complex_float const* A, lapack_int const* lda,
     lapack_complex_float* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9528,7 +9532,7 @@ void LAPACK_dlacpy_base(
     double const* A, lapack_int const* lda,
     double* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9544,7 +9548,7 @@ void LAPACK_slacpy_base(
     float const* A, lapack_int const* lda,
     float* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9560,7 +9564,7 @@ void LAPACK_zlacpy_base(
     lapack_complex_double const* A, lapack_int const* lda,
     lapack_complex_double* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9697,7 +9701,7 @@ void LAPACK_zlagsy(
 double LAPACK_dlamch_base(
     char const* cmach
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9710,7 +9714,7 @@ double LAPACK_dlamch_base(
 lapack_float_return LAPACK_slamch_base(
     char const* cmach
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9726,7 +9730,7 @@ lapack_float_return LAPACK_clangb_base(
     lapack_complex_float const* AB, lapack_int const* ldab,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9742,7 +9746,7 @@ double LAPACK_dlangb_base(
     double const* AB, lapack_int const* ldab,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9758,7 +9762,7 @@ lapack_float_return LAPACK_slangb_base(
     float const* AB, lapack_int const* ldab,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9774,7 +9778,7 @@ double LAPACK_zlangb_base(
     lapack_complex_double const* AB, lapack_int const* ldab,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9790,7 +9794,7 @@ lapack_float_return LAPACK_clange_base(
     lapack_complex_float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9806,7 +9810,7 @@ double LAPACK_dlange_base(
     double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9822,7 +9826,7 @@ lapack_float_return LAPACK_slange_base(
     float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9838,7 +9842,7 @@ double LAPACK_zlange_base(
     lapack_complex_double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9855,7 +9859,7 @@ lapack_float_return LAPACK_clangt_base(
     lapack_complex_float const* D,
     lapack_complex_float const* DU
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9872,7 +9876,7 @@ double LAPACK_dlangt_base(
     double const* D,
     double const* DU
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9889,7 +9893,7 @@ lapack_float_return LAPACK_slangt_base(
     float const* D,
     float const* DU
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9906,7 +9910,7 @@ double LAPACK_zlangt_base(
     lapack_complex_double const* D,
     lapack_complex_double const* DU
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9922,7 +9926,7 @@ lapack_float_return LAPACK_clanhb_base(
     lapack_complex_float const* AB, lapack_int const* ldab,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9938,7 +9942,7 @@ double LAPACK_zlanhb_base(
     lapack_complex_double const* AB, lapack_int const* ldab,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9954,7 +9958,7 @@ lapack_float_return LAPACK_clanhe_base(
     lapack_complex_float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9970,7 +9974,7 @@ double LAPACK_zlanhe_base(
     lapack_complex_double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -9986,7 +9990,7 @@ lapack_float_return LAPACK_clanhp_base(
     lapack_complex_float const* AP,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10002,7 +10006,7 @@ double LAPACK_zlanhp_base(
     lapack_complex_double const* AP,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10018,7 +10022,7 @@ lapack_float_return LAPACK_clanhs_base(
     lapack_complex_float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10034,7 +10038,7 @@ double LAPACK_dlanhs_base(
     double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10050,7 +10054,7 @@ lapack_float_return LAPACK_slanhs_base(
     float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10066,7 +10070,7 @@ double LAPACK_zlanhs_base(
     lapack_complex_double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10082,7 +10086,7 @@ lapack_float_return LAPACK_clanht_base(
     float const* D,
     lapack_complex_float const* E
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10098,7 +10102,7 @@ double LAPACK_zlanht_base(
     double const* D,
     lapack_complex_double const* E
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10114,7 +10118,7 @@ lapack_float_return LAPACK_clansb_base(
     lapack_complex_float const* AB, lapack_int const* ldab,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10130,7 +10134,7 @@ double LAPACK_dlansb_base(
     double const* AB, lapack_int const* ldab,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10146,7 +10150,7 @@ lapack_float_return LAPACK_slansb_base(
     float const* AB, lapack_int const* ldab,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10162,7 +10166,7 @@ double LAPACK_zlansb_base(
     lapack_complex_double const* AB, lapack_int const* ldab,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10178,7 +10182,7 @@ lapack_float_return LAPACK_clansp_base(
     lapack_complex_float const* AP,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10194,7 +10198,7 @@ double LAPACK_dlansp_base(
     double const* AP,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10210,7 +10214,7 @@ lapack_float_return LAPACK_slansp_base(
     float const* AP,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10226,7 +10230,7 @@ double LAPACK_zlansp_base(
     lapack_complex_double const* AP,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10242,7 +10246,7 @@ double LAPACK_dlanst_base(
     double const* D,
     double const* E
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10258,7 +10262,7 @@ lapack_float_return LAPACK_slanst_base(
     float const* D,
     float const* E
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10274,7 +10278,7 @@ lapack_float_return LAPACK_clansy_base(
     lapack_complex_float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10290,7 +10294,7 @@ double LAPACK_dlansy_base(
     double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10306,7 +10310,7 @@ lapack_float_return LAPACK_slansy_base(
     float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10322,7 +10326,7 @@ double LAPACK_zlansy_base(
     lapack_complex_double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10338,7 +10342,7 @@ lapack_float_return LAPACK_clantb_base(
     lapack_complex_float const* AB, lapack_int const* ldab,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10354,7 +10358,7 @@ double LAPACK_dlantb_base(
     double const* AB, lapack_int const* ldab,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10370,7 +10374,7 @@ lapack_float_return LAPACK_slantb_base(
     float const* AB, lapack_int const* ldab,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10386,7 +10390,7 @@ double LAPACK_zlantb_base(
     lapack_complex_double const* AB, lapack_int const* ldab,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10402,7 +10406,7 @@ lapack_float_return LAPACK_clantp_base(
     lapack_complex_float const* AP,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10418,7 +10422,7 @@ double LAPACK_dlantp_base(
     double const* AP,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10434,7 +10438,7 @@ lapack_float_return LAPACK_slantp_base(
     float const* AP,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10450,7 +10454,7 @@ double LAPACK_zlantp_base(
     lapack_complex_double const* AP,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10466,7 +10470,7 @@ lapack_float_return LAPACK_clantr_base(
     lapack_complex_float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10482,7 +10486,7 @@ double LAPACK_dlantr_base(
     double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10498,7 +10502,7 @@ lapack_float_return LAPACK_slantr_base(
     float const* A, lapack_int const* lda,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10514,7 +10518,7 @@ double LAPACK_zlantr_base(
     lapack_complex_double const* A, lapack_int const* lda,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10610,7 +10614,7 @@ void LAPACK_clarf_base(
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10628,7 +10632,7 @@ void LAPACK_dlarf_base(
     double* C, lapack_int const* ldc,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10646,7 +10650,7 @@ void LAPACK_slarf_base(
     float* C, lapack_int const* ldc,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10664,7 +10668,7 @@ void LAPACK_zlarf_base(
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10682,7 +10686,7 @@ void LAPACK_clarfb_base(
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10700,7 +10704,7 @@ void LAPACK_dlarfb_base(
     double* C, lapack_int const* ldc,
     double* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10718,7 +10722,7 @@ void LAPACK_slarfb_base(
     float* C, lapack_int const* ldc,
     float* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10736,7 +10740,7 @@ void LAPACK_zlarfb_base(
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10781,7 +10785,7 @@ void LAPACK_clarft_base(
     lapack_complex_float const* tau,
     lapack_complex_float* T, lapack_int const* ldt
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10798,7 +10802,7 @@ void LAPACK_dlarft_base(
     double const* tau,
     double* T, lapack_int const* ldt
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10815,7 +10819,7 @@ void LAPACK_slarft_base(
     float const* tau,
     float* T, lapack_int const* ldt
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10832,7 +10836,7 @@ void LAPACK_zlarft_base(
     lapack_complex_double const* tau,
     lapack_complex_double* T, lapack_int const* ldt
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10850,7 +10854,7 @@ void LAPACK_clarfx_base(
     lapack_complex_float* C, lapack_int const* ldc,
     lapack_complex_float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10868,7 +10872,7 @@ void LAPACK_dlarfx_base(
     double* C, lapack_int const* ldc,
     double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10886,7 +10890,7 @@ void LAPACK_slarfx_base(
     float* C, lapack_int const* ldc,
     float* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10904,7 +10908,7 @@ void LAPACK_zlarfx_base(
     lapack_complex_double* C, lapack_int const* ldc,
     lapack_complex_double* work
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10974,7 +10978,7 @@ void LAPACK_clascl_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -10992,7 +10996,7 @@ void LAPACK_dlascl_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11010,7 +11014,7 @@ void LAPACK_slascl_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11028,7 +11032,7 @@ void LAPACK_zlascl_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11045,7 +11049,7 @@ void LAPACK_claset_base(
     lapack_complex_float const* beta,
     lapack_complex_float* A, lapack_int const* lda
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11062,7 +11066,7 @@ void LAPACK_dlaset_base(
     double const* beta,
     double* A, lapack_int const* lda
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11079,7 +11083,7 @@ void LAPACK_slaset_base(
     float const* beta,
     float* A, lapack_int const* lda
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11096,7 +11100,7 @@ void LAPACK_zlaset_base(
     lapack_complex_double const* beta,
     lapack_complex_double* A, lapack_int const* lda
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11112,7 +11116,7 @@ void LAPACK_dlasrt_base(
     double* D,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11128,7 +11132,7 @@ void LAPACK_slasrt_base(
     float* D,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11198,7 +11202,7 @@ void LAPACK_clatms_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11220,7 +11224,7 @@ void LAPACK_dlatms_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11242,7 +11246,7 @@ void LAPACK_slatms_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11264,7 +11268,7 @@ void LAPACK_zlatms_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11280,7 +11284,7 @@ void LAPACK_clauum_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11296,7 +11300,7 @@ void LAPACK_dlauum_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11312,7 +11316,7 @@ void LAPACK_slauum_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11328,7 +11332,7 @@ void LAPACK_zlauum_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11351,7 +11355,7 @@ void LAPACK_dopgtr_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11370,7 +11374,7 @@ void LAPACK_sopgtr_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11389,7 +11393,7 @@ void LAPACK_dopmtr_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11408,7 +11412,7 @@ void LAPACK_sopmtr_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11434,7 +11438,7 @@ void LAPACK_dorbdb_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11460,7 +11464,7 @@ void LAPACK_sorbdb_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11486,7 +11490,7 @@ void LAPACK_dorcsd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11512,7 +11516,7 @@ void LAPACK_sorcsd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11535,7 +11539,7 @@ void LAPACK_dorcsd2by1_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11558,7 +11562,7 @@ void LAPACK_sorcsd2by1_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11576,7 +11580,7 @@ void LAPACK_dorgbr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11594,7 +11598,7 @@ void LAPACK_sorgbr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11692,7 +11696,7 @@ void LAPACK_dorgtr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11710,7 +11714,7 @@ void LAPACK_sorgtr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11763,7 +11767,7 @@ void LAPACK_dormbr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11782,7 +11786,7 @@ void LAPACK_sormbr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11801,7 +11805,7 @@ void LAPACK_dormhr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11820,7 +11824,7 @@ void LAPACK_sormhr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11839,7 +11843,7 @@ void LAPACK_dormlq_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11858,7 +11862,7 @@ void LAPACK_sormlq_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11877,7 +11881,7 @@ void LAPACK_dormql_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11896,7 +11900,7 @@ void LAPACK_sormql_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11915,7 +11919,7 @@ void LAPACK_dormqr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11934,7 +11938,7 @@ void LAPACK_sormqr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11953,7 +11957,7 @@ void LAPACK_dormrq_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11972,7 +11976,7 @@ void LAPACK_sormrq_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -11991,7 +11995,7 @@ void LAPACK_dormrz_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12010,7 +12014,7 @@ void LAPACK_sormrz_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12029,7 +12033,7 @@ void LAPACK_dormtr_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12048,7 +12052,7 @@ void LAPACK_sormtr_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12068,7 +12072,7 @@ void LAPACK_cpbcon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12088,7 +12092,7 @@ void LAPACK_dpbcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12108,7 +12112,7 @@ void LAPACK_spbcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12128,7 +12132,7 @@ void LAPACK_zpbcon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12147,7 +12151,7 @@ void LAPACK_cpbequ_base(
     float* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12166,7 +12170,7 @@ void LAPACK_dpbequ_base(
     double* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12185,7 +12189,7 @@ void LAPACK_spbequ_base(
     float* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12204,7 +12208,7 @@ void LAPACK_zpbequ_base(
     double* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12227,7 +12231,7 @@ void LAPACK_cpbrfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12250,7 +12254,7 @@ void LAPACK_dpbrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12273,7 +12277,7 @@ void LAPACK_spbrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12296,7 +12300,7 @@ void LAPACK_zpbrfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12312,7 +12316,7 @@ void LAPACK_cpbstf_base(
     lapack_complex_float* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12328,7 +12332,7 @@ void LAPACK_dpbstf_base(
     double* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12344,7 +12348,7 @@ void LAPACK_spbstf_base(
     float* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12360,7 +12364,7 @@ void LAPACK_zpbstf_base(
     lapack_complex_double* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12377,7 +12381,7 @@ void LAPACK_cpbsv_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12394,7 +12398,7 @@ void LAPACK_dpbsv_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12411,7 +12415,7 @@ void LAPACK_spbsv_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12428,7 +12432,7 @@ void LAPACK_zpbsv_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12454,7 +12458,7 @@ void LAPACK_cpbsvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12480,7 +12484,7 @@ void LAPACK_dpbsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12506,7 +12510,7 @@ void LAPACK_spbsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12532,7 +12536,7 @@ void LAPACK_zpbsvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12548,7 +12552,7 @@ void LAPACK_cpbtrf_base(
     lapack_complex_float* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12564,7 +12568,7 @@ void LAPACK_dpbtrf_base(
     double* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12580,7 +12584,7 @@ void LAPACK_spbtrf_base(
     float* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12596,7 +12600,7 @@ void LAPACK_zpbtrf_base(
     lapack_complex_double* AB, lapack_int const* ldab,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12613,7 +12617,7 @@ void LAPACK_cpbtrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12630,7 +12634,7 @@ void LAPACK_dpbtrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12647,7 +12651,7 @@ void LAPACK_spbtrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12664,7 +12668,7 @@ void LAPACK_zpbtrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12680,7 +12684,7 @@ void LAPACK_cpftrf_base(
     lapack_complex_float* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12696,7 +12700,7 @@ void LAPACK_dpftrf_base(
     double* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12712,7 +12716,7 @@ void LAPACK_spftrf_base(
     float* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12728,7 +12732,7 @@ void LAPACK_zpftrf_base(
     lapack_complex_double* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12744,7 +12748,7 @@ void LAPACK_cpftri_base(
     lapack_complex_float* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12760,7 +12764,7 @@ void LAPACK_dpftri_base(
     double* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12776,7 +12780,7 @@ void LAPACK_spftri_base(
     float* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12792,7 +12796,7 @@ void LAPACK_zpftri_base(
     lapack_complex_double* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12809,7 +12813,7 @@ void LAPACK_cpftrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12826,7 +12830,7 @@ void LAPACK_dpftrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12843,7 +12847,7 @@ void LAPACK_spftrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12860,7 +12864,7 @@ void LAPACK_zpftrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12880,7 +12884,7 @@ void LAPACK_cpocon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12900,7 +12904,7 @@ void LAPACK_dpocon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12920,7 +12924,7 @@ void LAPACK_spocon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -12940,7 +12944,7 @@ void LAPACK_zpocon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13035,7 +13039,7 @@ void LAPACK_cporfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13058,7 +13062,7 @@ void LAPACK_dporfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13081,7 +13085,7 @@ void LAPACK_sporfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13104,7 +13108,7 @@ void LAPACK_zporfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13131,7 +13135,7 @@ void LAPACK_cporfsx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13158,7 +13162,7 @@ void LAPACK_dporfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13185,7 +13189,7 @@ void LAPACK_sporfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13212,7 +13216,7 @@ void LAPACK_zporfsx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13229,7 +13233,7 @@ void LAPACK_cposv_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13246,7 +13250,7 @@ void LAPACK_dposv_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13263,7 +13267,7 @@ void LAPACK_sposv_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13280,7 +13284,7 @@ void LAPACK_zposv_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13300,7 +13304,7 @@ void LAPACK_dsposv_base(
     float* swork, lapack_int* iter,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13321,7 +13325,7 @@ void LAPACK_zcposv_base(
     double* rwork, lapack_int* iter,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13347,7 +13351,7 @@ void LAPACK_cposvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13373,7 +13377,7 @@ void LAPACK_dposvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13399,7 +13403,7 @@ void LAPACK_sposvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13425,7 +13429,7 @@ void LAPACK_zposvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13454,7 +13458,7 @@ void LAPACK_cposvxx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13483,7 +13487,7 @@ void LAPACK_dposvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13512,7 +13516,7 @@ void LAPACK_sposvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13541,7 +13545,7 @@ void LAPACK_zposvxx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13557,7 +13561,7 @@ void LAPACK_cpotf2_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13573,7 +13577,7 @@ void LAPACK_dpotf2_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13589,7 +13593,7 @@ void LAPACK_spotf2_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13605,7 +13609,7 @@ void LAPACK_zpotf2_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13621,7 +13625,7 @@ void LAPACK_cpotrf_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13637,7 +13641,7 @@ void LAPACK_dpotrf_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13653,7 +13657,7 @@ void LAPACK_spotrf_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13669,7 +13673,7 @@ void LAPACK_zpotrf_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13685,7 +13689,7 @@ void LAPACK_cpotrf2_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13701,7 +13705,7 @@ void LAPACK_dpotrf2_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13717,7 +13721,7 @@ void LAPACK_spotrf2_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13733,7 +13737,7 @@ void LAPACK_zpotrf2_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13749,7 +13753,7 @@ void LAPACK_cpotri_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13765,7 +13769,7 @@ void LAPACK_dpotri_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13781,7 +13785,7 @@ void LAPACK_spotri_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13797,7 +13801,7 @@ void LAPACK_zpotri_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13814,7 +13818,7 @@ void LAPACK_cpotrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13831,7 +13835,7 @@ void LAPACK_dpotrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13848,7 +13852,7 @@ void LAPACK_spotrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13865,7 +13869,7 @@ void LAPACK_zpotrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13885,7 +13889,7 @@ void LAPACK_cppcon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13905,7 +13909,7 @@ void LAPACK_dppcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13925,7 +13929,7 @@ void LAPACK_sppcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13945,7 +13949,7 @@ void LAPACK_zppcon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13964,7 +13968,7 @@ void LAPACK_cppequ_base(
     float* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -13983,7 +13987,7 @@ void LAPACK_dppequ_base(
     double* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14002,7 +14006,7 @@ void LAPACK_sppequ_base(
     float* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14021,7 +14025,7 @@ void LAPACK_zppequ_base(
     double* amax,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14044,7 +14048,7 @@ void LAPACK_cpprfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14067,7 +14071,7 @@ void LAPACK_dpprfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14090,7 +14094,7 @@ void LAPACK_spprfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14113,7 +14117,7 @@ void LAPACK_zpprfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14130,7 +14134,7 @@ void LAPACK_cppsv_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14147,7 +14151,7 @@ void LAPACK_dppsv_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14164,7 +14168,7 @@ void LAPACK_sppsv_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14181,7 +14185,7 @@ void LAPACK_zppsv_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14207,7 +14211,7 @@ void LAPACK_cppsvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14233,7 +14237,7 @@ void LAPACK_dppsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14259,7 +14263,7 @@ void LAPACK_sppsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14285,7 +14289,7 @@ void LAPACK_zppsvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14301,7 +14305,7 @@ void LAPACK_cpptrf_base(
     lapack_complex_float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14317,7 +14321,7 @@ void LAPACK_dpptrf_base(
     double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14333,7 +14337,7 @@ void LAPACK_spptrf_base(
     float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14349,7 +14353,7 @@ void LAPACK_zpptrf_base(
     lapack_complex_double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14365,7 +14369,7 @@ void LAPACK_cpptri_base(
     lapack_complex_float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14381,7 +14385,7 @@ void LAPACK_dpptri_base(
     double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14397,7 +14401,7 @@ void LAPACK_spptri_base(
     float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14413,7 +14417,7 @@ void LAPACK_zpptri_base(
     lapack_complex_double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14430,7 +14434,7 @@ void LAPACK_cpptrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14447,7 +14451,7 @@ void LAPACK_dpptrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14464,7 +14468,7 @@ void LAPACK_spptrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14481,7 +14485,7 @@ void LAPACK_zpptrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14499,7 +14503,7 @@ void LAPACK_cpstrf_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14517,7 +14521,7 @@ void LAPACK_dpstrf_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14535,7 +14539,7 @@ void LAPACK_spstrf_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14553,7 +14557,7 @@ void LAPACK_zpstrf_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14612,7 +14616,7 @@ void LAPACK_cpteqr_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14631,7 +14635,7 @@ void LAPACK_dpteqr_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14650,7 +14654,7 @@ void LAPACK_spteqr_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14669,7 +14673,7 @@ void LAPACK_zpteqr_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14694,7 +14698,7 @@ void LAPACK_cptrfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14747,7 +14751,7 @@ void LAPACK_zptrfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14805,7 +14809,7 @@ void LAPACK_cptsvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14830,7 +14834,7 @@ void LAPACK_dptsvx_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14855,7 +14859,7 @@ void LAPACK_sptsvx_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14881,7 +14885,7 @@ void LAPACK_zptsvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14927,7 +14931,7 @@ void LAPACK_cpttrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14961,7 +14965,7 @@ void LAPACK_zpttrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14980,7 +14984,7 @@ void LAPACK_dsbev_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -14999,7 +15003,7 @@ void LAPACK_ssbev_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15018,7 +15022,7 @@ void LAPACK_dsbev_2stage_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15037,7 +15041,7 @@ void LAPACK_ssbev_2stage_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15057,7 +15061,7 @@ void LAPACK_dsbevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15077,7 +15081,7 @@ void LAPACK_ssbevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15097,7 +15101,7 @@ void LAPACK_dsbevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15117,7 +15121,7 @@ void LAPACK_ssbevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15141,7 +15145,7 @@ void LAPACK_dsbevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15165,7 +15169,7 @@ void LAPACK_ssbevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15189,7 +15193,7 @@ void LAPACK_dsbevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15213,7 +15217,7 @@ void LAPACK_ssbevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15232,7 +15236,7 @@ void LAPACK_dsbgst_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15251,7 +15255,7 @@ void LAPACK_ssbgst_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15271,7 +15275,7 @@ void LAPACK_dsbgv_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15291,7 +15295,7 @@ void LAPACK_ssbgv_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15312,7 +15316,7 @@ void LAPACK_dsbgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15333,7 +15337,7 @@ void LAPACK_ssbgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15358,7 +15362,7 @@ void LAPACK_dsbgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15383,7 +15387,7 @@ void LAPACK_ssbgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15403,7 +15407,7 @@ void LAPACK_dsbtrd_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15423,7 +15427,7 @@ void LAPACK_ssbtrd_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15441,7 +15445,7 @@ void LAPACK_dsfrk_base(
     double const* beta,
     double* C
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15459,7 +15463,7 @@ void LAPACK_ssfrk_base(
     float const* beta,
     float* C
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15478,7 +15482,7 @@ void LAPACK_cspcon_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15498,7 +15502,7 @@ void LAPACK_dspcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15518,7 +15522,7 @@ void LAPACK_sspcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15537,7 +15541,7 @@ void LAPACK_zspcon_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15556,7 +15560,7 @@ void LAPACK_dspev_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15575,7 +15579,7 @@ void LAPACK_sspev_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15595,7 +15599,7 @@ void LAPACK_dspevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15615,7 +15619,7 @@ void LAPACK_sspevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15638,7 +15642,7 @@ void LAPACK_dspevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15661,7 +15665,7 @@ void LAPACK_sspevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15678,7 +15682,7 @@ void LAPACK_dspgst_base(
     double const* BP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15695,7 +15699,7 @@ void LAPACK_sspgst_base(
     float const* BP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15715,7 +15719,7 @@ void LAPACK_dspgv_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15735,7 +15739,7 @@ void LAPACK_sspgv_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15756,7 +15760,7 @@ void LAPACK_dspgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15777,7 +15781,7 @@ void LAPACK_sspgvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15801,7 +15805,7 @@ void LAPACK_dspgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15825,7 +15829,7 @@ void LAPACK_sspgvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15848,7 +15852,7 @@ void LAPACK_csprfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15871,7 +15875,7 @@ void LAPACK_dsprfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15894,7 +15898,7 @@ void LAPACK_ssprfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15917,7 +15921,7 @@ void LAPACK_zsprfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15934,7 +15938,7 @@ void LAPACK_cspsv_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15951,7 +15955,7 @@ void LAPACK_dspsv_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15968,7 +15972,7 @@ void LAPACK_sspsv_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -15985,7 +15989,7 @@ void LAPACK_zspsv_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16009,7 +16013,7 @@ void LAPACK_cspsvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16033,7 +16037,7 @@ void LAPACK_dspsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16057,7 +16061,7 @@ void LAPACK_sspsvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16081,7 +16085,7 @@ void LAPACK_zspsvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16100,7 +16104,7 @@ void LAPACK_dsptrd_base(
     double* tau,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16119,7 +16123,7 @@ void LAPACK_ssptrd_base(
     float* tau,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16135,7 +16139,7 @@ void LAPACK_csptrf_base(
     lapack_complex_float* AP, lapack_int* ipiv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16151,7 +16155,7 @@ void LAPACK_dsptrf_base(
     double* AP, lapack_int* ipiv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16167,7 +16171,7 @@ void LAPACK_ssptrf_base(
     float* AP, lapack_int* ipiv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16183,7 +16187,7 @@ void LAPACK_zsptrf_base(
     lapack_complex_double* AP, lapack_int* ipiv,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16200,7 +16204,7 @@ void LAPACK_csptri_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16217,7 +16221,7 @@ void LAPACK_dsptri_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16234,7 +16238,7 @@ void LAPACK_ssptri_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16251,7 +16255,7 @@ void LAPACK_zsptri_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16268,7 +16272,7 @@ void LAPACK_csptrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16285,7 +16289,7 @@ void LAPACK_dsptrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16302,7 +16306,7 @@ void LAPACK_ssptrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16319,7 +16323,7 @@ void LAPACK_zsptrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16342,7 +16346,7 @@ void LAPACK_dstebz_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16365,7 +16369,7 @@ void LAPACK_sstebz_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16386,7 +16390,7 @@ void LAPACK_cstedc_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16406,7 +16410,7 @@ void LAPACK_dstedc_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16426,7 +16430,7 @@ void LAPACK_sstedc_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16447,7 +16451,7 @@ void LAPACK_zstedc_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16471,7 +16475,7 @@ void LAPACK_cstegr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16495,7 +16499,7 @@ void LAPACK_dstegr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16519,7 +16523,7 @@ void LAPACK_sstegr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16543,7 +16547,7 @@ void LAPACK_zstegr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16610,7 +16614,7 @@ void LAPACK_cstemr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16633,7 +16637,7 @@ void LAPACK_dstemr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16656,7 +16660,7 @@ void LAPACK_sstemr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16679,7 +16683,7 @@ void LAPACK_zstemr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16698,7 +16702,7 @@ void LAPACK_csteqr_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16717,7 +16721,7 @@ void LAPACK_dsteqr_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16736,7 +16740,7 @@ void LAPACK_ssteqr_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16755,7 +16759,7 @@ void LAPACK_zsteqr_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16788,7 +16792,7 @@ void LAPACK_dstev_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16807,7 +16811,7 @@ void LAPACK_sstev_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16827,7 +16831,7 @@ void LAPACK_dstevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16847,7 +16851,7 @@ void LAPACK_sstevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16871,7 +16875,7 @@ void LAPACK_dstevr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16895,7 +16899,7 @@ void LAPACK_sstevr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16919,7 +16923,7 @@ void LAPACK_dstevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16943,7 +16947,7 @@ void LAPACK_sstevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16962,7 +16966,7 @@ void LAPACK_csycon_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -16982,7 +16986,7 @@ void LAPACK_dsycon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17002,7 +17006,7 @@ void LAPACK_ssycon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17021,7 +17025,7 @@ void LAPACK_zsycon_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17041,7 +17045,7 @@ void LAPACK_csycon_3_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17062,7 +17066,7 @@ void LAPACK_dsycon_3_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17083,7 +17087,7 @@ void LAPACK_ssycon_3_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17103,7 +17107,7 @@ void LAPACK_zsycon_3_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17120,7 +17124,7 @@ void LAPACK_csyconv_base(
     lapack_complex_float* E,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17137,7 +17141,7 @@ void LAPACK_dsyconv_base(
     double* E,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17154,7 +17158,7 @@ void LAPACK_ssyconv_base(
     float* E,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17171,7 +17175,7 @@ void LAPACK_zsyconv_base(
     lapack_complex_double* E,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17191,7 +17195,7 @@ void LAPACK_csyequb_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17211,7 +17215,7 @@ void LAPACK_dsyequb_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17231,7 +17235,7 @@ void LAPACK_ssyequb_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17251,7 +17255,7 @@ void LAPACK_zsyequb_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17269,7 +17273,7 @@ void LAPACK_dsyev_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17287,7 +17291,7 @@ void LAPACK_ssyev_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17305,7 +17309,7 @@ void LAPACK_dsyev_2stage_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17323,7 +17327,7 @@ void LAPACK_ssyev_2stage_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17342,7 +17346,7 @@ void LAPACK_dsyevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17361,7 +17365,7 @@ void LAPACK_ssyevd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17380,7 +17384,7 @@ void LAPACK_dsyevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17399,7 +17403,7 @@ void LAPACK_ssyevd_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17422,7 +17426,7 @@ void LAPACK_dsyevr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17445,7 +17449,7 @@ void LAPACK_ssyevr_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17468,7 +17472,7 @@ void LAPACK_dsyevr_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17491,7 +17495,7 @@ void LAPACK_ssyevr_2stage_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17514,7 +17518,7 @@ void LAPACK_dsyevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17537,7 +17541,7 @@ void LAPACK_ssyevx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17560,7 +17564,7 @@ void LAPACK_dsyevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17583,7 +17587,7 @@ void LAPACK_ssyevx_2stage_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17600,7 +17604,7 @@ void LAPACK_dsygst_base(
     double const* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17617,7 +17621,7 @@ void LAPACK_ssygst_base(
     float const* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17636,7 +17640,7 @@ void LAPACK_dsygv_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17655,7 +17659,7 @@ void LAPACK_ssygv_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17674,7 +17678,7 @@ void LAPACK_dsygv_2stage_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17693,7 +17697,7 @@ void LAPACK_ssygv_2stage_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17713,7 +17717,7 @@ void LAPACK_dsygvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17733,7 +17737,7 @@ void LAPACK_ssygvd_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17757,7 +17761,7 @@ void LAPACK_dsygvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17781,7 +17785,7 @@ void LAPACK_ssygvx_base(
     lapack_int* iwork, lapack_int* IFAIL,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17798,7 +17802,7 @@ void LAPACK_csyr_base(
     lapack_complex_float const* X, lapack_int const* incx,
     lapack_complex_float* A, lapack_int const* lda
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17815,7 +17819,7 @@ void LAPACK_zsyr_base(
     lapack_complex_double const* X, lapack_int const* incx,
     lapack_complex_double* A, lapack_int const* lda
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17838,7 +17842,7 @@ void LAPACK_csyrfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17861,7 +17865,7 @@ void LAPACK_dsyrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17884,7 +17888,7 @@ void LAPACK_ssyrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17907,7 +17911,7 @@ void LAPACK_zsyrfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17934,7 +17938,7 @@ void LAPACK_csyrfsx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17961,7 +17965,7 @@ void LAPACK_dsyrfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -17988,7 +17992,7 @@ void LAPACK_ssyrfsx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18015,7 +18019,7 @@ void LAPACK_zsyrfsx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18033,7 +18037,7 @@ void LAPACK_csysv_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18051,7 +18055,7 @@ void LAPACK_dsysv_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18069,7 +18073,7 @@ void LAPACK_ssysv_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18087,7 +18091,7 @@ void LAPACK_zsysv_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18105,7 +18109,7 @@ void LAPACK_csysv_aa_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18123,7 +18127,7 @@ void LAPACK_dsysv_aa_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18141,7 +18145,7 @@ void LAPACK_ssysv_aa_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18159,7 +18163,7 @@ void LAPACK_zsysv_aa_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18178,7 +18182,7 @@ void LAPACK_csysv_aa_2stage_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18197,7 +18201,7 @@ void LAPACK_dsysv_aa_2stage_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18216,7 +18220,7 @@ void LAPACK_ssysv_aa_2stage_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18235,7 +18239,7 @@ void LAPACK_zsysv_aa_2stage_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18254,7 +18258,7 @@ void LAPACK_csysv_rk_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18273,7 +18277,7 @@ void LAPACK_dsysv_rk_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18292,7 +18296,7 @@ void LAPACK_ssysv_rk_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18311,7 +18315,7 @@ void LAPACK_zsysv_rk_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18329,7 +18333,7 @@ void LAPACK_csysv_rook_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18347,7 +18351,7 @@ void LAPACK_dsysv_rook_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18365,7 +18369,7 @@ void LAPACK_ssysv_rook_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18383,7 +18387,7 @@ void LAPACK_zsysv_rook_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18407,7 +18411,7 @@ void LAPACK_csysvx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18431,7 +18435,7 @@ void LAPACK_dsysvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18455,7 +18459,7 @@ void LAPACK_ssysvx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18479,7 +18483,7 @@ void LAPACK_zsysvx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18508,7 +18512,7 @@ void LAPACK_csysvxx_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18537,7 +18541,7 @@ void LAPACK_dsysvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18566,7 +18570,7 @@ void LAPACK_ssysvxx_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18595,7 +18599,7 @@ void LAPACK_zsysvxx_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18610,7 +18614,7 @@ void LAPACK_csyswapr_base(
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18625,7 +18629,7 @@ void LAPACK_dsyswapr_base(
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18640,7 +18644,7 @@ void LAPACK_ssyswapr_base(
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18655,7 +18659,7 @@ void LAPACK_zsyswapr_base(
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* i1, lapack_int const* i2
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18675,7 +18679,7 @@ void LAPACK_dsytrd_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18695,7 +18699,7 @@ void LAPACK_ssytrd_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18716,7 +18720,7 @@ void LAPACK_dsytrd_2stage_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18737,7 +18741,7 @@ void LAPACK_ssytrd_2stage_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18754,7 +18758,7 @@ void LAPACK_csytrf_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18771,7 +18775,7 @@ void LAPACK_dsytrf_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18788,7 +18792,7 @@ void LAPACK_ssytrf_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18805,7 +18809,7 @@ void LAPACK_zsytrf_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18822,7 +18826,7 @@ void LAPACK_csytrf_aa_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18839,7 +18843,7 @@ void LAPACK_dsytrf_aa_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18856,7 +18860,7 @@ void LAPACK_ssytrf_aa_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18873,7 +18877,7 @@ void LAPACK_zsytrf_aa_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18891,7 +18895,7 @@ void LAPACK_csytrf_aa_2stage_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18909,7 +18913,7 @@ void LAPACK_dsytrf_aa_2stage_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18927,7 +18931,7 @@ void LAPACK_ssytrf_aa_2stage_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18945,7 +18949,7 @@ void LAPACK_zsytrf_aa_2stage_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18963,7 +18967,7 @@ void LAPACK_csytrf_rk_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18981,7 +18985,7 @@ void LAPACK_dsytrf_rk_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -18999,7 +19003,7 @@ void LAPACK_ssytrf_rk_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19017,7 +19021,7 @@ void LAPACK_zsytrf_rk_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19034,7 +19038,7 @@ void LAPACK_csytrf_rook_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19051,7 +19055,7 @@ void LAPACK_dsytrf_rook_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19068,7 +19072,7 @@ void LAPACK_ssytrf_rook_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19085,7 +19089,7 @@ void LAPACK_zsytrf_rook_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19102,7 +19106,7 @@ void LAPACK_csytri_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19119,7 +19123,7 @@ void LAPACK_dsytri_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19136,7 +19140,7 @@ void LAPACK_ssytri_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19153,7 +19157,7 @@ void LAPACK_zsytri_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19170,7 +19174,7 @@ void LAPACK_csytri2_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19187,7 +19191,7 @@ void LAPACK_dsytri2_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19204,7 +19208,7 @@ void LAPACK_ssytri2_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19221,7 +19225,7 @@ void LAPACK_zsytri2_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19238,7 +19242,7 @@ void LAPACK_csytri2x_base(
     lapack_complex_float* work, lapack_int const* nb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19255,7 +19259,7 @@ void LAPACK_dsytri2x_base(
     double* work, lapack_int const* nb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19272,7 +19276,7 @@ void LAPACK_ssytri2x_base(
     float* work, lapack_int const* nb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19289,7 +19293,7 @@ void LAPACK_zsytri2x_base(
     lapack_complex_double* work, lapack_int const* nb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19307,7 +19311,7 @@ void LAPACK_csytri_3_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19325,7 +19329,7 @@ void LAPACK_dsytri_3_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19343,7 +19347,7 @@ void LAPACK_ssytri_3_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19361,7 +19365,7 @@ void LAPACK_zsytri_3_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19378,7 +19382,7 @@ void LAPACK_csytrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19395,7 +19399,7 @@ void LAPACK_dsytrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19412,7 +19416,7 @@ void LAPACK_ssytrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19429,7 +19433,7 @@ void LAPACK_zsytrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19447,7 +19451,7 @@ void LAPACK_csytrs2_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19465,7 +19469,7 @@ void LAPACK_dsytrs2_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19483,7 +19487,7 @@ void LAPACK_ssytrs2_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19501,7 +19505,7 @@ void LAPACK_zsytrs2_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19519,7 +19523,7 @@ void LAPACK_csytrs_3_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19537,7 +19541,7 @@ void LAPACK_dsytrs_3_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19555,7 +19559,7 @@ void LAPACK_ssytrs_3_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19573,7 +19577,7 @@ void LAPACK_zsytrs_3_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19591,7 +19595,7 @@ void LAPACK_csytrs_aa_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19609,7 +19613,7 @@ void LAPACK_dsytrs_aa_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19627,7 +19631,7 @@ void LAPACK_ssytrs_aa_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19645,7 +19649,7 @@ void LAPACK_zsytrs_aa_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19663,7 +19667,7 @@ void LAPACK_csytrs_aa_2stage_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19681,7 +19685,7 @@ void LAPACK_dsytrs_aa_2stage_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19699,7 +19703,7 @@ void LAPACK_ssytrs_aa_2stage_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19717,7 +19721,7 @@ void LAPACK_zsytrs_aa_2stage_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19734,7 +19738,7 @@ void LAPACK_csytrs_rook_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19751,7 +19755,7 @@ void LAPACK_dsytrs_rook_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19768,7 +19772,7 @@ void LAPACK_ssytrs_rook_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19785,7 +19789,7 @@ void LAPACK_zsytrs_rook_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19804,7 +19808,7 @@ void LAPACK_ctbcon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19823,7 +19827,7 @@ void LAPACK_dtbcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19842,7 +19846,7 @@ void LAPACK_stbcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19861,7 +19865,7 @@ void LAPACK_ztbcon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19883,7 +19887,7 @@ void LAPACK_ctbrfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19905,7 +19909,7 @@ void LAPACK_dtbrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19927,7 +19931,7 @@ void LAPACK_stbrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19949,7 +19953,7 @@ void LAPACK_ztbrfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19966,7 +19970,7 @@ void LAPACK_ctbtrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -19983,7 +19987,7 @@ void LAPACK_dtbtrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20000,7 +20004,7 @@ void LAPACK_stbtrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20017,7 +20021,7 @@ void LAPACK_ztbtrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20034,7 +20038,7 @@ void LAPACK_ctfsm_base(
     lapack_complex_float const* A,
     lapack_complex_float* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20051,7 +20055,7 @@ void LAPACK_dtfsm_base(
     double const* A,
     double* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20068,7 +20072,7 @@ void LAPACK_stfsm_base(
     float const* A,
     float* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20085,7 +20089,7 @@ void LAPACK_ztfsm_base(
     lapack_complex_double const* A,
     lapack_complex_double* B, lapack_int const* ldb
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20101,7 +20105,7 @@ void LAPACK_ctftri_base(
     lapack_complex_float* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20117,7 +20121,7 @@ void LAPACK_dtftri_base(
     double* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20133,7 +20137,7 @@ void LAPACK_stftri_base(
     float* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20149,7 +20153,7 @@ void LAPACK_ztftri_base(
     lapack_complex_double* A,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20166,7 +20170,7 @@ void LAPACK_ctfttp_base(
     lapack_complex_float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20183,7 +20187,7 @@ void LAPACK_dtfttp_base(
     double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20200,7 +20204,7 @@ void LAPACK_stfttp_base(
     float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20217,7 +20221,7 @@ void LAPACK_ztfttp_base(
     lapack_complex_double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20234,7 +20238,7 @@ void LAPACK_ctfttr_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20251,7 +20255,7 @@ void LAPACK_dtfttr_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20268,7 +20272,7 @@ void LAPACK_stfttr_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20285,7 +20289,7 @@ void LAPACK_ztfttr_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20307,7 +20311,7 @@ void LAPACK_ctgevc_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20328,7 +20332,7 @@ void LAPACK_dtgevc_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20349,7 +20353,7 @@ void LAPACK_stgevc_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20371,7 +20375,7 @@ void LAPACK_ztgevc_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20500,7 +20504,7 @@ void LAPACK_ctgsja_base(
     lapack_complex_float* work, lapack_int* ncycle,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20525,7 +20529,7 @@ void LAPACK_dtgsja_base(
     double* work, lapack_int* ncycle,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20550,7 +20554,7 @@ void LAPACK_stgsja_base(
     float* work, lapack_int* ncycle,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20575,7 +20579,7 @@ void LAPACK_ztgsja_base(
     lapack_complex_double* work, lapack_int* ncycle,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20599,7 +20603,7 @@ void LAPACK_ctgsna_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20623,7 +20627,7 @@ void LAPACK_dtgsna_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20647,7 +20651,7 @@ void LAPACK_stgsna_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20671,7 +20675,7 @@ void LAPACK_ztgsna_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20696,7 +20700,7 @@ void LAPACK_ctgsyl_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20721,7 +20725,7 @@ void LAPACK_dtgsyl_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20746,7 +20750,7 @@ void LAPACK_stgsyl_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20771,7 +20775,7 @@ void LAPACK_ztgsyl_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20790,7 +20794,7 @@ void LAPACK_ctpcon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20809,7 +20813,7 @@ void LAPACK_dtpcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20828,7 +20832,7 @@ void LAPACK_stpcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20847,7 +20851,7 @@ void LAPACK_ztpcon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20935,7 +20939,7 @@ void LAPACK_ctpmlqt_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20955,7 +20959,7 @@ void LAPACK_dtpmlqt_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20975,7 +20979,7 @@ void LAPACK_stpmlqt_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -20995,7 +20999,7 @@ void LAPACK_ztpmlqt_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21015,7 +21019,7 @@ void LAPACK_ctpmqrt_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21035,7 +21039,7 @@ void LAPACK_dtpmqrt_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21055,7 +21059,7 @@ void LAPACK_stpmqrt_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21075,7 +21079,7 @@ void LAPACK_ztpmqrt_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21162,7 +21166,7 @@ void LAPACK_ctprfb_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_complex_float* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21181,7 +21185,7 @@ void LAPACK_dtprfb_base(
     double* B, lapack_int const* ldb,
     double* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21200,7 +21204,7 @@ void LAPACK_stprfb_base(
     float* B, lapack_int const* ldb,
     float* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21219,7 +21223,7 @@ void LAPACK_ztprfb_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_complex_double* work, lapack_int const* ldwork
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21241,7 +21245,7 @@ void LAPACK_ctprfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21263,7 +21267,7 @@ void LAPACK_dtprfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21285,7 +21289,7 @@ void LAPACK_stprfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21307,7 +21311,7 @@ void LAPACK_ztprfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21323,7 +21327,7 @@ void LAPACK_ctptri_base(
     lapack_complex_float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21339,7 +21343,7 @@ void LAPACK_dtptri_base(
     double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21355,7 +21359,7 @@ void LAPACK_stptri_base(
     float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21371,7 +21375,7 @@ void LAPACK_ztptri_base(
     lapack_complex_double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21388,7 +21392,7 @@ void LAPACK_ctptrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21405,7 +21409,7 @@ void LAPACK_dtptrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21422,7 +21426,7 @@ void LAPACK_stptrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21439,7 +21443,7 @@ void LAPACK_ztptrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21456,7 +21460,7 @@ void LAPACK_ctpttf_base(
     lapack_complex_float* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21473,7 +21477,7 @@ void LAPACK_dtpttf_base(
     double* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21490,7 +21494,7 @@ void LAPACK_stpttf_base(
     float* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21507,7 +21511,7 @@ void LAPACK_ztpttf_base(
     lapack_complex_double* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21524,7 +21528,7 @@ void LAPACK_ctpttr_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21541,7 +21545,7 @@ void LAPACK_dtpttr_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21558,7 +21562,7 @@ void LAPACK_stpttr_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21575,7 +21579,7 @@ void LAPACK_ztpttr_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21594,7 +21598,7 @@ void LAPACK_ctrcon_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21613,7 +21617,7 @@ void LAPACK_dtrcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21632,7 +21636,7 @@ void LAPACK_strcon_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21651,7 +21655,7 @@ void LAPACK_ztrcon_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21672,7 +21676,7 @@ void LAPACK_ctrevc_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21692,7 +21696,7 @@ void LAPACK_dtrevc_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21712,7 +21716,7 @@ void LAPACK_strevc_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21733,7 +21737,7 @@ void LAPACK_ztrevc_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21754,7 +21758,7 @@ void LAPACK_ctrevc3_base(
     float* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21774,7 +21778,7 @@ void LAPACK_dtrevc3_base(
     double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21794,7 +21798,7 @@ void LAPACK_strevc3_base(
     float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21815,7 +21819,7 @@ void LAPACK_ztrevc3_base(
     double* rwork, lapack_int const* lrwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21832,7 +21836,7 @@ void LAPACK_ctrexc_base(
     lapack_complex_float* Q, lapack_int const* ldq, lapack_int const* ifst, lapack_int const* ilst,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21850,7 +21854,7 @@ void LAPACK_dtrexc_base(
     double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21868,7 +21872,7 @@ void LAPACK_strexc_base(
     float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21885,7 +21889,7 @@ void LAPACK_ztrexc_base(
     lapack_complex_double* Q, lapack_int const* ldq, lapack_int const* ifst, lapack_int const* ilst,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21907,7 +21911,7 @@ void LAPACK_ctrrfs_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21929,7 +21933,7 @@ void LAPACK_dtrrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21951,7 +21955,7 @@ void LAPACK_strrfs_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21973,7 +21977,7 @@ void LAPACK_ztrrfs_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -21995,7 +21999,7 @@ void LAPACK_ctrsen_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22019,7 +22023,7 @@ void LAPACK_dtrsen_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22043,7 +22047,7 @@ void LAPACK_strsen_base(
     lapack_int* iwork, lapack_int const* liwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22065,7 +22069,7 @@ void LAPACK_ztrsen_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22088,7 +22092,7 @@ void LAPACK_ctrsna_base(
     float* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22111,7 +22115,7 @@ void LAPACK_dtrsna_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22134,7 +22138,7 @@ void LAPACK_strsna_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22157,7 +22161,7 @@ void LAPACK_ztrsna_base(
     double* rwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22176,7 +22180,7 @@ void LAPACK_ctrsyl_base(
     float* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22195,7 +22199,7 @@ void LAPACK_dtrsyl_base(
     double* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22214,7 +22218,7 @@ void LAPACK_strsyl_base(
     float* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22233,7 +22237,7 @@ void LAPACK_ztrsyl_base(
     double* scale,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22252,7 +22256,7 @@ void LAPACK_ctrsyl3_base(
     float* swork, lapack_int const *ldswork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22272,7 +22276,7 @@ void LAPACK_dtrsyl3_base(
     double* swork, lapack_int const *ldswork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22292,7 +22296,7 @@ void LAPACK_strsyl3_base(
     float* swork, lapack_int const *ldswork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22311,7 +22315,7 @@ void LAPACK_ztrsyl3_base(
     double* swork, lapack_int const *ldswork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22327,7 +22331,7 @@ void LAPACK_ctrtri_base(
     lapack_complex_float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22343,7 +22347,7 @@ void LAPACK_dtrtri_base(
     double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22359,7 +22363,7 @@ void LAPACK_strtri_base(
     float* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22375,7 +22379,7 @@ void LAPACK_ztrtri_base(
     lapack_complex_double* A, lapack_int const* lda,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22392,7 +22396,7 @@ void LAPACK_ctrtrs_base(
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22409,7 +22413,7 @@ void LAPACK_dtrtrs_base(
     double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22426,7 +22430,7 @@ void LAPACK_strtrs_base(
     float* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22443,7 +22447,7 @@ void LAPACK_ztrtrs_base(
     lapack_complex_double* B, lapack_int const* ldb,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22460,7 +22464,7 @@ void LAPACK_ctrttf_base(
     lapack_complex_float* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22477,7 +22481,7 @@ void LAPACK_dtrttf_base(
     double* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22494,7 +22498,7 @@ void LAPACK_strttf_base(
     float* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22511,7 +22515,7 @@ void LAPACK_ztrttf_base(
     lapack_complex_double* ARF,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22528,7 +22532,7 @@ void LAPACK_ctrttp_base(
     lapack_complex_float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22545,7 +22549,7 @@ void LAPACK_dtrttp_base(
     double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22562,7 +22566,7 @@ void LAPACK_strttp_base(
     float* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22579,7 +22583,7 @@ void LAPACK_ztrttp_base(
     lapack_complex_double* AP,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22637,7 +22641,7 @@ void LAPACK_cunbdb_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22663,7 +22667,7 @@ void LAPACK_zunbdb_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22690,7 +22694,7 @@ void LAPACK_cuncsd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22717,7 +22721,7 @@ void LAPACK_zuncsd_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t, size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22741,7 +22745,7 @@ void LAPACK_cuncsd2by1_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22765,7 +22769,7 @@ void LAPACK_zuncsd2by1_base(
     lapack_int* iwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22783,7 +22787,7 @@ void LAPACK_cungbr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22801,7 +22805,7 @@ void LAPACK_zungbr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22899,7 +22903,7 @@ void LAPACK_cungtr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22917,7 +22921,7 @@ void LAPACK_zungtr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22970,7 +22974,7 @@ void LAPACK_cunmbr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -22989,7 +22993,7 @@ void LAPACK_zunmbr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23008,7 +23012,7 @@ void LAPACK_cunmhr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23027,7 +23031,7 @@ void LAPACK_zunmhr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23046,7 +23050,7 @@ void LAPACK_cunmlq_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23065,7 +23069,7 @@ void LAPACK_zunmlq_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23084,7 +23088,7 @@ void LAPACK_cunmql_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23103,7 +23107,7 @@ void LAPACK_zunmql_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23122,7 +23126,7 @@ void LAPACK_cunmqr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23141,7 +23145,7 @@ void LAPACK_zunmqr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23160,7 +23164,7 @@ void LAPACK_cunmrq_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23179,7 +23183,7 @@ void LAPACK_zunmrq_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23198,7 +23202,7 @@ void LAPACK_cunmrz_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23217,7 +23221,7 @@ void LAPACK_zunmrz_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23236,7 +23240,7 @@ void LAPACK_cunmtr_base(
     lapack_complex_float* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23255,7 +23259,7 @@ void LAPACK_zunmtr_base(
     lapack_complex_double* work, lapack_int const* lwork,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23274,7 +23278,7 @@ void LAPACK_cupgtr_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23293,7 +23297,7 @@ void LAPACK_zupgtr_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t
+    , FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23312,7 +23316,7 @@ void LAPACK_cupmtr_base(
     lapack_complex_float* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END
@@ -23331,7 +23335,7 @@ void LAPACK_zupmtr_base(
     lapack_complex_double* work,
     lapack_int* info
 #ifdef LAPACK_FORTRAN_STRLEN_END
-    , size_t, size_t, size_t
+    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
 #ifdef LAPACK_FORTRAN_STRLEN_END


### PR DESCRIPTION
**Description**

Old GFortran versions (GCC < 8) use `int` instead of `size_t` for the hidden strlen arguments appended for the char arrays. See [https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gfortran/Argument-passing-conventions.html](https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gfortran/Argument-passing-conventions.html#:~:text=prototype%20as%20follows%3A-,%23if%20__GNUC__%20%3E%207,-typedef%20size_t%20fortran_charlen_t).

NAG Fortran still uses `int` by default. On Linux x86_64, it is configurable via the `-abi=...` flag.

Intel always used `size_t` (I think).


