### PR TITLE
Refactor IEEECK to avoid generating IEEE exceptions by using IEEE_ARITHMETIC

### DIFF
--- a/SRC/ieeeck.f
+++ b/SRC/ieeeck.f
@@ -77,6 +77,9 @@
 *
 *  =====================================================================
       INTEGER          FUNCTION IEEECK( ISPEC, ZERO, ONE )
+      USE, INTRINSIC :: IEEE_ARITHMETIC, ONLY:
+     &                                     IEEE_SUPPORT_INF,
+     &                                     IEEE_SUPPORT_NAN
       IMPLICIT NONE
 *
 *  -- LAPACK auxiliary routine --
@@ -90,57 +93,11 @@
 *
 *  =====================================================================
 *
-*     .. Local Scalars ..
-      REAL               NAN1, NAN2, NAN3, NAN4, NAN5, NAN6, NEGINF,
-     $                   NEGZRO, NEWZRO, POSINF
 *     ..
 *     .. Executable Statements ..
       IEEECK = 1
 *
-      POSINF = ONE / ZERO
-      IF( POSINF.LE.ONE ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      NEGINF = -ONE / ZERO
-      IF( NEGINF.GE.ZERO ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      NEGZRO = ONE / ( NEGINF+ONE )
-      IF( NEGZRO.NE.ZERO ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      NEGINF = ONE / NEGZRO
-      IF( NEGINF.GE.ZERO ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      NEWZRO = NEGZRO + ZERO
-      IF( NEWZRO.NE.ZERO ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      POSINF = ONE / NEWZRO
-      IF( POSINF.LE.ONE ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      NEGINF = NEGINF*POSINF
-      IF( NEGINF.GE.ZERO ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      POSINF = POSINF*POSINF
-      IF( POSINF.LE.ONE ) THEN
+      IF ( .NOT.IEEE_SUPPORT_INF(ONE) ) THEN
          IEEECK = 0
          RETURN
       END IF
@@ -153,44 +110,7 @@
       IF( ISPEC.EQ.0 )
      $   RETURN
 *
-      NAN1 = POSINF + NEGINF
-*
-      NAN2 = POSINF / NEGINF
-*
-      NAN3 = POSINF / POSINF
-*
-      NAN4 = POSINF*ZERO
-*
-      NAN5 = NEGINF*NEGZRO
-*
-      NAN6 = NAN5*ZERO
-*
-      IF( NAN1.EQ.NAN1 ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      IF( NAN2.EQ.NAN2 ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      IF( NAN3.EQ.NAN3 ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      IF( NAN4.EQ.NAN4 ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      IF( NAN5.EQ.NAN5 ) THEN
-         IEEECK = 0
-         RETURN
-      END IF
-*
-      IF( NAN6.EQ.NAN6 ) THEN
+      IF( .NOT.IEEE_SUPPORT_NAN(ONE) ) THEN
          IEEECK = 0
          RETURN
       END IF


### PR DESCRIPTION
**Description**

I've replaced division-by-zero and other invalid floating-point operations with IEEE_ARITHMETIC module from modern Fortran. It should simplify debugging of numerical instabilities of code that also uses LAPACK.   

Fixes #1172 

**Checklist**

- [x] The documentation has been updated: no need to update documentation. Keep old documentation as is for compability with previous behaviour.
- [x] If the PR solves a specific issue, it is set to be closed on merge.