### PR TITLE
Fix too strict leading dimension check on LAPACKE_?gesdd_work

### DIFF
--- a/LAPACKE/src/lapacke_cgesdd_work.c
+++ b/LAPACKE/src/lapacke_cgesdd_work.c
@@ -58,6 +58,9 @@ lapack_int API_SUFFIX(LAPACKE_cgesdd_work)( int matrix_layout, char jobz, lapack
         lapack_int nrows_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n :
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ? MIN(m,n) : 1);
+        lapack_int ncols_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
+                              API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ||
+                              ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n : 1;
         lapack_int lda_t = MAX(1,m);
         lapack_int ldu_t = MAX(1,nrows_u);
         lapack_int ldvt_t = MAX(1,nrows_vt);
@@ -75,7 +78,7 @@ lapack_int API_SUFFIX(LAPACKE_cgesdd_work)( int matrix_layout, char jobz, lapack
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_cgesdd_work", info );
             return info;
         }
-        if( ldvt < n ) {
+        if( ldvt < ncols_vt ) {
             info = -11;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_cgesdd_work", info );
             return info;

--- a/LAPACKE/src/lapacke_dgesdd_work.c
+++ b/LAPACKE/src/lapacke_dgesdd_work.c
@@ -56,6 +56,9 @@ lapack_int API_SUFFIX(LAPACKE_dgesdd_work)( int matrix_layout, char jobz, lapack
         lapack_int nrows_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n :
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ? MIN(m,n) : 1);
+        lapack_int ncols_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
+                              API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ||
+                              ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n : 1;
         lapack_int lda_t = MAX(1,m);
         lapack_int ldu_t = MAX(1,nrows_u);
         lapack_int ldvt_t = MAX(1,nrows_vt);
@@ -73,7 +76,7 @@ lapack_int API_SUFFIX(LAPACKE_dgesdd_work)( int matrix_layout, char jobz, lapack
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_dgesdd_work", info );
             return info;
         }
-        if( ldvt < n ) {
+        if( ldvt < ncols_vt ) {
             info = -11;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_dgesdd_work", info );
             return info;

--- a/LAPACKE/src/lapacke_sgesdd_work.c
+++ b/LAPACKE/src/lapacke_sgesdd_work.c
@@ -56,6 +56,9 @@ lapack_int API_SUFFIX(LAPACKE_sgesdd_work)( int matrix_layout, char jobz, lapack
         lapack_int nrows_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n :
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ? MIN(m,n) : 1);
+        lapack_int ncols_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
+                              API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ||
+                              ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n : 1;
         lapack_int lda_t = MAX(1,m);
         lapack_int ldu_t = MAX(1,nrows_u);
         lapack_int ldvt_t = MAX(1,nrows_vt);
@@ -73,7 +76,7 @@ lapack_int API_SUFFIX(LAPACKE_sgesdd_work)( int matrix_layout, char jobz, lapack
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_sgesdd_work", info );
             return info;
         }
-        if( ldvt < n ) {
+        if( ldvt < ncols_vt ) {
             info = -11;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_sgesdd_work", info );
             return info;

--- a/LAPACKE/src/lapacke_zgesdd_work.c
+++ b/LAPACKE/src/lapacke_zgesdd_work.c
@@ -58,6 +58,9 @@ lapack_int API_SUFFIX(LAPACKE_zgesdd_work)( int matrix_layout, char jobz, lapack
         lapack_int nrows_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n :
                               ( API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ? MIN(m,n) : 1);
+        lapack_int ncols_vt = ( API_SUFFIX(LAPACKE_lsame)( jobz, 'a' ) ||
+                              API_SUFFIX(LAPACKE_lsame)( jobz, 's' ) ||
+                              ( API_SUFFIX(LAPACKE_lsame)( jobz, 'o' ) && m>=n) ) ? n : 1;
         lapack_int lda_t = MAX(1,m);
         lapack_int ldu_t = MAX(1,nrows_u);
         lapack_int ldvt_t = MAX(1,nrows_vt);
@@ -75,7 +78,7 @@ lapack_int API_SUFFIX(LAPACKE_zgesdd_work)( int matrix_layout, char jobz, lapack
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_zgesdd_work", info );
             return info;
         }
-        if( ldvt < n ) {
+        if( ldvt < ncols_vt ) {
             info = -11;
             API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_zgesdd_work", info );
             return info;


### PR DESCRIPTION
**Description**

c.f. https://github.com/Reference-LAPACK/lapack/issues/1125

This PR consults the way to handle similar problem in point 3 of https://github.com/Reference-LAPACK/lapack/pull/534 (files `lapacke_?gesvd_work.c`).

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.