### PR TITLE
Fix bypassing corner cases due to uninitialized variable in [c,z]geqp3rk

### DIFF
--- a/SRC/cgeqp3rk.f
+++ b/SRC/cgeqp3rk.f
@@ -751,6 +751,7 @@
 *     for the whole original matrix stored in A(1:M,1:N).
 *
       KP1 = ISAMAX( N, RWORK( 1 ), 1 )
+      MAXC2NRM = RWORK( KP1 )
 *
 *     ==================================================================.
 *

--- a/SRC/zgeqp3rk.f
+++ b/SRC/zgeqp3rk.f
@@ -750,6 +750,7 @@
 *     for the whole original matrix stored in A(1:M,1:N).
 *
       KP1 = IDAMAX( N, RWORK( 1 ), 1 )
+      MAXC2NRM = RWORK( KP1 )
 *
 *     ==================================================================.
 *


### PR DESCRIPTION
**Description**

```
valgrind --leak-check=full ./LIN/xlintstc < ctest.in

==57234== Conditional jump or move depends on uninitialised value(s)
==57234==    at 0x40D6549: cgeqp3rk_ (cgeqp3rk.f:757)
==57234==    by 0x40320D6: cchkqp3rk_ (cchkqp3rk.f:630)
==57234==    by 0x401A288: MAIN__ (cchkaa.F:1129)
==57234==    by 0x40022BE: main (cchkaa.F:1260)
==57234== 
==57234== Conditional jump or move depends on uninitialised value(s)
==57234==    at 0x40D655F: cgeqp3rk_ (cgeqp3rk.f:779)
==57234==    by 0x40320D6: cchkqp3rk_ (cchkqp3rk.f:630)
==57234==    by 0x401A288: MAIN__ (cchkaa.F:1129)
==57234==    by 0x40022BE: main (cchkaa.F:1260)
```

The initialized variable `MAXC2NRM` is used to handle special cases
https://github.com/Reference-LAPACK/lapack/blob/2475f7b3911ef7874313fc63cefdf3af901d3b7a/SRC/cgeqp3rk.f#L757
and
https://github.com/Reference-LAPACK/lapack/blob/2475f7b3911ef7874313fc63cefdf3af901d3b7a/SRC/cgeqp3rk.f#L779 

The precisions 's' and 'd' are not affected.
