### PR TITLE
Remove CMake < 3 CMP0042 workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,30 +123,6 @@ message(STATUS "Build Index-64 API as extended API with _64 suffix: ${BUILD_INDE
 
 include(GNUInstallDirs)
 
-# Updated OSX RPATH settings
-# In response to CMake 3.0 generating warnings regarding policy CMP0042,
-# the OSX RPATH settings have been updated per recommendations found
-# in the CMake Wiki:
-#  http://www.cmake.org/Wiki/CMake_RPATH_handling#Mac_OS_X_and_the_RPATH
-option(CMAKE_MACOSX_RPATH "Enable macOS RPATH" ON)
-message(STATUS "Enable macOS RPATH: ${CMAKE_MACOSX_RPATH}")
-option(CMAKE_SKIP_BUILD_RPATH "Skip build-time RPATH" OFF)
-message(STATUS "Skip build-time RPATH: ${CMAKE_SKIP_BUILD_RPATH}")
-option(CMAKE_BUILD_WITH_INSTALL_RPATH "Build with install RPATH" OFF)
-message(STATUS "Build with install RPATH: ${CMAKE_BUILD_WITH_INSTALL_RPATH}")
-
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES ${CMAKE_INSTALL_FULL_LIBDIR} isSystemDir)
-
-if ("${isSystemDir}" STREQUAL "-1")
-  if(${CMAKE_INSTALL_FULL_LIBDIR})
-    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR})
-  endif()
-  message(STATUS "Install RPATH: ${CMAKE_INSTALL_RPATH}")
-  option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Use link path for RPATH" TRUE)
-  message(STATUS "Install RPATH use link path: ${CMAKE_INSTALL_RPATH_USE_LINK_PATH}")
-endif()
-
-
 # Configure the warning and code coverage suppression file
 configure_file(
   "${LAPACK_SOURCE_DIR}/CTestCustom.cmake.in"


### PR DESCRIPTION
**Description**

TL;DR: This deletes obsolete CMake code and improves upon #1002
by sticking to (sensible) CMake defaults, in accordance to the principle
of least astonishment ;)

CMake only sets install names on darwin to `@rpath/<name>` (which is
desired otherwise rpaths don't work at all) when CMP0042 is ON. That's
the default when CMake 3.0 or higher is required. And lapack requires it
already for years: as of v3.9.1 (8f004b353a876a117b9e9428fff3becdd22c79ce).

So, delete the old workarounds that effectively set CMP0042 to ON.

Further, delete the following three options that are redefinitions of
builtins and have values that are default anyways:
- `CMAKE_MACOSX_RPATH`
- `CMAKE_SKIP_BUILD_RPATH`
- `CMAKE_BUILD_WITH_INSTALL_RPATH`

Lastly, lapack automatically sets `CMAKE_INSTALL_RPATH_USE_LINK_PATH` to
`ON` whenever installing to a non-system dir. The assumption is that
whenever you install something to a non-system dir, you need rpaths to
locate dependencies. But this is just an assumption which may or may
not hold. The downside of it is that the option can be annoying when
lapack is used as a sub-project as it affects a global CMake variable
(for example OpenBLAS uses lapack as a sub-project). Instead, let users
or packagers provide this on the command line if they really need it --
remove it from lapack as it's as helpful as it is harmful.

**Checklist**
- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.
