### PR TITLE
Fix const qualifier warnings in CBLAS

### DIFF
--- a/CBLAS/examples/cblas_example1_64.c
+++ b/CBLAS/examples/cblas_example1_64.c
@@ -61,7 +61,7 @@ int main ( )
                 y, incy );
    /* Print y */
    for( i = 0; i < n; i++ )
-      printf(" y%" CBLAS_IFMT " = %f\n", i, y[i]);
+      printf(" y%d = %f\n", (int) i, y[i]);
    free(a);
    free(x);
    free(y);

--- a/CBLAS/src/cblas_cgbmv.c
+++ b/CBLAS/src/cblas_cgbmv.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_cgbmv)(const CBLAS_LAYOUT layout,
@@ -26,6 +28,7 @@ void API_SUFFIX(cblas_cgbmv)(const CBLAS_LAYOUT layout,
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
    F77_INT F77_KL=KL,F77_KU=KU;
 #else
+   CBLAS_INT incx=incX;
    #define F77_M M
    #define F77_N N
    #define F77_lda lda
@@ -34,14 +37,18 @@ void API_SUFFIX(cblas_cgbmv)(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n=0, i=0, incx=incX;
-   const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
+   CBLAS_INT n=0, i=0;
+   const float *xx= (const float *)X, *alp= (const float *)alpha, *bet = (const float *)beta;
    float ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   float *x=(float *)X, *y=(float *)Y, *st=0, *tx=0;
+   float *x, *y, *st=0, *tx=0;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+    memcpy(&x, &X, sizeof(float*));
+    memcpy(&y, &Y, sizeof(float*));
+
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -125,7 +132,7 @@ void API_SUFFIX(cblas_cgbmv)(const CBLAS_LAYOUT layout,
                y -= n;
             }
          }
-         else x = (float *) X;
+         else memcpy(&x, &X, sizeof(float*));
 
 
       }

--- a/CBLAS/src/cblas_cgemv.c
+++ b/CBLAS/src/cblas_cgemv.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_cgemv)(const CBLAS_LAYOUT layout,
@@ -31,17 +32,21 @@ void API_SUFFIX(cblas_cgemv)(const CBLAS_LAYOUT layout,
    #define F77_incY incY
 #endif
 
-   CBLAS_INT n=0, i=0, incx=incX;
+   CBLAS_INT n=0, i=0;
    const float *xx= (const float *)X;
    float ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   float *x=(float *)X, *y=(float *)Y, *st=0, *tx=0;
-   const float *stx = x;
+   float *x, *y, *st=0, *tx=0;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
 
    CBLAS_CallFromC = 1;
+
+   memcpy(&x, &X, sizeof(float *));
+   memcpy(&y, &Y, sizeof(float *));
+
+   const float *stx = x;
 
    if (layout == CblasColMajor)
    {

--- a/CBLAS/src/cblas_cgerc.c
+++ b/CBLAS/src/cblas_cgerc.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_cgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const CBLAS_INT N,
@@ -16,6 +18,7 @@ void API_SUFFIX(cblas_cgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incy = incY;
    #define F77_M M
    #define F77_N N
    #define F77_incX incX
@@ -23,8 +26,10 @@ void API_SUFFIX(cblas_cgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const
    #define F77_lda lda
 #endif
 
-   CBLAS_INT n, i, tincy, incy=incY;
-   float *y=(float *)Y, *yy=(float *)Y, *ty, *st;
+   CBLAS_INT n, i, tincy;
+   float *y, *yy, *ty, *st;
+   memcpy(&y,&Y,sizeof(float*));
+   memcpy(&yy,&Y,sizeof(float*));
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
@@ -70,7 +75,8 @@ void API_SUFFIX(cblas_cgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const
             incy = 1;
          #endif
       }
-      else y = (float *) Y;
+      else
+        memcpy(&y,&Y,sizeof(float*));
 
       F77_cgeru( &F77_N, &F77_M, alpha, y, &F77_incY, X, &F77_incX, A,
                       &F77_lda);

--- a/CBLAS/src/cblas_chbmv.c
+++ b/CBLAS/src/cblas_chbmv.c
@@ -9,6 +9,7 @@
 #include "cblas_f77.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 void API_SUFFIX(cblas_chbmv)(const CBLAS_LAYOUT layout,
                  const CBLAS_UPLO Uplo,const CBLAS_INT N,const CBLAS_INT K,
                  const void *alpha, const void  *A, const CBLAS_INT lda,
@@ -24,20 +25,24 @@ void API_SUFFIX(cblas_chbmv)(const CBLAS_LAYOUT layout,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_K=K, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_K K
    #define F77_lda lda
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n, i=0, incx=incX;
-   const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
+   CBLAS_INT n, i=0;
+   const float *xx= (const float *)X, *alp= (const float *)alpha, *bet = (const float *)beta;
    float ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   float *x=(float *)X, *y=(float *)Y, *st=0, *tx;
+   float *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x, &X, sizeof(float*));
+   memcpy(&y, &Y, sizeof(float*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -114,7 +119,7 @@ void API_SUFFIX(cblas_chbmv)(const CBLAS_LAYOUT layout,
          } while(y != st);
          y -= n;
       }  else
-         x = (float *) X;
+         memcpy(&x, &X, sizeof(float*));
 
       if (Uplo == CblasUpper) UL = 'L';
       else if (Uplo == CblasLower) UL = 'U';

--- a/CBLAS/src/cblas_chemv.c
+++ b/CBLAS/src/cblas_chemv.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_chemv)(const CBLAS_LAYOUT layout,
@@ -24,19 +26,23 @@ void API_SUFFIX(cblas_chemv)(const CBLAS_LAYOUT layout,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_lda lda
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n=0, i=0, incx=incX;
-   const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
+   CBLAS_INT n=0, i=0;
+   const float *xx= (const float *)X, *alp= (const float *)alpha, *bet = (const float *)beta;
    float ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   float *x=(float *)X, *y=(float *)Y, *st=0, *tx;
+   float *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x, &X, sizeof(float*));
+   memcpy(&y, &Y, sizeof(float*));
 
 
    CBLAS_CallFromC = 1;
@@ -114,7 +120,7 @@ void API_SUFFIX(cblas_chemv)(const CBLAS_LAYOUT layout,
          } while(y != st);
          y -= n;
       }  else
-         x = (float *) X;
+         memcpy(&x, &X, sizeof(float*));
 
 
       if (Uplo == CblasUpper) UL = 'L';

--- a/CBLAS/src/cblas_cher.c
+++ b/CBLAS/src/cblas_cher.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_cher)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -23,16 +24,21 @@ void API_SUFFIX(cblas_cher)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_lda=lda, F77_incX=incX;
 #else
+   CBLAS_INT incx;
    #define F77_N N
    #define F77_lda lda
    #define F77_incX incx
 #endif
-   CBLAS_INT n, i, tincx, incx=incX;
-   float *x=(float *)X, *xx=(float *)X, *tx, *st;
+   CBLAS_INT n, i, tincx;
+   float *x, *xx, *tx, *st;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(float*));
+   memcpy(&xx,&X,sizeof(float*));
+
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -98,7 +104,9 @@ void API_SUFFIX(cblas_cher)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
            incx = 1;
          #endif
       }
-      else x = (float *) X;
+      else
+        memcpy(&x,&X,sizeof(float*));
+
       F77_cher(F77_UL, &F77_N, &alpha, x, &F77_incX, A, &F77_lda);
    } else
    {

--- a/CBLAS/src/cblas_cher2.c
+++ b/CBLAS/src/cblas_cher2.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_cher2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -23,18 +24,24 @@ void API_SUFFIX(cblas_cher2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX, incy = incY;
    #define F77_N N
    #define F77_lda lda
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   CBLAS_INT n, i, j, tincx, tincy, incx=incX, incy=incY;
-   float *x=(float *)X, *xx=(float *)X, *y=(float *)Y,
-         *yy=(float *)Y, *tx, *ty, *stx, *sty;
+   CBLAS_INT n, i, j, tincx, tincy;
+   float *x, *xx, *y,
+         *yy, *tx, *ty, *stx, *sty;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(float*));
+   memcpy(&xx,&X,sizeof(float*));
+   memcpy(&y,&Y,sizeof(float*));
+   memcpy(&yy,&Y,sizeof(float*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -129,8 +136,8 @@ void API_SUFFIX(cblas_cher2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          #endif
       }  else
       {
-         x = (float *) X;
-         y = (float *) Y;
+         memcpy(&x,&X,sizeof(float*));
+         memcpy(&y,&Y,sizeof(float*));
       }
       F77_cher2(F77_UL, &F77_N, alpha, y, &F77_incY, x,
                                       &F77_incX, A, &F77_lda);

--- a/CBLAS/src/cblas_cher2k.c
+++ b/CBLAS/src/cblas_cher2k.c
@@ -37,7 +37,7 @@ void API_SUFFIX(cblas_cher2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    float ALPHA[2];
-   const float *alp=(float *)alpha;
+   const float *alp=(const float *)alpha;
 
    CBLAS_CallFromC = 1;
    RowMajorStrg = 0;

--- a/CBLAS/src/cblas_chpmv.c
+++ b/CBLAS/src/cblas_chpmv.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_chpmv)(const CBLAS_LAYOUT layout,
@@ -24,18 +26,23 @@ void API_SUFFIX(cblas_chpmv)(const CBLAS_LAYOUT layout,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n, i=0, incx=incX;
-   const float *xx= (float *)X, *alp= (float *)alpha, *bet = (float *)beta;
+   CBLAS_INT n, i=0;
+   const float *xx= (const float *)X, *alp= (const float *)alpha, *bet = (const float *)beta;
    float ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   float *x=(float *)X, *y=(float *)Y, *st=0, *tx;
+   float *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(float*));
+   memcpy(&y,&Y,sizeof(float*));
+
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -112,8 +119,7 @@ void API_SUFFIX(cblas_chpmv)(const CBLAS_LAYOUT layout,
          } while(y != st);
          y -= n;
       }  else
-         x = (float *) X;
-
+         memcpy(&x,&X,sizeof(float*));
 
       if (Uplo == CblasUpper) UL = 'L';
       else if (Uplo == CblasLower) UL = 'U';

--- a/CBLAS/src/cblas_chpr.c
+++ b/CBLAS/src/cblas_chpr.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_chpr)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -23,15 +25,19 @@ void API_SUFFIX(cblas_chpr)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_incX incx
 #endif
-   CBLAS_INT n, i, tincx, incx=incX;
-   float *x=(float *)X, *xx=(float *)X, *tx, *st;
+   CBLAS_INT n, i, tincx;
+   float *x, *xx, *tx, *st;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(float*));
+   memcpy(&xx,&X,sizeof(float*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -96,7 +102,8 @@ void API_SUFFIX(cblas_chpr)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
             incx = 1;
          #endif
       }
-      else x = (float *) X;
+      else
+          memcpy(&x,&X,sizeof(float*));
 
       F77_chpr(F77_UL, &F77_N, &alpha, x, &F77_incX, A);
 

--- a/CBLAS/src/cblas_chpr2.c
+++ b/CBLAS/src/cblas_chpr2.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_chpr2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -24,17 +25,24 @@ void API_SUFFIX(cblas_chpr2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N,  F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
+   CBLAS_INT incy = incY;
    #define F77_N N
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   CBLAS_INT n, i, j, tincx, tincy, incx=incX, incy=incY;
-   float *x=(float *)X, *xx=(float *)X, *y=(float *)Y,
-         *yy=(float *)Y, *tx, *ty, *stx, *sty;
+   CBLAS_INT n, i, j, tincx, tincy;
+   float *x, *xx, *y,
+         *yy, *tx, *ty, *stx, *sty;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(float*));
+   memcpy(&xx,&X,sizeof(float*));
+   memcpy(&y,&Y,sizeof(float*));
+   memcpy(&yy,&Y,sizeof(float*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -128,8 +136,8 @@ void API_SUFFIX(cblas_chpr2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 
       }  else
       {
-         x = (float *) X;
-         y = (void  *) Y;
+         memcpy(&x,&X,sizeof(float*));
+         memcpy(&y,&Y,sizeof(float*));
       }
       F77_chpr2(F77_UL, &F77_N, alpha, y, &F77_incY, x, &F77_incX, Ap);
    } else

--- a/CBLAS/src/cblas_zgbmv.c
+++ b/CBLAS/src/cblas_zgbmv.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zgbmv)(const CBLAS_LAYOUT layout,
@@ -26,6 +27,7 @@ void API_SUFFIX(cblas_zgbmv)(const CBLAS_LAYOUT layout,
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
    F77_INT F77_KL=KL,F77_KU=KU;
 #else
+   CBLAS_INT incx = incX;
    #define F77_M M
    #define F77_N N
    #define F77_lda lda
@@ -34,14 +36,17 @@ void API_SUFFIX(cblas_zgbmv)(const CBLAS_LAYOUT layout,
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n, i=0, incx=incX;
-   const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
+   CBLAS_INT n, i=0;
+   const double *xx= (const double *)X, *alp= (const double *)alpha, *bet = (const double *)beta;
    double ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
+   double *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&y,&Y,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -125,7 +130,8 @@ void API_SUFFIX(cblas_zgbmv)(const CBLAS_LAYOUT layout,
                y -= n;
             }
          }
-         else x = (double *) X;
+         else
+            memcpy(&x,&X,sizeof(double*));
 
 
       }

--- a/CBLAS/src/cblas_zgemv.c
+++ b/CBLAS/src/cblas_zgemv.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zgemv)(const CBLAS_LAYOUT layout,
@@ -24,6 +25,7 @@ void API_SUFFIX(cblas_zgemv)(const CBLAS_LAYOUT layout,
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
    #define F77_M M
    #define F77_N N
    #define F77_lda lda
@@ -31,14 +33,17 @@ void API_SUFFIX(cblas_zgemv)(const CBLAS_LAYOUT layout,
    #define F77_incY incY
 #endif
 
-   CBLAS_INT n, i=0, incx=incX;
-   const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
+   CBLAS_INT n, i=0;
+   const double *xx= (const double *)X, *alp= (const double *)alpha, *bet = (const double *)beta;
    double ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
+   double *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&y,&Y,sizeof(double*));
 
    CBLAS_CallFromC = 1;
 
@@ -124,7 +129,8 @@ void API_SUFFIX(cblas_zgemv)(const CBLAS_LAYOUT layout,
                y -= n;
             }
          }
-         else x = (double *) X;
+         else
+            memcpy(&x,&X,sizeof(double*));
       }
       else
       {
@@ -145,7 +151,7 @@ void API_SUFFIX(cblas_zgemv)(const CBLAS_LAYOUT layout,
 
       if (TransA == CblasConjTrans)
       {
-         if (x != (double *)X) free(x);
+         if (x != X) free(x);
          if (N > 0)
          {
             do

--- a/CBLAS/src/cblas_zgerc.c
+++ b/CBLAS/src/cblas_zgerc.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const CBLAS_INT N,
@@ -16,6 +18,7 @@ void API_SUFFIX(cblas_zgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const
 #ifdef F77_INT
    F77_INT F77_M=M, F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incy = incY;
    #define F77_M M
    #define F77_N N
    #define F77_incX incX
@@ -23,12 +26,15 @@ void API_SUFFIX(cblas_zgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const
    #define F77_lda lda
 #endif
 
-   CBLAS_INT n, i, tincy, incy=incY;
-   double *y=(double *)Y, *yy=(double *)Y, *ty, *st;
+   CBLAS_INT n, i, tincy;
+   double *y,  *yy, *ty, *st;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&y,&Y,sizeof(double*));
+   memcpy(&yy,&Y,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -56,7 +62,7 @@ void API_SUFFIX(cblas_zgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const
          }
          do
          {
-            *y = *yy;
+            *y = (double) *yy;
             y[1] = -yy[1];
             y += tincy ;
             yy += i;
@@ -70,7 +76,8 @@ void API_SUFFIX(cblas_zgerc)(const CBLAS_LAYOUT layout, const CBLAS_INT M, const
             incy = 1;
          #endif
       }
-      else y = (double *) Y;
+      else
+          memcpy(&y,&Y,sizeof(double*));
 
       F77_zgeru( &F77_N, &F77_M, alpha, y, &F77_incY, X, &F77_incX, A,
                       &F77_lda);

--- a/CBLAS/src/cblas_zhbmv.c
+++ b/CBLAS/src/cblas_zhbmv.c
@@ -9,6 +9,8 @@
 #include "cblas_f77.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 void API_SUFFIX(cblas_zhbmv)(const CBLAS_LAYOUT layout,
                  const CBLAS_UPLO Uplo,const CBLAS_INT N,const CBLAS_INT K,
                  const void *alpha, const void  *A, const CBLAS_INT lda,
@@ -24,20 +26,24 @@ void API_SUFFIX(cblas_zhbmv)(const CBLAS_LAYOUT layout,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_K=K, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_K K
    #define F77_lda lda
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n, i=0, incx=incX;
-   const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
+   CBLAS_INT n, i=0;
+   const double *xx= (const double *)X, *alp= (const double *)alpha, *bet = (const double *)beta;
    double ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
+   double *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&y,&Y,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -114,7 +120,7 @@ void API_SUFFIX(cblas_zhbmv)(const CBLAS_LAYOUT layout,
          } while(y != st);
          y -= n;
       }  else
-         x = (double *) X;
+        memcpy(&x,&X,sizeof(double*));
 
       if (Uplo == CblasUpper) UL = 'L';
       else if (Uplo == CblasLower) UL = 'U';

--- a/CBLAS/src/cblas_zhemv.c
+++ b/CBLAS/src/cblas_zhemv.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zhemv)(const CBLAS_LAYOUT layout,
@@ -24,20 +25,23 @@ void API_SUFFIX(cblas_zhemv)(const CBLAS_LAYOUT layout,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_lda lda
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n, i=0, incx=incX;
-   const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
+   CBLAS_INT n, i=0;
+   const double *xx= (const double *)X, *alp= (const double *)alpha, *bet = (const double *)beta;
    double ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
+   double *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
 
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&y,&Y,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -114,7 +118,8 @@ void API_SUFFIX(cblas_zhemv)(const CBLAS_LAYOUT layout,
          } while(y != st);
          y -= n;
       }  else
-         x = (double *) X;
+         memcpy(&x,&X,sizeof(double*));
+
 
 
       if (Uplo == CblasUpper) UL = 'L';

--- a/CBLAS/src/cblas_zher.c
+++ b/CBLAS/src/cblas_zher.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zher)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -23,16 +24,21 @@ void API_SUFFIX(cblas_zher)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_lda=lda, F77_incX=incX;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_lda lda
    #define F77_incX incx
 #endif
-   CBLAS_INT n, i, tincx, incx=incX;
-   double *x=(double *)X, *xx=(double *)X, *tx, *st;
+   CBLAS_INT n, i, tincx;
+   double *x, *xx, *tx, *st;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&xx,&X,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -98,7 +104,8 @@ void API_SUFFIX(cblas_zher)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
            incx = 1;
          #endif
       }
-      else x = (double *) X;
+      else
+          memcpy(&x,&X,sizeof(double*));
       F77_zher(F77_UL, &F77_N, &alpha, x, &F77_incX, A, &F77_lda);
    } else API_SUFFIX(cblas_xerbla)(1, "cblas_zher", "Illegal layout setting, %d\n", layout);
    if(X!=x)

--- a/CBLAS/src/cblas_zher2.c
+++ b/CBLAS/src/cblas_zher2.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zher2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -23,18 +24,26 @@ void API_SUFFIX(cblas_zher2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_lda=lda, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX, incy = incY;
    #define F77_N N
    #define F77_lda lda
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   CBLAS_INT n, i, j, tincx, tincy, incx=incX, incy=incY;
-   double *x=(double *)X, *xx=(double *)X, *y=(double *)Y,
-         *yy=(double *)Y, *tx, *ty, *stx, *sty;
+   CBLAS_INT n, i, j, tincx, tincy;
+   double *x, *xx, *y,
+         *yy, *tx, *ty, *stx, *sty;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&xx,&X,sizeof(double*));
+   memcpy(&y,&Y,sizeof(double*));
+   memcpy(&yy,&Y,sizeof(double*));
+
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -129,8 +138,9 @@ void API_SUFFIX(cblas_zher2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          #endif
       }  else
       {
-         x = (double *) X;
-         y = (double *) Y;
+
+        memcpy(&x,&X,sizeof(double*));
+        memcpy(&y,&Y,sizeof(double*));
       }
       F77_zher2(F77_UL, &F77_N, alpha, y, &F77_incY, x,
                                       &F77_incX, A, &F77_lda);

--- a/CBLAS/src/cblas_zher2k.c
+++ b/CBLAS/src/cblas_zher2k.c
@@ -37,7 +37,7 @@ void API_SUFFIX(cblas_zher2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    double ALPHA[2];
-   const double *alp=(double *)alpha;
+   const double *alp=(const double *)alpha;
 
    CBLAS_CallFromC = 1;
    RowMajorStrg = 0;

--- a/CBLAS/src/cblas_zhpmv.c
+++ b/CBLAS/src/cblas_zhpmv.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zhpmv)(const CBLAS_LAYOUT layout,
@@ -24,18 +26,22 @@ void API_SUFFIX(cblas_zhpmv)(const CBLAS_LAYOUT layout,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_incX incx
    #define F77_incY incY
 #endif
-   CBLAS_INT n, i=0, incx=incX;
-   const double *xx= (double *)X, *alp= (double *)alpha, *bet = (double *)beta;
+   CBLAS_INT n, i=0;
+   const double *xx= (const double *)X, *alp= (const double *)alpha, *bet = (const double *)beta;
    double ALPHA[2],BETA[2];
    CBLAS_INT tincY, tincx;
-   double *x=(double *)X, *y=(double *)Y, *st=0, *tx;
+   double *x, *y, *st=0, *tx;
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&y,&Y,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -112,8 +118,7 @@ void API_SUFFIX(cblas_zhpmv)(const CBLAS_LAYOUT layout,
          } while(y != st);
          y -= n;
       }  else
-         x = (double *) X;
-
+        memcpy(&x,&X,sizeof(double*));
 
       if (Uplo == CblasUpper) UL = 'L';
       else if (Uplo == CblasLower) UL = 'U';

--- a/CBLAS/src/cblas_zhpr.c
+++ b/CBLAS/src/cblas_zhpr.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zhpr)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -23,15 +24,19 @@ void API_SUFFIX(cblas_zhpr)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N, F77_incX=incX;
 #else
+   CBLAS_INT incx = incX;
    #define F77_N N
    #define F77_incX incx
 #endif
-   CBLAS_INT n, i, tincx, incx=incX;
-   double *x=(double *)X, *xx=(double *)X, *tx, *st;
+   CBLAS_INT n, i, tincx;
+   double *x, *xx, *tx, *st;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&xx,&X,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -96,7 +101,8 @@ void API_SUFFIX(cblas_zhpr)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
             incx = 1;
          #endif
       }
-      else x = (double *) X;
+      else
+          memcpy(&x,&X,sizeof(double*));
 
       F77_zhpr(F77_UL, &F77_N, &alpha, x, &F77_incX, A);
 

--- a/CBLAS/src/cblas_zhpr2.c
+++ b/CBLAS/src/cblas_zhpr2.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cblas.h"
 #include "cblas_f77.h"
 void API_SUFFIX(cblas_zhpr2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
@@ -24,17 +25,23 @@ void API_SUFFIX(cblas_zhpr2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 #ifdef F77_INT
    F77_INT F77_N=N,  F77_incX=incX, F77_incY=incY;
 #else
+   CBLAS_INT incx = incX, incy = incY;
    #define F77_N N
    #define F77_incX incx
    #define F77_incY incy
 #endif
-   CBLAS_INT n, i, j, incx=incX, incy=incY;
-   double *x=(double *)X, *xx=(double *)X, *y=(double *)Y,
-         *yy=(double *)Y, *stx, *sty;
+   CBLAS_INT n, i, j;
+   double *x, *xx, *y,
+         *yy, *stx, *sty;
 
    extern int CBLAS_CallFromC;
    extern int RowMajorStrg;
    RowMajorStrg = 0;
+
+   memcpy(&x,&X,sizeof(double*));
+   memcpy(&xx,&X,sizeof(double*));
+   memcpy(&y,&Y,sizeof(double*));
+   memcpy(&yy,&Y,sizeof(double*));
 
    CBLAS_CallFromC = 1;
    if (layout == CblasColMajor)
@@ -128,8 +135,9 @@ void API_SUFFIX(cblas_zhpr2)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
 
       }  else
       {
-         x = (double *) X;
-         y = (void  *) Y;
+
+        memcpy(&x,&X,sizeof(double*));
+        memcpy(&y,&Y,sizeof(double*));
       }
       F77_zhpr2(F77_UL, &F77_N, alpha, y, &F77_incY, x, &F77_incX, Ap);
    }

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -26,6 +26,7 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
 }
 
 void F77_c2chke(char *rout

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -26,6 +26,7 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
 }
 
 void  F77_c3chke(char *  rout

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -26,6 +26,7 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
 }
 
 void F77_d2chke(char *rout

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -26,6 +26,7 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
 }
 
 void F77_d3chke(char *rout

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -26,6 +26,7 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
 }
 
 void F77_s2chke(char *rout

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -26,6 +26,8 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
+
 }
 
 void F77_s3chke(char *rout

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -83,7 +83,7 @@ void cblas_xerbla(CBLAS_INT info, const char *rout, const char *form, ...)
    }
 
    if (info != cblas_info){
-      printf("***** XERBLA WAS CALLED WITH INFO = %" CBLAS_IFMT " INSTEAD OF %d in %s *******\n",info, cblas_info, rout);
+      printf("***** XERBLA WAS CALLED WITH INFO = %" CBLAS_IFMT " INSTEAD OF %d in %s *******\n",info, (int) cblas_info, rout);
       cblas_lerr = PASSED;
       cblas_ok = FALSE;
    } else cblas_lerr = FAILED;

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -26,6 +26,7 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
 }
 
 void F77_z2chke(char *rout

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -26,6 +26,7 @@ void chkxer(void) {
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
+   link_xerbla = TRUE;
 }
 
 void F77_z3chke(char *rout

--- a/LAPACKE/example/example_DGELS_rowmajor.c
+++ b/LAPACKE/example/example_DGELS_rowmajor.c
@@ -86,6 +86,9 @@ int main (int argc, const char * argv[])
    /* Solve least squares problem*/
    info = LAPACKE_dgels(LAPACK_ROW_MAJOR,'N',m,n,nrhs,*A,lda,*b,ldb);
 
+   if ( info != 0) {
+        printf("DGELS failed with %d\n", (int) info);
+   }
    /* Print Solution */
    print_matrix_rowmajor( "Solution", n, nrhs, *b, ldb );
    printf( "\n" );

--- a/LAPACKE/example/example_DGELS_rowmajor_64.c
+++ b/LAPACKE/example/example_DGELS_rowmajor_64.c
@@ -86,6 +86,9 @@ int main (int argc, const char * argv[])
    /* Solve least squares problem*/
    info = LAPACKE_dgels_64(LAPACK_ROW_MAJOR,'N',m,n,nrhs,*A,lda,*b,ldb);
 
+   if ( info != 0 ) {
+      printf("DGELS failed with info = %d\n", (int) info);
+   }
    /* Print Solution */
    print_matrix_rowmajor_64( "Solution", n, nrhs, *b, ldb );
    printf( "\n" );

--- a/LAPACKE/example/example_DGESV_colmajor_64.c
+++ b/LAPACKE/example/example_DGESV_colmajor_64.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         /* Check for the exact singularity */
         if( info > 0 ) {
             printf( "The diagonal element of the triangular factor of A,\n" );
-            printf( "U(%" LAPACK_IFMT ",%" LAPACK_IFMT ") is zero, so that A is singular;\n", info, info );
+            printf( "U(%d,%d) is zero, so that A is singular;\n", (int) info, (int) info );
             printf( "the solution could not be computed.\n" );
             free(A);
             free(b);

--- a/LAPACKE/example/example_DGESV_rowmajor_64.c
+++ b/LAPACKE/example/example_DGESV_rowmajor_64.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
         /* Check for the exact singularity */
         if( info > 0 ) {
             printf( "The diagonal element of the triangular factor of A,\n" );
-            printf( "U(%" LAPACK_IFMT ",%" LAPACK_IFMT ") is zero, so that A is singular;\n", info, info );
+            printf( "U(%d,%d) is zero, so that A is singular;\n", (int) info, (int) info );
             printf( "the solution could not be computed.\n" );
             free(A);
             free(b);

--- a/LAPACKE/example/lapacke_example_aux.c
+++ b/LAPACKE/example/lapacke_example_aux.c
@@ -60,6 +60,6 @@ void print_matrix_colmajor_64( char* desc, int64_t m, int64_t n, double* mat, in
 void print_vector_64( char* desc, int64_t n, int64_t* vec ) {
         int64_t j;
         printf( "\n %s\n", desc );
-        for( j = 0; j < n; j++ ) printf( " %6" LAPACK_IFMT, vec[j] );
+        for( j = 0; j < n; j++ ) printf( " %6d", (int) vec[j] );
         printf( "\n" );
 }

--- a/LAPACKE/include/lapacke_utils.h
+++ b/LAPACKE/include/lapacke_utils.h
@@ -5,30 +5,30 @@
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
+ * Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * Neither the name of Intel Corporation nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
 
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-  THE POSSIBILITY OF SUCH DAMAGE.
-******************************************************************************
-* Contents: Native C interface to LAPACK utility functions
-* Author: Intel Corporation
-*****************************************************************************/
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************
+ * Contents: Native C interface to LAPACK utility functions
+ * Author: Intel Corporation
+ *****************************************************************************/
 
 #ifndef _LAPACKE_UTILS_H_
 #define _LAPACKE_UTILS_H_
@@ -58,552 +58,552 @@ extern "C" {
 #define IS_S_NONZERO(x) ( (x) < 0 || (x) > 0 )
 #define IS_D_NONZERO(x) ( (x) < 0 || (x) > 0 )
 #define IS_C_NONZERO(x) ( IS_S_NONZERO(*((float*)&x)) ||  \
-                          IS_S_NONZERO(*(((float*)&x)+1)) )
+        IS_S_NONZERO(*(((float*)&x)+1)) )
 #define IS_Z_NONZERO(x) ( IS_D_NONZERO(*((double*)&x)) || \
-                          IS_D_NONZERO(*(((double*)&x)+1)) )
+        IS_D_NONZERO(*(((double*)&x)+1)) )
 
-/* Error handler */
-void API_SUFFIX(LAPACKE_xerbla)( const char *name, lapack_int info );
+    /* Error handler */
+    void API_SUFFIX(LAPACKE_xerbla)( const char *name, lapack_int info );
 
-/* Compare two chars (case-insensitive) */
-lapack_logical API_SUFFIX(LAPACKE_lsame)( char ca,  char cb )
+    /* Compare two chars (case-insensitive) */
+    lapack_logical API_SUFFIX(LAPACKE_lsame)( char ca,  char cb )
 #if defined __GNUC__
-  __attribute__((const))
+        __attribute__((const))
 #endif
-	;
+        ;
 
-/* Functions to convert column-major to row-major 2d arrays and vice versa. */
-void API_SUFFIX(LAPACKE_cgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        lapack_int kl, lapack_int ku,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_cge_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const lapack_complex_float* in, lapack_int ldin,
-                        lapack_complex_float* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_cgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const lapack_complex_float* in, lapack_int ldin,
-                        lapack_complex_float* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_chb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_che_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_chp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_float *in,
-                        lapack_complex_float *out );
-void API_SUFFIX(LAPACKE_chs_trans)( int matrix_layout, lapack_int n,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_cpb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_cpf_trans)( int matrix_layout, char transr, char uplo,
-                        lapack_int n, const lapack_complex_float *in,
-                        lapack_complex_float *out );
-void API_SUFFIX(LAPACKE_cpo_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_cpp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_float *in,
-                        lapack_complex_float *out );
-void API_SUFFIX(LAPACKE_csp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_float *in,
-                        lapack_complex_float *out );
-void API_SUFFIX(LAPACKE_csy_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_ctb_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, lapack_int kd,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_ctf_trans)( int matrix_layout, char transr, char uplo, char diag,
-                        lapack_int n, const lapack_complex_float *in,
-                        lapack_complex_float *out );
-void API_SUFFIX(LAPACKE_ctp_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, const lapack_complex_float *in,
-                        lapack_complex_float *out );
-void API_SUFFIX(LAPACKE_ctr_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_ctz_trans)( int matrix_layout, char direct, char uplo,
-                        char diag, lapack_int m, lapack_int n,
-                        const lapack_complex_float *in, lapack_int ldin,
-                        lapack_complex_float *out, lapack_int ldout );
+    /* Functions to convert column-major to row-major 2d arrays and vice versa. */
+    void API_SUFFIX(LAPACKE_cgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            lapack_int kl, lapack_int ku,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_cge_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const lapack_complex_float* in, lapack_int ldin,
+            lapack_complex_float* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_cgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const lapack_complex_float* in, lapack_int ldin,
+            lapack_complex_float* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_chb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_che_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_chp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_float *in,
+            lapack_complex_float *out );
+    void API_SUFFIX(LAPACKE_chs_trans)( int matrix_layout, lapack_int n,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_cpb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_cpf_trans)( int matrix_layout, char transr, char uplo,
+            lapack_int n, const lapack_complex_float *in,
+            lapack_complex_float *out );
+    void API_SUFFIX(LAPACKE_cpo_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_cpp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_float *in,
+            lapack_complex_float *out );
+    void API_SUFFIX(LAPACKE_csp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_float *in,
+            lapack_complex_float *out );
+    void API_SUFFIX(LAPACKE_csy_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_ctb_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_ctf_trans)( int matrix_layout, char transr, char uplo, char diag,
+            lapack_int n, const lapack_complex_float *in,
+            lapack_complex_float *out );
+    void API_SUFFIX(LAPACKE_ctp_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, const lapack_complex_float *in,
+            lapack_complex_float *out );
+    void API_SUFFIX(LAPACKE_ctr_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_ctz_trans)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const lapack_complex_float *in, lapack_int ldin,
+            lapack_complex_float *out, lapack_int ldout );
 
-void API_SUFFIX(LAPACKE_dgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        lapack_int kl, lapack_int ku,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dge_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const double* in, lapack_int ldin,
-                        double* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const double* in, lapack_int ldin,
-                        double* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dhs_trans)( int matrix_layout, lapack_int n,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dpb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dpf_trans)( int matrix_layout, char transr, char uplo,
-                        lapack_int n, const double *in,
-                        double *out );
-void API_SUFFIX(LAPACKE_dpo_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dpp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const double *in,
-                        double *out );
-void API_SUFFIX(LAPACKE_dsb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dsp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const double *in,
-                        double *out );
-void API_SUFFIX(LAPACKE_dsy_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dtb_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, lapack_int kd,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dtf_trans)( int matrix_layout, char transr, char uplo, char diag,
-                        lapack_int n, const double *in,
-                        double *out );
-void API_SUFFIX(LAPACKE_dtp_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, const double *in,
-                        double *out );
-void API_SUFFIX(LAPACKE_dtr_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_dtz_trans)( int matrix_layout, char direct, char uplo,
-                        char diag, lapack_int m, lapack_int n,
-                        const double *in, lapack_int ldin,
-                        double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            lapack_int kl, lapack_int ku,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dge_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const double* in, lapack_int ldin,
+            double* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const double* in, lapack_int ldin,
+            double* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dhs_trans)( int matrix_layout, lapack_int n,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dpb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dpf_trans)( int matrix_layout, char transr, char uplo,
+            lapack_int n, const double *in,
+            double *out );
+    void API_SUFFIX(LAPACKE_dpo_trans)( int matrix_layout, char uplo, lapack_int n,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dpp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const double *in,
+            double *out );
+    void API_SUFFIX(LAPACKE_dsb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dsp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const double *in,
+            double *out );
+    void API_SUFFIX(LAPACKE_dsy_trans)( int matrix_layout, char uplo, lapack_int n,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dtb_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dtf_trans)( int matrix_layout, char transr, char uplo, char diag,
+            lapack_int n, const double *in,
+            double *out );
+    void API_SUFFIX(LAPACKE_dtp_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, const double *in,
+            double *out );
+    void API_SUFFIX(LAPACKE_dtr_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_dtz_trans)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const double *in, lapack_int ldin,
+            double *out, lapack_int ldout );
 
-void API_SUFFIX(LAPACKE_sgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        lapack_int kl, lapack_int ku,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_sge_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const float* in, lapack_int ldin,
-                        float* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_sgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const float* in, lapack_int ldin,
-                        float* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_shs_trans)( int matrix_layout, lapack_int n,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_spb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_spf_trans)( int matrix_layout, char transr, char uplo,
-                        lapack_int n, const float *in,
-                        float *out );
-void API_SUFFIX(LAPACKE_spo_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_spp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const float *in,
-                        float *out );
-void API_SUFFIX(LAPACKE_ssb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_ssp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const float *in,
-                        float *out );
-void API_SUFFIX(LAPACKE_ssy_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_stb_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, lapack_int kd,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_stf_trans)( int matrix_layout, char transr, char uplo, char diag,
-                        lapack_int n, const float *in,
-                        float *out );
-void API_SUFFIX(LAPACKE_stp_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, const float *in,
-                        float *out );
-void API_SUFFIX(LAPACKE_str_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_stz_trans)( int matrix_layout, char direct, char uplo,
-                        char diag, lapack_int m, lapack_int n,
-                        const float *in, lapack_int ldin,
-                        float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_sgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            lapack_int kl, lapack_int ku,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_sge_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const float* in, lapack_int ldin,
+            float* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_sgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const float* in, lapack_int ldin,
+            float* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_shs_trans)( int matrix_layout, lapack_int n,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_spb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_spf_trans)( int matrix_layout, char transr, char uplo,
+            lapack_int n, const float *in,
+            float *out );
+    void API_SUFFIX(LAPACKE_spo_trans)( int matrix_layout, char uplo, lapack_int n,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_spp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const float *in,
+            float *out );
+    void API_SUFFIX(LAPACKE_ssb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_ssp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const float *in,
+            float *out );
+    void API_SUFFIX(LAPACKE_ssy_trans)( int matrix_layout, char uplo, lapack_int n,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_stb_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_stf_trans)( int matrix_layout, char transr, char uplo, char diag,
+            lapack_int n, const float *in,
+            float *out );
+    void API_SUFFIX(LAPACKE_stp_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, const float *in,
+            float *out );
+    void API_SUFFIX(LAPACKE_str_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_stz_trans)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const float *in, lapack_int ldin,
+            float *out, lapack_int ldout );
 
-void API_SUFFIX(LAPACKE_zgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        lapack_int kl, lapack_int ku,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zge_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const lapack_complex_double* in, lapack_int ldin,
-                        lapack_complex_double* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
-                        const lapack_complex_double* in, lapack_int ldin,
-                        lapack_complex_double* out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zhb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zhe_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zhp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_double *in,
-                        lapack_complex_double *out );
-void API_SUFFIX(LAPACKE_zhs_trans)( int matrix_layout, lapack_int n,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zpb_trans)( int matrix_layout, char uplo, lapack_int n,
-                        lapack_int kd,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zpf_trans)( int matrix_layout, char transr, char uplo,
-                        lapack_int n, const lapack_complex_double *in,
-                        lapack_complex_double *out );
-void API_SUFFIX(LAPACKE_zpo_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_zpp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_double *in,
-                        lapack_complex_double *out );
-void API_SUFFIX(LAPACKE_zsp_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_double *in,
-                        lapack_complex_double *out );
-void API_SUFFIX(LAPACKE_zsy_trans)( int matrix_layout, char uplo, lapack_int n,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_ztb_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, lapack_int kd,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_ztf_trans)( int matrix_layout, char transr, char uplo, char diag,
-                        lapack_int n, const lapack_complex_double *in,
-                        lapack_complex_double *out );
-void API_SUFFIX(LAPACKE_ztp_trans)( int matrix_layout, char uplo, char diag,
-                        lapack_int n, const lapack_complex_double *in,
-                        lapack_complex_double *out );
-void API_SUFFIX(LAPACKE_ztr_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
-void API_SUFFIX(LAPACKE_ztz_trans)( int matrix_layout, char direct, char uplo,
-                        char diag, lapack_int m, lapack_int n,
-                        const lapack_complex_double *in, lapack_int ldin,
-                        lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zgb_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            lapack_int kl, lapack_int ku,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zge_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const lapack_complex_double* in, lapack_int ldin,
+            lapack_complex_double* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zgg_trans)( int matrix_layout, lapack_int m, lapack_int n,
+            const lapack_complex_double* in, lapack_int ldin,
+            lapack_complex_double* out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zhb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zhe_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zhp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_double *in,
+            lapack_complex_double *out );
+    void API_SUFFIX(LAPACKE_zhs_trans)( int matrix_layout, lapack_int n,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zpb_trans)( int matrix_layout, char uplo, lapack_int n,
+            lapack_int kd,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zpf_trans)( int matrix_layout, char transr, char uplo,
+            lapack_int n, const lapack_complex_double *in,
+            lapack_complex_double *out );
+    void API_SUFFIX(LAPACKE_zpo_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_zpp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_double *in,
+            lapack_complex_double *out );
+    void API_SUFFIX(LAPACKE_zsp_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_double *in,
+            lapack_complex_double *out );
+    void API_SUFFIX(LAPACKE_zsy_trans)( int matrix_layout, char uplo, lapack_int n,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_ztb_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_ztf_trans)( int matrix_layout, char transr, char uplo, char diag,
+            lapack_int n, const lapack_complex_double *in,
+            lapack_complex_double *out );
+    void API_SUFFIX(LAPACKE_ztp_trans)( int matrix_layout, char uplo, char diag,
+            lapack_int n, const lapack_complex_double *in,
+            lapack_complex_double *out );
+    void API_SUFFIX(LAPACKE_ztr_trans)( int matrix_layout, char uplo, char diag, lapack_int n,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
+    void API_SUFFIX(LAPACKE_ztz_trans)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const lapack_complex_double *in, lapack_int ldin,
+            lapack_complex_double *out, lapack_int ldout );
 
-/* NaN checkers */
+    /* NaN checkers */
 #define LAPACK_SISNAN( x ) ( x != x )
 #define LAPACK_DISNAN( x ) ( x != x )
-#define LAPACK_CISNAN( x ) ( LAPACK_SISNAN(*((float*) &x)) || \
-                              LAPACK_SISNAN(*(((float*) &x)+1)) )
-#define LAPACK_ZISNAN( x ) ( LAPACK_DISNAN(*((double*)&x)) || \
-                              LAPACK_DISNAN(*(((double*)&x)+1)) )
+#define LAPACK_CISNAN( x ) ( LAPACK_SISNAN(*((const float*) &x)) || \
+        LAPACK_SISNAN(*(((const float*) &x)+1)) )
+#define LAPACK_ZISNAN( x ) ( LAPACK_DISNAN(*((const double*)&x)) || \
+        LAPACK_DISNAN(*(((const double*)&x)+1)) )
 
