### PR TITLE
fix leading dimension for matrix B in test routine get52

### DIFF
--- a/TESTING/EIG/cget52.f
+++ b/TESTING/EIG/cget52.f
@@ -256,7 +256,7 @@
          END IF
          CALL CGEMV( TRANS, N, N, ACOEFF, A, LDA, E( 1, JVEC ), 1,
      $               CZERO, WORK( N*( JVEC-1 )+1 ), 1 )
-         CALL CGEMV( TRANS, N, N, -BCOEFF, B, LDA, E( 1, JVEC ), 1,
+         CALL CGEMV( TRANS, N, N, -BCOEFF, B, LDB, E( 1, JVEC ), 1,
      $               CONE, WORK( N*( JVEC-1 )+1 ), 1 )
    10 CONTINUE
 *

--- a/TESTING/EIG/dget52.f
+++ b/TESTING/EIG/dget52.f
@@ -293,7 +293,7 @@
                BCOEFR = SCALE*SALFR
                CALL DGEMV( TRANS, N, N, ACOEF, A, LDA, E( 1, JVEC ), 1,
      $                     ZERO, WORK( N*( JVEC-1 )+1 ), 1 )
-               CALL DGEMV( TRANS, N, N, -BCOEFR, B, LDA, E( 1, JVEC ),
+               CALL DGEMV( TRANS, N, N, -BCOEFR, B, LDB, E( 1, JVEC ),
      $                     1, ONE, WORK( N*( JVEC-1 )+1 ), 1 )
             ELSE
 *
@@ -323,16 +323,16 @@
 *
                CALL DGEMV( TRANS, N, N, ACOEF, A, LDA, E( 1, JVEC ), 1,
      $                     ZERO, WORK( N*( JVEC-1 )+1 ), 1 )
-               CALL DGEMV( TRANS, N, N, -BCOEFR, B, LDA, E( 1, JVEC ),
+               CALL DGEMV( TRANS, N, N, -BCOEFR, B, LDB, E( 1, JVEC ),
      $                     1, ONE, WORK( N*( JVEC-1 )+1 ), 1 )
-               CALL DGEMV( TRANS, N, N, BCOEFI, B, LDA, E( 1, JVEC+1 ),
+               CALL DGEMV( TRANS, N, N, BCOEFI, B, LDB, E( 1, JVEC+1 ),
      $                     1, ONE, WORK( N*( JVEC-1 )+1 ), 1 )
 *
                CALL DGEMV( TRANS, N, N, ACOEF, A, LDA, E( 1, JVEC+1 ),
      $                     1, ZERO, WORK( N*JVEC+1 ), 1 )
-               CALL DGEMV( TRANS, N, N, -BCOEFI, B, LDA, E( 1, JVEC ),
+               CALL DGEMV( TRANS, N, N, -BCOEFI, B, LDB, E( 1, JVEC ),
      $                     1, ONE, WORK( N*JVEC+1 ), 1 )
-               CALL DGEMV( TRANS, N, N, -BCOEFR, B, LDA, E( 1, JVEC+1 ),
+               CALL DGEMV( TRANS, N, N, -BCOEFR, B, LDB, E( 1, JVEC+1 ),
      $                     1, ONE, WORK( N*JVEC+1 ), 1 )
             END IF
          END IF

--- a/TESTING/EIG/sget52.f
+++ b/TESTING/EIG/sget52.f
@@ -293,7 +293,7 @@
                BCOEFR = SCALE*SALFR
                CALL SGEMV( TRANS, N, N, ACOEF, A, LDA, E( 1, JVEC ), 1,
      $                     ZERO, WORK( N*( JVEC-1 )+1 ), 1 )
-               CALL SGEMV( TRANS, N, N, -BCOEFR, B, LDA, E( 1, JVEC ),
+               CALL SGEMV( TRANS, N, N, -BCOEFR, B, LDB, E( 1, JVEC ),
      $                     1, ONE, WORK( N*( JVEC-1 )+1 ), 1 )
             ELSE
 *
@@ -323,16 +323,16 @@
 *
                CALL SGEMV( TRANS, N, N, ACOEF, A, LDA, E( 1, JVEC ), 1,
      $                     ZERO, WORK( N*( JVEC-1 )+1 ), 1 )
-               CALL SGEMV( TRANS, N, N, -BCOEFR, B, LDA, E( 1, JVEC ),
+               CALL SGEMV( TRANS, N, N, -BCOEFR, B, LDB, E( 1, JVEC ),
      $                     1, ONE, WORK( N*( JVEC-1 )+1 ), 1 )
-               CALL SGEMV( TRANS, N, N, BCOEFI, B, LDA, E( 1, JVEC+1 ),
+               CALL SGEMV( TRANS, N, N, BCOEFI, B, LDB, E( 1, JVEC+1 ),
      $                     1, ONE, WORK( N*( JVEC-1 )+1 ), 1 )
 *
                CALL SGEMV( TRANS, N, N, ACOEF, A, LDA, E( 1, JVEC+1 ),
      $                     1, ZERO, WORK( N*JVEC+1 ), 1 )
-               CALL SGEMV( TRANS, N, N, -BCOEFI, B, LDA, E( 1, JVEC ),
+               CALL SGEMV( TRANS, N, N, -BCOEFI, B, LDB, E( 1, JVEC ),
      $                     1, ONE, WORK( N*JVEC+1 ), 1 )
-               CALL SGEMV( TRANS, N, N, -BCOEFR, B, LDA, E( 1, JVEC+1 ),
+               CALL SGEMV( TRANS, N, N, -BCOEFR, B, LDB, E( 1, JVEC+1 ),
      $                     1, ONE, WORK( N*JVEC+1 ), 1 )
             END IF
          END IF

--- a/TESTING/EIG/zget52.f
+++ b/TESTING/EIG/zget52.f
@@ -257,7 +257,7 @@
          END IF
          CALL ZGEMV( TRANS, N, N, ACOEFF, A, LDA, E( 1, JVEC ), 1,
      $               CZERO, WORK( N*( JVEC-1 )+1 ), 1 )
-         CALL ZGEMV( TRANS, N, N, -BCOEFF, B, LDA, E( 1, JVEC ), 1,
+         CALL ZGEMV( TRANS, N, N, -BCOEFF, B, LDB, E( 1, JVEC ), 1,
      $               CONE, WORK( N*( JVEC-1 )+1 ), 1 )
    10 CONTINUE
 *


### PR DESCRIPTION
**fix leading dimension for matrix B in test routine get52**

Led to fails of tests for eigensolver `ggev` for cases `lda != ldb`