### PR TITLE
Fix line reflow in some of the DEPRECATED sources

### DIFF
--- a/SRC/DEPRECATED/cgelsx.f
+++ b/SRC/DEPRECATED/cgelsx.f
@@ -364,8 +364,8 @@
 *
 *     B(1:M,1:NRHS) := Q**H * B(1:M,1:NRHS)
 *
-      CALL CUNM2R( 'Left', 'Conjugate transpose', M, NRHS, MN, A, LDA,
-     $             WORK( 1 ), B, LDB, WORK( 2*MN+1 ), INFO )
+      CALL CUNM2R( 'Left', 'Conjugate transpose', M, NRHS, MN, A,
+     $             LDA, WORK( 1 ), B, LDB, WORK( 2*MN+1 ), INFO )
 *
 *     workspace NRHS
 *

--- a/SRC/DEPRECATED/dgeqpf.f
+++ b/SRC/DEPRECATED/dgeqpf.f
@@ -218,8 +218,8 @@
          MA = MIN( ITEMP, M )
          CALL DGEQR2( M, MA, A, LDA, TAU, WORK, INFO )
          IF( MA.LT.N ) THEN
-            CALL DORM2R( 'Left', 'Transpose', M, N-MA, MA, A, LDA, TAU,
-     $                   A( 1, MA+1 ), LDA, WORK, INFO )
+            CALL DORM2R( 'Left', 'Transpose', M, N-MA, MA, A, LDA,
+     $                   TAU, A( 1, MA+1 ), LDA, WORK, INFO )
          END IF
       END IF
 *

--- a/SRC/DEPRECATED/sgeqpf.f
+++ b/SRC/DEPRECATED/sgeqpf.f
@@ -218,8 +218,8 @@
          MA = MIN( ITEMP, M )
          CALL SGEQR2( M, MA, A, LDA, TAU, WORK, INFO )
          IF( MA.LT.N ) THEN
-            CALL SORM2R( 'Left', 'Transpose', M, N-MA, MA, A, LDA, TAU,
-     $                   A( 1, MA+1 ), LDA, WORK, INFO )
+            CALL SORM2R( 'Left', 'Transpose', M, N-MA, MA, A, LDA,
+     $                   TAU, A( 1, MA+1 ), LDA, WORK, INFO )
          END IF
       END IF
 *


### PR DESCRIPTION
**Description**
This is a follow-on to PR #1093 - as noted in comments there, further files were affected by the addition of automatic symbol name suffixing, pushing code lines that ended in column 70 or 71 beyond the customary limit and thereby
creating bogus concatenations of argument names across continuation lines. As far as I can tell with the help of `nm`, there are currently no similarly suspicious symbols in the shared library after application of this PR.
**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.