-/* NaN checkers for vectors */
-lapack_logical API_SUFFIX(LAPACKE_c_nancheck)( lapack_int n,
-                                    const lapack_complex_float *x,
-                                    lapack_int incx );
-lapack_logical API_SUFFIX(LAPACKE_d_nancheck)( lapack_int n,
-                                    const double *x,
-                                    lapack_int incx );
-lapack_logical API_SUFFIX(LAPACKE_s_nancheck)( lapack_int n,
-                                    const float *x,
-                                    lapack_int incx );
-lapack_logical API_SUFFIX(LAPACKE_z_nancheck)( lapack_int n,
-                                    const lapack_complex_double *x,
-                                    lapack_int incx );
-/* NaN checkers for matrices */
-lapack_logical API_SUFFIX(LAPACKE_cgb_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n, lapack_int kl,
-                                      lapack_int ku,
-                                      const lapack_complex_float *ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_cge_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const lapack_complex_float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_cgg_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const lapack_complex_float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_cgt_nancheck)( lapack_int n,
-                                      const lapack_complex_float *dl,
-                                      const lapack_complex_float *d,
-                                      const lapack_complex_float *du );
-lapack_logical API_SUFFIX(LAPACKE_chb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const lapack_complex_float* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_che_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const lapack_complex_float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_chp_nancheck)( lapack_int n,
-                                      const lapack_complex_float *ap );
-lapack_logical API_SUFFIX(LAPACKE_chs_nancheck)( int matrix_layout, lapack_int n,
-                                      const lapack_complex_float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_cpb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const lapack_complex_float* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_cpf_nancheck)( lapack_int n,
-                                      const lapack_complex_float *a );
-lapack_logical API_SUFFIX(LAPACKE_cpo_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const lapack_complex_float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_cpp_nancheck)( lapack_int n,
-                                      const lapack_complex_float *ap );
-lapack_logical API_SUFFIX(LAPACKE_cpt_nancheck)( lapack_int n,
-                                      const float *d,
-                                      const lapack_complex_float *e );
-lapack_logical API_SUFFIX(LAPACKE_csp_nancheck)( lapack_int n,
-                                      const lapack_complex_float *ap );
-lapack_logical API_SUFFIX(LAPACKE_cst_nancheck)( lapack_int n,
-                                      const lapack_complex_float *d,
-                                      const lapack_complex_float *e );
-lapack_logical API_SUFFIX(LAPACKE_csy_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const lapack_complex_float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_ctb_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n, lapack_int kd,
-                                      const lapack_complex_float* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_ctf_nancheck)( int matrix_layout, char transr,
-                                      char uplo, char diag,
-                                      lapack_int n,
-                                      const lapack_complex_float *a );
-lapack_logical API_SUFFIX(LAPACKE_ctp_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const lapack_complex_float *ap );
-lapack_logical API_SUFFIX(LAPACKE_ctr_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const lapack_complex_float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_ctz_nancheck)( int matrix_layout, char direct, char uplo,
-                                     char diag, lapack_int m, lapack_int n,
-                                     const lapack_complex_float *a,
-                                     lapack_int lda );
+    /* NaN checkers for vectors */
+    lapack_logical API_SUFFIX(LAPACKE_c_nancheck)( lapack_int n,
+            const lapack_complex_float *x,
+            lapack_int incx );
+    lapack_logical API_SUFFIX(LAPACKE_d_nancheck)( lapack_int n,
+            const double *x,
+            lapack_int incx );
+    lapack_logical API_SUFFIX(LAPACKE_s_nancheck)( lapack_int n,
+            const float *x,
+            lapack_int incx );
+    lapack_logical API_SUFFIX(LAPACKE_z_nancheck)( lapack_int n,
+            const lapack_complex_double *x,
+            lapack_int incx );
+    /* NaN checkers for matrices */
+    lapack_logical API_SUFFIX(LAPACKE_cgb_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n, lapack_int kl,
+            lapack_int ku,
+            const lapack_complex_float *ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_cge_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_cgg_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_cgt_nancheck)( lapack_int n,
+            const lapack_complex_float *dl,
+            const lapack_complex_float *d,
+            const lapack_complex_float *du );
+    lapack_logical API_SUFFIX(LAPACKE_chb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_float* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_che_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_chp_nancheck)( lapack_int n,
+            const lapack_complex_float *ap );
+    lapack_logical API_SUFFIX(LAPACKE_chs_nancheck)( int matrix_layout, lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_cpb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_float* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_cpf_nancheck)( lapack_int n,
+            const lapack_complex_float *a );
+    lapack_logical API_SUFFIX(LAPACKE_cpo_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_cpp_nancheck)( lapack_int n,
+            const lapack_complex_float *ap );
+    lapack_logical API_SUFFIX(LAPACKE_cpt_nancheck)( lapack_int n,
+            const float *d,
+            const lapack_complex_float *e );
+    lapack_logical API_SUFFIX(LAPACKE_csp_nancheck)( lapack_int n,
+            const lapack_complex_float *ap );
+    lapack_logical API_SUFFIX(LAPACKE_cst_nancheck)( lapack_int n,
+            const lapack_complex_float *d,
+            const lapack_complex_float *e );
+    lapack_logical API_SUFFIX(LAPACKE_csy_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_ctb_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_float* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_ctf_nancheck)( int matrix_layout, char transr,
+            char uplo, char diag,
+            lapack_int n,
+            const lapack_complex_float *a );
+    lapack_logical API_SUFFIX(LAPACKE_ctp_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const lapack_complex_float *ap );
+    lapack_logical API_SUFFIX(LAPACKE_ctr_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_ctz_nancheck)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const lapack_complex_float *a,
+            lapack_int lda );
 
