### PR TITLE
Implement MSVC complex types

### DIFF
--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -47,7 +47,11 @@
 #else
 #include <complex>
 #endif
+#if _MSC_VER
+#define lapack_complex_float    _Fcomplex
+#else
 #define lapack_complex_float    float _Complex
+#endif
 #endif
 
 #ifndef lapack_complex_float_real
@@ -65,7 +69,11 @@
 #else
 #include <complex>
 #endif
+#if _MSC_VER
+#define lapack_complex_double   _Dcomplex
+#else
 #define lapack_complex_double   double _Complex
+#endif
 #endif
 
 #ifndef lapack_complex_double_real

--- a/LAPACKE/include/lapacke_config.h
+++ b/LAPACKE/include/lapacke_config.h
@@ -99,6 +99,16 @@ typedef struct { double real, imag; } _lapack_complex_double;
 #define lapack_complex_double_real(z)       ((z).real())
 #define lapack_complex_double_imag(z)       ((z).imag())
 
+#elif _MSC_VER
+
+#include <complex.h>
+#define lapack_complex_float    _Fcomplex
+#define lapack_complex_double   _Dcomplex
+#define lapack_complex_float_real(z)       (crealf(z))
+#define lapack_complex_float_imag(z)       (cimagf(z))
+#define lapack_complex_double_real(z)       (creal(z))
+#define lapack_complex_double_imag(z)       (cimag(z))
+
 #else
 
 #include <complex.h>

--- a/LAPACKE/utils/lapacke_make_complex_double.c
+++ b/LAPACKE/utils/lapacke_make_complex_double.c
@@ -43,6 +43,8 @@ lapack_complex_double lapack_make_complex_double( double re, double im ) {
     z = re + im * I;
 #elif defined(LAPACK_COMPLEX_CPP)
     z = std::complex<double>(re,im);
+#elif _MSC_VER
+    z = _Cbuild(re, im);
 #else /* C99 is default */
     z = re + im*I;
 #endif

--- a/LAPACKE/utils/lapacke_make_complex_float.c
+++ b/LAPACKE/utils/lapacke_make_complex_float.c
@@ -43,6 +43,8 @@ lapack_complex_float lapack_make_complex_float( float re, float im ) {
     z = re + im * I;
 #elif defined(LAPACK_COMPLEX_CPP)
     z = std::complex<float>(re,im);
+#elif _MSC_VER
+    z = _FCbuild(re, im);
 #else /* C99 is default */
     z = re + im*I;
 #endif


### PR DESCRIPTION
**Description**

Implement the support for the `_Fcomplex` and `_Dcomplex` types used by MSVC in place of the standard C99 complex types.  This is necessary to make LAPACK build out of the box with MSVC, since it does not implement the default C99 types.

See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support

I went for the simplest implementation possible, limiting the changes to swapping the default types used when MSVC is used as the compiler, also when `lapack_config.h` is not used.  I haven't added a `LAPACK_COMPLEX_*` ifdef for it, but I can do that if you prefer.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.