### PR TITLE
Fixes of STEBZ

### DIFF
--- a/SRC/dstebz.f
+++ b/SRC/dstebz.f
@@ -597,7 +597,7 @@
             END IF
 *
             IF( IRANGE.GT.1 ) THEN
-               IF( GU.LT.WL ) THEN
+               IF( GU.LE.WL ) THEN
                   NWL = NWL + IN
                   NWU = NWU + IN
                   GO TO 70
@@ -701,7 +701,7 @@
                         WKILL = W( JE )
                      END IF
    90             CONTINUE
-                  IBLOCK( IW ) = 0
+                  IF( IW .NE. 0) IBLOCK( IW ) = 0
   100          CONTINUE
             END IF
             IF( IDISCU.GT.0 ) THEN
@@ -716,7 +716,7 @@
                         WKILL = W( JE )
                      END IF
   110             CONTINUE
-                  IBLOCK( IW ) = 0
+                  IF( IW .NE. 0) IBLOCK( IW ) = 0
   120          CONTINUE
             END IF
             IM = 0

--- a/SRC/sstebz.f
+++ b/SRC/sstebz.f
@@ -293,7 +293,7 @@
       PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0, TWO = 2.0E0,
      $                   HALF = 1.0E0 / TWO )
       REAL               FUDGE, RELFAC
-      PARAMETER          ( FUDGE = 2.1E0, RELFAC = 2.0E0 )
+      PARAMETER          ( FUDGE = 2.3E0, RELFAC = 2.0E0 )
 *     ..
 *     .. Local Scalars ..
       LOGICAL            NCNVRG, TOOFEW
@@ -596,7 +596,7 @@
             END IF
 *
             IF( IRANGE.GT.1 ) THEN
-               IF( GU.LT.WL ) THEN
+               IF( GU.LE.WL ) THEN
                   NWL = NWL + IN
                   NWU = NWU + IN
                   GO TO 70
@@ -700,7 +700,7 @@
                         WKILL = W( JE )
                      END IF
    90             CONTINUE
-                  IBLOCK( IW ) = 0
+                  IF( IW .NE. 0) IBLOCK( IW ) = 0
   100          CONTINUE
             END IF
             IF( IDISCU.GT.0 ) THEN
@@ -715,7 +715,7 @@
                         WKILL = W( JE )
                      END IF
   110             CONTINUE
-                  IBLOCK( IW ) = 0
+                  IF( IW .NE. 0) IBLOCK( IW ) = 0
   120          CONTINUE
             END IF
             IM = 0


### PR DESCRIPTION
**Description**

This PR fixes d/sSTEBZ:

1. Fix accumulation of number of eigenvalues by changing .LT. to .LE. in line 600 (599 for sstebz.f) as line 538 (537 for sstebz.f) states that “NWL accumulates the number of eigenvalues .le. WL” .
2. Fix possible out of bounds write of IBLOCK. There are IBLOCK(IW) = 0 in lines 704 and 719 (703 and 718 for sstebz.f), which IW are initialized to 0. IF statements are added to check whether IW equals to zero.
3. Fix failures of test case 53 of SSBEVX in sdrvst.f on Power8 and Power9 by increasing the FUDGE factor in sstebz.f to 2.3.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.