-lapack_logical API_SUFFIX(LAPACKE_dgb_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n, lapack_int kl,
-                                      lapack_int ku,
-                                      const double *ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_dge_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_dgg_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_dgt_nancheck)( lapack_int n,
-                                      const double *dl,
-                                      const double *d,
-                                      const double *du );
-lapack_logical API_SUFFIX(LAPACKE_dhs_nancheck)( int matrix_layout, lapack_int n,
-                                      const double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_dpb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const double* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_dpf_nancheck)( lapack_int n,
-                                      const double *a );
-lapack_logical API_SUFFIX(LAPACKE_dpo_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_dpp_nancheck)( lapack_int n,
-                                      const double *ap );
-lapack_logical API_SUFFIX(LAPACKE_dpt_nancheck)( lapack_int n,
-                                      const double *d,
-                                      const double *e );
-lapack_logical API_SUFFIX(LAPACKE_dsb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const double* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_dsp_nancheck)( lapack_int n,
-                                      const double *ap );
-lapack_logical API_SUFFIX(LAPACKE_dst_nancheck)( lapack_int n,
-                                      const double *d,
-                                      const double *e );
-lapack_logical API_SUFFIX(LAPACKE_dsy_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_dtb_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n, lapack_int kd,
-                                      const double* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_dtf_nancheck)( int matrix_layout, char transr,
-                                      char uplo, char diag,
-                                      lapack_int n,
-                                      const double *a );
-lapack_logical API_SUFFIX(LAPACKE_dtp_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const double *ap );
-lapack_logical API_SUFFIX(LAPACKE_dtr_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_dtz_nancheck)( int matrix_layout, char direct, char uplo,
-                                     char diag, lapack_int m, lapack_int n,
-                                     const double *a, lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_dgb_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n, lapack_int kl,
+            lapack_int ku,
+            const double *ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_dge_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_dgg_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_dgt_nancheck)( lapack_int n,
+            const double *dl,
+            const double *d,
+            const double *du );
+    lapack_logical API_SUFFIX(LAPACKE_dhs_nancheck)( int matrix_layout, lapack_int n,
+            const double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_dpb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const double* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_dpf_nancheck)( lapack_int n,
+            const double *a );
+    lapack_logical API_SUFFIX(LAPACKE_dpo_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_dpp_nancheck)( lapack_int n,
+            const double *ap );
+    lapack_logical API_SUFFIX(LAPACKE_dpt_nancheck)( lapack_int n,
+            const double *d,
+            const double *e );
+    lapack_logical API_SUFFIX(LAPACKE_dsb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const double* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_dsp_nancheck)( lapack_int n,
+            const double *ap );
+    lapack_logical API_SUFFIX(LAPACKE_dst_nancheck)( lapack_int n,
+            const double *d,
+            const double *e );
+    lapack_logical API_SUFFIX(LAPACKE_dsy_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_dtb_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const double* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_dtf_nancheck)( int matrix_layout, char transr,
+            char uplo, char diag,
+            lapack_int n,
+            const double *a );
+    lapack_logical API_SUFFIX(LAPACKE_dtp_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const double *ap );
+    lapack_logical API_SUFFIX(LAPACKE_dtr_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_dtz_nancheck)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const double *a, lapack_int lda );
 
