### PR TITLE
Two fixes of STEVX

### DIFF
--- a/SRC/dstevx.f
+++ b/SRC/dstevx.f
@@ -251,8 +251,8 @@
       CHARACTER          ORDER
       INTEGER            I, IMAX, INDISP, INDIWO, INDWRK,
      $                   ISCALE, ITMP1, J, JJ, NSPLIT
-      DOUBLE PRECISION   BIGNUM, EPS, RMAX, RMIN, SAFMIN, SIGMA, SMLNUM,
-     $                   TMP1, TNRM, VLL, VUU
+      DOUBLE PRECISION   ABSTLL, BIGNUM, EPS, RMAX, RMIN, SAFMIN, SIGMA,
+     $                   SMLNUM, TMP1, TNRM, VLL, VUU
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -321,8 +321,10 @@
                W( 1 ) = D( 1 )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = ONE
+         IF( WANTZ ) THEN
+           Z( 1, 1 ) = ONE
+           IFAIL(1) = ZERO
+         ENDIF
          RETURN
       END IF
 *
@@ -338,6 +340,7 @@
 *     Scale matrix to allowable range, if necessary.
 *
       ISCALE = 0
+      ABSTLL = ABSTOL
       IF( VALEIG ) THEN
          VLL = VL
          VUU = VU
@@ -356,6 +359,8 @@
       IF( ISCALE.EQ.1 ) THEN
          CALL DSCAL( N, SIGMA, D, 1 )
          CALL DSCAL( N-1, SIGMA, E( 1 ), 1 )
+         IF( ABSTOL.GT.0 )
+     $      ABSTLL = ABSTOL*SIGMA
          IF( VALEIG ) THEN
             VLL = VL*SIGMA
             VUU = VU*SIGMA
@@ -404,7 +409,7 @@
       INDWRK = 1
       INDISP = 1 + N
       INDIWO = INDISP + N
-      CALL DSTEBZ( RANGE, ORDER, N, VLL, VUU, IL, IU, ABSTOL, D, E,
+      CALL DSTEBZ( RANGE, ORDER, N, VLL, VUU, IL, IU, ABSTLL, D, E,
      $             M,
      $             NSPLIT, W, IWORK( 1 ), IWORK( INDISP ),
      $             WORK( INDWRK ), IWORK( INDIWO ), INFO )

--- a/SRC/sstevx.f
+++ b/SRC/sstevx.f
@@ -251,8 +251,8 @@
       CHARACTER          ORDER
       INTEGER            I, IMAX, INDISP, INDIWO, INDWRK,
      $                   ISCALE, ITMP1, J, JJ, NSPLIT
-      REAL               BIGNUM, EPS, RMAX, RMIN, SAFMIN, SIGMA, SMLNUM,
-     $                   TMP1, TNRM, VLL, VUU
+      REAL               ABSTLL, BIGNUM, EPS, RMAX, RMIN, SAFMIN, SIGMA,
+     $                   SMLNUM, TMP1, TNRM, VLL, VUU
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -321,8 +321,10 @@
                W( 1 ) = D( 1 )
             END IF
          END IF
-         IF( WANTZ )
-     $      Z( 1, 1 ) = ONE
+         IF( WANTZ ) THEN
+           Z( 1, 1 ) = ONE
+           IFAIL(1) = ZERO
+         ENDIF
          RETURN
       END IF
 *
@@ -338,6 +340,7 @@
 *     Scale matrix to allowable range, if necessary.
 *
       ISCALE = 0
+      ABSTLL = ABSTOL
       IF ( VALEIG ) THEN
          VLL = VL
          VUU = VU
@@ -356,6 +359,8 @@
       IF( ISCALE.EQ.1 ) THEN
          CALL SSCAL( N, SIGMA, D, 1 )
          CALL SSCAL( N-1, SIGMA, E( 1 ), 1 )
+         IF( ABSTOL.GT.0 )
+     $      ABSTLL = ABSTOL*SIGMA
          IF( VALEIG ) THEN
             VLL = VL*SIGMA
             VUU = VU*SIGMA
@@ -404,7 +409,7 @@
       INDWRK = 1
       INDISP = 1 + N
       INDIWO = INDISP + N
-      CALL SSTEBZ( RANGE, ORDER, N, VLL, VUU, IL, IU, ABSTOL, D, E,
+      CALL SSTEBZ( RANGE, ORDER, N, VLL, VUU, IL, IU, ABSTLL, D, E,
      $             M,
      $             NSPLIT, W, IWORK( 1 ), IWORK( INDISP ),
      $             WORK( INDWRK ), IWORK( INDIWO ), INFO )


### PR DESCRIPTION
**Description**
This PR is for two fixes of d/sSTEVX:

1. Set IFAIL when N = 1 and WANTZ = .TRUE.
2. Scale ABSTOL when matrix being scaled to allowable range.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.