### PR TITLE
Remove comparison as these conditions are never true

### DIFF
--- a/LAPACKE/src/lapacke_ctpmqrt_work.c
+++ b/LAPACKE/src/lapacke_ctpmqrt_work.c
@@ -51,8 +51,8 @@ lapack_int API_SUFFIX(LAPACKE_ctpmqrt_work)( int matrix_layout, char side, char 
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int nrowsA, ncolsA, nrowsV;
-        if      ( side == API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
-        else if ( side == API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
+        if      ( API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
+        else if ( API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
         else {
             info = -2;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_ctpmqrt_work", info );

--- a/LAPACKE/src/lapacke_dtpmqrt_work.c
+++ b/LAPACKE/src/lapacke_dtpmqrt_work.c
@@ -49,8 +49,8 @@ lapack_int API_SUFFIX(LAPACKE_dtpmqrt_work)( int matrix_layout, char side, char 
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int nrowsA, ncolsA, nrowsV;
-        if      ( side == API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
-        else if ( side == API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
+        if      ( API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
+        else if ( API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
         else {
             info = -2;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_dtpmqrt_work", info );

--- a/LAPACKE/src/lapacke_nancheck.c
+++ b/LAPACKE/src/lapacke_nancheck.c
@@ -47,7 +47,7 @@ int LAPACKE_get_nancheck( )
     }
 
     /* Check environment variable, once and only once */
-    env = getenv( "API_SUFFIX(LAPACKE_)NANCHECK" );
+    env = getenv( "LAPACKE_NANCHECK" );
     if ( !env ) {
         /* By default, NaN checking is enabled */
         nancheck_flag = 1;

--- a/LAPACKE/src/lapacke_stpmqrt_work.c
+++ b/LAPACKE/src/lapacke_stpmqrt_work.c
@@ -49,8 +49,8 @@ lapack_int API_SUFFIX(LAPACKE_stpmqrt_work)( int matrix_layout, char side, char 
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int nrowsA, ncolsA, nrowsV;
-        if      ( side == API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
-        else if ( side == API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
+        if      ( API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
+        else if ( API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
         else {
             info = -2;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_stpmqrt_work", info );

--- a/LAPACKE/src/lapacke_ztpmqrt_work.c
+++ b/LAPACKE/src/lapacke_ztpmqrt_work.c
@@ -51,8 +51,8 @@ lapack_int API_SUFFIX(LAPACKE_ztpmqrt_work)( int matrix_layout, char side, char 
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int nrowsA, ncolsA, nrowsV;
-        if      ( side == API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
-        else if ( side == API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
+        if      ( API_SUFFIX(LAPACKE_lsame)(side, 'l') ) { nrowsA = k; ncolsA = n; nrowsV = m; }
+        else if ( API_SUFFIX(LAPACKE_lsame)(side, 'r') ) { nrowsA = m; ncolsA = k; nrowsV = n; }
         else {
             info = -2;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_ztpmqrt_work", info );


### PR DESCRIPTION
**Description**
The problem is that dtpmqrt is impossible to use because `side` must be either `l` (`L`) or `r` (`R`). The condition not only uses `LAPACKE_lsame` to compare against the possible values, but also compare the boolean result against `side` (which is a `char`). This situation ultimately leads to a logical expression that will never be true, making it impossible to use `dtpmqrt` and others routines affected by similar code. The commit simply removes `side ==` as this fix the problem.

**Checklist**

- [ ] The documentation has been updated.
  - No documentation change required as in previous version it was OK
- [ ] If the PR solves a specific issue, it is set to be closed on merge.
  - No issues found describing this problem