### PR TITLE
fix library names in `lapack64.pc`

### DIFF
--- a/lapack.pc.in
+++ b/lapack.pc.in
@@ -5,5 +5,5 @@ Name: LAPACK
 Description: FORTRAN reference implementation of LAPACK Linear Algebra PACKage
 Version: @LAPACK_VERSION@
 URL: http://www.netlib.org/lapack/
-Libs: -L${libdir} -llapack
-Requires.private: blas
+Libs: -L${libdir} -l@LAPACKLIB@
+Requires.private: @BLASLIB@


### PR DESCRIPTION
**Description**

Add substitutions to `lapack.pc.in`, in order to ensure that the generated `lapack64.pc` file correctly references the index64 library and BLAS dependency.  It seems that other pkg-config templates have been updated as part of #462 but this one was omitted. As a result, finding a lapack64 via pkg-config gave non-index64 libraries.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.

CC @epsilon-0 @langou 