### PR TITLE
Declare project dependency on C to avoid the CMAKE default of C,C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(LAPACK)
+project(LAPACK C)
 
 set(LAPACK_MAJOR_VERSION 3)
 set(LAPACK_MINOR_VERSION 12)


### PR DESCRIPTION
**Description**
#834 had removed all language requirements from the `project` command in the toplevel CMakeLists.txt in order to move the dependencies on a Fortran compiler to those subprojects that actually need them (and make LAPACKE buildable without one). 
However, the default in CMAKE is to assume a project dependency on both C and C++ if no language was
expressly requested. In the absence of any actual C++ code, this creates a spurious dependency that can prevent building
LAPACK on systems where such a compiler is not available or at least not installed by default. (This was noted in a comment on #988)
