### PR TITLE
LAPACKE const correctness fixes

### DIFF
--- a/LAPACKE/include/lapacke.h
+++ b/LAPACKE/include/lapacke.h
@@ -106,13 +106,13 @@ lapack_int LAPACKE_zbdsqr( int matrix_layout, char uplo, lapack_int n,
                            lapack_int ldu, lapack_complex_double* c,
                            lapack_int ldc );
 lapack_int LAPACKE_sbdsvdx( int matrix_layout, char uplo, char jobz, char range,
-                           lapack_int n, float* d, float* e,
+                           lapack_int n, const float* d, const float* e,
                            float vl, float vu,
                            lapack_int il, lapack_int iu, lapack_int* ns,
                            float* s, float* z, lapack_int ldz,
                            lapack_int* superb );
 lapack_int LAPACKE_dbdsvdx( int matrix_layout, char uplo, char jobz, char range,
-                           lapack_int n, double* d, double* e,
+                           lapack_int n, const double* d, const double* e,
                            double vl, double vu,
                            lapack_int il, lapack_int iu, lapack_int* ns,
                            double* s, double* z, lapack_int ldz,
@@ -897,11 +897,11 @@ lapack_int LAPACKE_zgesv( int matrix_layout, lapack_int n, lapack_int nrhs,
                           lapack_int ldb );
 lapack_int LAPACKE_dsgesv( int matrix_layout, lapack_int n, lapack_int nrhs,
                            double* a, lapack_int lda, lapack_int* ipiv,
-                           double* b, lapack_int ldb, double* x, lapack_int ldx,
+                           const double* b, lapack_int ldb, double* x, lapack_int ldx,
                            lapack_int* iter );
 lapack_int LAPACKE_zcgesv( int matrix_layout, lapack_int n, lapack_int nrhs,
                            lapack_complex_double* a, lapack_int lda,
-                           lapack_int* ipiv, lapack_complex_double* b,
+                           lapack_int* ipiv, const lapack_complex_double* b,
                            lapack_int ldb, lapack_complex_double* x,
                            lapack_int ldx, lapack_int* iter );
 
@@ -2514,10 +2514,10 @@ lapack_int LAPACKE_zlaset( int matrix_layout, char uplo, lapack_int m,
 lapack_int LAPACKE_slasrt( char id, lapack_int n, float* d );
 lapack_int LAPACKE_dlasrt( char id, lapack_int n, double* d );
 
-lapack_int LAPACKE_slassq( lapack_int n,                 float* x, lapack_int incx,  float* scale,  float* sumsq );
-lapack_int LAPACKE_dlassq( lapack_int n,                double* x, lapack_int incx, double* scale, double* sumsq );
-lapack_int LAPACKE_classq( lapack_int n,  lapack_complex_float* x, lapack_int incx,  float* scale,  float* sumsq );
-lapack_int LAPACKE_zlassq( lapack_int n, lapack_complex_double* x, lapack_int incx, double* scale, double* sumsq );
+lapack_int LAPACKE_slassq( lapack_int n,                 const float* x, lapack_int incx,  float* scale,  float* sumsq );
+lapack_int LAPACKE_dlassq( lapack_int n,                const double* x, lapack_int incx, double* scale, double* sumsq );
+lapack_int LAPACKE_classq( lapack_int n,  const lapack_complex_float* x, lapack_int incx,  float* scale,  float* sumsq );
+lapack_int LAPACKE_zlassq( lapack_int n, const lapack_complex_double* x, lapack_int incx, double* scale, double* sumsq );
 
 lapack_int LAPACKE_slaswp( int matrix_layout, lapack_int n, float* a,
                            lapack_int lda, lapack_int k1, lapack_int k2,
@@ -2988,11 +2988,11 @@ lapack_int LAPACKE_zposv( int matrix_layout, char uplo, lapack_int n,
                           lapack_int ldb );
 lapack_int LAPACKE_dsposv( int matrix_layout, char uplo, lapack_int n,
                            lapack_int nrhs, double* a, lapack_int lda,
-                           double* b, lapack_int ldb, double* x, lapack_int ldx,
+                           const double* b, lapack_int ldb, double* x, lapack_int ldx,
                            lapack_int* iter );
 lapack_int LAPACKE_zcposv( int matrix_layout, char uplo, lapack_int n,
                            lapack_int nrhs, lapack_complex_double* a,
-                           lapack_int lda, lapack_complex_double* b,
+                           lapack_int lda, const lapack_complex_double* b,
                            lapack_int ldb, lapack_complex_double* x,
                            lapack_int ldx, lapack_int* iter );
 
@@ -4759,13 +4759,13 @@ lapack_int LAPACKE_dbdsdc_work( int matrix_layout, char uplo, char compq,
                                 lapack_int* iwork );
 
 lapack_int LAPACKE_sbdsvdx_work( int matrix_layout, char uplo, char jobz, char range,
-                                 lapack_int n, float* d, float* e,
+                                 lapack_int n, const float* d, const float* e,
                                  float vl, float vu,
                                  lapack_int il, lapack_int iu, lapack_int* ns,
                                  float* s, float* z, lapack_int ldz,
                                  float* work, lapack_int* iwork );
 lapack_int LAPACKE_dbdsvdx_work( int matrix_layout, char uplo, char jobz, char range,
-                                 lapack_int n, double* d, double* e,
+                                 lapack_int n, const double* d, const double* e,
                                  double vl, double vu,
                                  lapack_int il, lapack_int iu, lapack_int* ns,
                                  double* s, double* z, lapack_int ldz,
@@ -5859,12 +5859,12 @@ lapack_int LAPACKE_zgesv_work( int matrix_layout, lapack_int n, lapack_int nrhs,
                                lapack_int ldb );
 lapack_int LAPACKE_dsgesv_work( int matrix_layout, lapack_int n, lapack_int nrhs,
                                 double* a, lapack_int lda, lapack_int* ipiv,
-                                double* b, lapack_int ldb, double* x,
+                                const double* b, lapack_int ldb, double* x,
                                 lapack_int ldx, double* work, float* swork,
                                 lapack_int* iter );
 lapack_int LAPACKE_zcgesv_work( int matrix_layout, lapack_int n, lapack_int nrhs,
                                 lapack_complex_double* a, lapack_int lda,
-                                lapack_int* ipiv, lapack_complex_double* b,
+                                lapack_int* ipiv, const lapack_complex_double* b,
                                 lapack_int ldb, lapack_complex_double* x,
                                 lapack_int ldx, lapack_complex_double* work,
                                 lapack_complex_float* swork, double* rwork,
@@ -7942,10 +7942,10 @@ lapack_int LAPACKE_zlaset_work( int matrix_layout, char uplo, lapack_int m,
 lapack_int LAPACKE_slasrt_work( char id, lapack_int n, float* d );
 lapack_int LAPACKE_dlasrt_work( char id, lapack_int n, double* d );
 
-lapack_int LAPACKE_slassq_work( lapack_int n,                 float* x, lapack_int incx,  float* scale,  float* sumsq );
-lapack_int LAPACKE_dlassq_work( lapack_int n,                double* x, lapack_int incx, double* scale, double* sumsq );
-lapack_int LAPACKE_classq_work( lapack_int n,  lapack_complex_float* x, lapack_int incx,  float* scale,  float* sumsq );
-lapack_int LAPACKE_zlassq_work( lapack_int n, lapack_complex_double* x, lapack_int incx, double* scale, double* sumsq );
+lapack_int LAPACKE_slassq_work( lapack_int n,                 const float* x, lapack_int incx,  float* scale,  float* sumsq );
+lapack_int LAPACKE_dlassq_work( lapack_int n,                const double* x, lapack_int incx, double* scale, double* sumsq );
+lapack_int LAPACKE_classq_work( lapack_int n,  const lapack_complex_float* x, lapack_int incx,  float* scale,  float* sumsq );
+lapack_int LAPACKE_zlassq_work( lapack_int n, const lapack_complex_double* x, lapack_int incx, double* scale, double* sumsq );
 
 lapack_int LAPACKE_slaswp_work( int matrix_layout, lapack_int n, float* a,
                                 lapack_int lda, lapack_int k1, lapack_int k2,
@@ -8491,12 +8491,12 @@ lapack_int LAPACKE_zposv_work( int matrix_layout, char uplo, lapack_int n,
                                lapack_int ldb );
 lapack_int LAPACKE_dsposv_work( int matrix_layout, char uplo, lapack_int n,
                                 lapack_int nrhs, double* a, lapack_int lda,
-                                double* b, lapack_int ldb, double* x,
+                                const double* b, lapack_int ldb, double* x,
                                 lapack_int ldx, double* work, float* swork,
                                 lapack_int* iter );
 lapack_int LAPACKE_zcposv_work( int matrix_layout, char uplo, lapack_int n,
                                 lapack_int nrhs, lapack_complex_double* a,
-                                lapack_int lda, lapack_complex_double* b,
+                                lapack_int lda, const lapack_complex_double* b,
                                 lapack_int ldb, lapack_complex_double* x,
                                 lapack_int ldx, lapack_complex_double* work,
                                 lapack_complex_float* swork, double* rwork,
@@ -12801,62 +12801,62 @@ lapack_int LAPACKE_zhetrf_aa_2stage_work( int matrix_layout, char uplo, lapack_i
 
 
 lapack_int LAPACKE_ssytrs_aa_2stage( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, float* a, lapack_int lda,
-                          float* tb, lapack_int ltb, lapack_int* ipiv,
-                          lapack_int* ipiv2, float* b, lapack_int ldb );
+                          lapack_int nrhs, const float* a, lapack_int lda,
+                          float* tb, lapack_int ltb, const lapack_int* ipiv,
+                          const lapack_int* ipiv2, float* b, lapack_int ldb );
 lapack_int LAPACKE_ssytrs_aa_2stage_work( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, float* a, lapack_int lda,
-                               float* tb, lapack_int ltb, lapack_int* ipiv,
-                               lapack_int* ipiv2, float* b, lapack_int ldb );
+                               lapack_int nrhs, const float* a, lapack_int lda,
+                               float* tb, lapack_int ltb, const lapack_int* ipiv,
+                               const lapack_int* ipiv2, float* b, lapack_int ldb );
 lapack_int LAPACKE_dsytrs_aa_2stage( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, double* a, lapack_int lda,
+                          lapack_int nrhs, const double* a, lapack_int lda,
                           double* tb, lapack_int ltb,
-                          lapack_int* ipiv, lapack_int* ipiv2,
+                          const lapack_int* ipiv, const lapack_int* ipiv2,
                           double* b, lapack_int ldb );
 lapack_int LAPACKE_dsytrs_aa_2stage_work( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, double* a, lapack_int lda,
+                               lapack_int nrhs, const double* a, lapack_int lda,
                                double* tb, lapack_int ltb,
-                               lapack_int* ipiv, lapack_int* ipiv2,
+                               const lapack_int* ipiv, const lapack_int* ipiv2,
                                double* b, lapack_int ldb );
 lapack_int LAPACKE_csytrs_aa_2stage( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_float* a,
+                          lapack_int nrhs, const lapack_complex_float* a,
                           lapack_int lda, lapack_complex_float* tb,
-                          lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                          lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                           lapack_complex_float* b, lapack_int ldb );
 lapack_int LAPACKE_csytrs_aa_2stage_work( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_float* a,
+                               lapack_int nrhs, const lapack_complex_float* a,
                                lapack_int lda, lapack_complex_float* tb,
-                               lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                               lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                                lapack_complex_float* b, lapack_int ldb );
 lapack_int LAPACKE_zsytrs_aa_2stage( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_double* a,
+                          lapack_int nrhs, const lapack_complex_double* a,
                           lapack_int lda, lapack_complex_double* tb,
-                          lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                          lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                           lapack_complex_double* b, lapack_int ldb );
 lapack_int LAPACKE_zsytrs_aa_2stage_work( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_double* a,
+                               lapack_int nrhs, const lapack_complex_double* a,
                                lapack_int lda, lapack_complex_double* tb,
-                               lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                               lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                                lapack_complex_double* b, lapack_int ldb );
 lapack_int LAPACKE_chetrs_aa_2stage( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_float* a,
+                          lapack_int nrhs, const lapack_complex_float* a,
                           lapack_int lda, lapack_complex_float* tb,
-                          lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                          lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                           lapack_complex_float* b, lapack_int ldb );
 lapack_int LAPACKE_chetrs_aa_2stage_work( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_float* a,
+                               lapack_int nrhs, const lapack_complex_float* a,
                                lapack_int lda, lapack_complex_float* tb,
-                               lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                               lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                                lapack_complex_float* b, lapack_int ldb );
 lapack_int LAPACKE_zhetrs_aa_2stage( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_double* a,
+                          lapack_int nrhs, const lapack_complex_double* a,
                           lapack_int lda, lapack_complex_double* tb,
-                          lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                          lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                           lapack_complex_double* b, lapack_int ldb );
 lapack_int LAPACKE_zhetrs_aa_2stage_work( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_double* a,
+                               lapack_int nrhs, const lapack_complex_double* a,
                                lapack_int lda, lapack_complex_double* tb,
-                               lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                               lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                                lapack_complex_double* b, lapack_int ldb );
 //LAPACK 3.10.0
 lapack_int LAPACKE_sorhr_col( int matrix_layout, lapack_int m, lapack_int n,

--- a/LAPACKE/include/lapacke_64.h
+++ b/LAPACKE/include/lapacke_64.h
@@ -72,13 +72,13 @@ int64_t LAPACKE_zbdsqr_64( int matrix_layout, char uplo, int64_t n,
                            int64_t ldu, lapack_complex_double* c,
                            int64_t ldc );
 int64_t LAPACKE_sbdsvdx_64( int matrix_layout, char uplo, char jobz, char range,
-                           int64_t n, float* d, float* e,
+                           int64_t n, const float* d, const float* e,
                            float vl, float vu,
                            int64_t il, int64_t iu, int64_t* ns,
                            float* s, float* z, int64_t ldz,
                            int64_t* superb );
 int64_t LAPACKE_dbdsvdx_64( int matrix_layout, char uplo, char jobz, char range,
-                           int64_t n, double* d, double* e,
+                           int64_t n, const double* d, const double* e,
                            double vl, double vu,
                            int64_t il, int64_t iu, int64_t* ns,
                            double* s, double* z, int64_t ldz,
@@ -863,11 +863,11 @@ int64_t LAPACKE_zgesv_64( int matrix_layout, int64_t n, int64_t nrhs,
                           int64_t ldb );
 int64_t LAPACKE_dsgesv_64( int matrix_layout, int64_t n, int64_t nrhs,
                            double* a, int64_t lda, int64_t* ipiv,
-                           double* b, int64_t ldb, double* x, int64_t ldx,
+                           const double* b, int64_t ldb, double* x, int64_t ldx,
                            int64_t* iter );
 int64_t LAPACKE_zcgesv_64( int matrix_layout, int64_t n, int64_t nrhs,
                            lapack_complex_double* a, int64_t lda,
-                           int64_t* ipiv, lapack_complex_double* b,
+                           int64_t* ipiv, const lapack_complex_double* b,
                            int64_t ldb, lapack_complex_double* x,
                            int64_t ldx, int64_t* iter );
 
@@ -2480,10 +2480,10 @@ int64_t LAPACKE_zlaset_64( int matrix_layout, char uplo, int64_t m,
 int64_t LAPACKE_slasrt_64( char id, int64_t n, float* d );
 int64_t LAPACKE_dlasrt_64( char id, int64_t n, double* d );
 
-int64_t LAPACKE_slassq_64( int64_t n,                 float* x, int64_t incx,  float* scale,  float* sumsq );
-int64_t LAPACKE_dlassq_64( int64_t n,                double* x, int64_t incx, double* scale, double* sumsq );
-int64_t LAPACKE_classq_64( int64_t n,  lapack_complex_float* x, int64_t incx,  float* scale,  float* sumsq );
-int64_t LAPACKE_zlassq_64( int64_t n, lapack_complex_double* x, int64_t incx, double* scale, double* sumsq );
+int64_t LAPACKE_slassq_64( int64_t n,                 const float* x, int64_t incx,  float* scale,  float* sumsq );
+int64_t LAPACKE_dlassq_64( int64_t n,                const double* x, int64_t incx, double* scale, double* sumsq );
+int64_t LAPACKE_classq_64( int64_t n,  const lapack_complex_float* x, int64_t incx,  float* scale,  float* sumsq );
+int64_t LAPACKE_zlassq_64( int64_t n, const lapack_complex_double* x, int64_t incx, double* scale, double* sumsq );
 
 int64_t LAPACKE_slaswp_64( int matrix_layout, int64_t n, float* a,
                            int64_t lda, int64_t k1, int64_t k2,
@@ -2954,11 +2954,11 @@ int64_t LAPACKE_zposv_64( int matrix_layout, char uplo, int64_t n,
                           int64_t ldb );
 int64_t LAPACKE_dsposv_64( int matrix_layout, char uplo, int64_t n,
                            int64_t nrhs, double* a, int64_t lda,
-                           double* b, int64_t ldb, double* x, int64_t ldx,
+                           const double* b, int64_t ldb, double* x, int64_t ldx,
                            int64_t* iter );
 int64_t LAPACKE_zcposv_64( int matrix_layout, char uplo, int64_t n,
                            int64_t nrhs, lapack_complex_double* a,
-                           int64_t lda, lapack_complex_double* b,
+                           int64_t lda, const lapack_complex_double* b,
                            int64_t ldb, lapack_complex_double* x,
                            int64_t ldx, int64_t* iter );
 
@@ -4725,13 +4725,13 @@ int64_t LAPACKE_dbdsdc_work_64( int matrix_layout, char uplo, char compq,
                                 int64_t* iwork );
 
 int64_t LAPACKE_sbdsvdx_work_64( int matrix_layout, char uplo, char jobz, char range,
-                                 int64_t n, float* d, float* e,
+                                 int64_t n, const float* d, const float* e,
                                  float vl, float vu,
                                  int64_t il, int64_t iu, int64_t* ns,
                                  float* s, float* z, int64_t ldz,
                                  float* work, int64_t* iwork );
 int64_t LAPACKE_dbdsvdx_work_64( int matrix_layout, char uplo, char jobz, char range,
-                                 int64_t n, double* d, double* e,
+                                 int64_t n, const double* d, const double* e,
                                  double vl, double vu,
                                  int64_t il, int64_t iu, int64_t* ns,
                                  double* s, double* z, int64_t ldz,
@@ -5826,12 +5826,12 @@ int64_t LAPACKE_zgesv_work_64( int matrix_layout, int64_t n, int64_t nrhs,
                                int64_t ldb );
 int64_t LAPACKE_dsgesv_work_64( int matrix_layout, int64_t n, int64_t nrhs,
                                 double* a, int64_t lda, int64_t* ipiv,
-                                double* b, int64_t ldb, double* x,
+                                const double* b, int64_t ldb, double* x,
                                 int64_t ldx, double* work, float* swork,
                                 int64_t* iter );
 int64_t LAPACKE_zcgesv_work_64( int matrix_layout, int64_t n, int64_t nrhs,
                                 lapack_complex_double* a, int64_t lda,
-                                int64_t* ipiv, lapack_complex_double* b,
+                                int64_t* ipiv, const lapack_complex_double* b,
                                 int64_t ldb, lapack_complex_double* x,
                                 int64_t ldx, lapack_complex_double* work,
                                 lapack_complex_float* swork, double* rwork,
@@ -7909,10 +7909,10 @@ int64_t LAPACKE_zlaset_work_64( int matrix_layout, char uplo, int64_t m,
 int64_t LAPACKE_slasrt_work_64( char id, int64_t n, float* d );
 int64_t LAPACKE_dlasrt_work_64( char id, int64_t n, double* d );
 
-int64_t LAPACKE_slassq_work_64( int64_t n,                 float* x, int64_t incx,  float* scale,  float* sumsq );
-int64_t LAPACKE_dlassq_work_64( int64_t n,                double* x, int64_t incx, double* scale, double* sumsq );
-int64_t LAPACKE_classq_work_64( int64_t n,  lapack_complex_float* x, int64_t incx,  float* scale,  float* sumsq );
-int64_t LAPACKE_zlassq_work_64( int64_t n, lapack_complex_double* x, int64_t incx, double* scale, double* sumsq );
+int64_t LAPACKE_slassq_work_64( int64_t n,                 const float* x, int64_t incx,  float* scale,  float* sumsq );
+int64_t LAPACKE_dlassq_work_64( int64_t n,                const double* x, int64_t incx, double* scale, double* sumsq );
+int64_t LAPACKE_classq_work_64( int64_t n,  const lapack_complex_float* x, int64_t incx,  float* scale,  float* sumsq );
+int64_t LAPACKE_zlassq_work_64( int64_t n, const lapack_complex_double* x, int64_t incx, double* scale, double* sumsq );
 
 int64_t LAPACKE_slaswp_work_64( int matrix_layout, int64_t n, float* a,
                                 int64_t lda, int64_t k1, int64_t k2,
@@ -8458,12 +8458,12 @@ int64_t LAPACKE_zposv_work_64( int matrix_layout, char uplo, int64_t n,
                                int64_t ldb );
 int64_t LAPACKE_dsposv_work_64( int matrix_layout, char uplo, int64_t n,
                                 int64_t nrhs, double* a, int64_t lda,
-                                double* b, int64_t ldb, double* x,
+                                const double* b, int64_t ldb, double* x,
                                 int64_t ldx, double* work, float* swork,
                                 int64_t* iter );
 int64_t LAPACKE_zcposv_work_64( int matrix_layout, char uplo, int64_t n,
                                 int64_t nrhs, lapack_complex_double* a,
-                                int64_t lda, lapack_complex_double* b,
+                                int64_t lda, const lapack_complex_double* b,
                                 int64_t ldb, lapack_complex_double* x,
                                 int64_t ldx, lapack_complex_double* work,
                                 lapack_complex_float* swork, double* rwork,
@@ -12768,62 +12768,62 @@ int64_t LAPACKE_zhetrf_aa_2stage_work_64( int matrix_layout, char uplo, int64_t 
 
 
 int64_t LAPACKE_ssytrs_aa_2stage_64( int matrix_layout, char uplo, int64_t n,
-                          int64_t nrhs, float* a, int64_t lda,
-                          float* tb, int64_t ltb, int64_t* ipiv,
-                          int64_t* ipiv2, float* b, int64_t ldb );
+                          int64_t nrhs, const float* a, int64_t lda,
+                          float* tb, int64_t ltb, const int64_t* ipiv,
+                          const int64_t* ipiv2, float* b, int64_t ldb );
 int64_t LAPACKE_ssytrs_aa_2stage_work_64( int matrix_layout, char uplo, int64_t n,
-                               int64_t nrhs, float* a, int64_t lda,
-                               float* tb, int64_t ltb, int64_t* ipiv,
-                               int64_t* ipiv2, float* b, int64_t ldb );
+                               int64_t nrhs, const float* a, int64_t lda,
+                               float* tb, int64_t ltb, const int64_t* ipiv,
+                               const int64_t* ipiv2, float* b, int64_t ldb );
 int64_t LAPACKE_dsytrs_aa_2stage_64( int matrix_layout, char uplo, int64_t n,
-                          int64_t nrhs, double* a, int64_t lda,
+                          int64_t nrhs, const double* a, int64_t lda,
                           double* tb, int64_t ltb,
-                          int64_t* ipiv, int64_t* ipiv2,
+                          const int64_t* ipiv, const int64_t* ipiv2,
                           double* b, int64_t ldb );
 int64_t LAPACKE_dsytrs_aa_2stage_work_64( int matrix_layout, char uplo, int64_t n,
-                               int64_t nrhs, double* a, int64_t lda,
+                               int64_t nrhs, const double* a, int64_t lda,
                                double* tb, int64_t ltb,
-                               int64_t* ipiv, int64_t* ipiv2,
+                               const int64_t* ipiv, const int64_t* ipiv2,
                                double* b, int64_t ldb );
 int64_t LAPACKE_csytrs_aa_2stage_64( int matrix_layout, char uplo, int64_t n,
-                          int64_t nrhs, lapack_complex_float* a,
+                          int64_t nrhs, const lapack_complex_float* a,
                           int64_t lda, lapack_complex_float* tb,
-                          int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                          int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                           lapack_complex_float* b, int64_t ldb );
 int64_t LAPACKE_csytrs_aa_2stage_work_64( int matrix_layout, char uplo, int64_t n,
-                               int64_t nrhs, lapack_complex_float* a,
+                               int64_t nrhs, const lapack_complex_float* a,
                                int64_t lda, lapack_complex_float* tb,
-                               int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                               int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                                lapack_complex_float* b, int64_t ldb );
 int64_t LAPACKE_zsytrs_aa_2stage_64( int matrix_layout, char uplo, int64_t n,
-                          int64_t nrhs, lapack_complex_double* a,
+                          int64_t nrhs, const lapack_complex_double* a,
                           int64_t lda, lapack_complex_double* tb,
-                          int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                          int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                           lapack_complex_double* b, int64_t ldb );
 int64_t LAPACKE_zsytrs_aa_2stage_work_64( int matrix_layout, char uplo, int64_t n,
-                               int64_t nrhs, lapack_complex_double* a,
+                               int64_t nrhs, const lapack_complex_double* a,
                                int64_t lda, lapack_complex_double* tb,
-                               int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                               int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                                lapack_complex_double* b, int64_t ldb );
 int64_t LAPACKE_chetrs_aa_2stage_64( int matrix_layout, char uplo, int64_t n,
-                          int64_t nrhs, lapack_complex_float* a,
+                          int64_t nrhs, const lapack_complex_float* a,
                           int64_t lda, lapack_complex_float* tb,
-                          int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                          int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                           lapack_complex_float* b, int64_t ldb );
 int64_t LAPACKE_chetrs_aa_2stage_work_64( int matrix_layout, char uplo, int64_t n,
-                               int64_t nrhs, lapack_complex_float* a,
+                               int64_t nrhs, const lapack_complex_float* a,
                                int64_t lda, lapack_complex_float* tb,
-                               int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                               int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                                lapack_complex_float* b, int64_t ldb );
 int64_t LAPACKE_zhetrs_aa_2stage_64( int matrix_layout, char uplo, int64_t n,
-                          int64_t nrhs, lapack_complex_double* a,
+                          int64_t nrhs, const lapack_complex_double* a,
                           int64_t lda, lapack_complex_double* tb,
-                          int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                          int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                           lapack_complex_double* b, int64_t ldb );
 int64_t LAPACKE_zhetrs_aa_2stage_work_64( int matrix_layout, char uplo, int64_t n,
-                               int64_t nrhs, lapack_complex_double* a,
+                               int64_t nrhs, const lapack_complex_double* a,
                                int64_t lda, lapack_complex_double* tb,
-                               int64_t ltb, int64_t* ipiv, int64_t* ipiv2,
+                               int64_t ltb, const int64_t* ipiv, const int64_t* ipiv2,
                                lapack_complex_double* b, int64_t ldb );
 //LAPACK 3.10.0
 int64_t LAPACKE_sorhr_col_64( int matrix_layout, int64_t m, int64_t n,

--- a/LAPACKE/src/lapacke_chetrs_aa_2stage.c
+++ b/LAPACKE/src/lapacke_chetrs_aa_2stage.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_chetrs_aa_2stage)( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_float* a,
+                          lapack_int nrhs, const lapack_complex_float* a,
                           lapack_int lda, lapack_complex_float* tb,
-                          lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                          lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                           lapack_complex_float* b, lapack_int ldb )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_chetrs_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_chetrs_aa_2stage_work.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_chetrs_aa_2stage_work)( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_float* a, lapack_int lda,
-                               lapack_complex_float* tb, lapack_int ltb, lapack_int* ipiv, 
-                               lapack_int* ipiv2, lapack_complex_float* b, lapack_int ldb )
+                               lapack_int nrhs, const lapack_complex_float* a, lapack_int lda,
+                               lapack_complex_float* tb, lapack_int ltb, const lapack_int* ipiv, 
+                               const lapack_int* ipiv2, lapack_complex_float* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
@@ -94,7 +94,6 @@ lapack_int API_SUFFIX(LAPACKE_chetrs_aa_2stage_work)( int matrix_layout, char up
             info = info - 1;
         }
         /* Transpose output matrices */
-        API_SUFFIX(LAPACKE_che_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
         API_SUFFIX(LAPACKE_cge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         /* Release memory and exit */
         LAPACKE_free( b_t );

--- a/LAPACKE/src/lapacke_classq.c
+++ b/LAPACKE/src/lapacke_classq.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_classq)( lapack_int n, lapack_complex_float* x,
+lapack_int API_SUFFIX(LAPACKE_classq)( lapack_int n, const lapack_complex_float* x,
                            lapack_int incx, float* scale, float* sumsq )
 {
 #ifndef LAPACK_DISABLE_NAN_CHECK

--- a/LAPACKE/src/lapacke_classq_work.c
+++ b/LAPACKE/src/lapacke_classq_work.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_classq_work)( lapack_int n, lapack_complex_float* x, lapack_int incx, float* scale, float* sumsq )
+lapack_int API_SUFFIX(LAPACKE_classq_work)( lapack_int n, const lapack_complex_float* x, lapack_int incx, float* scale, float* sumsq )
 {
     lapack_int info = 0;
     LAPACK_classq( &n, x, &incx, scale, sumsq );

--- a/LAPACKE/src/lapacke_csytrs_aa_2stage.c
+++ b/LAPACKE/src/lapacke_csytrs_aa_2stage.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_csytrs_aa_2stage)( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_float* a, lapack_int lda,
-                          lapack_complex_float* tb, lapack_int ltb, lapack_int* ipiv, 
-                          lapack_int* ipiv2, lapack_complex_float* b, lapack_int ldb )
+                          lapack_int nrhs, const lapack_complex_float* a, lapack_int lda,
+                          lapack_complex_float* tb, lapack_int ltb, const lapack_int* ipiv, 
+                          const lapack_int* ipiv2, lapack_complex_float* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {

--- a/LAPACKE/src/lapacke_csytrs_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_csytrs_aa_2stage_work.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_csytrs_aa_2stage_work)( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_float* a, lapack_int lda,
-                               lapack_complex_float* tb, lapack_int ltb, lapack_int* ipiv, 
-                               lapack_int* ipiv2, lapack_complex_float* b, lapack_int ldb )
+                               lapack_int nrhs, const lapack_complex_float* a, lapack_int lda,
+                               lapack_complex_float* tb, lapack_int ltb, const lapack_int* ipiv,
+                               const lapack_int* ipiv2, lapack_complex_float* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
@@ -93,7 +93,6 @@ lapack_int API_SUFFIX(LAPACKE_csytrs_aa_2stage_work)( int matrix_layout, char up
             info = info - 1;
         }
         /* Transpose output matrices */
-        API_SUFFIX(LAPACKE_csy_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
         API_SUFFIX(LAPACKE_cge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         /* Release memory and exit */
         LAPACKE_free( b_t );

--- a/LAPACKE/src/lapacke_dbdsvdx.c
+++ b/LAPACKE/src/lapacke_dbdsvdx.c
@@ -33,7 +33,7 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_dbdsvdx)( int matrix_layout, char uplo, char jobz, char range,
-                           lapack_int n, double* d, double* e,
+                           lapack_int n, const double* d, const double* e,
                            double vl, double vu,
                            lapack_int il, lapack_int iu, lapack_int* ns,
                            double* s, double* z, lapack_int ldz,

--- a/LAPACKE/src/lapacke_dbdsvdx_work.c
+++ b/LAPACKE/src/lapacke_dbdsvdx_work.c
@@ -33,7 +33,7 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_dbdsvdx_work)( int matrix_layout, char uplo, char jobz, char range,
-                                 lapack_int n, double* d, double* e,
+                                 lapack_int n, const double* d, const double* e,
                                  double vl, double vu,
                                  lapack_int il, lapack_int iu, lapack_int* ns,
                                  double* s, double* z, lapack_int ldz,

--- a/LAPACKE/src/lapacke_dlassq.c
+++ b/LAPACKE/src/lapacke_dlassq.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_dlassq)( lapack_int n, double* x, lapack_int incx, double* scale, double* sumsq )
+lapack_int API_SUFFIX(LAPACKE_dlassq)( lapack_int n, const double* x, lapack_int incx, double* scale, double* sumsq )
 {
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {

--- a/LAPACKE/src/lapacke_dlassq_work.c
+++ b/LAPACKE/src/lapacke_dlassq_work.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_dlassq_work)( lapack_int n, double* x, lapack_int incx, double* scale, double* sumsq )
+lapack_int API_SUFFIX(LAPACKE_dlassq_work)( lapack_int n, const double* x, lapack_int incx, double* scale, double* sumsq )
 {
     lapack_int info = 0;
     LAPACK_dlassq( &n, x, &incx, scale, sumsq );

--- a/LAPACKE/src/lapacke_dsgesv.c
+++ b/LAPACKE/src/lapacke_dsgesv.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_dsgesv)( int matrix_layout, lapack_int n, lapack_int nrhs,
                            double* a, lapack_int lda, lapack_int* ipiv,
-                           double* b, lapack_int ldb, double* x, lapack_int ldx,
+                           const double* b, lapack_int ldb, double* x, lapack_int ldx,
                            lapack_int* iter )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_dsgesv_work.c
+++ b/LAPACKE/src/lapacke_dsgesv_work.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_dsgesv_work)( int matrix_layout, lapack_int n, lapack_int nrhs,
                                 double* a, lapack_int lda, lapack_int* ipiv,
-                                double* b, lapack_int ldb, double* x,
+                                const double* b, lapack_int ldb, double* x,
                                 lapack_int ldx, double* work, float* swork,
                                 lapack_int* iter )
 {
@@ -96,7 +96,6 @@ lapack_int API_SUFFIX(LAPACKE_dsgesv_work)( int matrix_layout, lapack_int n, lap
         }
         /* Transpose output matrices */
         API_SUFFIX(LAPACKE_dge_trans)( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
-        API_SUFFIX(LAPACKE_dge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         API_SUFFIX(LAPACKE_dge_trans)( LAPACK_COL_MAJOR, n, nrhs, x_t, ldx_t, x, ldx );
         /* Release memory and exit */
         LAPACKE_free( x_t );

--- a/LAPACKE/src/lapacke_dsposv.c
+++ b/LAPACKE/src/lapacke_dsposv.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_dsposv)( int matrix_layout, char uplo, lapack_int n,
                            lapack_int nrhs, double* a, lapack_int lda,
-                           double* b, lapack_int ldb, double* x, lapack_int ldx,
+                           const double* b, lapack_int ldb, double* x, lapack_int ldx,
                            lapack_int* iter )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_dsposv_work.c
+++ b/LAPACKE/src/lapacke_dsposv_work.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_dsposv_work)( int matrix_layout, char uplo, lapack_int n,
                                 lapack_int nrhs, double* a, lapack_int lda,
-                                double* b, lapack_int ldb, double* x,
+                                const double* b, lapack_int ldb, double* x,
                                 lapack_int ldx, double* work, float* swork,
                                 lapack_int* iter )
 {
@@ -96,7 +96,6 @@ lapack_int API_SUFFIX(LAPACKE_dsposv_work)( int matrix_layout, char uplo, lapack
         }
         /* Transpose output matrices */
         API_SUFFIX(LAPACKE_dpo_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
-        API_SUFFIX(LAPACKE_dge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         API_SUFFIX(LAPACKE_dge_trans)( LAPACK_COL_MAJOR, n, nrhs, x_t, ldx_t, x, ldx );
         /* Release memory and exit */
         LAPACKE_free( x_t );

--- a/LAPACKE/src/lapacke_dsytrs_aa_2stage.c
+++ b/LAPACKE/src/lapacke_dsytrs_aa_2stage.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_dsytrs_aa_2stage)( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, double* a, lapack_int lda,
-                          double* tb, lapack_int ltb, lapack_int* ipiv, 
-                          lapack_int* ipiv2, double* b, lapack_int ldb )
+                          lapack_int nrhs, const double* a, lapack_int lda,
+                          double* tb, lapack_int ltb, const lapack_int* ipiv, 
+                          const lapack_int* ipiv2, double* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {

--- a/LAPACKE/src/lapacke_dsytrs_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_dsytrs_aa_2stage_work.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_dsytrs_aa_2stage_work)( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, double* a, lapack_int lda,
-                               double* tb, lapack_int ltb, lapack_int* ipiv, 
-                               lapack_int* ipiv2, double* b, lapack_int ldb )
+                               lapack_int nrhs, const double* a, lapack_int lda,
+                               double* tb, lapack_int ltb, const lapack_int* ipiv, 
+                               const lapack_int* ipiv2, double* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
@@ -93,7 +93,6 @@ lapack_int API_SUFFIX(LAPACKE_dsytrs_aa_2stage_work)( int matrix_layout, char up
             info = info - 1;
         }
         /* Transpose output matrices */
-        API_SUFFIX(LAPACKE_dsy_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
         API_SUFFIX(LAPACKE_dge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         /* Release memory and exit */
         LAPACKE_free( b_t );

--- a/LAPACKE/src/lapacke_sbdsvdx.c
+++ b/LAPACKE/src/lapacke_sbdsvdx.c
@@ -33,7 +33,7 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_sbdsvdx)( int matrix_layout, char uplo, char jobz, char range,
-                           lapack_int n, float* d, float* e,
+                           lapack_int n, const float* d, const float* e,
                            float vl, float vu,
                            lapack_int il, lapack_int iu, lapack_int* ns,
                            float* s, float* z, lapack_int ldz,

--- a/LAPACKE/src/lapacke_sbdsvdx_work.c
+++ b/LAPACKE/src/lapacke_sbdsvdx_work.c
@@ -33,7 +33,7 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_sbdsvdx_work)( int matrix_layout, char uplo, char jobz, char range,
-                                 lapack_int n, float* d, float* e,
+                                 lapack_int n, const float* d, const float* e,
                                  float vl, float vu,
                                  lapack_int il, lapack_int iu, lapack_int* ns,
                                  float* s, float* z, lapack_int ldz,

--- a/LAPACKE/src/lapacke_slassq.c
+++ b/LAPACKE/src/lapacke_slassq.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_slassq)( lapack_int n, float* x, lapack_int incx, float* scale, float* sumsq )
+lapack_int API_SUFFIX(LAPACKE_slassq)( lapack_int n, const float* x, lapack_int incx, float* scale, float* sumsq )
 {
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {

--- a/LAPACKE/src/lapacke_slassq_work.c
+++ b/LAPACKE/src/lapacke_slassq_work.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_slassq_work)( lapack_int n, float* x, lapack_int incx, float* scale, float* sumsq )
+lapack_int API_SUFFIX(LAPACKE_slassq_work)( lapack_int n, const float* x, lapack_int incx, float* scale, float* sumsq )
 {
     lapack_int info = 0;
     LAPACK_slassq( &n, x, &incx, scale, sumsq );

--- a/LAPACKE/src/lapacke_ssytrs_aa_2stage.c
+++ b/LAPACKE/src/lapacke_ssytrs_aa_2stage.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_ssytrs_aa_2stage)( int matrix_layout, char uplo, lapack_int n,
-                            lapack_int nrhs, float* a, lapack_int lda,
+                            lapack_int nrhs, const float* a, lapack_int lda,
                             float* tb, lapack_int ltb, 
-                            lapack_int* ipiv, lapack_int* ipiv2, 
+                            const lapack_int* ipiv, const lapack_int* ipiv2, 
                             float* b, lapack_int ldb )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_ssytrs_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_ssytrs_aa_2stage_work.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_ssytrs_aa_2stage_work)( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, float* a, lapack_int lda,
-                               float* tb, lapack_int ltb, lapack_int* ipiv, 
-                               lapack_int* ipiv2, float* b, lapack_int ldb )
+                               lapack_int nrhs, const float* a, lapack_int lda,
+                               float* tb, lapack_int ltb, const lapack_int* ipiv, 
+                               const lapack_int* ipiv2, float* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
@@ -93,7 +93,6 @@ lapack_int API_SUFFIX(LAPACKE_ssytrs_aa_2stage_work)( int matrix_layout, char up
             info = info - 1;
         }
         /* Transpose output matrices */
-        API_SUFFIX(LAPACKE_ssy_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
         API_SUFFIX(LAPACKE_sge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         /* Release memory and exit */
         LAPACKE_free( b_t );

--- a/LAPACKE/src/lapacke_zcgesv.c
+++ b/LAPACKE/src/lapacke_zcgesv.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_zcgesv)( int matrix_layout, lapack_int n, lapack_int nrhs,
                            lapack_complex_double* a, lapack_int lda,
-                           lapack_int* ipiv, lapack_complex_double* b,
+                           lapack_int* ipiv, const lapack_complex_double* b,
                            lapack_int ldb, lapack_complex_double* x,
                            lapack_int ldx, lapack_int* iter )
 {

--- a/LAPACKE/src/lapacke_zcgesv_work.c
+++ b/LAPACKE/src/lapacke_zcgesv_work.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_zcgesv_work)( int matrix_layout, lapack_int n, lapack_int nrhs,
                                 lapack_complex_double* a, lapack_int lda,
-                                lapack_int* ipiv, lapack_complex_double* b,
+                                lapack_int* ipiv, const lapack_complex_double* b,
                                 lapack_int ldb, lapack_complex_double* x,
                                 lapack_int ldx, lapack_complex_double* work,
                                 lapack_complex_float* swork, double* rwork,
@@ -103,7 +103,6 @@ lapack_int API_SUFFIX(LAPACKE_zcgesv_work)( int matrix_layout, lapack_int n, lap
         }
         /* Transpose output matrices */
         API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, n, n, a_t, lda_t, a, lda );
-        API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, n, nrhs, x_t, ldx_t, x, ldx );
         /* Release memory and exit */
         LAPACKE_free( x_t );

--- a/LAPACKE/src/lapacke_zcposv.c
+++ b/LAPACKE/src/lapacke_zcposv.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_zcposv)( int matrix_layout, char uplo, lapack_int n,
                            lapack_int nrhs, lapack_complex_double* a,
-                           lapack_int lda, lapack_complex_double* b,
+                           lapack_int lda, const lapack_complex_double* b,
                            lapack_int ldb, lapack_complex_double* x,
                            lapack_int ldx, lapack_int* iter )
 {

--- a/LAPACKE/src/lapacke_zcposv_work.c
+++ b/LAPACKE/src/lapacke_zcposv_work.c
@@ -34,7 +34,7 @@
 
 lapack_int API_SUFFIX(LAPACKE_zcposv_work)( int matrix_layout, char uplo, lapack_int n,
                                 lapack_int nrhs, lapack_complex_double* a,
-                                lapack_int lda, lapack_complex_double* b,
+                                lapack_int lda, const lapack_complex_double* b,
                                 lapack_int ldb, lapack_complex_double* x,
                                 lapack_int ldx, lapack_complex_double* work,
                                 lapack_complex_float* swork, double* rwork,
@@ -103,7 +103,6 @@ lapack_int API_SUFFIX(LAPACKE_zcposv_work)( int matrix_layout, char uplo, lapack
         }
         /* Transpose output matrices */
         API_SUFFIX(LAPACKE_zpo_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
-        API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, n, nrhs, x_t, ldx_t, x, ldx );
         /* Release memory and exit */
         LAPACKE_free( x_t );

--- a/LAPACKE/src/lapacke_zhetrs_aa_2stage.c
+++ b/LAPACKE/src/lapacke_zhetrs_aa_2stage.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_zhetrs_aa_2stage)( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_double* a,
+                          lapack_int nrhs, const lapack_complex_double* a,
                           lapack_int lda, lapack_complex_double* tb,
-                          lapack_int ltb, lapack_int* ipiv, lapack_int* ipiv2,
+                          lapack_int ltb, const lapack_int* ipiv, const lapack_int* ipiv2,
                           lapack_complex_double* b, lapack_int ldb )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_zhetrs_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_zhetrs_aa_2stage_work.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_zhetrs_aa_2stage_work)( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_double* a, lapack_int lda,
-                               lapack_complex_double* tb, lapack_int ltb, lapack_int* ipiv, 
-                               lapack_int* ipiv2, lapack_complex_double* b, lapack_int ldb )
+                               lapack_int nrhs, const lapack_complex_double* a, lapack_int lda,
+                               lapack_complex_double* tb, lapack_int ltb, const lapack_int* ipiv, 
+                               const lapack_int* ipiv2, lapack_complex_double* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
@@ -93,7 +93,6 @@ lapack_int API_SUFFIX(LAPACKE_zhetrs_aa_2stage_work)( int matrix_layout, char up
             info = info - 1;
         }
         /* Transpose output matrices */
-        API_SUFFIX(LAPACKE_zhe_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
         API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         /* Release memory and exit */
         LAPACKE_free( b_t );

--- a/LAPACKE/src/lapacke_zlassq.c
+++ b/LAPACKE/src/lapacke_zlassq.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_zlassq)( lapack_int n, lapack_complex_double* x,
+lapack_int API_SUFFIX(LAPACKE_zlassq)( lapack_int n, const lapack_complex_double* x,
                            lapack_int incx, double* scale, double* sumsq )
 {
 #ifndef LAPACK_DISABLE_NAN_CHECK

--- a/LAPACKE/src/lapacke_zlassq_work.c
+++ b/LAPACKE/src/lapacke_zlassq_work.c
@@ -32,7 +32,7 @@
 
 #include "lapacke_utils.h"
 
-lapack_int API_SUFFIX(LAPACKE_zlassq_work)( lapack_int n, lapack_complex_double* x,
+lapack_int API_SUFFIX(LAPACKE_zlassq_work)( lapack_int n, const lapack_complex_double* x,
                                 lapack_int incx, double* scale, double* sumsq )
 {
     lapack_int info = 0;

--- a/LAPACKE/src/lapacke_zsytrs_aa_2stage.c
+++ b/LAPACKE/src/lapacke_zsytrs_aa_2stage.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_zsytrs_aa_2stage)( int matrix_layout, char uplo, lapack_int n,
-                          lapack_int nrhs, lapack_complex_double* a, lapack_int lda,
-                          lapack_complex_double* tb, lapack_int ltb, lapack_int* ipiv, 
-                          lapack_int* ipiv2, lapack_complex_double* b, lapack_int ldb )
+                          lapack_int nrhs, const lapack_complex_double* a, lapack_int lda,
+                          lapack_complex_double* tb, lapack_int ltb, const lapack_int* ipiv, 
+                          const lapack_int* ipiv2, lapack_complex_double* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {

--- a/LAPACKE/src/lapacke_zsytrs_aa_2stage_work.c
+++ b/LAPACKE/src/lapacke_zsytrs_aa_2stage_work.c
@@ -33,9 +33,9 @@
 #include "lapacke_utils.h"
 
 lapack_int API_SUFFIX(LAPACKE_zsytrs_aa_2stage_work)( int matrix_layout, char uplo, lapack_int n,
-                               lapack_int nrhs, lapack_complex_double* a, lapack_int lda,
-                               lapack_complex_double* tb, lapack_int ltb, lapack_int* ipiv, 
-                               lapack_int* ipiv2, lapack_complex_double* b, lapack_int ldb )
+                               lapack_int nrhs, const lapack_complex_double* a, lapack_int lda,
+                               lapack_complex_double* tb, lapack_int ltb, const lapack_int* ipiv, 
+                               const lapack_int* ipiv2, lapack_complex_double* b, lapack_int ldb )
 {
     lapack_int info = 0;
     if( matrix_layout == LAPACK_COL_MAJOR ) {
@@ -93,7 +93,6 @@ lapack_int API_SUFFIX(LAPACKE_zsytrs_aa_2stage_work)( int matrix_layout, char up
             info = info - 1;
         }
         /* Transpose output matrices */
-        API_SUFFIX(LAPACKE_zsy_trans)( LAPACK_COL_MAJOR, uplo, n, a_t, lda_t, a, lda );
         API_SUFFIX(LAPACKE_zge_trans)( LAPACK_COL_MAJOR, n, nrhs, b_t, ldb_t, b, ldb );
         /* Release memory and exit */
         LAPACKE_free( b_t );


### PR DESCRIPTION
**Description**

Some matrix arguments in the LAPACKE interfaces were not specified as const, even though they are clearly marked as pure inputs on the Fortran side and are correctly specified as const in the LAPACK C interfaces.

I changed all the pure inputs to be const. That revealed some spurious transpositions of "output" matrices (row-major cases) that are, in fact, only inputs. I removed those as well.

**Checklist**

- [x] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.