### PR TITLE
Fix lto type mismatch

### DIFF
--- a/CBLAS/examples/cblas_example2_64.c
+++ b/CBLAS/examples/cblas_example2_64.c
@@ -1,10 +1,11 @@
 /* cblas_example2.c */
 
+#define CBLAS_API64
+#define F77_INT int64_t
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "cblas_64.h"
-#define CBLAS_API64
-#define F77_INT int64_t
 #include "cblas_f77.h"
 
 #define INVALID -1

--- a/CBLAS/include/cblas_f77.h
+++ b/CBLAS/include/cblas_f77.h
@@ -884,7 +884,7 @@ void F77_chpr_base(FCHAR, FINT, const float *, const void *, FINT, void *
    , FORTRAN_STRLEN
 #endif
 );
-void F77_chpr2_base(FCHAR, FINT, const float *, const void *, FINT, const void *, FINT, void *
+void F77_chpr2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN
 #endif
@@ -964,7 +964,7 @@ void F77_zhpr_base(FCHAR, FINT, const double *, const void *, FINT, void *
    , FORTRAN_STRLEN
 #endif
 );
-void F77_zhpr2_base(FCHAR, FINT, const double *, const void *, FINT, const void *, FINT, void *
+void F77_zhpr2_base(FCHAR, FINT, const void *, const void *, FINT, const void *, FINT, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN
 #endif
@@ -1042,47 +1042,47 @@ void F77_dtrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, cons
 
 /* Single Complex Precision */
 
-void F77_cgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+void F77_cgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_csymm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+void F77_csymm_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_chemm_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+void F77_chemm_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_csyrk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
+void F77_csyrk_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_cherk_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, float *, FINT
+void F77_cherk_base(FCHAR, FCHAR, FINT, FINT, const float *, const void *, FINT, const float *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_csyr2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+void F77_csyr2k_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_cher2k_base(FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, const float *, FINT, const float *, float *, FINT
+void F77_cher2k_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const float *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_ctrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
+void F77_ctrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const float *, FINT, float *, FINT
+void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
@@ -1090,47 +1090,47 @@ void F77_ctrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const float *, const
 
 /* Double Complex Precision */
 
-void F77_zgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+void F77_zgemm_base(FCHAR, FCHAR, FINT, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_zsymm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+void F77_zsymm_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_zhemm_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+void F77_zhemm_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_zsyrk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
+void F77_zsyrk_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_zherk_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, double *, FINT
+void F77_zherk_base(FCHAR, FCHAR, FINT, FINT, const double *, const void *, FINT, const double *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_zsyr2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+void F77_zsyr2k_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const void *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_zher2k_base(FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, const double *, FINT, const double *, double *, FINT
+void F77_zher2k_base(FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, const void *, FINT, const double *, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_ztrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
+void F77_ztrmm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif
 );
-void F77_ztrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const double *, const double *, FINT, double *, FINT
+void F77_ztrsm_base(FCHAR, FCHAR, FCHAR, FCHAR, FINT, FINT, const void *, const void *, FINT, void *, FINT
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif

--- a/CBLAS/include/cblas_test.h
+++ b/CBLAS/include/cblas_test.h
@@ -7,6 +7,15 @@
 #include "cblas.h"
 #include "cblas_mangling.h"
 
+/* It seems all current Fortran compilers put strlen at end.
+*  Some historical compilers put strlen after the str argument
+*  or make the str argument into a struct. */
+#define BLAS_FORTRAN_STRLEN_END
+
+#ifndef FORTRAN_STRLEN
+  #define FORTRAN_STRLEN size_t
+#endif
+
 #define  TRUE           1
 #define  PASSED         1
 #define  TEST_ROW_MJR	1

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;
@@ -48,7 +48,7 @@ void F77_c2chke(char *rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void F77_c2chke(char *rout) {
+void F77_c2chke(char *rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    float  A[2] = {0.0,0.0},
           X[2] = {0.0,0.0},

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;
@@ -51,7 +51,7 @@ void  F77_c3chke(char *  rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void  F77_c3chke(char *  rout) {
+void  F77_c3chke(char *  rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    float   A[4]     = {0.0,0.0,0.0,0.0},
            B[4]     = {0.0,0.0,0.0,0.0},

--- a/CBLAS/testing/c_cblas2.c
+++ b/CBLAS/testing/c_cblas2.c
@@ -11,7 +11,11 @@
 void F77_cgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n,
           const void *alpha,
           CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda, const void *x, CBLAS_INT *incx,
-          const void *beta, void *y, CBLAS_INT *incy) {
+          const void *beta, void *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT i,j,LDA;
@@ -41,7 +45,11 @@ void F77_cgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n,
 void F77_cgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku,
 	      CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
 	      CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx,
-	      CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy) {
+	      CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT i,j,irow,jcol,LDA;
@@ -144,7 +152,11 @@ void F77_cgerc(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_COMPLEX
 
 void F77_chemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
       CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_COMPLEX *x,
-      CBLAS_INT *incx, CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy){
+      CBLAS_INT *incx, CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
 
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT i,j,LDA;
@@ -175,7 +187,11 @@ void F77_chemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
 void F77_chbmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_INT *k,
      CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
      CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_COMPLEX *beta,
-     CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy){
+     CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
 
 CBLAS_TEST_COMPLEX *A;
 CBLAS_INT i,irow,j,jcol,LDA;
@@ -238,7 +254,11 @@ CBLAS_INT i,irow,j,jcol,LDA;
 
 void F77_chpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
      CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx,
-     CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy){
+     CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
 
   CBLAS_TEST_COMPLEX *A, *AP;
   CBLAS_INT i,j,k,LDA;
@@ -294,7 +314,11 @@ void F77_chpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
 
 void F77_ctbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
      CBLAS_INT *n, CBLAS_INT *k, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_COMPLEX *x,
-     CBLAS_INT *incx) {
+     CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT irow, jcol, i, j, LDA;
   CBLAS_TRANSPOSE trans;
@@ -357,7 +381,11 @@ void F77_ctbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
 void F77_ctbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
       CBLAS_INT *n, CBLAS_INT *k, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_COMPLEX *x,
-      CBLAS_INT *incx) {
+      CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT irow, jcol, i, j, LDA;
@@ -420,7 +448,11 @@ void F77_ctbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_ctpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-      CBLAS_INT *n, CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx) {
+      CBLAS_INT *n, CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -475,7 +507,11 @@ void F77_ctpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_ctpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-     CBLAS_INT *n, CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx) {
+     CBLAS_INT *n, CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -531,7 +567,11 @@ void F77_ctpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
 void F77_ctrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
      CBLAS_INT *n, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_COMPLEX *x,
-      CBLAS_INT *incx) {
+      CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -560,7 +600,11 @@ void F77_ctrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 void F77_ctrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
        CBLAS_INT *n, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_COMPLEX *x,
-              CBLAS_INT *incx) {
+              CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -589,7 +633,11 @@ void F77_ctrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_chpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
-	     CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_COMPLEX *ap) {
+	     CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_COMPLEX *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -665,7 +713,11 @@ void F77_chpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
 
 void F77_chpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
        CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy,
-       CBLAS_TEST_COMPLEX *ap) {
+       CBLAS_TEST_COMPLEX *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -741,7 +793,11 @@ void F77_chpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
 }
 
 void F77_cher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
-  CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda) {
+  CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -774,7 +830,11 @@ void F77_cher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
 
 void F77_cher2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
           CBLAS_TEST_COMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_COMPLEX *y, CBLAS_INT *incy,
-	  CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda) {
+	  CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_COMPLEX *A;
   CBLAS_INT i,j,LDA;

--- a/CBLAS/testing/c_cblas3.c
+++ b/CBLAS/testing/c_cblas3.c
@@ -14,7 +14,11 @@
 void F77_cgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
      CBLAS_INT *k, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
      CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_COMPLEX *beta,
-     CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc ) {
+     CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_COMPLEX *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -89,8 +93,12 @@ void F77_cgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
 }
 void F77_chemm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
         CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
-	CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_COMPLEX *beta,
-        CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc ) {
+	      CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_COMPLEX *beta,
+        CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_COMPLEX *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -153,8 +161,12 @@ void F77_chemm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
 }
 void F77_csymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
           CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
-	  CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_COMPLEX *beta,
-          CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc ) {
+	        CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_COMPLEX *beta,
+          CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_COMPLEX *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -208,7 +220,11 @@ void F77_csymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
 
 void F77_cherk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
      float *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
-     float *beta, CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc ) {
+     float *beta, CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_INT i,j,LDA,LDC;
   CBLAS_TEST_COMPLEX *A, *C;
@@ -264,7 +280,11 @@ void F77_cherk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
 
 void F77_csyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
      CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
-     CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc ) {
+     CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_INT i,j,LDA,LDC;
   CBLAS_TEST_COMPLEX *A, *C;
@@ -320,7 +340,11 @@ void F77_csyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
 void F77_cher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
         CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
 	CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb, float *beta,
-        CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc ) {
+        CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB,LDC;
   CBLAS_TEST_COMPLEX *A, *B, *C;
   CBLAS_UPLO uplo;
@@ -384,7 +408,11 @@ void F77_cher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
 void F77_csyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
          CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
 	 CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_COMPLEX *beta,
-         CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc ) {
+         CBLAS_TEST_COMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB,LDC;
   CBLAS_TEST_COMPLEX *A, *B, *C;
   CBLAS_UPLO uplo;
@@ -447,7 +475,11 @@ void F77_csyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
 }
 void F77_ctrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
        CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a,
-       CBLAS_INT *lda, CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb) {
+       CBLAS_INT *lda, CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   CBLAS_TEST_COMPLEX *A, *B;
   CBLAS_SIDE side;
@@ -506,7 +538,11 @@ void F77_ctrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
 
 void F77_ctrsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
          CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a,
-         CBLAS_INT *lda, CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb) {
+         CBLAS_INT *lda, CBLAS_TEST_COMPLEX *b, CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   CBLAS_TEST_COMPLEX *A, *B;
   CBLAS_SIDE side;

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void F77_d2chke(char *rout) {
+void F77_d2chke(char *rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    double A[2] = {0.0,0.0},
           X[2] = {0.0,0.0},

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;
@@ -46,7 +46,7 @@ void F77_d2chke(char *rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;
@@ -46,7 +46,7 @@ void F77_d3chke(char *rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void F77_d3chke(char *rout) {
+void F77_d3chke(char *rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    double A[2] = {0.0,0.0},
           B[2] = {0.0,0.0},

--- a/CBLAS/testing/c_dblas2.c
+++ b/CBLAS/testing/c_dblas2.c
@@ -10,7 +10,11 @@
 
 void F77_dgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, double *alpha,
 	       double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx, double *beta,
-	       double *y, CBLAS_INT *incy ) {
+	       double *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   double *A;
   CBLAS_INT i,j,LDA;
@@ -61,7 +65,11 @@ void F77_dger(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, double *alpha, doub
 }
 
 void F77_dtrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -89,7 +97,11 @@ void F77_dtrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_dtrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	       CBLAS_INT *n, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx ) {
+	       CBLAS_INT *n, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -114,7 +126,11 @@ void F77_dtrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 void F77_dsymv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, double *a,
 	      CBLAS_INT *lda, double *x, CBLAS_INT *incx, double *beta, double *y,
-	      CBLAS_INT *incy) {
+	      CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -137,7 +153,11 @@ void F77_dsymv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, doub
 }
 
 void F77_dsyr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, double *x,
-	     CBLAS_INT *incx, double *a, CBLAS_INT *lda) {
+	     CBLAS_INT *incx, double *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -161,7 +181,11 @@ void F77_dsyr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, doubl
 }
 
 void F77_dsyr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, double *x,
-	     CBLAS_INT *incx, double *y, CBLAS_INT *incy, double *a, CBLAS_INT *lda) {
+	     CBLAS_INT *incx, double *y, CBLAS_INT *incy, double *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -186,7 +210,11 @@ void F77_dsyr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, doub
 
 void F77_dgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku,
 	       double *alpha, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx,
-	       double *beta, double *y, CBLAS_INT *incy ) {
+	       double *beta, double *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   double *A;
   CBLAS_INT i,irow,j,jcol,LDA;
@@ -223,7 +251,11 @@ void F77_dgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLA
 }
 
 void F77_dtbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, CBLAS_INT *k, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, CBLAS_INT *k, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT irow, jcol, i, j, LDA;
   CBLAS_TRANSPOSE trans;
@@ -269,7 +301,11 @@ void F77_dtbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_dtbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, CBLAS_INT *k, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, CBLAS_INT *k, double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT irow, jcol, i, j, LDA;
   CBLAS_TRANSPOSE trans;
@@ -316,7 +352,11 @@ void F77_dtbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
 void F77_dsbmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_INT *k, double *alpha,
 	      double *a, CBLAS_INT *lda, double *x, CBLAS_INT *incx, double *beta,
-	      double *y, CBLAS_INT *incy) {
+	      double *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   double *A;
   CBLAS_INT i,j,irow,jcol,LDA;
   CBLAS_UPLO uplo;
@@ -360,7 +400,11 @@ void F77_dsbmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_INT *k, doubl
 }
 
 void F77_dspmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, double *ap,
-	      double *x, CBLAS_INT *incx, double *beta, double *y, CBLAS_INT *incy) {
+	      double *x, CBLAS_INT *incx, double *beta, double *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   double *A,*AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -398,7 +442,11 @@ void F77_dspmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, doub
 }
 
 void F77_dtpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, double *ap, double *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, double *ap, double *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   double *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -438,7 +486,11 @@ void F77_dtpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_dtpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, double *ap, double *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, double *ap, double *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   double *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -479,7 +531,11 @@ void F77_dtpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_dspr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, double *x,
-	     CBLAS_INT *incx, double *ap ){
+	     CBLAS_INT *incx, double *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
   double *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -531,7 +587,11 @@ void F77_dspr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, doubl
 }
 
 void F77_dspr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha, double *x,
-	     CBLAS_INT *incx, double *y, CBLAS_INT *incy, double *ap ){
+	     CBLAS_INT *incx, double *y, CBLAS_INT *incy, double *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
   double *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;

--- a/CBLAS/testing/c_dblas3.c
+++ b/CBLAS/testing/c_dblas3.c
@@ -13,7 +13,11 @@
 
 void F77_dgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
               CBLAS_INT *k, double *alpha, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb,
-              double *beta, double *c, CBLAS_INT *ldc ) {
+              double *beta, double *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   double *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -75,7 +79,11 @@ void F77_dgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
 }
 void F77_dsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
               double *alpha, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb,
-              double *beta, double *c, CBLAS_INT *ldc ) {
+              double *beta, double *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   double *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -129,7 +137,11 @@ void F77_dsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
 
 void F77_dsyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
               double *alpha, double *a, CBLAS_INT *lda,
-              double *beta, double *c, CBLAS_INT *ldc ) {
+              double *beta, double *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_INT i,j,LDA,LDC;
   double *A, *C;
@@ -177,7 +189,11 @@ void F77_dsyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
 
 void F77_dsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
                double *alpha, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb,
-               double *beta, double *c, CBLAS_INT *ldc ) {
+               double *beta, double *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB,LDC;
   double *A, *B, *C;
   CBLAS_UPLO uplo;
@@ -232,7 +248,11 @@ void F77_dsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
 }
 void F77_dtrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
               CBLAS_INT *m, CBLAS_INT *n, double *alpha, double *a, CBLAS_INT *lda, double *b,
-              CBLAS_INT *ldb) {
+              CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   double *A, *B;
   CBLAS_SIDE side;
@@ -283,7 +303,11 @@ void F77_dtrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
 
 void F77_dtrsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
               CBLAS_INT *m, CBLAS_INT *n, double *alpha, double *a, CBLAS_INT *lda, double *b,
-              CBLAS_INT *ldb) {
+              CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   double *A, *B;
   CBLAS_SIDE side;

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -46,7 +46,7 @@ void F77_s2chke(char *rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void F77_s2chke(char *rout) {
+void F77_s2chke(char *rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    float  A[2] = {0.0,0.0},
           X[2] = {0.0,0.0},

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;
@@ -46,7 +46,7 @@ void F77_s3chke(char *rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void F77_s3chke(char *rout) {
+void F77_s3chke(char *rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    float  A[2] = {0.0,0.0},
           B[2] = {0.0,0.0},

--- a/CBLAS/testing/c_sblas2.c
+++ b/CBLAS/testing/c_sblas2.c
@@ -10,7 +10,11 @@
 
 void F77_sgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, float *alpha,
 	       float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx, float *beta,
-	       float *y, CBLAS_INT *incy ) {
+	       float *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   float *A;
   CBLAS_INT i,j,LDA;
@@ -61,7 +65,11 @@ void F77_sger(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, float *alpha, float
 }
 
 void F77_strmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -89,7 +97,11 @@ void F77_strmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_strsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	       CBLAS_INT *n, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx ) {
+	       CBLAS_INT *n, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -114,7 +126,11 @@ void F77_strsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 void F77_ssymv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float *a,
 	      CBLAS_INT *lda, float *x, CBLAS_INT *incx, float *beta, float *y,
-	      CBLAS_INT *incy) {
+	      CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -137,7 +153,11 @@ void F77_ssymv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float
 }
 
 void F77_ssyr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float *x,
-	     CBLAS_INT *incx, float *a, CBLAS_INT *lda) {
+	     CBLAS_INT *incx, float *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -161,7 +181,11 @@ void F77_ssyr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float 
 }
 
 void F77_ssyr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float *x,
-	     CBLAS_INT *incx, float *y, CBLAS_INT *incy, float *a, CBLAS_INT *lda) {
+	     CBLAS_INT *incx, float *y, CBLAS_INT *incy, float *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -186,7 +210,11 @@ void F77_ssyr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float
 
 void F77_sgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku,
 	       float *alpha, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx,
-	       float *beta, float *y, CBLAS_INT *incy ) {
+	       float *beta, float *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   float *A;
   CBLAS_INT i,irow,j,jcol,LDA;
@@ -223,7 +251,11 @@ void F77_sgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLA
 }
 
 void F77_stbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, CBLAS_INT *k, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, CBLAS_INT *k, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT irow, jcol, i, j, LDA;
   CBLAS_TRANSPOSE trans;
@@ -269,7 +301,11 @@ void F77_stbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_stbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, CBLAS_INT *k, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, CBLAS_INT *k, float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT irow, jcol, i, j, LDA;
   CBLAS_TRANSPOSE trans;
@@ -316,7 +352,11 @@ void F77_stbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
 void F77_ssbmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_INT *k, float *alpha,
 	      float *a, CBLAS_INT *lda, float *x, CBLAS_INT *incx, float *beta,
-	      float *y, CBLAS_INT *incy) {
+	      float *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   float *A;
   CBLAS_INT i,j,irow,jcol,LDA;
   CBLAS_UPLO uplo;
@@ -360,7 +400,11 @@ void F77_ssbmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_INT *k, float
 }
 
 void F77_sspmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float *ap,
-	      float *x, CBLAS_INT *incx, float *beta, float *y, CBLAS_INT *incy) {
+	      float *x, CBLAS_INT *incx, float *beta, float *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   float *A,*AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -397,7 +441,11 @@ void F77_sspmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float
 }
 
 void F77_stpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, float *ap, float *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, float *ap, float *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   float *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -436,7 +484,11 @@ void F77_stpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_stpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-	      CBLAS_INT *n, float *ap, float *x, CBLAS_INT *incx) {
+	      CBLAS_INT *n, float *ap, float *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   float *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -476,7 +528,11 @@ void F77_stpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_sspr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float *x,
-	     CBLAS_INT *incx, float *ap ){
+	     CBLAS_INT *incx, float *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
   float *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -527,7 +583,11 @@ void F77_sspr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float 
 }
 
 void F77_sspr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha, float *x,
-	     CBLAS_INT *incx, float *y, CBLAS_INT *incy, float *ap ){
+	     CBLAS_INT *incx, float *y, CBLAS_INT *incy, float *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
   float *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;

--- a/CBLAS/testing/c_sblas3.c
+++ b/CBLAS/testing/c_sblas3.c
@@ -11,7 +11,11 @@
 
 void F77_sgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
               CBLAS_INT *k, float *alpha, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb,
-              float *beta, float *c, CBLAS_INT *ldc ) {
+              float *beta, float *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   float *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -72,7 +76,11 @@ void F77_sgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
 }
 void F77_ssymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
               float *alpha, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb,
-              float *beta, float *c, CBLAS_INT *ldc ) {
+              float *beta, float *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   float *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -126,7 +134,11 @@ void F77_ssymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
 
 void F77_ssyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
               float *alpha, float *a, CBLAS_INT *lda,
-              float *beta, float *c, CBLAS_INT *ldc ) {
+              float *beta, float *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_INT i,j,LDA,LDC;
   float *A, *C;
@@ -174,7 +186,11 @@ void F77_ssyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
 
 void F77_ssyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
                float *alpha, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb,
-               float *beta, float *c, CBLAS_INT *ldc ) {
+               float *beta, float *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB,LDC;
   float *A, *B, *C;
   CBLAS_UPLO uplo;
@@ -229,7 +245,11 @@ void F77_ssyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
 }
 void F77_strmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
               CBLAS_INT *m, CBLAS_INT *n, float *alpha, float *a, CBLAS_INT *lda, float *b,
-              CBLAS_INT *ldb) {
+              CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   float *A, *B;
   CBLAS_SIDE side;
@@ -280,7 +300,11 @@ void F77_strmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
 
 void F77_strsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
               CBLAS_INT *m, CBLAS_INT *n, float *alpha, float *a, CBLAS_INT *lda, float *b,
-              CBLAS_INT *ldb) {
+              CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   float *A, *B;
   CBLAS_SIDE side;

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -85,14 +85,14 @@ void cblas_xerbla(CBLAS_INT info, const char *rout, const char *form, ...)
 }
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo)
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
 , FORTRAN_STRLEN
 #endif
 )
-#endif
 {
 #ifdef F77_Char
    char *srname;

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -87,7 +87,11 @@ void cblas_xerbla(CBLAS_INT info, const char *rout, const char *form, ...)
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo)
 #else
-void F77_xerbla(char *srname, void *vinfo)
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+, FORTRAN_STRLEN
+#endif
+)
 #endif
 {
 #ifdef F77_Char

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;
@@ -48,7 +48,7 @@ void F77_z2chke(char *rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void F77_z2chke(char *rout) {
+void F77_z2chke(char *rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    double  A[2] = {0.0,0.0},
           X[2] = {0.0,0.0},

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -10,7 +10,11 @@ char *cblas_rout;
 #ifdef F77_Char
 void F77_xerbla(F77_Char F77_srname, void *vinfo);
 #else
-void F77_xerbla(char *srname, void *vinfo);
+void F77_xerbla(char *srname, void *vinfo
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+);
 #endif
 
 void chkxer(void) {
@@ -24,7 +28,11 @@ void chkxer(void) {
    cblas_lerr = 1 ;
 }
 
-void  F77_z3chke(char *  rout) {
+void F77_z3chke(char *rout
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
    char *sf = ( rout ) ;
    double  A[4]     = {0.0,0.0,0.0,0.0},
            B[4]     = {0.0,0.0,0.0,0.0},

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -8,14 +8,14 @@ CBLAS_INT link_xerbla=TRUE;
 char *cblas_rout;
 
 #ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
+void F77_xerbla(F77_Char F77_srname, void *vinfo
 #else
 void F77_xerbla(char *srname, void *vinfo
+#endif
 #ifdef BLAS_FORTRAN_STRLEN_END
   , FORTRAN_STRLEN
 #endif
 );
-#endif
 
 void chkxer(void) {
    extern CBLAS_INT cblas_ok, cblas_lerr, cblas_info;
@@ -51,7 +51,7 @@ void F77_z3chke(char *rout
    if (link_xerbla) /* call these first to link */
    {
       cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
+      F77_xerbla(cblas_rout,&cblas_info, 1);
    }
 #endif
 

--- a/CBLAS/testing/c_zblas2.c
+++ b/CBLAS/testing/c_zblas2.c
@@ -11,7 +11,11 @@
 void F77_zgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n,
           const void *alpha,
           CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda, const void *x, CBLAS_INT *incx,
-          const void *beta, void *y, CBLAS_INT *incy) {
+          const void *beta, void *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT i,j,LDA;
@@ -41,7 +45,11 @@ void F77_zgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n,
 void F77_zgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku,
 	      CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
 	      CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx,
-	      CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy) {
+	      CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT i,j,irow,jcol,LDA;
@@ -144,7 +152,11 @@ void F77_zgerc(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX
 
 void F77_zhemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
       CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *x,
-      CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy){
+      CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
 
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT i,j,LDA;
@@ -175,7 +187,11 @@ void F77_zhemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
 void F77_zhbmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_INT *k,
      CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
      CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *beta,
-     CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy){
+     CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
 
 CBLAS_TEST_ZOMPLEX *A;
 CBLAS_INT i,irow,j,jcol,LDA;
@@ -238,7 +254,11 @@ CBLAS_INT i,irow,j,jcol,LDA;
 
 void F77_zhpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
      CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx,
-     CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy){
+     CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+){
 
   CBLAS_TEST_ZOMPLEX *A, *AP;
   CBLAS_INT i,j,k,LDA;
@@ -294,7 +314,11 @@ void F77_zhpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
 
 void F77_ztbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
      CBLAS_INT *n, CBLAS_INT *k, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *x,
-     CBLAS_INT *incx) {
+     CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT irow, jcol, i, j, LDA;
   CBLAS_TRANSPOSE trans;
@@ -357,7 +381,11 @@ void F77_ztbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
 void F77_ztbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
       CBLAS_INT *n, CBLAS_INT *k, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *x,
-      CBLAS_INT *incx) {
+      CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT irow, jcol, i, j, LDA;
@@ -420,7 +448,11 @@ void F77_ztbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_ztpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-      CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx) {
+      CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -475,7 +507,11 @@ void F77_ztpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_ztpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
-     CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx) {
+     CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A, *AP;
   CBLAS_INT i, j, k, LDA;
   CBLAS_TRANSPOSE trans;
@@ -531,7 +567,11 @@ void F77_ztpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
 void F77_ztrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
      CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *x,
-      CBLAS_INT *incx) {
+      CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -560,7 +600,11 @@ void F77_ztrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 void F77_ztrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
        CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *x,
-              CBLAS_INT *incx) {
+              CBLAS_INT *incx
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT i,j,LDA;
   CBLAS_TRANSPOSE trans;
@@ -589,7 +633,11 @@ void F77_ztrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 }
 
 void F77_zhpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
-	     CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *ap) {
+	     CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -665,7 +713,11 @@ void F77_zhpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
 
 void F77_zhpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
        CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy,
-       CBLAS_TEST_ZOMPLEX *ap) {
+       CBLAS_TEST_ZOMPLEX *ap
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A, *AP;
   CBLAS_INT i,j,k,LDA;
   CBLAS_UPLO uplo;
@@ -741,7 +793,11 @@ void F77_zhpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
 }
 
 void F77_zher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
-  CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda) {
+  CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT i,j,LDA;
   CBLAS_UPLO uplo;
@@ -774,7 +830,11 @@ void F77_zher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
 
 void F77_zher2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
           CBLAS_TEST_ZOMPLEX *x, CBLAS_INT *incx, CBLAS_TEST_ZOMPLEX *y, CBLAS_INT *incy,
-	  CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda) {
+	  CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_ZOMPLEX *A;
   CBLAS_INT i,j,LDA;

--- a/CBLAS/testing/c_zblas3.c
+++ b/CBLAS/testing/c_zblas3.c
@@ -14,7 +14,11 @@
 void F77_zgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
      CBLAS_INT *k, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
      CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_ZOMPLEX *beta,
-     CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc ) {
+     CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_ZOMPLEX *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -90,7 +94,11 @@ void F77_zgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
 void F77_zhemm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
         CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
 	CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_ZOMPLEX *beta,
-        CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc ) {
+        CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_ZOMPLEX *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -154,7 +162,11 @@ void F77_zhemm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
 void F77_zsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
           CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
 	  CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_ZOMPLEX *beta,
-          CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc ) {
+          CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_TEST_ZOMPLEX *A, *B, *C;
   CBLAS_INT i,j,LDA, LDB, LDC;
@@ -208,7 +220,11 @@ void F77_zsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
 
 void F77_zherk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
      double *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
-     double *beta, CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc ) {
+     double *beta, CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_INT i,j,LDA,LDC;
   CBLAS_TEST_ZOMPLEX *A, *C;
@@ -264,7 +280,11 @@ void F77_zherk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
 
 void F77_zsyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
      CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
-     CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc ) {
+     CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
 
   CBLAS_INT i,j,LDA,LDC;
   CBLAS_TEST_ZOMPLEX *A, *C;
@@ -320,7 +340,11 @@ void F77_zsyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
 void F77_zher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
         CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
 	CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb, double *beta,
-        CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc ) {
+        CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB,LDC;
   CBLAS_TEST_ZOMPLEX *A, *B, *C;
   CBLAS_UPLO uplo;
@@ -384,7 +408,11 @@ void F77_zher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
 void F77_zsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
          CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
 	 CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb, CBLAS_TEST_ZOMPLEX *beta,
-         CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc ) {
+         CBLAS_TEST_ZOMPLEX *c, CBLAS_INT *ldc
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB,LDC;
   CBLAS_TEST_ZOMPLEX *A, *B, *C;
   CBLAS_UPLO uplo;
@@ -447,7 +475,11 @@ void F77_zsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
 }
 void F77_ztrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
        CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a,
-       CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb) {
+       CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   CBLAS_TEST_ZOMPLEX *A, *B;
   CBLAS_SIDE side;
@@ -506,7 +538,11 @@ void F77_ztrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
 
 void F77_ztrsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
          CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a,
-         CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb) {
+         CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *b, CBLAS_INT *ldb
+#ifdef BLAS_FORTRAN_STRLEN_END
+  , FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN, FORTRAN_STRLEN
+#endif
+) {
   CBLAS_INT i,j,LDA,LDB;
   CBLAS_TEST_ZOMPLEX *A, *B;
   CBLAS_SIDE side;

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -135,8 +135,7 @@ typedef lapack_logical (*LAPACK_Z_SELECT2)
     ( const lapack_complex_double*, const lapack_complex_double* );
 
 #define LAPACK_lsame_base LAPACK_GLOBAL(lsame,LSAME)
-lapack_logical LAPACK_lsame_base( const char* ca,  const char* cb,
-                              lapack_int lca, lapack_int lcb
+lapack_logical LAPACK_lsame_base( const char* ca,  const char* cb
 #ifdef LAPACK_FORTRAN_STRLEN_END
     , FORTRAN_STRLEN, FORTRAN_STRLEN
 #endif

--- a/LAPACKE/utils/lapacke_lsame.c
+++ b/LAPACKE/utils/lapacke_lsame.c
@@ -34,7 +34,7 @@
 
 lapack_logical API_SUFFIX(LAPACKE_lsame)( char ca,  char cb )
 {
-    return (lapack_logical) LAPACK_lsame( &ca, &cb, 1, 1 );
+    return (lapack_logical) LAPACK_lsame( &ca, &cb );
 }
 
 


### PR DESCRIPTION
**Description**

There were several issues flagged by GCC when using LTO. The things I fixed are the following:

- The `cblas_f77.h` header contained some wrong declarations, where complex arguments had types like `float*` or `double*` instead of `void*`
- The CBLAS examples showcasing the external 64bit interface actually used the normal interface instead. Some definitions and includes needed to be reordered
- The CBLAS testing framework was missing the hidden FORTRAN_STRLEN arguments
- The `LAPACK_lsame` declaration had 4 STRLEN arguments instead of the necessary 2

I compiled with `-Werror=lto-type-mismatch` and it seems all issues are resolved.

We could enable LTO in the CI pipelines (CMake: `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`) and add the `-Werror=lto-type-mismatch` flag as well now.

Fixes #334
Fixes #990

**Checklist**

- [x] If the PR solves a specific issue, it is set to be closed on merge.