### PR TITLE
Revert "Avoid memory corruption with non-finite inputs in ?GEEV"

### DIFF
--- a/SRC/cgeev.f
+++ b/SRC/cgeev.f
@@ -496,7 +496,7 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND. INFO.GE.0) THEN
+      IF( SCALEA ) THEN
          CALL CLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1,
      $                W( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )

--- a/SRC/dgeev.f
+++ b/SRC/dgeev.f
@@ -517,7 +517,7 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND. INFO.GE.0 ) THEN
+      IF( SCALEA ) THEN
          CALL DLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1,
      $                WR( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )

--- a/SRC/sgeev.f
+++ b/SRC/sgeev.f
@@ -519,7 +519,7 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND. INFO.GE.0 ) THEN
+      IF( SCALEA ) THEN
          CALL SLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1,
      $                WR( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )

--- a/SRC/zgeev.f
+++ b/SRC/zgeev.f
@@ -493,7 +493,7 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND.INFO.GE.0) THEN
+      IF( SCALEA ) THEN
          CALL ZLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1,
      $                W( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )


### PR DESCRIPTION
Reverts Reference-LAPACK/lapack#1129 as I've found out belatedly that this change is unwarranted (the condition would have been unreachable if it hadn't been for a diverging implementation of xerbla in "my" code) and actually causes a number of regressions in the testsuite.