-lapack_logical API_SUFFIX(LAPACKE_sgb_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n, lapack_int kl,
-                                      lapack_int ku,
-                                      const float *ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_sge_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_sgg_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_sgt_nancheck)( lapack_int n,
-                                      const float *dl,
-                                      const float *d,
-                                      const float *du );
-lapack_logical API_SUFFIX(LAPACKE_shs_nancheck)( int matrix_layout, lapack_int n,
-                                      const float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_spb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const float* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_spf_nancheck)( lapack_int n,
-                                      const float *a );
-lapack_logical API_SUFFIX(LAPACKE_spo_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_spp_nancheck)( lapack_int n,
-                                      const float *ap );
-lapack_logical API_SUFFIX(LAPACKE_spt_nancheck)( lapack_int n,
-                                      const float *d,
-                                      const float *e );
-lapack_logical API_SUFFIX(LAPACKE_ssb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const float* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_ssp_nancheck)( lapack_int n,
-                                      const float *ap );
-lapack_logical API_SUFFIX(LAPACKE_sst_nancheck)( lapack_int n,
-                                      const float *d,
-                                      const float *e );
-lapack_logical API_SUFFIX(LAPACKE_ssy_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_stb_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n, lapack_int kd,
-                                      const float* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_stf_nancheck)( int matrix_layout, char transr,
-                                      char uplo, char diag,
-                                      lapack_int n,
-                                      const float *a );
-lapack_logical API_SUFFIX(LAPACKE_stp_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const float *ap );
-lapack_logical API_SUFFIX(LAPACKE_str_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const float *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_stz_nancheck)( int matrix_layout, char direct, char uplo,
-                                     char diag, lapack_int m, lapack_int n,
-                                     const float *a, lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_sgb_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n, lapack_int kl,
+            lapack_int ku,
+            const float *ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_sge_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_sgg_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_sgt_nancheck)( lapack_int n,
+            const float *dl,
+            const float *d,
+            const float *du );
+    lapack_logical API_SUFFIX(LAPACKE_shs_nancheck)( int matrix_layout, lapack_int n,
+            const float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_spb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const float* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_spf_nancheck)( lapack_int n,
+            const float *a );
+    lapack_logical API_SUFFIX(LAPACKE_spo_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_spp_nancheck)( lapack_int n,
+            const float *ap );
+    lapack_logical API_SUFFIX(LAPACKE_spt_nancheck)( lapack_int n,
+            const float *d,
+            const float *e );
+    lapack_logical API_SUFFIX(LAPACKE_ssb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const float* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_ssp_nancheck)( lapack_int n,
+            const float *ap );
+    lapack_logical API_SUFFIX(LAPACKE_sst_nancheck)( lapack_int n,
+            const float *d,
+            const float *e );
+    lapack_logical API_SUFFIX(LAPACKE_ssy_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_stb_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const float* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_stf_nancheck)( int matrix_layout, char transr,
+            char uplo, char diag,
+            lapack_int n,
+            const float *a );
+    lapack_logical API_SUFFIX(LAPACKE_stp_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const float *ap );
+    lapack_logical API_SUFFIX(LAPACKE_str_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const float *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_stz_nancheck)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const float *a, lapack_int lda );
 
