### PR TITLE
Update step length selection in LAED4 overshoot fallback

### DIFF
--- a/SRC/dlaed4.f
+++ b/SRC/dlaed4.f
@@ -168,8 +168,9 @@
       LOGICAL            ORGATI, SWTCH, SWTCH3
       INTEGER            II, IIM1, IIP1, IP1, ITER, J, NITER
       DOUBLE PRECISION   A, B, C, DEL, DLTLB, DLTUB, DPHI, DPSI, DW,
-     $                   EPS, ERRETM, ETA, MIDPT, PHI, PREW, PSI,
-     $                   RHOINV, TAU, TEMP, TEMP1, W
+     $                   EPS, ERRETM, ETA, ETA1, ETA2, MIDPT, PHI,
+     $                   PREW, PSI, RHOINV, TAU, TEMP, TEMP1, W
+
 *     ..
 *     .. Local Arrays ..
       DOUBLE PRECISION   ZZ( 3 )
@@ -182,7 +183,7 @@
       EXTERNAL           DLAED5, DLAED6
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, MAX, MIN, SQRT
+      INTRINSIC          ABS, MAX, MIN, SIGN, SQRT
 *     ..
 *     .. Executable Statements ..
 *
@@ -349,10 +350,23 @@
      $      ETA = -W / ( DPSI+DPHI )
          TEMP = TAU + ETA
          IF( TEMP.GT.DLTUB .OR. TEMP.LT.DLTLB ) THEN
+            ETA1 = -W / ( DPSI+DPHI )
+            TEMP = TAU + ETA1
             IF( W.LT.ZERO ) THEN
-               ETA = ( DLTUB-TAU ) / TWO
+               ETA2 = ( DLTUB-TAU ) / TWO
             ELSE
-               ETA = ( DLTLB-TAU ) / TWO
+               ETA2 = ( DLTLB-TAU ) / TWO
+            END IF
+            IF ( DLTLB.LE.TEMP .AND. TEMP.LE.DLTUB ) THEN
+*
+*                 If Newton step is within boundaries,
+*                 use the geometric mean of the distance
+*                 and keep the direction (sign).
+*
+               ETA = SIGN(ONE, ETA1) *
+     $               SQRT( ABS( ETA1 ) ) * SQRT( ABS( ETA2 ) )
+            ELSE
+               ETA = ETA2
             END IF
          END IF
          DO 50 J = 1, N
@@ -848,10 +862,23 @@
      $         ETA = -W / DW
             TEMP = TAU + ETA
             IF( TEMP.GT.DLTUB .OR. TEMP.LT.DLTLB ) THEN
+               ETA1 = -W / DW
+               TEMP = TAU + ETA1
                IF( W.LT.ZERO ) THEN
-                  ETA = ( DLTUB-TAU ) / TWO
+                  ETA2 = ( DLTUB-TAU ) / TWO
                ELSE
-                  ETA = ( DLTLB-TAU ) / TWO
+                  ETA2 = ( DLTLB-TAU ) / TWO
+               END IF
+               IF ( DLTLB.LE.TEMP .AND. TEMP.LE.DLTUB ) THEN
+*
+*                 If Newton step is within boundaries,
+*                 use the geometric mean of the distance
+*                 and keep the direction (sign).
+*
+                  ETA = SIGN( ONE, ETA1 ) *
+     $                  SQRT( ABS( ETA1 ) ) * SQRT( ABS( ETA2 ) )
+               ELSE
+                  ETA = ETA2
                END IF
             END IF
 *

--- a/SRC/slaed4.f
+++ b/SRC/slaed4.f
@@ -168,8 +168,8 @@
       LOGICAL            ORGATI, SWTCH, SWTCH3
       INTEGER            II, IIM1, IIP1, IP1, ITER, J, NITER
       REAL               A, B, C, DEL, DLTLB, DLTUB, DPHI, DPSI, DW,
-     $                   EPS, ERRETM, ETA, MIDPT, PHI, PREW, PSI,
-     $                   RHOINV, TAU, TEMP, TEMP1, W
+     $                   EPS, ERRETM, ETA, ETA1, ETA2, MIDPT, PHI,
+     $                   PREW, PSI, RHOINV, TAU, TEMP, TEMP1, W
 *     ..
 *     .. Local Arrays ..
       REAL               ZZ( 3 )
@@ -182,7 +182,7 @@
       EXTERNAL           SLAED5, SLAED6
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, MAX, MIN, SQRT
+      INTRINSIC          ABS, MAX, MIN, SIGN, SQRT
 *     ..
 *     .. Executable Statements ..
 *
