### PR TITLE
Fix format string in LAPACK tests to match two-digit minor versions

### DIFF
--- a/TESTING/EIG/cchkee.F
+++ b/TESTING/EIG/cchkee.F
@@ -2524,7 +2524,7 @@
  9974 FORMAT( ' Tests of CHBTRD', / ' (reduction of a Hermitian band ',
      $      'matrix to real tridiagonal form)' )
  9973 FORMAT( / 1X, 71( '-' ) )
- 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I1, '.', I1 )
+ 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I2, '.', I1 )
  9971 FORMAT( / ' Tests of the Generalized Linear Regression Model ',
      $      'routines' )
  9970 FORMAT( / ' Tests of the Generalized QR and RQ routines' )

--- a/TESTING/EIG/dchkee.F
+++ b/TESTING/EIG/dchkee.F
@@ -2508,7 +2508,7 @@
  9974 FORMAT( ' Tests of DSBTRD', / ' (reduction of a symmetric band ',
      $      'matrix to tridiagonal form)' )
  9973 FORMAT( / 1X, 71( '-' ) )
- 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I1, '.', I1 )
+ 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I2, '.', I1 )
  9971 FORMAT( / ' Tests of the Generalized Linear Regression Model ',
      $      'routines' )
  9970 FORMAT( / ' Tests of the Generalized QR and RQ routines' )

--- a/TESTING/EIG/schkee.F
+++ b/TESTING/EIG/schkee.F
@@ -2511,7 +2511,7 @@
  9974 FORMAT( ' Tests of SSBTRD', / ' (reduction of a symmetric band ',
      $      'matrix to tridiagonal form)' )
  9973 FORMAT( / 1X, 71( '-' ) )
- 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I1, '.', I1 )
+ 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I2, '.', I1 )
  9971 FORMAT( / ' Tests of the Generalized Linear Regression Model ',
      $      'routines' )
  9970 FORMAT( / ' Tests of the Generalized QR and RQ routines' )

--- a/TESTING/EIG/zchkee.F
+++ b/TESTING/EIG/zchkee.F
@@ -2522,7 +2522,7 @@
  9974 FORMAT( ' Tests of ZHBTRD', / ' (reduction of a Hermitian band ',
      $      'matrix to real tridiagonal form)' )
  9973 FORMAT( / 1X, 71( '-' ) )
- 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I1, '.', I1 )
+ 9972 FORMAT( / ' LAPACK VERSION ', I1, '.', I2, '.', I1 )
  9971 FORMAT( / ' Tests of the Generalized Linear Regression Model ',
      $      'routines' )
  9970 FORMAT( / ' Tests of the Generalized QR and RQ routines' )

--- a/TESTING/LIN/cchkaa.F
+++ b/TESTING/LIN/cchkaa.F
@@ -1245,7 +1245,7 @@
  9995 FORMAT( ' Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( ' Tests of the COMPLEX LAPACK routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/cchkrfp.f
+++ b/TESTING/LIN/cchkrfp.f
@@ -276,7 +276,7 @@
  9995 FORMAT( ' !! Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( /  ' Tests of the COMPLEX LAPACK RFP routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/dchkaa.F
+++ b/TESTING/LIN/dchkaa.F
@@ -1089,7 +1089,7 @@
  9995 FORMAT( ' Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( ' Tests of the DOUBLE PRECISION LAPACK routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/dchkab.f
+++ b/TESTING/LIN/dchkab.f
@@ -350,7 +350,7 @@
      $      I6 )
  9994 FORMAT( ' Tests of the DOUBLE PRECISION LAPACK DSGESV/DSPOSV',
      $  ' routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/dchkrfp.f
+++ b/TESTING/LIN/dchkrfp.f
@@ -275,7 +275,7 @@
  9995 FORMAT( ' !! Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( /  ' Tests of the DOUBLE PRECISION LAPACK RFP routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/schkaa.F
+++ b/TESTING/LIN/schkaa.F
@@ -1083,7 +1083,7 @@
  9995 FORMAT( ' Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( ' Tests of the REAL LAPACK routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/schkrfp.f
+++ b/TESTING/LIN/schkrfp.f
@@ -274,7 +274,7 @@
  9995 FORMAT( ' !! Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( /  ' Tests of the REAL LAPACK RFP routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/zchkaa.F
+++ b/TESTING/LIN/zchkaa.F
@@ -1281,7 +1281,7 @@
  9995 FORMAT( ' Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( ' Tests of the COMPLEX*16 LAPACK routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/zchkab.f
+++ b/TESTING/LIN/zchkab.f
@@ -350,7 +350,7 @@
  9995 FORMAT( ' Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( ' Tests of the COMPLEX*16 LAPACK ZCGESV/ZCPOSV routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',

--- a/TESTING/LIN/zchkrfp.f
+++ b/TESTING/LIN/zchkrfp.f
@@ -276,7 +276,7 @@
  9995 FORMAT( ' !! Invalid input value: ', A4, '=', I6, '; must be <=',
      $      I6 )
  9994 FORMAT( /  ' Tests of the COMPLEX*16 LAPACK RFP routines ',
-     $      / ' LAPACK VERSION ', I1, '.', I1, '.', I1,
+     $      / ' LAPACK VERSION ', I1, '.', I2, '.', I1,
      $      / / ' The following parameter values will be used:' )
  9993 FORMAT( 4X, A4, ':  ', 10I6, / 11X, 10I6 )
  9992 FORMAT( / ' Routines pass computational tests if test ratio is ',


### PR DESCRIPTION
**Description**

After calling `ilaver` in the LAPACK tests, the version is displayed. But the minor version is a two-digit number and thus `I1` in the format string will display a `*` instead of  `12`. This PR fixes the format strings in the tests. 



**Checklist**
 - nothing apply here
