### PR TITLE
Remove hardcoded "version 3.X"

### DIFF
--- a/BLAS/SRC/dnrm2.f90
+++ b/BLAS/SRC/dnrm2.f90
@@ -89,7 +89,7 @@ function DNRM2( n, x, incx )
    integer, parameter :: wp = kind(1.d0)
    real(wp) :: DNRM2
 !
-!  -- Reference BLAS level1 routine (version 3.9.1) --
+!  -- Reference BLAS level1 routine --
 !  -- Reference BLAS is a software package provided by Univ. of Tennessee,    --
 !  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 !     March 2021

--- a/BLAS/SRC/dznrm2.f90
+++ b/BLAS/SRC/dznrm2.f90
@@ -90,7 +90,7 @@ function DZNRM2( n, x, incx )
    integer, parameter :: wp = kind(1.d0)
    real(wp) :: DZNRM2
 !
-!  -- Reference BLAS level1 routine (version 3.9.1) --
+!  -- Reference BLAS level1 routine --
 !  -- Reference BLAS is a software package provided by Univ. of Tennessee,    --
 !  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 !     March 2021

--- a/BLAS/SRC/scnrm2.f90
+++ b/BLAS/SRC/scnrm2.f90
@@ -90,7 +90,7 @@ function SCNRM2( n, x, incx )
    integer, parameter :: wp = kind(1.e0)
    real(wp) :: SCNRM2
 !
-!  -- Reference BLAS level1 routine (version 3.9.1) --
+!  -- Reference BLAS level1 routine --
 !  -- Reference BLAS is a software package provided by Univ. of Tennessee,    --
 !  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 !     March 2021

--- a/BLAS/SRC/snrm2.f90
+++ b/BLAS/SRC/snrm2.f90
@@ -89,7 +89,7 @@ function SNRM2( n, x, incx )
    integer, parameter :: wp = kind(1.e0)
    real(wp) :: SNRM2
 !
-!  -- Reference BLAS level1 routine (version 3.9.1) --
+!  -- Reference BLAS level1 routine --
 !  -- Reference BLAS is a software package provided by Univ. of Tennessee,    --
 !  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 !     March 2021

--- a/SRC/VARIANTS/lu/REC/cgetrf.f
+++ b/SRC/VARIANTS/lu/REC/cgetrf.f
@@ -134,7 +134,7 @@ C> \ingroup variantsGEcomputational
 *  =====================================================================
       SUBROUTINE CGETRF( M, N, A, LDA, IPIV, INFO )
 *
-*  -- LAPACK computational routine (version 3.X) --
+*  -- LAPACK computational routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
 *  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 *

--- a/SRC/VARIANTS/lu/REC/dgetrf.f
+++ b/SRC/VARIANTS/lu/REC/dgetrf.f
@@ -134,7 +134,7 @@ C> \ingroup variantsGEcomputational
 *  =====================================================================
       SUBROUTINE DGETRF( M, N, A, LDA, IPIV, INFO )
 *
-*  -- LAPACK computational routine (version 3.X) --
+*  -- LAPACK computational routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
 *  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 *

--- a/SRC/VARIANTS/lu/REC/sgetrf.f
+++ b/SRC/VARIANTS/lu/REC/sgetrf.f
@@ -134,7 +134,7 @@ C> \ingroup variantsGEcomputational
 *  =====================================================================
       SUBROUTINE SGETRF( M, N, A, LDA, IPIV, INFO )
 *
-*  -- LAPACK computational routine (version 3.X) --
+*  -- LAPACK computational routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
 *  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 *

--- a/SRC/VARIANTS/lu/REC/zgetrf.f
+++ b/SRC/VARIANTS/lu/REC/zgetrf.f
@@ -134,7 +134,7 @@ C> \ingroup variantsGEcomputational
 *  =====================================================================
       SUBROUTINE ZGETRF( M, N, A, LDA, IPIV, INFO )
 *
-*  -- LAPACK computational routine (version 3.X) --
+*  -- LAPACK computational routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
 *  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
 *


### PR DESCRIPTION
**Description**

https://github.com/Reference-LAPACK/lapack/pull/522 replaced the hardcoded version ("LAPACK 3.8") with version handling through git. This PR removes the remaining vestiges of the old versioning. 