-lapack_logical API_SUFFIX(LAPACKE_zgb_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n, lapack_int kl,
-                                      lapack_int ku,
-                                      const lapack_complex_double *ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_zge_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const lapack_complex_double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_zgg_nancheck)( int matrix_layout, lapack_int m,
-                                      lapack_int n,
-                                      const lapack_complex_double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_zgt_nancheck)( lapack_int n,
-                                      const lapack_complex_double *dl,
-                                      const lapack_complex_double *d,
-                                      const lapack_complex_double *du );
-lapack_logical API_SUFFIX(LAPACKE_zhb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const lapack_complex_double* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_zhe_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const lapack_complex_double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_zhp_nancheck)( lapack_int n,
-                                      const lapack_complex_double *ap );
-lapack_logical API_SUFFIX(LAPACKE_zhs_nancheck)( int matrix_layout, lapack_int n,
-                                      const lapack_complex_double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_zpb_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n, lapack_int kd,
-                                      const lapack_complex_double* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_zpf_nancheck)( lapack_int n,
-                                      const lapack_complex_double *a );
-lapack_logical API_SUFFIX(LAPACKE_zpo_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const lapack_complex_double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_zpp_nancheck)( lapack_int n,
-                                      const lapack_complex_double *ap );
-lapack_logical API_SUFFIX(LAPACKE_zpt_nancheck)( lapack_int n,
-                                      const double *d,
-                                      const lapack_complex_double *e );
-lapack_logical API_SUFFIX(LAPACKE_zsp_nancheck)( lapack_int n,
-                                      const lapack_complex_double *ap );
-lapack_logical API_SUFFIX(LAPACKE_zst_nancheck)( lapack_int n,
-                                      const lapack_complex_double *d,
-                                      const lapack_complex_double *e );
-lapack_logical API_SUFFIX(LAPACKE_zsy_nancheck)( int matrix_layout, char uplo,
-                                      lapack_int n,
-                                      const lapack_complex_double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_ztb_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n, lapack_int kd,
-                                      const lapack_complex_double* ab,
-                                      lapack_int ldab );
-lapack_logical API_SUFFIX(LAPACKE_ztf_nancheck)( int matrix_layout, char transr,
-                                      char uplo, char diag,
-                                      lapack_int n,
-                                      const lapack_complex_double *a );
-lapack_logical API_SUFFIX(LAPACKE_ztp_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const lapack_complex_double *ap );
-lapack_logical API_SUFFIX(LAPACKE_ztr_nancheck)( int matrix_layout, char uplo, char diag,
-                                      lapack_int n,
-                                      const lapack_complex_double *a,
-                                      lapack_int lda );
-lapack_logical API_SUFFIX(LAPACKE_ztz_nancheck)( int matrix_layout, char direct, char uplo,
-                                     char diag, lapack_int m, lapack_int n,
-                                     const lapack_complex_double *a,
-                                     lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_zgb_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n, lapack_int kl,
+            lapack_int ku,
+            const lapack_complex_double *ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_zge_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_zgg_nancheck)( int matrix_layout, lapack_int m,
+            lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_zgt_nancheck)( lapack_int n,
+            const lapack_complex_double *dl,
+            const lapack_complex_double *d,
+            const lapack_complex_double *du );
+    lapack_logical API_SUFFIX(LAPACKE_zhb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_double* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_zhe_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_zhp_nancheck)( lapack_int n,
+            const lapack_complex_double *ap );
+    lapack_logical API_SUFFIX(LAPACKE_zhs_nancheck)( int matrix_layout, lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_zpb_nancheck)( int matrix_layout, char uplo,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_double* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_zpf_nancheck)( lapack_int n,
+            const lapack_complex_double *a );
+    lapack_logical API_SUFFIX(LAPACKE_zpo_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_zpp_nancheck)( lapack_int n,
+            const lapack_complex_double *ap );
+    lapack_logical API_SUFFIX(LAPACKE_zpt_nancheck)( lapack_int n,
+            const double *d,
+            const lapack_complex_double *e );
+    lapack_logical API_SUFFIX(LAPACKE_zsp_nancheck)( lapack_int n,
+            const lapack_complex_double *ap );
+    lapack_logical API_SUFFIX(LAPACKE_zst_nancheck)( lapack_int n,
+            const lapack_complex_double *d,
+            const lapack_complex_double *e );
+    lapack_logical API_SUFFIX(LAPACKE_zsy_nancheck)( int matrix_layout, char uplo,
+            lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_ztb_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n, lapack_int kd,
+            const lapack_complex_double* ab,
+            lapack_int ldab );
+    lapack_logical API_SUFFIX(LAPACKE_ztf_nancheck)( int matrix_layout, char transr,
+            char uplo, char diag,
+            lapack_int n,
+            const lapack_complex_double *a );
+    lapack_logical API_SUFFIX(LAPACKE_ztp_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const lapack_complex_double *ap );
+    lapack_logical API_SUFFIX(LAPACKE_ztr_nancheck)( int matrix_layout, char uplo, char diag,
+            lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
+    lapack_logical API_SUFFIX(LAPACKE_ztz_nancheck)( int matrix_layout, char direct, char uplo,
+            char diag, lapack_int m, lapack_int n,
+            const lapack_complex_double *a,
+            lapack_int lda );
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Description**
Compiling CBLAS with `-Wall -Wcast-qual` produces a set of warnings, which point to portions of code that discard the `const` qualifier in CBLAS. This avoids using of `-Werror` in an even more hardened build environment. The patch removes these warning for CBLAS. 


**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.