### PR TITLE
Use ROUNDUP_LWORK and remove redundant type conversions in *gvd routines

### DIFF
--- a/SRC/chegvd.f
+++ b/SRC/chegvd.f
@@ -319,7 +319,7 @@
 *
       IF( INFO.EQ.0 ) THEN
          WORK( 1 ) = SROUNDUP_LWORK(LOPT)
-         RWORK( 1 ) = REAL( LROPT )
+         RWORK( 1 ) = SROUNDUP_LWORK(LROPT)
          IWORK( 1 ) = LIOPT
 *
          IF( LWORK.LT.LWMIN .AND. .NOT.LQUERY ) THEN
@@ -357,9 +357,9 @@
       CALL CHEEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, RWORK,
      $             LRWORK,
      $             IWORK, LIWORK, INFO )
-      LOPT = INT( MAX( REAL( LOPT ), REAL( WORK( 1 ) ) ) )
-      LROPT = INT( MAX( REAL( LROPT ), REAL( RWORK( 1 ) ) ) )
-      LIOPT = INT( MAX( REAL( LIOPT ), REAL( IWORK( 1 ) ) ) )
+      LOPT = MAX( LOPT, INT( REAL( WORK( 1 ) ) ) )
+      LROPT = MAX( LROPT, INT( RWORK( 1 ) ) )
+      LIOPT = MAX( LIOPT, IWORK( 1 ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *
@@ -396,7 +396,7 @@
       END IF
 *
       WORK( 1 ) = SROUNDUP_LWORK(LOPT)
-      RWORK( 1 ) = REAL( LROPT )
+      RWORK( 1 ) = SROUNDUP_LWORK(LROPT)
       IWORK( 1 ) = LIOPT
 *
       RETURN

--- a/SRC/chpgvd.f
+++ b/SRC/chpgvd.f
@@ -295,7 +295,7 @@
          END IF
 *
          WORK( 1 ) = SROUNDUP_LWORK(LWMIN)
-         RWORK( 1 ) = REAL( LRWMIN )
+         RWORK( 1 ) = SROUNDUP_LWORK(LRWMIN)
          IWORK( 1 ) = LIWMIN
          IF( LWORK.LT.LWMIN .AND. .NOT.LQUERY ) THEN
             INFO = -11
@@ -331,9 +331,9 @@
       CALL CHPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL CHPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, RWORK,
      $             LRWORK, IWORK, LIWORK, INFO )
-      LWMIN = INT( MAX( REAL( LWMIN ), REAL( WORK( 1 ) ) ) )
-      LRWMIN = INT( MAX( REAL( LRWMIN ), REAL( RWORK( 1 ) ) ) )
-      LIWMIN = INT( MAX( REAL( LIWMIN ), REAL( IWORK( 1 ) ) ) )
+      LWMIN = MAX( LWMIN, INT( REAL( WORK( 1 ) ) ) )
+      LRWMIN = MAX( LRWMIN, INT( RWORK( 1 ) ) )
+      LIWMIN = MAX( LIWMIN, IWORK( 1 ) )
 *
       IF( WANTZ ) THEN
 *
@@ -377,7 +377,7 @@
       END IF
 *
       WORK( 1 ) = SROUNDUP_LWORK(LWMIN)
-      RWORK( 1 ) = REAL( LRWMIN )
+      RWORK( 1 ) = SROUNDUP_LWORK(LRWMIN)
       IWORK( 1 ) = LIWMIN
       RETURN
 *

--- a/SRC/dspgvd.f
+++ b/SRC/dspgvd.f
@@ -225,14 +225,15 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DROUNDUP_LWORK
+      EXTERNAL           LSAME, DROUNDUP_LWORK
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DPPTRF, DSPEVD, DSPGST, DTPMV, DTPSV,
      $                   XERBLA
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          DBLE, MAX
+      INTRINSIC          MAX
 *     ..
 *     .. Executable Statements ..
 *
@@ -268,7 +269,7 @@
                LWMIN = 2*N
             END IF
          END IF
-         WORK( 1 ) = LWMIN
+         WORK( 1 ) = DROUNDUP_LWORK(LWMIN)
          IWORK( 1 ) = LIWMIN
          IF( LWORK.LT.LWMIN .AND. .NOT.LQUERY ) THEN
             INFO = -11
@@ -302,8 +303,8 @@
       CALL DSPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL DSPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, IWORK,
      $             LIWORK, INFO )
-      LWMIN = INT( MAX( DBLE( LWMIN ), DBLE( WORK( 1 ) ) ) )
-      LIWMIN = INT( MAX( DBLE( LIWMIN ), DBLE( IWORK( 1 ) ) ) )
+      LWMIN = MAX( LWMIN, INT( WORK( 1 ) ) )
+      LIWMIN = MAX( LIWMIN, IWORK( 1 ) )
 *
       IF( WANTZ ) THEN
 *
