### PR TITLE
add NaN check for input scalars `s` and `c` to lapacke_crot and lapacke_srot

### DIFF
--- a/LAPACKE/src/lapacke_crot.c
+++ b/LAPACKE/src/lapacke_crot.c
@@ -46,10 +46,10 @@ lapack_int API_SUFFIX(LAPACKE_crot)( lapack_int n,
         if( API_SUFFIX(LAPACKE_c_nancheck)( n, cy, incy ) ) {
             return -4;
         }
-        if( API_SUFFIX(LAPACKE_s_nancheck)( 1, c, 1 ) ) {
+        if( API_SUFFIX(LAPACKE_s_nancheck)( 1, &c, 1 ) ) {
             return -6;
         }
-        if( API_SUFFIX(LAPACKE_c_nancheck)( 1, s, 1 ) ) {
+        if( API_SUFFIX(LAPACKE_c_nancheck)( 1, &s, 1 ) ) {
             return -7;
         }
     }

--- a/LAPACKE/src/lapacke_crot.c
+++ b/LAPACKE/src/lapacke_crot.c
@@ -46,6 +46,12 @@ lapack_int API_SUFFIX(LAPACKE_crot)( lapack_int n,
         if( API_SUFFIX(LAPACKE_c_nancheck)( n, cy, incy ) ) {
             return -4;
         }
+        if( API_SUFFIX(LAPACKE_s_nancheck)( 1, c, 1 ) ) {
+            return -6;
+        }
+        if( API_SUFFIX(LAPACKE_c_nancheck)( 1, s, 1 ) ) {
+            return -7;
+        }
     }
 #endif
     return API_SUFFIX(LAPACKE_crot_work)( n, cx, incx, cy, incy, c, s );

--- a/LAPACKE/src/lapacke_zrot.c
+++ b/LAPACKE/src/lapacke_zrot.c
@@ -46,6 +46,12 @@ lapack_int API_SUFFIX(LAPACKE_zrot)( lapack_int n,
         if( API_SUFFIX(LAPACKE_z_nancheck)( n, cy, incy ) ) {
             return -4;
         }
+        if( API_SUFFIX(LAPACKE_d_nancheck)( 1, c, 1 ) ) {
+            return -6;
+        }
+        if( API_SUFFIX(LAPACKE_z_nancheck)( 1, s, 1 ) ) {
+            return -7;
+        }
     }
 #endif
     return API_SUFFIX(LAPACKE_zrot_work)( n, cx, incx, cy, incy, c, s );

--- a/LAPACKE/src/lapacke_zrot.c
+++ b/LAPACKE/src/lapacke_zrot.c
@@ -46,10 +46,10 @@ lapack_int API_SUFFIX(LAPACKE_zrot)( lapack_int n,
         if( API_SUFFIX(LAPACKE_z_nancheck)( n, cy, incy ) ) {
             return -4;
         }
-        if( API_SUFFIX(LAPACKE_d_nancheck)( 1, c, 1 ) ) {
+        if( API_SUFFIX(LAPACKE_d_nancheck)( 1, &c, 1 ) ) {
             return -6;
         }
-        if( API_SUFFIX(LAPACKE_z_nancheck)( 1, s, 1 ) ) {
+        if( API_SUFFIX(LAPACKE_z_nancheck)( 1, &s, 1 ) ) {
             return -7;
         }
     }


### PR DESCRIPTION
add NaN check for input scalars `s` and `c` to lapacke_crot and lapacke_srot