### PR TITLE
Fix LDSWORK being overwritten during workspace query in xTRSYL3

### DIFF
--- a/SRC/ctrsyl3.f
+++ b/SRC/ctrsyl3.f
@@ -229,7 +229,6 @@
       INFO = 0
       LQUERY = ( LDSWORK.EQ.-1 )
       IF( LQUERY ) THEN
-         LDSWORK = 2
          SWORK(1,1) = REAL( MAX( NBA, NBB ) )
          SWORK(2,1) = REAL( 2 * NBB + NBA )
       END IF

--- a/SRC/dtrsyl3.f
+++ b/SRC/dtrsyl3.f
@@ -260,7 +260,6 @@
       LQUERY = ( LIWORK.EQ.-1 .OR. LDSWORK.EQ.-1 )
       IWORK( 1 ) = NBA + NBB + 2
       IF( LQUERY ) THEN
-         LDSWORK = 2
          SWORK( 1, 1 ) = MAX( NBA, NBB )
          SWORK( 2, 1 ) = 2 * NBB + NBA
       END IF

--- a/SRC/strsyl3.f
+++ b/SRC/strsyl3.f
@@ -259,7 +259,6 @@
       LQUERY = ( LIWORK.EQ.-1 .OR. LDSWORK.EQ.-1 )
       IWORK( 1 ) = NBA + NBB + 2
       IF( LQUERY ) THEN
-         LDSWORK = 2
          SWORK( 1, 1 ) = REAL( MAX( NBA, NBB ) )
          SWORK( 2, 1 ) = REAL( 2 * NBB + NBA )
       END IF

--- a/SRC/ztrsyl3.f
+++ b/SRC/ztrsyl3.f
@@ -230,7 +230,6 @@
       INFO = 0
       LQUERY = ( LDSWORK.EQ.-1 )
       IF( LQUERY ) THEN
-         LDSWORK = 2
          SWORK(1,1) = MAX( NBA, NBB )
          SWORK(2,1) = 2 * NBB + NBA
       END IF


### PR DESCRIPTION
```
Title: Fix LDSWORK overwrite during workspace query in xTRSYL3

## Summary

Remove the erroneous `LDSWORK = 2` assignment in the workspace query
branch of STRSYL3, DTRSYL3, CTRSYL3, and ZTRSYL3.

## Problem

When the caller passes `LDSWORK = -1` to perform a workspace query,
the routines overwrite LDSWORK with 2 before returning. This silently
corrupts the caller's variable, violating the documented intent(in)
contract. A subsequent call with the same variable would use
LDSWORK=2 instead of the caller's allocated leading dimension,
potentially triggering the unblocked fallback path or causing
out-of-bounds access.

## Fix

Delete the `LDSWORK = 2` line from all four routines. The assignment
was unnecessary: the only SWORK accesses in the LQUERY branch are
SWORK(1,1) and SWORK(2,1), both in column 1. In Fortran column-major
layout, the offset is `(i-1) + (j-1)*LDSWORK`; with j=1 the LDSWORK
term vanishes, so the stores are valid regardless of the LDSWORK value.

## Files changed

- SRC/strsyl3.f
- SRC/dtrsyl3.f
- SRC/ctrsyl3.f
- SRC/ztrsyl3.f

## Testing

No new tests required. Existing xTRSYL3 tests continue to pass.
The fix is a pure deletion of a dead store that only manifested as
caller-side corruption.
```