### PR TITLE
dlahrd.f: consistent line reflow for DTRMV calls

### DIFF
--- a/SRC/DEPRECATED/dlahrd.f
+++ b/SRC/DEPRECATED/dlahrd.f
@@ -231,8 +231,8 @@
 *
 *           w := T**T *w
 *
-            CALL DTRMV( 'Upper', 'Transpose', 'Non-unit', I-1, T, LDT,
-     $                  T( 1, NB ), 1 )
+            CALL DTRMV( 'Upper', 'Transpose', 'Non-unit', I-1,
+     $                  T, LDT, T( 1, NB ), 1 )
 *
 *           b2 := b2 - V2*w
 *
@@ -270,8 +270,8 @@
 *        Compute T(1:i,i)
 *
          CALL DSCAL( I-1, -TAU( I ), T( 1, I ), 1 )
-         CALL DTRMV( 'Upper', 'No transpose', 'Non-unit', I-1, T, LDT,
-     $               T( 1, I ), 1 )
+         CALL DTRMV( 'Upper', 'No transpose', 'Non-unit', I-1,
+     $               T, LDT, T( 1, I ), 1 )
          T( I, I ) = TAU( I )
 *
    10 CONTINUE


### PR DESCRIPTION
**Description**
Under gcc-12.3.0, we are noticing spurious type mismatch errors due to different line reflow in dlahrd.f, see e.g. https://gitlab.spack.io/spack/spack/-/jobs/14595649#L1131. Notice that the types of different arguments are compared in that error message.

This PR makes the line reflow for two DTRMV calls identical, which resolves the spurious report.

**Checklist**

- [ ] The documentation has been updated.
  - No documentation updates needed
- [ ] If the PR solves a specific issue, it is set to be closed on merge.
  - No specific issue reported, but see https://github.com/spack/spack/pull/48318#issuecomment-2583610274.