### PR TITLE
TESTING/LIN: align ISEED declarations with documented dimension in four test routines

### DIFF
--- a/TESTING/LIN/clatsp.f
+++ b/TESTING/LIN/clatsp.f
@@ -15,7 +15,7 @@
 *       INTEGER            N
 *       ..
 *       .. Array Arguments ..
-*       INTEGER            ISEED( * )
+*       INTEGER            ISEED( 4 )
 *       COMPLEX            X( * )
 *       ..
 *
@@ -92,7 +92,7 @@
       INTEGER            N
 *     ..
 *     .. Array Arguments ..
-      INTEGER            ISEED( * )
+      INTEGER            ISEED( 4 )
       COMPLEX            X( * )
 *     ..
 *

--- a/TESTING/LIN/clatsy.f
+++ b/TESTING/LIN/clatsy.f
@@ -15,7 +15,7 @@
 *       INTEGER            LDX, N
 *       ..
 *       .. Array Arguments ..
-*       INTEGER            ISEED( * )
+*       INTEGER            ISEED( 4 )
 *       COMPLEX            X( LDX, * )
 *       ..
 *
@@ -97,7 +97,7 @@
       INTEGER            LDX, N
 *     ..
 *     .. Array Arguments ..
-      INTEGER            ISEED( * )
+      INTEGER            ISEED( 4 )
       COMPLEX            X( LDX, * )
 *     ..
 *

--- a/TESTING/LIN/zlatsp.f
+++ b/TESTING/LIN/zlatsp.f
@@ -15,7 +15,7 @@
 *       INTEGER            N
 *       ..
 *       .. Array Arguments ..
-*       INTEGER            ISEED( * )
+*       INTEGER            ISEED( 4 )
 *       COMPLEX*16         X( * )
 *       ..
 *
@@ -92,7 +92,7 @@
       INTEGER            N
 *     ..
 *     .. Array Arguments ..
-      INTEGER            ISEED( * )
+      INTEGER            ISEED( 4 )
       COMPLEX*16         X( * )
 *     ..
 *

--- a/TESTING/LIN/zlatsy.f
+++ b/TESTING/LIN/zlatsy.f
@@ -15,7 +15,7 @@
 *       INTEGER            LDX, N
 *       ..
 *       .. Array Arguments ..
-*       INTEGER            ISEED( * )
+*       INTEGER            ISEED( 4 )
 *       COMPLEX*16         X( LDX, * )
 *       ..
 *
@@ -97,7 +97,7 @@
       INTEGER            LDX, N
 *     ..
 *     .. Array Arguments ..
-      INTEGER            ISEED( * )
+      INTEGER            ISEED( 4 )
       COMPLEX*16         X( LDX, * )
 *     ..
 *


### PR DESCRIPTION
This PR updates four TESTING/LIN routines:

- `clatsp`
- `clatsy`
- `zlatsp`
- `zlatsy`

In all four files, the parameter documentation says that `ISEED` is an
`INTEGER` array of dimension `(4)`, but the actual dummy argument
declaration is currently `ISEED(*)`.

These routines pass `ISEED` to `CLARND`/`ZLARND`, whose interfaces use
`ISEED(4)` and whose documentation states that the fourth element must
be odd.

This patch changes both the commented argument declarations and the
actual dummy argument declarations from `ISEED(*)` to `ISEED(4)` so
that the routine declarations match the documented contract and the
callee interfaces.

No functional change is intended.