### PR TITLE
Prevent csrscl/zdrscl from going to infinite loop on Infinity input

### DIFF
--- a/SRC/csrscl.f
+++ b/SRC/csrscl.f
@@ -112,6 +112,7 @@
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS
+      INTRINSIC          HUGE
 *     ..
 *     .. Executable Statements ..
 *
@@ -119,6 +120,11 @@
 *
       IF( N.LE.0 )
      $   RETURN
+*
+      IF( SA.GT.HUGE(SA) .OR. SA.LT.-HUGE(SA) ) THEN
+         CALL CSSCAL( N, SA, SX, INCX )
+         RETURN
+      END IF
 *
 *     Get machine parameters
 *

--- a/SRC/zdrscl.f
+++ b/SRC/zdrscl.f
@@ -112,6 +112,7 @@
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS
+      INTRINSIC          HUGE
 *     ..
 *     .. Executable Statements ..
 *
@@ -119,6 +120,11 @@
 *
       IF( N.LE.0 )
      $   RETURN
+*
+      IF( SA.GT.HUGE(SA) .OR. SA.LT.-HUGE(SA) ) THEN
+         CALL ZDSCAL( N, SA, SX, INCX )
+         RETURN
+      END IF
 *
 *     Get machine parameters
 *


### PR DESCRIPTION
Mathworks complained about Intel MKL issue that came from LAPACK 3.12, related to a hang on certain input to zgetrf/cgetrf. The problem is that if (inf, 0) appears on a diagonal, it branches to zdrscl/csrscl where it falls into an infinite loop.

This commit makes subroutine skip the scaling loop on infinity input. This patch has been tested with Intel MKL tests and Mathworks provided test, already integrated into MKL.