### PR TITLE
Fix the quick return code in Eigen subroutines

### DIFF
--- a/SRC/cgeesx.f
+++ b/SRC/cgeesx.f
@@ -373,6 +373,8 @@
 *
       IF( N.EQ.0 ) THEN
          SDIM = 0
+         IF (WANTSE .OR. WANTSB) RCONDE = 1.0E0
+         IF (WANTSV .OR. WANTSB) RCONDV = 0.0E0
          RETURN
       END IF
 *

--- a/SRC/chbevx.f
+++ b/SRC/chbevx.f
@@ -382,8 +382,11 @@
          END IF
          IF( M.EQ.1 ) THEN
             W( 1 ) = REAL( CTMP1 )
-            IF( WANTZ )
-     $         Z( 1, 1 ) = CONE
+            IF( WANTZ ) THEN
+               Q( 1, 1 ) = ONE
+               Z( 1, 1 ) = ONE
+               IFAIL(1) = 0
+            ENDIF
          END IF
          RETURN
       END IF

--- a/SRC/cheevx.f
+++ b/SRC/cheevx.f
@@ -390,8 +390,10 @@
                W( 1 ) = REAL( A( 1, 1 ) )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = CONE
+         IF( WANTZ ) THEN
+            Z( 1, 1 ) = ONE
+            IFAIL(1) = 0
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/chpevx.f
+++ b/SRC/chpevx.f
@@ -341,8 +341,10 @@
                W( 1 ) = REAL( AP( 1 ) )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = CONE
+         IF( WANTZ ) THEN
+            Z( 1, 1 ) = CONE
+            IFAIL(1) = 0
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/chpgvx.f
+++ b/SRC/chpgvx.f
@@ -355,6 +355,7 @@
 *
 *     Quick return if possible
 *
+      M = 0
       IF( N.EQ.0 )
      $   RETURN
 *

--- a/SRC/dgeesx.f
+++ b/SRC/dgeesx.f
@@ -421,6 +421,8 @@
 *
       IF( N.EQ.0 ) THEN
          SDIM = 0
+         IF (WANTSE .OR. WANTSB) RCONDE = 1.0D0
+         IF (WANTSV .OR. WANTSB) RCONDV = 0.0D0
          RETURN
       END IF
 *

--- a/SRC/dsbevx.f
+++ b/SRC/dsbevx.f
@@ -373,8 +373,11 @@
          END IF
          IF( M.EQ.1 ) THEN
             W( 1 ) = TMP1
-            IF( WANTZ )
-     $         Z( 1, 1 ) = ONE
+            IF( WANTZ ) THEN
+              Q( 1, 1 ) = ONE
+              Z( 1, 1 ) = ONE
+              IFAIL(1) = ZERO
+            ENDIF
          END IF
          RETURN
       END IF

--- a/SRC/dspevx.f
+++ b/SRC/dspevx.f
@@ -332,8 +332,10 @@
                W( 1 ) = AP( 1 )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = ONE
+         IF( WANTZ ) THEN
+           Z( 1, 1 ) = ONE
+           IFAIL(1) = ZERO
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/dsyevx.f
+++ b/SRC/dsyevx.f
@@ -378,8 +378,10 @@
                W( 1 ) = A( 1, 1 )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = ONE
+         IF( WANTZ ) THEN
+           Z( 1, 1 ) = ONE
+           IFAIL(1) = ZERO
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/sgeesx.f
+++ b/SRC/sgeesx.f
@@ -422,6 +422,8 @@
 *
       IF( N.EQ.0 ) THEN
          SDIM = 0
+         IF (WANTSE .OR. WANTSB) RCONDE = 1.0E0
+         IF (WANTSV .OR. WANTSB) RCONDV = 0.0E0
          RETURN
       END IF
 *

--- a/SRC/ssbevx.f
+++ b/SRC/ssbevx.f
@@ -373,8 +373,11 @@
          END IF
          IF( M.EQ.1 ) THEN
             W( 1 ) = TMP1
-            IF( WANTZ )
-     $         Z( 1, 1 ) = ONE
+            IF( WANTZ ) THEN
+              Q( 1, 1 ) = ONE
+              Z( 1, 1 ) = ONE
+              IFAIL(1) = ZERO
+            ENDIF
          END IF
          RETURN
       END IF

--- a/SRC/sspevx.f
+++ b/SRC/sspevx.f
@@ -332,8 +332,10 @@
                W( 1 ) = AP( 1 )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = ONE
+         IF( WANTZ ) THEN
+           Z( 1, 1 ) = ONE
+           IFAIL(1) = ZERO
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/ssyevx.f
+++ b/SRC/ssyevx.f
@@ -379,8 +379,10 @@
                W( 1 ) = A( 1, 1 )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = ONE
+         IF( WANTZ ) THEN
+           Z( 1, 1 ) = ONE
+           IFAIL(1) = ZERO
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/zgeesx.f
+++ b/SRC/zgeesx.f
@@ -372,6 +372,8 @@
 *
       IF( N.EQ.0 ) THEN
          SDIM = 0
+         IF (WANTSE .OR. WANTSB) RCONDE = 1.0D0
+         IF (WANTSV .OR. WANTSB) RCONDV = 0.0D0
          RETURN
       END IF
 *

--- a/SRC/zhbevx.f
+++ b/SRC/zhbevx.f
@@ -382,8 +382,11 @@
          END IF
          IF( M.EQ.1 ) THEN
             W( 1 ) = DBLE( CTMP1 )
-            IF( WANTZ )
-     $         Z( 1, 1 ) = CONE
+            IF( WANTZ ) THEN
+               Q( 1, 1 ) = ONE
+               Z( 1, 1 ) = ONE
+               IFAIL(1) = 0
+            ENDIF
          END IF
          RETURN
       END IF

--- a/SRC/zheevx.f
+++ b/SRC/zheevx.f
@@ -389,8 +389,10 @@
                W( 1 ) = DBLE( A( 1, 1 ) )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = CONE
+         IF( WANTZ ) THEN
+            Z( 1, 1 ) = ONE
+            IFAIL(1) = 0
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/zhpevx.f
+++ b/SRC/zhpevx.f
@@ -341,8 +341,10 @@
                W( 1 ) = DBLE( AP( 1 ) )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = CONE
+         IF( WANTZ ) THEN
+            Z( 1, 1 ) = CONE
+            IFAIL(1) = 0
+         ENDIF
          RETURN
       END IF
 *

--- a/SRC/zhpgvx.f
+++ b/SRC/zhpgvx.f
@@ -355,6 +355,7 @@
 *
 *     Quick return if possible
 *
+      M = 0
       IF( N.EQ.0 )
      $   RETURN
 *


### PR DESCRIPTION
**Description**
Fix the quick return code for S/D/C/ZGEESX, C/ZHBEVX, S/DSBEVX, C/ZHEEVX, S/DSYEVX, C/ZHPEVX, S/DSPEVX, C/ZHPGVX.

1. set RCONDE and RCONDV in S/D/C/ZGEESX when N = 0.
2. set Q in C/ZHBEVX, S/DSBEVX when N = 1 and WANTZ.
3. set IFAIL in C/ZHBEVX, S/DSBEVX, C/ZHEEVX, S/DSYEVX, C/ZHPEVX, S/DSPEVX when N = 1 and WANTZ.
4. set M = 0 in C/ZHPGVX when N = 0.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.