### PR TITLE
Fixed NAG Fortran compiler flag

### DIFF
--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -126,7 +126,7 @@ macro(CheckLAPACKCompilerFlags)
         get_directory_property(COMP_OPTIONS COMPILE_OPTIONS)
 
         if(NOT("${CMAKE_Fortran_FLAGS};${COMP_OPTIONS}" MATCHES "-abi=64c"))
-          add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:FORTRAN_STRLEN=int>")
+          add_compile_definitions("$<$<COMPILE_LANGUAGE:C>:FORTRAN_STRLEN=int>")
         endif()
       endif()
     endif()


### PR DESCRIPTION
**Description**

In an earlier PR (#1025), I accidentally used `add_compile_options` instead of `add_compile_definitions`.