@@ -349,10 +349,23 @@
      $      ETA = -W / ( DPSI+DPHI )
          TEMP = TAU + ETA
          IF( TEMP.GT.DLTUB .OR. TEMP.LT.DLTLB ) THEN
+            ETA1 = -W / ( DPSI+DPHI )
+            TEMP = TAU + ETA1
             IF( W.LT.ZERO ) THEN
-               ETA = ( DLTUB-TAU ) / TWO
+               ETA2 = ( DLTUB-TAU ) / TWO
             ELSE
-               ETA = ( DLTLB-TAU ) / TWO
+               ETA2 = ( DLTLB-TAU ) / TWO
+            END IF
+            IF ( DLTLB.LE.TEMP .AND. TEMP.LE.DLTUB ) THEN
+*
+*                 If Newton step is within boundaries,
+*                 use the geometric mean of the distance
+*                 and keep the direction (sign).
+*
+               ETA = SIGN(ONE, ETA1) *
+     $               SQRT( ABS( ETA1 ) ) * SQRT( ABS( ETA2 ) )
+            ELSE
+               ETA = ETA2
             END IF
          END IF
          DO 50 J = 1, N
@@ -848,10 +861,23 @@
      $         ETA = -W / DW
             TEMP = TAU + ETA
             IF( TEMP.GT.DLTUB .OR. TEMP.LT.DLTLB ) THEN
+               ETA1 = -W / DW
+               TEMP = TAU + ETA1
                IF( W.LT.ZERO ) THEN
-                  ETA = ( DLTUB-TAU ) / TWO
+                  ETA2 = ( DLTUB-TAU ) / TWO
                ELSE
-                  ETA = ( DLTLB-TAU ) / TWO
+                  ETA2 = ( DLTLB-TAU ) / TWO
+               END IF
+               IF ( DLTLB.LE.TEMP .AND. TEMP.LE.DLTUB ) THEN
+*
+*                 If Newton step is within boundaries,
+*                 use the geometric mean of the distance
+*                 and keep the direction (sign).
+*
+                  ETA = SIGN( ONE, ETA1 ) *
+     $                  SQRT( ABS( ETA1 ) ) * SQRT( ABS( ETA2 ) )
+               ELSE
+                  ETA = ETA2
                END IF
             END IF
 *


### PR DESCRIPTION
**Description**

On behalf of the NVIDIA cuSolver team, I am proposing a fix of #1166.

When LAED4 overshoots, bisection is used as fallback. This was introduced with LAPACK 3.0. This MR updates the heuristic to account for cases where the bisection step is a poor choice: The relative distance is large (details in the issue), and the step can be too large, increasing the objective function value a lot. The new heuristic exploits that we know that the root is close to a cell boundary if we enter the fallback branch. As a consequence, we know that a plain Newton step is too short; a bisection step is be too long if we are far away from the cell boundary; so we combine both by using the geometric mean for a more balanced step length selection. If we are close to cell boundary, the bisection step and the Newton step are essentially the same, so there is no difference in that case. 

| iter | W | relative position |
|------|---------|---------|
| 3 | -1.51832E+01 | 9.3224424664962507E-012 |
| 4 | -7.25413E+00 | 2.8321247865713130E-011 |
| 5* | 8.18857E+01 | 3.0407842273038627E-006 |
| 6 | 4.09510E+01 | 1.5161499861086540E-006 |
| 7 | -2.46969E+00 | 1.0185715189871375E-010 |
| 8 | -1.22757E+00 | 2.1967449887941141E-010 |
| 9* | 3.65801E-01 | 1.3670968645180088E-008 |
| 10 | 1.60693E-01 | 7.1757532425621201E-009 |
| 11 | -4.84878E-02 | 2.6748870916100162E-009 |
| 12 | -5.24972E-03 | 3.3293874740295193E-009 |
| 13 | 7.41175E-05 | 3.4204917465753645E-009 |
| 14 | 1.46778E-08 | 3.4192075727019548E-009 |
| 15 | 1.07595E-12 | 3.4192073183864720E-009 |

The iterations marked with * go into the fallback branch; the objective function value `W` is much better than with plain bisection (compare with table in bug report). Instead of 31 iterations and 3 overshoots as in the bug report, we now have 15 iterations and only 2 overshoots.


**Checklist**

- [ ] The documentation has been updated.
- [X] If the PR solves a specific issue, it is set to be closed on merge.