### PR TITLE
Converge >= and > usage in docs and implementation of GESVJ

### DIFF
--- a/SRC/cgesvj.f
+++ b/SRC/cgesvj.f
@@ -101,7 +101,7 @@
 *> \param[in] M
 *> \verbatim
 *>          M is INTEGER
-*>          The number of rows of the input matrix A. 1/SLAMCH('E') > M >= 0.
+*>          The number of rows of the input matrix A. 1/SLAMCH('E') >= M >= 0.
 *> \endverbatim
 *>
 *> \param[in] N
@@ -217,7 +217,7 @@
 *>          LWORK >= 1, if MIN(M,N) = 0, and LWORK >= M+N, otherwise.
 *>
 *>          If on entry LWORK = -1, then a workspace query is assumed and
-*>          no computation is done; CWORK(1) is set to the minial (and optimal)
+*>          no computation is done; CWORK(1) is set to the minimal (and optimal)
 *>          length of CWORK.
 *> \endverbatim
 *>
@@ -258,7 +258,7 @@
 *>         LRWORK >= 1, if MIN(M,N) = 0, and LRWORK >= MAX(6,N), otherwise
 *>
 *>         If on entry LRWORK = -1, then a workspace query is assumed and
-*>         no computation is done; RWORK(1) is set to the minial (and optimal)
+*>         no computation is done; RWORK(1) is set to the minimal (and optimal)
 *>         length of RWORK.
 *> \endverbatim
 *>
@@ -459,7 +459,7 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $          ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( RWORK( 1 ).LE.ONE ) ) THEN
+      ELSE IF( UCTOL .AND. ( RWORK( 1 ).LT.ONE ) ) THEN
          INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13

--- a/SRC/dgesvj.f
+++ b/SRC/dgesvj.f
@@ -103,7 +103,7 @@
 *> \param[in] M
 *> \verbatim
 *>          M is INTEGER
-*>          The number of rows of the input matrix A. 1/DLAMCH('E') > M >= 0.
+*>          The number of rows of the input matrix A. 1/DLAMCH('E') >= M >= 0.
 *> \endverbatim
 *>
 *> \param[in] N
@@ -243,7 +243,7 @@
 *>          LWORK >= 1, if MIN(M,N) = 0, and LWORK >= MAX(6,M+N), otherwise.
 *>
 *>          If on entry LWORK = -1, then a workspace query is assumed and
-*>          no computation is done; WORK(1) is set to the minial (and optimal)
+*>          no computation is done; WORK(1) is set to the minimal (and optimal)
 *>          length of WORK.
 *> \endverbatim
 *>
@@ -442,7 +442,7 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $         ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( WORK( 1 ).LE.ONE ) ) THEN
+      ELSE IF( UCTOL .AND. ( WORK( 1 ).LT.ONE ) ) THEN
          INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13

--- a/SRC/sgesvj.f
+++ b/SRC/sgesvj.f
@@ -103,7 +103,7 @@
 *> \param[in] M
 *> \verbatim
 *>          M is INTEGER
-*>          The number of rows of the input matrix A. 1/SLAMCH('E') > M >= 0.
+*>          The number of rows of the input matrix A. 1/SLAMCH('E') >= M >= 0.
 *> \endverbatim
 *>
 *> \param[in] N
@@ -243,7 +243,7 @@
 *>          LWORK >= 1, if MIN(M,N) = 0, and LWORK >= MAX(6,M+N), otherwise.
 *>
 *>          If on entry LWORK = -1, then a workspace query is assumed and
-*>          no computation is done; WORK(1) is set to the minial (and optimal)
+*>          no computation is done; WORK(1) is set to the minimal (and optimal)
 *>          length of WORK.
 *> \endverbatim
 *>
@@ -428,7 +428,7 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $         ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( WORK( 1 ).LE.ONE ) ) THEN
+      ELSE IF( UCTOL .AND. ( WORK( 1 ).LT.ONE ) ) THEN
          INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13

--- a/SRC/zgesvj.f
+++ b/SRC/zgesvj.f
@@ -101,7 +101,7 @@
 *> \param[in] M
 *> \verbatim
 *>          M is INTEGER
-*>          The number of rows of the input matrix A. 1/DLAMCH('E') > M >= 0.
+*>          The number of rows of the input matrix A. 1/DLAMCH('E') >= M >= 0.
 *> \endverbatim
 *>
 *> \param[in] N
@@ -217,7 +217,7 @@
 *>          LWORK >= 1, if MIN(M,N) = 0, and LWORK >= M+N, otherwise.
 *>
 *>          If on entry LWORK = -1, then a workspace query is assumed and
-*>          no computation is done; CWORK(1) is set to the minial (and optimal)
+*>          no computation is done; CWORK(1) is set to the minimal (and optimal)
 *>          length of CWORK.
 *> \endverbatim
 *>
@@ -258,7 +258,7 @@
 *>         LRWORK >= 1, if MIN(M,N) = 0, and LRWORK >= MAX(6,N), otherwise.
 *>
 *>         If on entry LRWORK = -1, then a workspace query is assumed and
-*>         no computation is done; RWORK(1) is set to the minial (and optimal)
+*>         no computation is done; RWORK(1) is set to the minimal (and optimal)
 *>         length of RWORK.
 *> \endverbatim
 *>
@@ -460,7 +460,7 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $          ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( RWORK( 1 ).LE.ONE ) ) THEN
+      ELSE IF( UCTOL .AND. ( RWORK( 1 ).LT.ONE ) ) THEN
          INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13


### PR DESCRIPTION
**Description**

The documentation and the code of GESVJ deviate in two spots with respect to the usage of `.GT.` and `.GE.`:


https://github.com/Reference-LAPACK/lapack/blob/4b3d8a46435f57462075f7c8f33b9bd1cf29a1dc/SRC/dgesvj.f#L106
https://github.com/Reference-LAPACK/lapack/blob/4b3d8a46435f57462075f7c8f33b9bd1cf29a1dc/SRC/dgesvj.f#L501

The PR takes the version in the code and updates the documentation.

https://github.com/Reference-LAPACK/lapack/blob/4b3d8a46435f57462075f7c8f33b9bd1cf29a1dc/SRC/dgesvj.f#L217
https://github.com/Reference-LAPACK/lapack/blob/4b3d8a46435f57462075f7c8f33b9bd1cf29a1dc/SRC/dgesvj.f#L445

This deviation is fixed in the code, which now literally permits EPS as threshold.
