### PR TITLE
?ge(lq|qr)s.f: WORK( LWORK ) -> WORK( * )

### DIFF
--- a/SRC/DEPRECATED/cgelqs.f
+++ b/SRC/DEPRECATED/cgelqs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================

--- a/SRC/DEPRECATED/cgeqrs.f
+++ b/SRC/DEPRECATED/cgeqrs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================

--- a/SRC/DEPRECATED/dgelqs.f
+++ b/SRC/DEPRECATED/dgelqs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================

--- a/SRC/DEPRECATED/dgeqrs.f
+++ b/SRC/DEPRECATED/dgeqrs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================

--- a/SRC/DEPRECATED/sgelqs.f
+++ b/SRC/DEPRECATED/sgelqs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================

--- a/SRC/DEPRECATED/sgeqrs.f
+++ b/SRC/DEPRECATED/sgeqrs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================

--- a/SRC/DEPRECATED/zgelqs.f
+++ b/SRC/DEPRECATED/zgelqs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================

--- a/SRC/DEPRECATED/zgeqrs.f
+++ b/SRC/DEPRECATED/zgeqrs.f
@@ -16,7 +16,7 @@
 *       ..
 *       .. Array Arguments ..
 *       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
-*      $                   WORK( LWORK )
+*      $                   WORK( * )
 *       ..
 *
 *
@@ -128,7 +128,7 @@
 *     ..
 *     .. Array Arguments ..
       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
-     $                   WORK( LWORK )
+     $                   WORK( * )
 *     ..
 *
 *  =====================================================================


### PR DESCRIPTION
**Description**
In #1092, compilation of 3.12.1 is reported to fail due to `WORK( LWORK )` in `SRC/DEPRECATED/?ge(lq|qr)s.f`. I can reproduce this locally (gcc-14.2.0). Suggested in the report is a change to `WORK( * )`.

This PR changs `WORK( LWORK )` to `WORK( * )` in all `SRC/DEPRECATED/?ge(lq|qr)s.f`, which is confirmed to cause compilation to succeed (when combined with #1093).

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge. Fixes #1092.