### PR TITLE
For building shared libs with flang, use C linker instead of Fortran linker to avoid macOS-specific flags that CMake adds (tested CMake 4.2).

### DIFF
--- a/BLAS/SRC/CMakeLists.txt
+++ b/BLAS/SRC/CMakeLists.txt
@@ -152,6 +152,12 @@ add_library(${BLASLIB}
         $<TARGET_OBJECTS:${BLASLIB}_obj>
         $<$<BOOL:${BUILD_INDEX64_EXT_API}>: $<TARGET_OBJECTS:${BLASLIB}_64_obj>>)
 
+# For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+# that CMake adds (tested CMake 4.2).
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+   set_target_properties (${BLASLIB} PROPERTIES LINKER_LANGUAGE C)
+endif()
+
 set_target_properties(
   ${BLASLIB} PROPERTIES
   VERSION ${LAPACK_VERSION}

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -578,6 +578,11 @@ add_library(${LAPACKLIB}
   $<TARGET_OBJECTS:mod_files>
   $<TARGET_OBJECTS:${LAPACKLIB}_obj>
   $<$<BOOL:${BUILD_INDEX64_EXT_API}>: $<TARGET_OBJECTS:${LAPACKLIB}_64_obj>>)
+# For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+# that CMake adds (tested CMake 4.2).
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+   set_target_properties (${LAPACKLIB} PROPERTIES LINKER_LANGUAGE C)
+endif()
 set_target_properties(
   ${LAPACKLIB} PROPERTIES
   VERSION ${LAPACK_VERSION}


### PR DESCRIPTION

**Description**

Close https://github.com/Reference-LAPACK/lapack/issues/1184


**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.