### PR TITLE
Adjust line reflow in LA_GEAM for ILP64 build

### DIFF
--- a/SRC/dla_geamv.f
+++ b/SRC/dla_geamv.f
@@ -169,7 +169,8 @@
 *> \ingroup la_geamv
 *
 *  =====================================================================
-      SUBROUTINE DLA_GEAMV ( TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA,
+      SUBROUTINE DLA_GEAMV ( TRANS, M, N, ALPHA, A, LDA, X, INCX,
+     $                       BETA,
      $                       Y, INCY )
 *
 *  -- LAPACK computational routine --


### PR DESCRIPTION
**Description**
Fixes #1132. The other precisions have a line break already; precision 'd' must have been missed. It's not clear to me why the line limit overflow due to the _64 suffix did not surface earlier...

**Checklist**

- [ ] The documentation has been updated.
- [X] If the PR solves a specific issue, it is set to be closed on merge.