### PR TITLE
Calculate CUNMLQ LWORK consistently when K=0

### DIFF
--- a/SRC/cunmlq.f
+++ b/SRC/cunmlq.f
@@ -243,14 +243,10 @@
 *
 *        Compute the workspace requirements
 *
-         IF( M.EQ.0 .OR. N.EQ.0 .OR. K.EQ.0 ) THEN
-            LWKOPT = 1
-         ELSE
-            NB = MIN( NBMAX, ILAENV( 1, 'CUNMLQ', SIDE // TRANS, M,
-     $                N,
-     $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
-         END IF
+        NB = MIN( NBMAX, ILAENV( 1, 'CUNMLQ', SIDE // TRANS, M, N,
+     $             K,
+     $        -1 ) )
+         LWKOPT = NW*NB + TSIZE
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
 *
@@ -264,6 +260,7 @@
 *     Quick return if possible
 *
       IF( M.EQ.0 .OR. N.EQ.0 .OR. K.EQ.0 ) THEN
+         WORK( 1 ) = 1
          RETURN
       END IF
 *


### PR DESCRIPTION
**Description**

CUNMLQ's documentation says LWORK must be:

          If SIDE = 'L', LWORK >= max(1,N);
          if SIDE = 'R', LWORK >= max(1,M).

In the current implementation, however, when K=0 a workspace query will return LWORK=1 in WORK(1). This means a subsequent call to CUNMLQ with a workspace of that size will fail with INFO = -12.

The other ???MLQ routines return consistent values of LWORK when K=0 (that is, equal to or greater than NW) so this patch makes CUNMLQ's behaviour match theirs.

**Checklist**

- [ ] The documentation has been updated. No docs update needed -- this makes the implementation match the documentation.
- [ ] If the PR solves a specific issue, it is set to be closed on merge. No issue raised to close.