### PR TITLE
fix(xlaqp2rk): do not modify [in] argument KMAX; introduce KBOUND

### DIFF
--- a/SRC/claqp2rk.f
+++ b/SRC/claqp2rk.f
@@ -358,8 +358,8 @@
       PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
 *     ..
 *     .. Local Scalars ..
-      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP, KBOUND, MINMNFACT,
-     $                   MINMNUPDT
+      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP,
+     $                   KBOUND, MINMNFACT, MINMNUPDT
       REAL               HUGEVAL, TAUNAN, TEMP, TEMP2, TOL3Z
 *     ..
 *     .. External Subroutines ..

--- a/SRC/dlaqp2rk.f
+++ b/SRC/dlaqp2rk.f
@@ -355,8 +355,8 @@
       PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
-      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP, KBOUND, MINMNFACT,
-     $                   MINMNUPDT
+      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP,
+     $                   KBOUND, MINMNFACT, MINMNUPDT
       DOUBLE PRECISION   HUGEVAL, TEMP, TEMP2, TOL3Z
 *     ..
 *     .. External Subroutines ..

--- a/SRC/slaqp2rk.f
+++ b/SRC/slaqp2rk.f
@@ -355,8 +355,8 @@
       PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
-      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP, KBOUND, MINMNFACT,
-     $                   MINMNUPDT
+      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP,
+     $                   KBOUND, MINMNFACT, MINMNUPDT
       REAL               HUGEVAL, TEMP, TEMP2, TOL3Z
 *     ..
 *     .. External Subroutines ..

--- a/SRC/zlaqp2rk.f
+++ b/SRC/zlaqp2rk.f
@@ -359,8 +359,8 @@
      $                   CONE = ( 1.0D+0, 0.0D+0 ) )
 *     ..
 *     .. Local Scalars ..
-      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP, KBOUND, MINMNFACT,
-     $                   MINMNUPDT
+      INTEGER            I, ITEMP, J, JMAXC2NRM, KK, KP,
+     $                   KBOUND, MINMNFACT, MINMNUPDT
       DOUBLE PRECISION   HUGEVAL, TAUNAN, TEMP, TEMP2, TOL3Z
 *     ..
 *     .. External Subroutines ..


### PR DESCRIPTION
**Summary**

In `SLAQP2RK`, `DLAQP2RK`, `CLAQP2RK`, and `ZLAQP2RK`, the argument `KMAX` is documented as `[in]`, but the implementation overwrites it:

```fortran
KMAX = MIN( KMAX, MINMNFACT )
```

This is a contradiction between the documentation and the implementation.

**Root cause**

Fortran callers are insulated from this side effect because `DGEQP3RK` (and its variants) pass a temporary expression `JMAX - J + 1` rather than a named variable, so the write to `KMAX` inside `xLAQP2RK` is silently discarded. However:

- The `[in]` annotation is violated.
- C and C++ translations of these routines fail to compile, since an rvalue cannot be bound to a non-const reference.
- Any caller that passes a named variable directly (e.g., in testing or alternative driver routines) will have that variable silently corrupted.

**Fix**

Introduce a local variable `KBOUND` to hold the clamped value. `KMAX` is no longer written to.

```fortran
-      KMAX = MIN( KMAX, MINMNFACT )
-      DO KK = 1, KMAX
+      KBOUND = MIN( KMAX, MINMNFACT )
+      DO KK = 1, KBOUND
 ...
-      K = KMAX
+      K = KBOUND
```

**Files changed**

- `SRC/slaqp2rk.f`
- `SRC/dlaqp2rk.f`
- `SRC/claqp2rk.f`
- `SRC/zlaqp2rk.f`

**No behavior change**

The computed result is identical for all existing callers. This is a correctness fix for the argument intent annotation and a robustness fix for non-Fortran consumers of these routines.