### PR TITLE
Capture module file dependencies in CMake

### DIFF
--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -36,7 +36,9 @@
 #
 #######################################################################
 
-set(ALLMOD la_xisnan.F90 la_constants.f90)
+set(CONSTMOD la_constants.f90)
+
+set(NANMOD la_xisnan.F90)
 
 set(ALLAUX ilaenv.f ilaenv2stage.f ieeeck.f lsamen.f iparmq.f iparam2stage.F
    ilaprec.f ilatrans.f ilauplo.f iladiag.f chla_transtype.f
@@ -519,7 +521,14 @@ list(REMOVE_DUPLICATES SOURCES)
 
 # Use special target for MOD files to guarantee they are built before
 # any other files that depend on them
-add_library(mod_files OBJECT ${ALLMOD})
+add_library(const_mod_file OBJECT ${CONSTMOD})
+set_target_properties(
+  const_mod_file PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  Fortran_PREPROCESS ON
+  )
+
+add_library(mod_files OBJECT ${NANMOD} $<TARGET_OBJECTS:const_mod_file>)
 set_target_properties(
   mod_files PROPERTIES
   POSITION_INDEPENDENT_CODE ON


### PR DESCRIPTION
**Description**

The modulefile la_xisnan.F90 depends on the modulefile la_constants.f90 but this dependency is not expressed in the CMake rules. In some parallel builds we have observed failures where compilation of objects that depend on la_constants.mod starts before compilation of la_constants.f90 has finished.

This patch modifies CMakeLists.txt to ensure that la_constants.mod is built before any other object or modulefile that depends on it.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.