@@ -346,7 +347,7 @@
          END IF
       END IF
 *
-      WORK( 1 ) = LWMIN
+      WORK( 1 ) = DROUNDUP_LWORK(LWMIN)
       IWORK( 1 ) = LIWMIN
 *
       RETURN

--- a/SRC/dsygvd.f
+++ b/SRC/dsygvd.f
@@ -245,14 +245,15 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DROUNDUP_LWORK
+      EXTERNAL           LSAME, DROUNDUP_LWORK
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DPOTRF, DSYEVD, DSYGST, DTRMM, DTRSM,
      $                   XERBLA
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          DBLE, MAX
+      INTRINSIC          MAX
 *     ..
 *     .. Executable Statements ..
 *
@@ -290,7 +291,7 @@
       END IF
 *
       IF( INFO.EQ.0 ) THEN
-         WORK( 1 ) = LOPT
+         WORK( 1 ) = DROUNDUP_LWORK(LOPT)
          IWORK( 1 ) = LIOPT
 *
          IF( LWORK.LT.LWMIN .AND. .NOT.LQUERY ) THEN
@@ -326,8 +327,8 @@
       CALL DSYEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, IWORK,
      $             LIWORK,
      $             INFO )
-      LOPT = INT( MAX( DBLE( LOPT ), DBLE( WORK( 1 ) ) ) )
-      LIOPT = INT( MAX( DBLE( LIOPT ), DBLE( IWORK( 1 ) ) ) )
+      LOPT = MAX( LOPT, INT( WORK( 1 ) ) )
+      LIOPT = MAX( LIOPT, IWORK( 1 ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *
@@ -363,7 +364,7 @@
          END IF
       END IF
 *
-      WORK( 1 ) = LOPT
+      WORK( 1 ) = DROUNDUP_LWORK(LOPT)
       IWORK( 1 ) = LIOPT
 *
       RETURN

--- a/SRC/sspgvd.f
+++ b/SRC/sspgvd.f
@@ -233,7 +233,7 @@
      $                   XERBLA
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          MAX, REAL
+      INTRINSIC          MAX
 *     ..
 *     .. Executable Statements ..
 *
@@ -303,8 +303,8 @@
       CALL SSPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL SSPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, IWORK,
      $             LIWORK, INFO )
-      LWMIN = INT( MAX( REAL( LWMIN ), REAL( WORK( 1 ) ) ) )
-      LIWMIN = INT( MAX( REAL( LIWMIN ), REAL( IWORK( 1 ) ) ) )
+      LWMIN = MAX( LWMIN, INT( WORK( 1 ) ) )
+      LIWMIN = MAX( LIWMIN, IWORK( 1 ) )
 *
       IF( WANTZ ) THEN
 *

--- a/SRC/ssygvd.f
+++ b/SRC/ssygvd.f
@@ -253,7 +253,7 @@
      $                   XERBLA
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          MAX, REAL
+      INTRINSIC          MAX
 *     ..
 *     .. Executable Statements ..
 *
@@ -327,8 +327,8 @@
       CALL SSYEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, IWORK,
      $             LIWORK,
      $             INFO )
