### PR TITLE
Prevent compilers from using FMA instructions

### DIFF
--- a/SRC/dlanv2.f
+++ b/SRC/dlanv2.f
@@ -144,7 +144,7 @@
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION   AA, BB, BCMAX, BCMIS, CC, CS1, DD, EPS, P, SAB,
-     $                   SAC, SCALE, SIGMA, SN1, TAU, TEMP, Z, SAFMIN, 
+     $                   SAC, SCALE, SIGMA, SN1, TAU, TEMP, Z, SAFMIN,
      $                   SAFMN2, SAFMX2
       INTEGER            COUNT
 *     ..

--- a/SRC/dlanv2.f
+++ b/SRC/dlanv2.f
@@ -249,9 +249,13 @@
 *           Compute [ A  B ] = [ CS  SN ] [ AA  BB ]
 *                   [ C  D ]   [-SN  CS ] [ CC  DD ]
 *
+*           Note: Some of the multiplications are wrapped in parentheses to
+*                 prevent compilers from using FMA instructions. See
+*                 https://github.com/Reference-LAPACK/lapack/issues/1031.
+*
             A = AA*CS + CC*SN
-            B = BB*CS + DD*SN
-            C = -AA*SN + CC*CS
+            B = ( BB*CS ) + ( DD*SN )
+            C = -( AA*SN ) + ( CC*CS )
             D = -BB*SN + DD*CS
 *
             TEMP = HALF*( A+D )

--- a/SRC/slanv2.f
+++ b/SRC/slanv2.f
@@ -144,7 +144,7 @@
 *     ..
 *     .. Local Scalars ..
       REAL               AA, BB, BCMAX, BCMIS, CC, CS1, DD, EPS, P, SAB,
-     $                   SAC, SCALE, SIGMA, SN1, TAU, TEMP, Z, SAFMIN, 
+     $                   SAC, SCALE, SIGMA, SN1, TAU, TEMP, Z, SAFMIN,
      $                   SAFMN2, SAFMX2
       INTEGER            COUNT
 *     ..
@@ -249,9 +249,13 @@
 *           Compute [ A  B ] = [ CS  SN ] [ AA  BB ]
 *                   [ C  D ]   [-SN  CS ] [ CC  DD ]
 *
+*           Note: Some of the multiplications are wrapped in parentheses to
+*                 prevent compilers from using FMA instructions. See
+*                 https://github.com/Reference-LAPACK/lapack/issues/1031.
+*
             A = AA*CS + CC*SN
-            B = BB*CS + DD*SN
-            C = -AA*SN + CC*CS
+            B = ( BB*CS ) + ( DD*SN )
+            C = -( AA*SN ) + ( CC*CS )
             D = -BB*SN + DD*CS
 *
             TEMP = HALF*( A+D )


### PR DESCRIPTION
Fixes #1031

**Description**

As described in #1031 when the compiler uses FMA instructions, errors in `?GEEVX` can increase up to `SQRT(EPS)`. The different rounding of the FMA instructions causes a change in control flow, which produces the errors. This MR uses explicit parentheses to prevent the compiler from using FMA instructions for those results, which are compared against zero in subsequent if-statements. 

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.