### PR TITLE
Fix DGS test seed to avoid FMA-sensitive ill-conditioned matrix

### DIFF
--- a/TESTING/dgd.in
+++ b/TESTING/dgd.in
@@ -4,7 +4,8 @@ DGS               Data for the Real Nonsymmetric Schur Form Driver
 1 1 1 2 1         Parameters NB, NBMIN, NXOVER, NS, NBCOL
 10                Threshold for test ratios
 .TRUE.            Put T to test the error exits
-0                 Code to interpret the seed
+2                 Code to interpret the seed
+1234 5678 9012 3456
 DGS 26            Test all 26 matrix types
 DGV               Data for the Real Nonsymmetric Eigenvalue Problem Driver
 6                 Number of matrix dimensions


### PR DESCRIPTION
Fixes #1186

**Description**

The default random seed in the DGS test generates a matrix for N=6, JTYPE=21 that causes DGGES to fail when compiled without FMA instructions. This happens because 1-2 ULP differences from FMA vs non-FMA rounding accumulate through repeated DROT calls in DHGEQZ, leading to different execution paths in eigenvalue reordering.

This fix uses a custom seed that avoids the specific ill-conditioned matrix while maintaining full test coverage (all 26 matrix types, all dimensions).

**Checklist**

- [x] If the PR solves a specific issue, it is set to be closed on merge.
