### PR TITLE
add crot and zrot to LAPACKE

### DIFF
--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -14981,6 +14981,22 @@ void LAPACK_zpttrs_base(
     #define LAPACK_zpttrs(...) LAPACK_zpttrs_base(__VA_ARGS__)
 #endif
 
+#define LAPACK_crot LAPACK_GLOBAL_SUFFIX(crot,CROT)
+void LAPACK_crot(
+    lapack_int const* n,
+    lapack_complex_float* CX, lapack_int const* incx,
+    lapack_complex_float* CY, lapack_int const* incy,
+    float const* c,
+    lapack_complex_float const* s );
+
+#define LAPACK_zrot LAPACK_GLOBAL_SUFFIX(zrot,ZROT)
+void LAPACK_zrot(
+    lapack_int const* n,
+    lapack_complex_double* CX, lapack_int const* incx,
+    lapack_complex_double* CY, lapack_int const* incy,
+    double const* c,
+    lapack_complex_double const* s );
+
 #define LAPACK_dsbev_base LAPACK_GLOBAL_SUFFIX(dsbev,DSBEV)
 void LAPACK_dsbev_base(
     char const* jobz, char const* uplo,

--- a/LAPACKE/include/lapacke.h
+++ b/LAPACKE/include/lapacke.h
@@ -3326,6 +3326,15 @@ lapack_int LAPACKE_zpttrs( int matrix_layout, char uplo, lapack_int n,
                            const lapack_complex_double* e,
                            lapack_complex_double* b, lapack_int ldb );
 
+lapack_int LAPACKE_crot( lapack_int n,
+                         lapack_complex_float* cx, lapack_int incx,
+                         lapack_complex_float* cy, lapack_int incy,
+                         float c, lapack_complex_float s );
+lapack_int LAPACKE_zrot( lapack_int n,
+                         lapack_complex_double* cx, lapack_int incx,
+                         lapack_complex_double* cy, lapack_int incy,
+                         double c, lapack_complex_double s );
+
 lapack_int LAPACKE_ssbev( int matrix_layout, char jobz, char uplo, lapack_int n,
                           lapack_int kd, float* ab, lapack_int ldab, float* w,
                           float* z, lapack_int ldz );
@@ -8883,6 +8892,15 @@ lapack_int LAPACKE_zpttrs_work( int matrix_layout, char uplo, lapack_int n,
                                 lapack_int nrhs, const double* d,
                                 const lapack_complex_double* e,
                                 lapack_complex_double* b, lapack_int ldb );
+
+lapack_int LAPACKE_crot_work( lapack_int n,
+                              lapack_complex_float* cx, lapack_int incx,
+                              lapack_complex_float* cy, lapack_int incy,
+                              float c, lapack_complex_float s );
+lapack_int LAPACKE_zrot_work( lapack_int n,
+                              lapack_complex_double* cx, lapack_int incx,
+                              lapack_complex_double* cy, lapack_int incy,
+                              double c, lapack_complex_double s );
 
 lapack_int LAPACKE_ssbev_work( int matrix_layout, char jobz, char uplo,
                                lapack_int n, lapack_int kd, float* ab,

--- a/LAPACKE/include/lapacke_64.h
+++ b/LAPACKE/include/lapacke_64.h
@@ -3292,6 +3292,15 @@ int64_t LAPACKE_zpttrs_64( int matrix_layout, char uplo, int64_t n,
                            const lapack_complex_double* e,
                            lapack_complex_double* b, int64_t ldb );
 
+int64_t LAPACKE_crot_64( int64_t n,
+                         lapack_complex_float* cx, int64_t incx,
+                         lapack_complex_float* cy, int64_t incy,
+                         float c, lapack_complex_float s );
+int64_t LAPACKE_zrot_64( int64_t n,
+                         lapack_complex_double* cx, int64_t incx,
+                         lapack_complex_double* cy, int64_t incy,
+                         double c, lapack_complex_double s );
+
 int64_t LAPACKE_ssbev_64( int matrix_layout, char jobz, char uplo, int64_t n,
                           int64_t kd, float* ab, int64_t ldab, float* w,
                           float* z, int64_t ldz );
@@ -8850,6 +8859,15 @@ int64_t LAPACKE_zpttrs_work_64( int matrix_layout, char uplo, int64_t n,
                                 int64_t nrhs, const double* d,
                                 const lapack_complex_double* e,
                                 lapack_complex_double* b, int64_t ldb );
+
+int64_t LAPACKE_crot_work_64( int64_t n,
+                              lapack_complex_float* cx, int64_t incx,
+                              lapack_complex_float* cy, int64_t incy,
+                              float c, lapack_complex_float s );
+int64_t LAPACKE_zrot_work_64( int64_t n,
+                              lapack_complex_double* cx, int64_t incx,
+                              lapack_complex_double* cy, int64_t incy,
+                              double c, lapack_complex_double s );
 
 int64_t LAPACKE_ssbev_work_64( int matrix_layout, char jobz, char uplo,
                                int64_t n, int64_t kd, float* ab,

--- a/LAPACKE/src/CMakeLists.txt
+++ b/LAPACKE/src/CMakeLists.txt
@@ -423,6 +423,8 @@ lapacke_cpttrf.c
 lapacke_cpttrf_work.c
 lapacke_cpttrs.c
 lapacke_cpttrs_work.c
+lapacke_crot.c
+lapacke_crot_work.c
 lapacke_cspcon.c
 lapacke_cspcon_work.c
 lapacke_csprfs.c
@@ -2210,6 +2212,8 @@ lapacke_zpttrf.c
 lapacke_zpttrf_work.c
 lapacke_zpttrs.c
 lapacke_zpttrs_work.c
+lapacke_zrot.c
+lapacke_zrot_work.c
 lapacke_zspcon.c
 lapacke_zspcon_work.c
 lapacke_zsprfs.c

--- a/LAPACKE/src/lapacke_crot.c
+++ b/LAPACKE/src/lapacke_crot.c
@@ -1,0 +1,52 @@
+/*****************************************************************************
+  Copyright (c) 2026, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native high-level C interface to LAPACK function crot
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+lapack_int API_SUFFIX(LAPACKE_crot)( lapack_int n,
+                          lapack_complex_float* cx, lapack_int incx,
+                          lapack_complex_float* cy, lapack_int incy,
+                          float c, lapack_complex_float s )
+{
+#ifndef LAPACK_DISABLE_NAN_CHECK
+    if( LAPACKE_get_nancheck() ) {
+        /* Optionally check input vectors `cx` and `cy` for NaNs */
+        if( API_SUFFIX(LAPACKE_c_nancheck)( n, cx, incx ) ) {
+            return -2;
+        }
+        if( API_SUFFIX(LAPACKE_c_nancheck)( n, cy, incy ) ) {
+            return -4;
+        }
+    }
+#endif
+    return API_SUFFIX(LAPACKE_crot_work)( n, cx, incx, cy, incy, c, s );
+}

--- a/LAPACKE/src/lapacke_crot_work.c
+++ b/LAPACKE/src/lapacke_crot_work.c
@@ -1,0 +1,43 @@
+/*****************************************************************************
+  Copyright (c) 2026, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native middle-level C interface to LAPACK function crot
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+lapack_int API_SUFFIX(LAPACKE_crot_work)( lapack_int n,
+                               lapack_complex_float* cx, lapack_int incx,
+                               lapack_complex_float* cy, lapack_int incy,
+                               float c, lapack_complex_float s )
+{
+    lapack_int info = 0;
+    LAPACK_crot( &n, cx, &incx, cy, &incy, &c, &s );
+    return info;
+}

--- a/LAPACKE/src/lapacke_zrot.c
+++ b/LAPACKE/src/lapacke_zrot.c
@@ -1,0 +1,52 @@
+/*****************************************************************************
+  Copyright (c) 2026, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native high-level C interface to LAPACK function zrot
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+lapack_int API_SUFFIX(LAPACKE_zrot)( lapack_int n,
+                          lapack_complex_double* cx, lapack_int incx,
+                          lapack_complex_double* cy, lapack_int incy,
+                          double c, lapack_complex_double s )
+{
+#ifndef LAPACK_DISABLE_NAN_CHECK
+    if( LAPACKE_get_nancheck() ) {
+        /* Optionally check input vectors `cx` and `cy` for NaNs */
+        if( API_SUFFIX(LAPACKE_z_nancheck)( n, cx, incx ) ) {
+            return -2;
+        }
+        if( API_SUFFIX(LAPACKE_z_nancheck)( n, cy, incy ) ) {
+            return -4;
+        }
+    }
+#endif
+    return API_SUFFIX(LAPACKE_zrot_work)( n, cx, incx, cy, incy, c, s );
+}

