### PR TITLE
Revert "Revert "Add a few forgotten API_SUFFIX wrappers in the recently changed LAPACKE ?TFSM""

### DIFF
--- a/LAPACKE/src/lapacke_ctfsm.c
+++ b/LAPACKE/src/lapacke_ctfsm.c
@@ -45,7 +45,7 @@ lapack_int API_SUFFIX(LAPACKE_ctfsm)( int matrix_layout, char transr, char side,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         lapack_int mn = m;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         /* Optionally check input matrices for NaNs */
         if( IS_C_NONZERO(alpha) ) {
             if( API_SUFFIX(LAPACKE_ctf_nancheck)( matrix_layout, transr, uplo, diag, mn, a ) ) {

--- a/LAPACKE/src/lapacke_ctfsm_work.c
+++ b/LAPACKE/src/lapacke_ctfsm_work.c
@@ -51,7 +51,7 @@ lapack_int API_SUFFIX(LAPACKE_ctfsm_work)( int matrix_layout, char transr, char 
         lapack_int mn = m;
         lapack_complex_float* b_t = NULL;
         lapack_complex_float* a_t = NULL;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         /* Check leading dimension(s) */
         if( ldb < m ) {
             info = -12;

--- a/LAPACKE/src/lapacke_dtfsm.c
+++ b/LAPACKE/src/lapacke_dtfsm.c
@@ -45,7 +45,7 @@ lapack_int API_SUFFIX(LAPACKE_dtfsm)( int matrix_layout, char transr, char side,
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
         lapack_int mn = m;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         if( IS_D_NONZERO(alpha) ) {
             if( API_SUFFIX(LAPACKE_dtf_nancheck)( matrix_layout, transr, uplo, diag, mn, a ) ) {
                 return -10;

--- a/LAPACKE/src/lapacke_dtfsm_work.c
+++ b/LAPACKE/src/lapacke_dtfsm_work.c
@@ -50,7 +50,7 @@ lapack_int API_SUFFIX(LAPACKE_dtfsm_work)( int matrix_layout, char transr, char 
         lapack_int mn = m;
         double* b_t = NULL;
         double* a_t = NULL;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         /* Check leading dimension(s) */
         if( ldb < m ) {
             info = -12;

--- a/LAPACKE/src/lapacke_stfsm.c
+++ b/LAPACKE/src/lapacke_stfsm.c
@@ -44,7 +44,7 @@ lapack_int API_SUFFIX(LAPACKE_stfsm)( int matrix_layout, char transr, char side,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         lapack_int mn = m;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         /* Optionally check input matrices for NaNs */
         if( IS_S_NONZERO(alpha) ) {
             if( API_SUFFIX(LAPACKE_stf_nancheck)( matrix_layout, transr, uplo, diag, mn, a ) ) {

--- a/LAPACKE/src/lapacke_stfsm_work.c
+++ b/LAPACKE/src/lapacke_stfsm_work.c
@@ -50,7 +50,7 @@ lapack_int API_SUFFIX(LAPACKE_stfsm_work)( int matrix_layout, char transr, char 
         lapack_int mn = MAX(1,m);
         float* b_t = NULL;
         float* a_t = NULL;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         /* Check leading dimension(s) */
         if( ldb < m ) {
             info = -12;

--- a/LAPACKE/src/lapacke_ztfsm.c
+++ b/LAPACKE/src/lapacke_ztfsm.c
@@ -45,7 +45,7 @@ lapack_int API_SUFFIX(LAPACKE_ztfsm)( int matrix_layout, char transr, char side,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         lapack_int mn = m;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         /* Optionally check input matrices for NaNs */
         if( IS_Z_NONZERO(alpha) ) {
             if( API_SUFFIX(LAPACKE_ztf_nancheck)( matrix_layout, transr, uplo, diag, mn, a ) ) {

--- a/LAPACKE/src/lapacke_ztfsm_work.c
+++ b/LAPACKE/src/lapacke_ztfsm_work.c
@@ -51,7 +51,7 @@ lapack_int API_SUFFIX(LAPACKE_ztfsm_work)( int matrix_layout, char transr, char 
         lapack_int mn = m;
         lapack_complex_double* b_t = NULL;
         lapack_complex_double* a_t = NULL;
-        if( LAPACKE_lsame( side, 'r' ) ) mn = n;
+        if( API_SUFFIX(LAPACKE_lsame)( side, 'r' ) ) mn = n;
         /* Check leading dimension(s) */
         if( ldb < m ) {
             info = -12;
@@ -86,7 +86,7 @@ lapack_int API_SUFFIX(LAPACKE_ztfsm_work)( int matrix_layout, char transr, char 
                       b_t, &ldb_t );
         info = 0;  /* LAPACK call is ok! */
         /* Transpose output matrices */
-        LAPACKE_zge_trans( LAPACK_COL_MAJOR, m, n, b_t, ldb_t, b, ldb );
+        API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, m, n, b_t, ldb_t, b, ldb );
         /* Release memory and exit */
         if( IS_Z_NONZERO(alpha) ) {
             LAPACKE_free( a_t );


### PR DESCRIPTION
Reverts Reference-LAPACK/lapack#1058.

That got complicated as @martin-frbg predicted in https://github.com/Reference-LAPACK/lapack/pull/1057#issuecomment-2386273263. Sorry for that.