### PR TITLE
CI: Update the MacOS jobs to use gcc-14 in github workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -75,12 +75,12 @@ jobs:
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@16b940825621068d98711680b6c3ff92201f8fc0 # v3
 
-    - name: Use GCC-11 on MacOS
+    - name: Use GCC-14 on MacOS
       if: ${{ matrix.os == 'macos-latest' }}
       run: >
         cmake -B build -G Ninja
-        -D CMAKE_C_COMPILER="gcc-11"
-        -D CMAKE_Fortran_COMPILER="gfortran-11"
+        -D CMAKE_C_COMPILER="gcc-14"
+        -D CMAKE_Fortran_COMPILER="gfortran-14"
         -D USE_FLAT_NAMESPACE:BOOL=ON
 
     - name: Special flags for Windows

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -90,8 +90,8 @@ jobs:
         echo "DOCSDIR = ${{github.workspace}}/DOCS" >> make.inc
     - name: Alias for GCC compilers
       run: |
-        sudo ln -s $(which gcc-11) /usr/local/bin/gcc
-        sudo ln -s $(which gfortran-11) /usr/local/bin/gfortran
+        sudo ln -s $(which gcc-14) /usr/local/bin/gcc
+        sudo ln -s $(which gfortran-14) /usr/local/bin/gfortran
     - name: Install
       run: |
         make -s -j2 all


### PR DESCRIPTION
**Description**
gcc-11 was removed from the runner images provided by github on August 12, 2024. As gcc-11 was the most recent release available at the time the workflow files were created, I have updated them to gcc-14 directly, although gcc-12 and gcc-13 would also be available for the time being.
