### PR TITLE
Re-enable disabled checks in TESTING *bb.in and *gg.in inputs

### DIFF
--- a/TESTING/cbb.in
+++ b/TESTING/cbb.in
@@ -7,6 +7,6 @@ CBB:  Data file for testing banded Singular Value Decomposition routines
 2                                 Number of values of NRHS
 1 2                               Values of NRHS
 20.0                              Threshold value
-F                                 Put T to test the error exits
+T                                 Put T to test the error exits
 1                                 Code to interpret the seed
 CBB 15

--- a/TESTING/cgg.in
+++ b/TESTING/cgg.in
@@ -10,7 +10,7 @@ CGG:  Data file for testing Nonsymmetric Eigenvalue Problem routines
 40  40  2   2                   Values of NBCOL (minimum col. dimension)
 20.0                            Threshold value
 T                               Put T to test the LAPACK routines
-F                               Put T to test the driver routines
+T                               Put T to test the driver routines
 T                               Put T to test the error exits
 1                               Code to interpret the seed
 CGG  26

--- a/TESTING/dbb.in
+++ b/TESTING/dbb.in
@@ -7,6 +7,6 @@ DBB:  Data file for testing banded Singular Value Decomposition routines
 2                                 Number of values of NRHS
 1 2                               Values of NRHS
 20.0                              Threshold value
-F                                 Put T to test the error exits
+T                                 Put T to test the error exits
 1                                 Code to interpret the seed
 DBB 15

--- a/TESTING/dgg.in
+++ b/TESTING/dgg.in
@@ -10,7 +10,7 @@ DGG:  Data file for testing Nonsymmetric Eigenvalue Problem routines
 40  40  2   2                   Values of NBCOL (minimum col. dimension)
 20.0                            Threshold value
 T                               Put T to test the LAPACK routines
-F                               Put T to test the driver routines
+T                               Put T to test the driver routines
 T                               Put T to test the error exits
 1                               Code to interpret the seed
 DGG  26

--- a/TESTING/sbb.in
+++ b/TESTING/sbb.in
@@ -7,6 +7,6 @@ SBB:  Data file for testing banded Singular Value Decomposition routines
 2                                 Number of values of NRHS
 1 2                               Values of NRHS
 20.0                              Threshold value
-F                                 Put T to test the error exits
+T                                 Put T to test the error exits
 1                                 Code to interpret the seed
 SBB 15

--- a/TESTING/sgg.in
+++ b/TESTING/sgg.in
@@ -10,7 +10,7 @@ SGG:  Data file for testing Nonsymmetric Eigenvalue Problem routines
 40  40  2   2                   Values of NBCOL (minimum col. dimension)
 20.0                            Threshold value
 T                               Put T to test the LAPACK routines
-F                               Put T to test the driver routines
+T                               Put T to test the driver routines
 T                               Put T to test the error exits
 1                               Code to interpret the seed
 SGG  26

--- a/TESTING/zbb.in
+++ b/TESTING/zbb.in
@@ -7,6 +7,6 @@ ZBB:  Data file for testing banded Singular Value Decomposition routines
 2                                 Number of values of NRHS
 1 2                               Values of NRHS
 20.0                              Threshold value
-F                                 Put T to test the error exits
+T                                 Put T to test the error exits
 1                                 Code to interpret the seed
 ZBB 15

--- a/TESTING/zgg.in
+++ b/TESTING/zgg.in
@@ -10,7 +10,7 @@ ZGG:  Data file for testing Nonsymmetric Eigenvalue Problem routines
 40  40  2   2                   Values of NBCOL (minimum col. dimension)
 20.0                            Threshold value
 T                               Put T to test the LAPACK routines
-F                               Put T to test the driver routines
+T                               Put T to test the driver routines
 T                               Put T to test the error exits
 1                               Code to interpret the seed
 ZGG  26


### PR DESCRIPTION
This PR re-enables test options that are currently disabled in several
LAPACK TESTING input files.

Changes
- Set "Put T to test the error exits" from F to T in:
  - TESTING/cbb.in
  - TESTING/dbb.in
  - TESTING/sbb.in
  - TESTING/zbb.in

- Set "Put T to test the driver routines" from F to T in:
  - TESTING/cgg.in
  - TESTING/dgg.in
  - TESTING/sgg.in
  - TESTING/zgg.in

Without these changes, the corresponding checks are skipped when these
input files are used.

This restores the intended test coverage for the affected TESTING inputs.