### PR TITLE
Fix errors in the documentation of ?gelqt

### DIFF
--- a/SRC/cgelqt.f
+++ b/SRC/cgelqt.f
@@ -40,7 +40,7 @@
 *> \param[in] MB
 *> \verbatim
 *>          MB is INTEGER
-*>          The block size to be used in the blocked QR.  MIN(M,N) >= MB >= 1.
+*>          The block size to be used in the blocked LQ.  MIN(M,N) >= MB >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -75,7 +75,10 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX array, dimension (MB*N)
+*>          WORK is COMPLEX array, dimension (MB*M).
+*>          Note: A smaller workspace of MB*(M-MB) may also be sufficient, but
+*>          that is yet to be proven. MB*M is a conservative estimate and the
+*>          recommended value to use.
 *> \endverbatim
 *>
 *> \param[out] INFO
@@ -101,7 +104,7 @@
 *> \verbatim
 *>
 *>  The matrix V stores the elementary reflectors H(i) in the i-th row
-*>  above the diagonal. For example, if M=5 and N=3, the matrix V is
+*>  above the diagonal. For example, if M=3 and N=5, the matrix V is
 *>
 *>               V = (  1  v1 v1 v1 v1 )
 *>                   (     1  v2 v2 v2 )

--- a/SRC/dgelqt.f
+++ b/SRC/dgelqt.f
@@ -53,7 +53,7 @@
 *> \param[in] MB
 *> \verbatim
 *>          MB is INTEGER
-*>          The block size to be used in the blocked QR.  MIN(M,N) >= MB >= 1.
+*>          The block size to be used in the blocked LQ.  MIN(M,N) >= MB >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -88,7 +88,10 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is DOUBLE PRECISION array, dimension (MB*N)
+*>          WORK is DOUBLE PRECISION array, dimension (MB*M).
+*>          Note: A smaller workspace of MB*(M-MB) may also be sufficient, but
+*>          that is yet to be proven. MB*M is a conservative estimate and the
+*>          recommended value to use.
 *> \endverbatim
 *>
 *> \param[out] INFO
@@ -114,7 +117,7 @@
 *> \verbatim
 *>
 *>  The matrix V stores the elementary reflectors H(i) in the i-th row
-*>  above the diagonal. For example, if M=5 and N=3, the matrix V is
+*>  above the diagonal. For example, if M=3 and N=5, the matrix V is
 *>
 *>               V = (  1  v1 v1 v1 v1 )
 *>                   (     1  v2 v2 v2 )

--- a/SRC/sgelqt.f
+++ b/SRC/sgelqt.f
@@ -40,7 +40,7 @@
 *> \param[in] MB
 *> \verbatim
 *>          MB is INTEGER
-*>          The block size to be used in the blocked QR.  MIN(M,N) >= MB >= 1.
+*>          The block size to be used in the blocked LQ.  MIN(M,N) >= MB >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -75,7 +75,10 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is REAL array, dimension (MB*N)
+*>          WORK is REAL array, dimension (MB*M).
+*>          Note: A smaller workspace of MB*(M-MB) may also be sufficient, but
+*>          that is yet to be proven. MB*M is a conservative estimate and the
+*>          recommended value to use.
 *> \endverbatim
 *>
 *> \param[out] INFO
@@ -101,7 +104,7 @@
 *> \verbatim
 *>
 *>  The matrix V stores the elementary reflectors H(i) in the i-th row
-*>  above the diagonal. For example, if M=5 and N=3, the matrix V is
+*>  above the diagonal. For example, if M=3 and N=5, the matrix V is
 *>
 *>               V = (  1  v1 v1 v1 v1 )
 *>                   (     1  v2 v2 v2 )

--- a/SRC/zgelqt.f
+++ b/SRC/zgelqt.f
@@ -53,7 +53,7 @@
 *> \param[in] MB
 *> \verbatim
 *>          MB is INTEGER
-*>          The block size to be used in the blocked QR.  MIN(M,N) >= MB >= 1.
+*>          The block size to be used in the blocked LQ.  MIN(M,N) >= MB >= 1.
 *> \endverbatim
 *>
 *> \param[in,out] A
@@ -88,7 +88,10 @@
 *>
 *> \param[out] WORK
 *> \verbatim
-*>          WORK is COMPLEX*16 array, dimension (MB*N)
+*>          WORK is COMPLEX*16 array, dimension (MB*M).
+*>          Note: A smaller workspace of MB*(M-MB) may also be sufficient, but
+*>          that is yet to be proven. MB*M is a conservative estimate and the
+*>          recommended value to use.
 *> \endverbatim
 *>
 *> \param[out] INFO
@@ -114,7 +117,7 @@
 *> \verbatim
 *>
 *>  The matrix V stores the elementary reflectors H(i) in the i-th row
-*>  above the diagonal. For example, if M=5 and N=3, the matrix V is
+*>  above the diagonal. For example, if M=3 and N=5, the matrix V is
 *>
 *>               V = (  1  v1 v1 v1 v1 )
 *>                   (     1  v2 v2 v2 )


### PR DESCRIPTION
**Description**
Fixes and closes #1113.
Besides the typo in the issue this PR also corrects two other errors in the docs.

1. The description of `MB` mentions QR instead of LQ
2. In the "Further Details" section the dimensions of the example matrix are accidentally transposed.

I am not fully confident in the MB*(M-MB) bound, therefore I only included it as a note. Trying to figure out what is the minimum safe amount of workspace is gets kinda complicated, but perhaps someone in the future will see this note and prove/disprove this conjecture.

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.