### PR TITLE
fix(TESTING/EIG): pass IINFO instead of INFO to xSPGVX/xHPGVX in *drvsg2stg

### DIFF
--- a/TESTING/EIG/cdrvsg2stg.f
+++ b/TESTING/EIG/cdrvsg2stg.f
@@ -1009,7 +1009,7 @@ C     $                         LDZ, D, WORK, RWORK, RESULT( NTEST ) )
 *
                   CALL CHPGVX( IBTYPE, 'V', 'A', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         RWORK, IWORK( N+1 ), IWORK, INFO )
+     $                         RWORK, IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'CHPGVX(V,A' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1055,7 +1055,7 @@ C     $                         LDZ, D, WORK, RWORK, RESULT( NTEST ) )
                   VU = ANORM
                   CALL CHPGVX( IBTYPE, 'V', 'V', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         RWORK, IWORK( N+1 ), IWORK, INFO )
+     $                         RWORK, IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'CHPGVX(V,V' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1099,7 +1099,7 @@ C     $                         LDZ, D, WORK, RWORK, RESULT( NTEST ) )
 *
                   CALL CHPGVX( IBTYPE, 'V', 'I', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         RWORK, IWORK( N+1 ), IWORK, INFO )
+     $                         RWORK, IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'CHPGVX(V,I' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD

--- a/TESTING/EIG/ddrvsg2stg.f
+++ b/TESTING/EIG/ddrvsg2stg.f
@@ -989,7 +989,7 @@ C     $                         LDZ, D, WORK, RESULT( NTEST ) )
 *
                   CALL DSPGVX( IBTYPE, 'V', 'A', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         IWORK( N+1 ), IWORK, INFO )
+     $                         IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'DSPGVX(V,A' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1035,7 +1035,7 @@ C     $                         LDZ, D, WORK, RESULT( NTEST ) )
                   VU = ANORM
                   CALL DSPGVX( IBTYPE, 'V', 'V', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         IWORK( N+1 ), IWORK, INFO )
+     $                         IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'DSPGVX(V,V' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1079,7 +1079,7 @@ C     $                         LDZ, D, WORK, RESULT( NTEST ) )
 *
                   CALL DSPGVX( IBTYPE, 'V', 'I', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         IWORK( N+1 ), IWORK, INFO )
+     $                         IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'DSPGVX(V,I' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD

--- a/TESTING/EIG/sdrvsg2stg.f
+++ b/TESTING/EIG/sdrvsg2stg.f
@@ -990,7 +990,7 @@ C     $                         LDZ, D, WORK, RESULT( NTEST ) )
 *
                   CALL SSPGVX( IBTYPE, 'V', 'A', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         IWORK( N+1 ), IWORK, INFO )
+     $                         IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'SSPGVX(V,A' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1036,7 +1036,7 @@ C     $                         LDZ, D, WORK, RESULT( NTEST ) )
                   VU = ANORM
                   CALL SSPGVX( IBTYPE, 'V', 'V', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         IWORK( N+1 ), IWORK, INFO )
+     $                         IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'SSPGVX(V,V' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1080,7 +1080,7 @@ C     $                         LDZ, D, WORK, RESULT( NTEST ) )
 *
                   CALL SSPGVX( IBTYPE, 'V', 'I', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         IWORK( N+1 ), IWORK, INFO )
+     $                         IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'SSPGVX(V,I' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD

--- a/TESTING/EIG/zdrvsg2stg.f
+++ b/TESTING/EIG/zdrvsg2stg.f
@@ -1009,7 +1009,7 @@ C     $                         LDZ, D, WORK, RWORK, RESULT( NTEST ) )
 *
                   CALL ZHPGVX( IBTYPE, 'V', 'A', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         RWORK, IWORK( N+1 ), IWORK, INFO )
+     $                         RWORK, IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'ZHPGVX(V,A' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1055,7 +1055,7 @@ C     $                         LDZ, D, WORK, RWORK, RESULT( NTEST ) )
                   VU = ANORM
                   CALL ZHPGVX( IBTYPE, 'V', 'V', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         RWORK, IWORK( N+1 ), IWORK, INFO )
+     $                         RWORK, IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'ZHPGVX(V,V' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD
@@ -1099,7 +1099,7 @@ C     $                         LDZ, D, WORK, RWORK, RESULT( NTEST ) )
 *
                   CALL ZHPGVX( IBTYPE, 'V', 'I', UPLO, N, AP, BP, VL,
      $                         VU, IL, IU, ABSTOL, M, D, Z, LDZ, WORK,
-     $                         RWORK, IWORK( N+1 ), IWORK, INFO )
+     $                         RWORK, IWORK( N+1 ), IWORK, IINFO )
                   IF( IINFO.NE.0 ) THEN
                      WRITE( NOUNIT, FMT = 9999 )'ZHPGVX(V,I' // UPLO //
      $                  ')', IINFO, N, JTYPE, IOLDSD


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><p><strong>Title:</strong>
<code>fix(TESTING/EIG): pass IINFO instead of INFO to xSPGVX/xHPGVX in *drvsg2stg</code></p>
<hr>
<p><strong>Description:</strong></p>
<h2>Summary</h2>
<p>Fix a bug in <code>cdrvsg2stg.f</code>, <code>ddrvsg2stg.f</code>, <code>sdrvsg2stg.f</code>, and <code>zdrvsg2stg.f</code> where <code>CHPGVX</code> / <code>DSPGVX</code> / <code>SSPGVX</code> / <code>ZHPGVX</code> were passed <code>INFO</code> instead of <code>IINFO</code> as the error output argument. This affects all three <code>RANGE='A'</code>/<code>'V'</code>/<code>'I'</code> call sites in each file, 12 locations in total.</p>
<h2>Problem</h2>
<p>The error-check block immediately following each affected call tests <code>IINFO.NE.0</code>, but the routine writes its return code into <code>INFO</code>, leaving <code>IINFO</code> unchanged. As a result, errors from these routines are silently ignored. A secondary issue is that the block sets <code>INFO = ABS(IINFO)</code>, which overwrites the value the routine had written into <code>INFO</code> with the stale value of <code>IINFO</code>.</p>
<p>All other driver calls in these files (<code>ZHEGV</code>, <code>ZHEGVD</code>, <code>ZHEGVX</code>, <code>ZHPGV</code>, <code>ZHPGVD</code>, <code>ZHBGV</code>, <code>ZHBGVD</code>, <code>ZHBGVX</code> and their s/d/c equivalents) correctly use <code>IINFO</code>. This fix aligns the <code>xSPGVX</code>/<code>xHPGVX</code> calls with the established pattern.</p>
<h2>Changes</h2>

File | Routine | Fixed call sites
-- | -- | --
cdrvsg2stg.f | CHPGVX | RANGE='A', 'V', 'I'
ddrvsg2stg.f | DSPGVX | RANGE='A', 'V', 'I'
sdrvsg2stg.f | SSPGVX | RANGE='A', 'V', 'I'
zdrvsg2stg.f | ZHPGVX | RANGE='A', 'V', 'I'


<h2>Impact</h2>
<p>This change affects test code only. No LAPACK library routines are modified.</p></body></html><!--EndFragment-->
</body>
</html>