### PR TITLE
clargv,zlargv: rename local ABS1 helper to CABSMAX

### DIFF
--- a/SRC/clargv.f
+++ b/SRC/clargv.f
@@ -155,7 +155,7 @@
      $                   SQRT
 *     ..
 *     .. Statement Functions ..
-      REAL               ABS1, ABSSQ
+      REAL               CABSMAX, ABSSQ
 *     ..
 *     .. Save statement ..
 *     SAVE               FIRST, SAFMX2, SAFMIN, SAFMN2
@@ -164,7 +164,7 @@
 *     DATA               FIRST / .TRUE. /
 *     ..
 *     .. Statement Function definitions ..
-      ABS1( FF ) = MAX( ABS( REAL( FF ) ), ABS( AIMAG( FF ) ) )
+      CABSMAX( FF ) = MAX( ABS( REAL( FF ) ), ABS( AIMAG( FF ) ) )
       ABSSQ( FF ) = REAL( FF )**2 + AIMAG( FF )**2
 *     ..
 *     .. Executable Statements ..
@@ -186,7 +186,7 @@
 *
 *        Use identical algorithm as in CLARTG
 *
-         SCALE = MAX( ABS1( F ), ABS1( G ) )
+         SCALE = MAX( CABSMAX( F ), CABSMAX( G ) )
          FS = F
          GS = G
          COUNT = 0
@@ -242,7 +242,7 @@
             CS = F2S / G2S
 *           Make sure abs(FF) = 1
 *           Do complex/real division explicitly with 2 real divisions
-            IF( ABS1( F ).GT.ONE ) THEN
+            IF( CABSMAX( F ).GT.ONE ) THEN
                D = SLAPY2( REAL( F ), AIMAG( F ) )
                FF = CMPLX( REAL( F ) / D, AIMAG( F ) / D )
             ELSE

--- a/SRC/zlargv.f
+++ b/SRC/zlargv.f
@@ -156,7 +156,7 @@
      $                   MAX, SQRT
 *     ..
 *     .. Statement Functions ..
-      DOUBLE PRECISION   ABS1, ABSSQ
+      DOUBLE PRECISION   CABSMAX, ABSSQ
 *     ..
 *     .. Save statement ..
 *     SAVE               FIRST, SAFMX2, SAFMIN, SAFMN2
@@ -165,7 +165,7 @@
 *     DATA               FIRST / .TRUE. /
 *     ..
 *     .. Statement Function definitions ..
-      ABS1( FF ) = MAX( ABS( DBLE( FF ) ), ABS( DIMAG( FF ) ) )
+      CABSMAX( FF ) = MAX( ABS( DBLE( FF ) ), ABS( DIMAG( FF ) ) )
       ABSSQ( FF ) = DBLE( FF )**2 + DIMAG( FF )**2
 *     ..
 *     .. Executable Statements ..
@@ -187,7 +187,7 @@
 *
 *        Use identical algorithm as in ZLARTG
 *
-         SCALE = MAX( ABS1( F ), ABS1( G ) )
+         SCALE = MAX( CABSMAX( F ), CABSMAX( G ) )
          FS = F
          GS = G
          COUNT = 0
@@ -243,7 +243,7 @@
             CS = F2S / G2S
 *           Make sure abs(FF) = 1
 *           Do complex/real division explicitly with 2 real divisions
-            IF( ABS1( F ).GT.ONE ) THEN
+            IF( CABSMAX( F ).GT.ONE ) THEN
                D = DLAPY2( DBLE( F ), DIMAG( F ) )
                FF = DCMPLX( DBLE( F ) / D, DIMAG( F ) / D )
             ELSE


### PR DESCRIPTION
The local ABS1 statement function in CLARGV and ZLARGV does not compute the usual complex ABS1/CABS1 quantity. It returns

    max(abs(real(z)), abs(aimag(z)))

and is used only as a scaling helper in the same algorithmic path as CLARTG/ZLARTG.

Rename the helper to CABSMAX so that the name matches its actual behavior and does not suggest CABS1 semantics.

No numerical behavior is changed.

**Description**

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.