### PR TITLE
Fixing misspelling of 'triangular' in {s,d,c,z}gemmtr.f

### DIFF
--- a/BLAS/SRC/cgemmtr.f
+++ b/BLAS/SRC/cgemmtr.f
@@ -50,9 +50,9 @@
 *>           On entry, UPLO specifies whether the lower or the upper
 *>           triangular part of C is access and updated.
 *>
-*>              UPLO = 'L' or 'l', the lower tringular part of C is used.
+*>              UPLO = 'L' or 'l', the lower triangular part of C is used.
 *>
-*>              UPLO = 'U' or 'u', the upper tringular part of C is used.
+*>              UPLO = 'U' or 'u', the upper triangular part of C is used.
 *> \endverbatim
 *
 *> \param[in] TRANSA
@@ -154,7 +154,7 @@
 *>           Before entry, the leading  n by n  part of the array  C must
 *>           contain the matrix  C,  except when  beta  is zero, in which
 *>           case C need not be set on entry.
-*>           On exit, the upper or lower trinangular part of the matrix
+*>           On exit, the upper or lower triangular part of the matrix
 *>           C  is overwritten by the n by n matrix
 *>           ( alpha*op( A )*op( B ) + beta*C ).
 *> \endverbatim

--- a/BLAS/SRC/dgemmtr.f
+++ b/BLAS/SRC/dgemmtr.f
@@ -50,9 +50,9 @@
 *>           On entry, UPLO specifies whether the lower or the upper
 *>           triangular part of C is access and updated.
 *>
-*>              UPLO = 'L' or 'l', the lower tringular part of C is used.
+*>              UPLO = 'L' or 'l', the lower triangular part of C is used.
 *>
-*>              UPLO = 'U' or 'u', the upper tringular part of C is used.
+*>              UPLO = 'U' or 'u', the upper triangular part of C is used.
 *> \endverbatim
 *
 *> \param[in] TRANSA
@@ -154,7 +154,7 @@
 *>           Before entry, the leading  n by n  part of the array  C must
 *>           contain the matrix  C,  except when  beta  is zero, in which
 *>           case C need not be set on entry.
-*>           On exit, the upper or lower trinangular part of the matrix
+*>           On exit, the upper or lower triangular part of the matrix
 *>           C  is overwritten by the n by n matrix
 *>           ( alpha*op( A )*op( B ) + beta*C ).
 *> \endverbatim

--- a/BLAS/SRC/sgemmtr.f
+++ b/BLAS/SRC/sgemmtr.f
@@ -50,9 +50,9 @@
 *>           On entry, UPLO specifies whether the lower or the upper
 *>           triangular part of C is access and updated.
 *>
-*>              UPLO = 'L' or 'l', the lower tringular part of C is used.
+*>              UPLO = 'L' or 'l', the lower triangular part of C is used.
 *>
-*>              UPLO = 'U' or 'u', the upper tringular part of C is used.
+*>              UPLO = 'U' or 'u', the upper triangular part of C is used.
 *> \endverbatim
 *
 *> \param[in] TRANSA
@@ -154,7 +154,7 @@
 *>           Before entry, the leading  n by n  part of the array  C must
 *>           contain the matrix  C,  except when  beta  is zero, in which
 *>           case C need not be set on entry.
-*>           On exit, the upper or lower trinangular part of the matrix
+*>           On exit, the upper or lower triangular part of the matrix
 *>           C  is overwritten by the n by n matrix
 *>           ( alpha*op( A )*op( B ) + beta*C ).
 *> \endverbatim

--- a/BLAS/SRC/zgemmtr.f
+++ b/BLAS/SRC/zgemmtr.f
@@ -50,9 +50,9 @@
 *>           On entry, UPLO specifies whether the lower or the upper
 *>           triangular part of C is access and updated.
 *>
-*>              UPLO = 'L' or 'l', the lower tringular part of C is used.
+*>              UPLO = 'L' or 'l', the lower triangular part of C is used.
 *>
-*>              UPLO = 'U' or 'u', the upper tringular part of C is used.
+*>              UPLO = 'U' or 'u', the upper triangular part of C is used.
 *> \endverbatim
 *
 *> \param[in] TRANSA
@@ -154,7 +154,7 @@
 *>           Before entry, the leading  n by n  part of the array  C must
 *>           contain the matrix  C,  except when  beta  is zero, in which
 *>           case C need not be set on entry.
-*>           On exit, the upper or lower trinangular part of the matrix
+*>           On exit, the upper or lower triangular part of the matrix
 *>           C  is overwritten by the n by n matrix
 *>           ( alpha*op( A )*op( B ) + beta*C ).
 *> \endverbatim


### PR DESCRIPTION
**Description**
Fixed misspelling of "triangular" in BLAS/SRC/{s,d,c,z}gemmtr.f

There doesn't seem to be an issue for this, but if there is I'm sorry for missing it!

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.