### PR TITLE
DOC:trsly3: Add dtrsyl3/strsyl3 grouping statements

### DIFF
--- a/SRC/dtrsyl3.f
+++ b/SRC/dtrsyl3.f
@@ -178,6 +178,8 @@
 *>               A and B are unchanged).
 *> \endverbatim
 *
+*> \ingroup trsyl3
+*
 *  =====================================================================
 *  References:
 *   E. S. Quintana-Orti and R. A. Van De Geijn (2003). Formal derivation of

--- a/SRC/strsyl3.f
+++ b/SRC/strsyl3.f
@@ -177,6 +177,8 @@
 *>               A and B are unchanged).
 *> \endverbatim
 *
+*> \ingroup trsyl3
+*
 *  =====================================================================
 *  References:
 *   E. S. Quintana-Orti and R. A. Van De Geijn (2003). Formal derivation of


### PR DESCRIPTION
**Description**
In the current documentation dtrsyl3 and strsyl3 are not added to the trsyl3 group

![image](https://github.com/user-attachments/assets/ee829468-803c-491a-93fa-a364815c6ac2)

and they show up under SRC folder as standalone entries

![image](https://github.com/user-attachments/assets/1795d0a2-14c4-440d-9e46-40b3196b7bb4)

This PR adds them to the right group.

**Checklist**

- [x] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.