### PR TITLE
BLAS: inline SCABS1/DCABS1 into CAXPY/ZAXPY as statement function CABS1

### DIFF
--- a/BLAS/SRC/caxpy.f
+++ b/BLAS/SRC/caxpy.f
@@ -103,13 +103,16 @@
 *
 *     .. Local Scalars ..
       INTEGER I,IX,IY
+      COMPLEX CDUM
 *     ..
-*     .. External Functions ..
-      REAL SCABS1
-      EXTERNAL SCABS1
+*     .. Statement Functions ..
+      REAL CABS1
+*     ..
+*     .. Statement Function definitions ..
+      CABS1(CDUM) = ABS(REAL(CDUM)) + ABS(AIMAG(CDUM))
 *     ..
       IF (N.LE.0) RETURN
-      IF (SCABS1(CA).EQ.0.0E+0) RETURN
+      IF (CABS1(CA).EQ.0.0E+0) RETURN
       IF (INCX.EQ.1 .AND. INCY.EQ.1) THEN
 *
 *        code for both increments equal to 1

--- a/BLAS/SRC/zaxpy.f
+++ b/BLAS/SRC/zaxpy.f
@@ -103,13 +103,16 @@
 *
 *     .. Local Scalars ..
       INTEGER I,IX,IY
+      COMPLEX*16 ZDUM
 *     ..
-*     .. External Functions ..
-      DOUBLE PRECISION DCABS1
-      EXTERNAL DCABS1
+*     .. Statement Functions ..
+      DOUBLE PRECISION CABS1
+*     ..
+*     .. Statement Function definitions ..
+      CABS1(ZDUM) = ABS(DBLE(ZDUM)) + ABS(DIMAG(ZDUM))
 *     ..
       IF (N.LE.0) RETURN
-      IF (DCABS1(ZA).EQ.0.0d0) RETURN
+      IF (CABS1(ZA).EQ.0.0D+0) RETURN
       IF (INCX.EQ.1 .AND. INCY.EQ.1) THEN
 *
 *        code for both increments equal to 1


### PR DESCRIPTION
As suggested by @langou, this PR removes the dependency on the auxiliary routines SCABS1 and DCABS1 by inlining the equivalent logic into CAXPY and ZAXPY as a local statement function named CABS1.
Changes:

CAXPY: replace EXTERNAL SCABS1 with a local statement function CABS1(CDUM) = ABS(REAL(CDUM)) + ABS(AIMAG(CDUM))
ZAXPY: replace EXTERNAL DCABS1 with a local statement function CABS1(ZDUM) = ABS(DBLE(ZDUM)) + ABS(DIMAG(ZDUM))

The function name CABS1 is used in both routines for consistency, as the semantics are identical; only the precision of the dummy argument differs.

cf. https://github.com/Reference-LAPACK/lapack/issues/1200