### PR TITLE
Update Function Arguments in `?gees`, `?geesx`, `?gges`, `?ggesx`, and `?gges3`

### DIFF
--- a/SRC/cgees.f
+++ b/SRC/cgees.f
@@ -208,8 +208,12 @@
       COMPLEX            A( LDA, * ), VS( LDVS, * ), W( * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(EV) BIND(C)
+          COMPLEX EV
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/cgeesx.f
+++ b/SRC/cgeesx.f
@@ -252,8 +252,12 @@
       COMPLEX            A( LDA, * ), VS( LDVS, * ), W( * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(EV) BIND(C)
+          COMPLEX EV
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/cgges.f
+++ b/SRC/cgges.f
@@ -284,8 +284,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHA,BETA) BIND(C)
+          COMPLEX ALPHA, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/cgges3.f
+++ b/SRC/cgges3.f
@@ -283,8 +283,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHA,BETA) BIND(C)
+          COMPLEX ALPHA, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/cggesx.f
+++ b/SRC/cggesx.f
@@ -346,8 +346,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHA,BETA) BIND(C)
+          COMPLEX ALPHA, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/dgees.f
+++ b/SRC/dgees.f
@@ -227,8 +227,12 @@
      $                   WR( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(WR, WI) BIND(C)
+          DOUBLE PRECISION WR, WI
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/dgeesx.f
+++ b/SRC/dgeesx.f
@@ -294,8 +294,12 @@
      $                   WR( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(WR, WI) BIND(C)
+          DOUBLE PRECISION WR, WI
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/dgges.f
+++ b/SRC/dgges.f
@@ -297,8 +297,12 @@
      $                   VSR( LDVSR, * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHAR, ALPHAI, BETA) BIND(C)
+          DOUBLE PRECISION ALPHAR, ALPHAI, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/dgges3.f
+++ b/SRC/dgges3.f
@@ -296,8 +296,12 @@
      $                   VSR( LDVSR, * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHAR, ALPHAI, BETA) BIND(C)
+          DOUBLE PRECISION ALPHAR, ALPHAI, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/dggesx.f
+++ b/SRC/dggesx.f
@@ -381,8 +381,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHAR, ALPHAI, BETA) BIND(C)
+          DOUBLE PRECISION ALPHAR, ALPHAI, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/sgees.f
+++ b/SRC/sgees.f
@@ -227,8 +227,12 @@
      $                   WR( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(WR, WI) BIND(C)
+          REAL WR, WI
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/sgeesx.f
+++ b/SRC/sgeesx.f
@@ -294,8 +294,12 @@
      $                   WR( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(WR, WI) BIND(C)
+          REAL WR, WI
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/sgges.f
+++ b/SRC/sgges.f
@@ -297,8 +297,12 @@
      $                   VSR( LDVSR, * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHAR, ALPHAI, BETA) BIND(C)
+          REAL ALPHAR, ALPHAI, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/sgges3.f
+++ b/SRC/sgges3.f
@@ -296,8 +296,12 @@
      $                   VSR( LDVSR, * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHAR, ALPHAI, BETA) BIND(C)
+          REAL ALPHAR, ALPHAI, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/sggesx.f
+++ b/SRC/sggesx.f
@@ -381,8 +381,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHAR, ALPHAI, BETA) BIND(C)
+          REAL ALPHAR, ALPHAI, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/zgees.f
+++ b/SRC/zgees.f
@@ -208,8 +208,12 @@
       COMPLEX*16         A( LDA, * ), VS( LDVS, * ), W( * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(EV) BIND(C)
+          COMPLEX*16 EV
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/zgeesx.f
+++ b/SRC/zgeesx.f
@@ -252,8 +252,12 @@
       COMPLEX*16         A( LDA, * ), VS( LDVS, * ), W( * ), WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELECT
-      EXTERNAL           SELECT
+      INTERFACE
+        LOGICAL FUNCTION SELECT_PROC_TYPE(EV) BIND(C)
+          COMPLEX*16 EV
+        END FUNCTION SELECT_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELECT_PROC_TYPE) :: SELECT
 *     ..
 *
 *  =====================================================================

--- a/SRC/zgges.f
+++ b/SRC/zgges.f
@@ -284,8 +284,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHA,BETA) BIND(C)
+          COMPLEX*16 ALPHA, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/zgges3.f
+++ b/SRC/zgges3.f
@@ -283,8 +283,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHA,BETA) BIND(C)
+          COMPLEX*16 ALPHA, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================

--- a/SRC/zggesx.f
+++ b/SRC/zggesx.f
@@ -346,8 +346,12 @@
      $                   WORK( * )
 *     ..
 *     .. Function Arguments ..
-      LOGICAL            SELCTG
-      EXTERNAL           SELCTG
+      INTERFACE
+        LOGICAL FUNCTION SELCTG_PROC_TYPE(ALPHA,BETA) BIND(C)
+          COMPLEX*16 ALPHA, BETA
+        END FUNCTION SELCTG_PROC_TYPE
+      END INTERFACE
+      PROCEDURE(SELCTG_PROC_TYPE) :: SELCTG
 *     ..
 *
 *  =====================================================================


### PR DESCRIPTION
Instead of using external keyword for Function Arguments, this PR introduces explicit interfaces for Function Arguments. The code should be more safe now, and source code reflect documented behaviour. Later, it will help a lot to generate proper interfaces for these functions.

BIND(C) is used since code can be called from other than Fortran languages.

**Checklist**

- [x] The documentation has been updated: no need to update documentation.
- [x] Closes #1171 