### PR TITLE
align documentation of BDSQR workspace with code

### DIFF
--- a/SRC/cbdsqr.f
+++ b/SRC/cbdsqr.f
@@ -166,7 +166,9 @@
 *>
 *> \param[out] RWORK
 *> \verbatim
-*>          RWORK is REAL array, dimension (4*(N-1))
+*>          RWORK is REAL array, dimension (LRWORK)
+*>          LRWORK = 4*N, if NCVT = NRU = NCC = 0, and
+*>          LRWORK = 4*(N-1), otherwise
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/dbdsqr.f
+++ b/SRC/dbdsqr.f
@@ -166,7 +166,9 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is DOUBLE PRECISION array, dimension (4*(N-1))
+*>          WORK is DOUBLE PRECISION array, dimension (LWORK)
+*>          LWORK = 4*N, if NCVT = NRU = NCC = 0, and
+*>          LWORK = 4*(N-1), otherwise
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/sbdsqr.f
+++ b/SRC/sbdsqr.f
@@ -166,7 +166,9 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension (4*(N-1))
+*>          WORK is REAL array, dimension (LWORK)
+*>          LWORK = 4*N, if NCVT = NRU = NCC = 0, and
+*>          LWORK = 4*(N-1), otherwise
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/zbdsqr.f
+++ b/SRC/zbdsqr.f
@@ -166,7 +166,9 @@
 *>
 *> \param[out] RWORK
 *> \verbatim
-*>          RWORK is DOUBLE PRECISION array, dimension (4*(N-1))
+*>          RWORK is DOUBLE PRECISION array, dimension (LRWORK)
+*>          LRWORK = 4*N, if NCVT = NRU = NCC = 0, and
+*>          LRWORK = 4*(N-1), otherwise
 *> \endverbatim
 *>
 *> \param[out] INFO


### PR DESCRIPTION
One more fix of BDSQR documentation.

Branch `NCVT = NRU = NCC` requires `4 * N` memory at the moment.

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue #996, it is set to be closed on merge.