--- a/LAPACKE/src/lapacke_zrot_work.c
+++ b/LAPACKE/src/lapacke_zrot_work.c
@@ -1,0 +1,43 @@
+/*****************************************************************************
+  Copyright (c) 2026, Intel Corp.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************
+* Contents: Native middle-level C interface to LAPACK function zrot
+* Author: Intel Corporation
+*****************************************************************************/
+
+#include "lapacke_utils.h"
+
+lapack_int API_SUFFIX(LAPACKE_zrot_work)( lapack_int n,
+                               lapack_complex_double* cx, lapack_int incx,
+                               lapack_complex_double* cy, lapack_int incy,
+                               double c, lapack_complex_double s )
+{
+    lapack_int info = 0;
+    LAPACK_zrot( &n, cx, &incx, cy, &incy, &c, &s );
+    return info;
+}


### PR DESCRIPTION
**Description**

Fixes #962.

I tested this by creating a file
```c
/* test_rot.c */
#include <lapacke.h>
#include <stdio.h>

int main() {
    lapack_complex_float  cx = lapack_make_complex_float(1.0f, 0.0f);
    lapack_complex_float  cy = lapack_make_complex_float(0.0f, 1.0f);
    lapack_complex_float  cs = lapack_make_complex_float(0.0f, 1.0f);
    lapack_complex_double zx = lapack_make_complex_double(1.0, 0.0);
    lapack_complex_double zy = lapack_make_complex_double(0.0, 1.0);
    lapack_complex_double zs = lapack_make_complex_double(0.0, 1.0);

    LAPACKE_crot(1, &cx, 1, &cy, 1, 0.0f, cs);
    LAPACKE_zrot(1, &zx, 1, &zy, 1, 0.0,  zs);
    printf("crot and zrot succeeded\n");
    return 0;
}
```
and then running
```
mkdir build
pushd build
cmake .. -DLAPACKE=ON -DBUILD_TESTING=ON
cmake --build . --target lapacke -j$(nproc)
popd
gcc -o test_rot test_rot.c -I LAPACKE/include -I build/include \
    -L build/lib -llapacke -llapack -lblas -lm && ./test_rot
```

**Checklist**

- [X] The documentation has been updated.
- [X] If the PR solves a specific issue, it is set to be closed on merge.