### PR TITLE
add NaN checks for input matrix A in GEEV, return error if NaN are in matrix A, NaNs in input are detected with LANGE (needed for scaling)

### DIFF
--- a/SRC/cgeev.f
+++ b/SRC/cgeev.f
@@ -217,7 +217,7 @@
      $                   CTREVC3, CUNGHR
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       INTEGER            ISAMAX, ILAENV
       REAL               SLAMCH, SCNRM2, CLANGE,
      $                   SROUNDUP_LWORK
@@ -335,6 +335,10 @@
       ELSE IF( ANRM.GT.BIGNUM ) THEN
          SCALEA = .TRUE.
          CSCALE = BIGNUM
+      ELSE IF( SISNAN( ANRM ) ) THEN
+         INFO = -4
+         CALL XERBLA( 'CGEEV ', -INFO )
+         RETURN
       END IF
       IF( SCALEA )
      $   CALL CLASCL( 'G', 0, 0, ANRM, CSCALE, N, N, A, LDA, IERR )

--- a/SRC/dgeev.f
+++ b/SRC/dgeev.f
@@ -227,7 +227,7 @@
      $                   DLASCL, DORGHR, DROT, DSCAL, DTREVC3, XERBLA
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, DISNAN
       INTEGER            IDAMAX, ILAENV
       DOUBLE PRECISION   DLAMCH, DLANGE, DLAPY2, DNRM2
       EXTERNAL           LSAME, IDAMAX, ILAENV, DLAMCH, DLANGE,
@@ -353,6 +353,10 @@
       ELSE IF( ANRM.GT.BIGNUM ) THEN
          SCALEA = .TRUE.
          CSCALE = BIGNUM
+      ELSE IF( DISNAN( ANRM ) ) THEN
+         INFO = -4
+         CALL XERBLA( 'DGEEV ', -INFO )
+         RETURN
       END IF
       IF( SCALEA )
      $   CALL DLASCL( 'G', 0, 0, ANRM, CSCALE, N, N, A, LDA, IERR )

--- a/SRC/sgeev.f
+++ b/SRC/sgeev.f
@@ -228,7 +228,7 @@
      $                   SSCAL, STREVC3, XERBLA
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       INTEGER            ISAMAX, ILAENV
       REAL               SLAMCH, SLANGE, SLAPY2, SNRM2,
      $                   SROUNDUP_LWORK
@@ -355,6 +355,10 @@
       ELSE IF( ANRM.GT.BIGNUM ) THEN
          SCALEA = .TRUE.
          CSCALE = BIGNUM
+      ELSE IF( SISNAN( ANRM ) ) THEN
+         INFO = -4
+         CALL XERBLA( 'SGEEV ', -INFO )
+         RETURN
       END IF
       IF( SCALEA )
      $   CALL SLASCL( 'G', 0, 0, ANRM, CSCALE, N, N, A, LDA, IERR )

--- a/SRC/zgeev.f
+++ b/SRC/zgeev.f
@@ -216,7 +216,7 @@
      $                   ZLACPY, ZLASCL, ZSCAL, ZTREVC3, ZUNGHR
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, DISNAN
       INTEGER            IDAMAX, ILAENV
       DOUBLE PRECISION   DLAMCH, DZNRM2, ZLANGE
       EXTERNAL           LSAME, IDAMAX, ILAENV, DLAMCH, DZNRM2,
@@ -332,6 +332,10 @@
       ELSE IF( ANRM.GT.BIGNUM ) THEN
          SCALEA = .TRUE.
          CSCALE = BIGNUM
+      ELSE IF( DISNAN( ANRM ) ) THEN
+         INFO = -4
+         CALL XERBLA( 'ZGEEV ', -INFO )
+         RETURN
       END IF
       IF( SCALEA )
      $   CALL ZLASCL( 'G', 0, 0, ANRM, CSCALE, N, N, A, LDA, IERR )


### PR DESCRIPTION
This adds a NaN check on the entries of the input matrix A in GEEV, 

GEEV would now return error `INFO = -4` if there are NaNs in matrix A in input.

NaNs in input are detected with LANGE. Since LANGE is called for scaling anyway, there is no extra cost.

This follows @angsch's suggestion in issue #1128. This uses `DISNAN` instead of `DISFINITE` (as initially suggested). I am not opposed to create a `DISFINITE` function and use it, but I think it needs more decisions and consensus.

See as well PR#471 for a "similar" behavior.