-      LOPT = INT( MAX( REAL( LOPT ), REAL( WORK( 1 ) ) ) )
-      LIOPT = INT( MAX( REAL( LIOPT ), REAL( IWORK( 1 ) ) ) )
+      LOPT = MAX( LOPT, INT( WORK( 1 ) ) )
+      LIOPT = MAX( LIOPT, IWORK( 1 ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *

--- a/SRC/zhegvd.f
+++ b/SRC/zhegvd.f
@@ -268,7 +268,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DROUNDUP_LWORK
+      EXTERNAL           LSAME, DROUNDUP_LWORK
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZHEEVD, ZHEGST, ZPOTRF, ZTRMM,
@@ -317,8 +318,8 @@
       END IF
 *
       IF( INFO.EQ.0 ) THEN
-         WORK( 1 ) = LOPT
-         RWORK( 1 ) = REAL( LROPT )
+         WORK( 1 ) = DROUNDUP_LWORK(LOPT)
+         RWORK( 1 ) = DROUNDUP_LWORK(LROPT)
          IWORK( 1 ) = LIOPT
 *
          IF( LWORK.LT.LWMIN .AND. .NOT.LQUERY ) THEN
@@ -356,9 +357,9 @@
       CALL ZHEEVD( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, RWORK,
      $             LRWORK,
      $             IWORK, LIWORK, INFO )
-      LOPT = INT( MAX( DBLE( LOPT ), DBLE( WORK( 1 ) ) ) )
-      LROPT = INT( MAX( DBLE( LROPT ), DBLE( RWORK( 1 ) ) ) )
-      LIOPT = INT( MAX( DBLE( LIOPT ), DBLE( IWORK( 1 ) ) ) )
+      LOPT = MAX( LOPT, INT( DBLE( WORK( 1 ) ) ) )
+      LROPT = MAX( LROPT, INT( RWORK( 1 ) ) )
+      LIOPT = MAX( LIOPT, IWORK( 1 ) )
 *
       IF( WANTZ .AND. INFO.EQ.0 ) THEN
 *
@@ -394,8 +395,8 @@
          END IF
       END IF
 *
-      WORK( 1 ) = LOPT
-      RWORK( 1 ) = REAL( LROPT )
+      WORK( 1 ) = DROUNDUP_LWORK(LOPT)
+      RWORK( 1 ) = DROUNDUP_LWORK(LROPT)
       IWORK( 1 ) = LIOPT
 *
       RETURN

--- a/SRC/zhpgvd.f
+++ b/SRC/zhpgvd.f
@@ -246,7 +246,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DROUNDUP_LWORK
+      EXTERNAL           LSAME, DROUNDUP_LWORK
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZHPEVD, ZHPGST, ZPPTRF, ZTPMV,
@@ -293,8 +294,8 @@
             END IF
          END IF
 *
-         WORK( 1 ) = LWMIN
-         RWORK( 1 ) = REAL( LRWMIN )
+         WORK( 1 ) = DROUNDUP_LWORK(LWMIN)
+         RWORK( 1 ) = DROUNDUP_LWORK(LRWMIN)
          IWORK( 1 ) = LIWMIN
          IF( LWORK.LT.LWMIN .AND. .NOT.LQUERY ) THEN
             INFO = -11
@@ -330,9 +331,9 @@
       CALL ZHPGST( ITYPE, UPLO, N, AP, BP, INFO )
       CALL ZHPEVD( JOBZ, UPLO, N, AP, W, Z, LDZ, WORK, LWORK, RWORK,
      $             LRWORK, IWORK, LIWORK, INFO )
-      LWMIN = INT( MAX( DBLE( LWMIN ), DBLE( WORK( 1 ) ) ) )
-      LRWMIN = INT( MAX( DBLE( LRWMIN ), DBLE( RWORK( 1 ) ) ) )
-      LIWMIN = INT( MAX( DBLE( LIWMIN ), DBLE( IWORK( 1 ) ) ) )
+      LWMIN = MAX( LWMIN, INT( DBLE( WORK( 1 ) ) ) )
+      LRWMIN = MAX( LRWMIN, INT( RWORK( 1 ) ) )
+      LIWMIN = MAX( LIWMIN, IWORK( 1 ) )
 *
       IF( WANTZ ) THEN
 *
@@ -375,8 +376,8 @@
          END IF
       END IF
 *
-      WORK( 1 ) = LWMIN
-      RWORK( 1 ) = REAL( LRWMIN )
+      WORK( 1 ) = DROUNDUP_LWORK(LWMIN)
+      RWORK( 1 ) = DROUNDUP_LWORK(LRWMIN)
       IWORK( 1 ) = LIWMIN
       RETURN
 *


### PR DESCRIPTION
Fix workspace size handling in {s,d,c,z}{sy,sp,he,hp}gvd:

1. Workspace readback: remove redundant REAL()/DBLE() casts on INTEGER and same-type operands in the post-CHEEVD/ZHEEVD/etc. MAX expressions. The old pattern INT(MAX(REAL(int_var), REAL(fp_var))) needlessly round-tripped integers through floating-point; for IWORK (already INTEGER) the conversion was entirely spurious and risks precision loss when 5*N+3 exceeds the 23-bit (single) or 52-bit (double) significand.

2. WORK(1) writes: use SROUNDUP_LWORK/DROUNDUP_LWORK in dspgvd, dsygvd, zhegvd, zhpgvd where the optimal workspace size was previously stored via bare assignment (WORK(1) = LOPT), losing the ceiling guarantee that ROUNDUP_LWORK provides.

3. RWORK(1) writes: replace REAL(LROPT) with SROUNDUP_LWORK (chegvd, chpgvd) or DROUNDUP_LWORK (zhegvd, zhpgvd).  The zhegvd/zhpgvd case was a latent bug: RWORK is DOUBLE PRECISION but REAL() truncated to single precision before storing.

4. Add DROUNDUP_LWORK declarations (type + EXTERNAL) to the four double-precision / complex-16 routines that lacked them.  Remove now-unused REAL/DBLE from INTRINSIC lists where applicable.

**Description**

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.