### PR TITLE
fix: correct trailing routine comment in dgemmtr

### DIFF
--- a/BLAS/SRC/dgemmtr.f
+++ b/BLAS/SRC/dgemmtr.f
@@ -426,6 +426,6 @@
 *
       RETURN
 *
-*     End of SGEMM
+*     End of DGEMMTR
 *
       END


### PR DESCRIPTION
**Description**
The routine body is unchanged. This patch only corrects the end-of-routine comment so that it matches the actual subroutine name.

If the PR solves a specific issue, it is set to be closed on merge. #1198 