### PR TITLE
updating gitignore to ignore the mod files when we compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ build*
 DOCS/man
 DOCS/explore-html
 output_err
+
+# Mod files from compilation in SRC
+SRC/la_constants.mod
+SRC/la_xisnan.mod


### PR DESCRIPTION
**Description**
Added the 'la_*.mod' files to the gitignore file to solve some annoyance found in PR #1080 

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.