### PR TITLE
cleanup: first batch of named-constant normalization in LAPACK sources

### DIFF
--- a/SRC/cbbcsd.f
+++ b/SRC/cbbcsd.f
@@ -351,10 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      REAL               HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
+      REAL               HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0E0, MEIGHTH = -0.125E0,
-     $                     ONE = 1.0E0, TEN = 10.0E0, TWO = 2.0E0,
-     $                     ZERO = 0.0E0 )
+     $                     ZERO = 0.0E0, ONE = 1.0E0, TEN = 10.0E0 )
       COMPLEX            NEGONECOMPLEX
       PARAMETER          ( NEGONECOMPLEX = (-1.0E0,0.0E0) )
       REAL               PIOVER2

--- a/SRC/cbbcsd.f
+++ b/SRC/cbbcsd.f
@@ -351,9 +351,10 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      REAL               HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      REAL               HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
       PARAMETER          ( HUNDRED = 100.0E0, MEIGHTH = -0.125E0,
-     $                     ONE = 1.0E0, TEN = 10.0E0, ZERO = 0.0E0 )
+     $                     ONE = 1.0E0, TEN = 10.0E0, TWO = 2.0E0,
+     $                     ZERO = 0.0E0 )
       COMPLEX            NEGONECOMPLEX
       PARAMETER          ( NEGONECOMPLEX = (-1.0E0,0.0E0) )
       REAL               PIOVER2
@@ -576,7 +577,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1092,4 +1093,3 @@
 *     End of CBBCSD
 *
       END
-

--- a/SRC/dbbcsd.f
+++ b/SRC/dbbcsd.f
@@ -351,9 +351,10 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
       PARAMETER          ( HUNDRED = 100.0D0, MEIGHTH = -0.125D0,
-     $                     ONE = 1.0D0, TEN = 10.0D0, ZERO = 0.0D0 )
+     $                     ONE = 1.0D0, TEN = 10.0D0, TWO = 2.0D0,
+     $                     ZERO = 0.0D0 )
       DOUBLE PRECISION   NEGONE
       PARAMETER          ( NEGONE = -1.0D0 )
       DOUBLE PRECISION   PIOVER2
@@ -576,7 +577,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1086,4 +1087,3 @@
 *     End of DBBCSD
 *
       END
-

--- a/SRC/dbbcsd.f
+++ b/SRC/dbbcsd.f
@@ -351,10 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
+      DOUBLE PRECISION   HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0D0, MEIGHTH = -0.125D0,
-     $                     ONE = 1.0D0, TEN = 10.0D0, TWO = 2.0D0,
-     $                     ZERO = 0.0D0 )
+     $                     ZERO = 0.0D0, ONE = 1.0D0, TEN = 10.0D0 )
       DOUBLE PRECISION   NEGONE
       PARAMETER          ( NEGONE = -1.0D0 )
       DOUBLE PRECISION   PIOVER2

--- a/SRC/sbbcsd.f
+++ b/SRC/sbbcsd.f
@@ -351,10 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      REAL               HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
+      REAL               HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0E0, MEIGHTH = -0.125E0,
-     $                     ONE = 1.0E0, TEN = 10.0E0, TWO = 2.0E0,
-     $                     ZERO = 0.0E0 )
+     $                     ZERO = 0.0E0, ONE = 1.0E0, TEN = 10.0E0 )
       REAL               NEGONE
       PARAMETER          ( NEGONE = -1.0E0 )
       REAL               PIOVER2

--- a/SRC/sbbcsd.f
+++ b/SRC/sbbcsd.f
@@ -351,9 +351,10 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      REAL               HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      REAL               HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
       PARAMETER          ( HUNDRED = 100.0E0, MEIGHTH = -0.125E0,
-     $                     ONE = 1.0E0, TEN = 10.0E0, ZERO = 0.0E0 )
+     $                     ONE = 1.0E0, TEN = 10.0E0, TWO = 2.0E0,
+     $                     ZERO = 0.0E0 )
       REAL               NEGONE
       PARAMETER          ( NEGONE = -1.0E0 )
       REAL               PIOVER2
@@ -576,7 +577,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1086,4 +1087,3 @@
 *     End of SBBCSD
 *
       END
-

--- a/SRC/zbbcsd.f
+++ b/SRC/zbbcsd.f
@@ -351,9 +351,10 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
       PARAMETER          ( HUNDRED = 100.0D0, MEIGHTH = -0.125D0,
-     $                     ONE = 1.0D0, TEN = 10.0D0, ZERO = 0.0D0 )
+     $                     ONE = 1.0D0, TEN = 10.0D0, TWO = 2.0D0,
+     $                     ZERO = 0.0D0 )
       COMPLEX*16         NEGONECOMPLEX
       PARAMETER          ( NEGONECOMPLEX = (-1.0D0,0.0D0) )
       DOUBLE PRECISION   PIOVER2
@@ -575,7 +576,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1091,4 +1092,3 @@
 *     End of ZBBCSD
 *
       END
-

--- a/SRC/zbbcsd.f
+++ b/SRC/zbbcsd.f
@@ -351,10 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, TWO, ZERO
+      DOUBLE PRECISION   HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0D0, MEIGHTH = -0.125D0,
-     $                     ONE = 1.0D0, TEN = 10.0D0, TWO = 2.0D0,
-     $                     ZERO = 0.0D0 )
+     $                     ZERO = 0.0D0, ONE = 1.0D0, TEN = 10.0D0 )
       COMPLEX*16         NEGONECOMPLEX
       PARAMETER          ( NEGONECOMPLEX = (-1.0D0,0.0D0) )
       DOUBLE PRECISION   PIOVER2


### PR DESCRIPTION
## Summary

This PR collects a small first batch of no-functional-change cleanup
in LAPACK sources by normalizing scalar constant spelling.

In particular, it replaces typed literal `1` values with the existing
routine-local named constant `ONE` in the `{s,d,c,z}bbcsd` family.

## Rationale

These routines already define named scalar parameters such as `ZERO`,
`ONE`, and `TEN`. Using those names consistently improves readability,
keeps the precision variants aligned, and avoids mixing routine-local
named constants with ad hoc typed literals.

## Scope

This PR is intentionally limited to mechanical consistency changes:
- replace existing scalar literals with already-defined named constants
- keep the s/d/c/z variants in sync
- no algorithmic or numerical behavior changes intended

## Non-goals

This PR does not:
- change convergence logic
- change thresholds or iteration behavior
- alter test expectations
- introduce algorithmic fixes

## Notes

This is intended as a small cleanup-first PR rather than a broad
refactor. If this direction is acceptable, similar purely mechanical
normalizations can be submitted in follow-up PRs.