### PR TITLE
cleanup: normalize named constants in LAPACK *equb routines

### DIFF
--- a/SRC/cgbequb.f
+++ b/SRC/cgbequb.f
@@ -175,8 +175,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J, KD

--- a/SRC/cgeequb.f
+++ b/SRC/cgeequb.f
@@ -160,8 +160,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J

--- a/SRC/cheequb.f
+++ b/SRC/cheequb.f
@@ -147,8 +147,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE, TWO
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0, TWO = 2.0E0 )
       INTEGER            MAX_ITER
       PARAMETER          ( MAX_ITER = 100 )
 *     ..
@@ -231,14 +231,14 @@
          END DO
       END IF
       DO J = 1, N
-         S( J ) = 1.0E0 / S( J )
+         S( J ) = ONE / S( J )
       END DO
 
-      TOL = ONE / SQRT( 2.0E0 * REAL( N ) )
+      TOL = ONE / SQRT( TWO * REAL( N ) )
 
       DO ITER = 1, MAX_ITER
-         SCALE = 0.0E0
-         SUMSQ = 0.0E0
+         SCALE = ZERO
+         SUMSQ = ZERO
 *        beta = |A|s
          DO I = 1, N
             WORK( I ) = ZERO
@@ -262,13 +262,13 @@
          END IF
 
 *        avg = s^T beta / n
-         AVG = 0.0E0
+         AVG = ZERO
          DO I = 1, N
             AVG = AVG + REAL( S( I )*WORK( I ) )
          END DO
          AVG = AVG / REAL( N )
 
-         STD = 0.0E0
+         STD = ZERO
          DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO

--- a/SRC/cpoequb.f
+++ b/SRC/cpoequb.f
@@ -132,8 +132,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ZERO, ONE
-      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
+      REAL               ZERO, HALF, ONE
+      PARAMETER          ( ZERO = 0.0E+0, HALF = 0.5E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I
@@ -175,7 +175,7 @@
       END IF
 
       BASE = SLAMCH( 'B' )
-      TMP = -0.5 / LOG ( BASE )
+      TMP = -HALF / LOG ( BASE )
 *
 *     Find the minimum and maximum diagonal elements.
 *

--- a/SRC/csyequb.f
+++ b/SRC/csyequb.f
@@ -147,8 +147,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE, TWO
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0, TWO = 2.0E0 )
       INTEGER            MAX_ITER
       PARAMETER          ( MAX_ITER = 100 )
 *     ..
@@ -231,14 +231,14 @@
          END DO
       END IF
       DO J = 1, N
-         S( J ) = 1.0 / S( J )
+         S( J ) = ONE / S( J )
       END DO
 
-      TOL = ONE / SQRT( 2.0E0 * REAL( N ) )
+      TOL = ONE / SQRT( TWO * REAL( N ) )
 
       DO ITER = 1, MAX_ITER
-         SCALE = 0.0E0
-         SUMSQ = 0.0E0
+         SCALE = ZERO
+         SUMSQ = ZERO
 *        beta = |A|s
          DO I = 1, N
              WORK( I ) = ZERO
@@ -262,13 +262,13 @@
          END IF
 
 *        avg = s^T beta / n
-         AVG = 0.0E0
+         AVG = ZERO
          DO I = 1, N
             AVG = AVG + REAL( S( I )*WORK( I ) )
          END DO
          AVG = AVG / REAL( N )
 
-         STD = 0.0E0
+         STD = ZERO
          DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO

--- a/SRC/dgbequb.f
+++ b/SRC/dgbequb.f
@@ -173,8 +173,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J, KD

--- a/SRC/dgeequb.f
+++ b/SRC/dgeequb.f
@@ -158,8 +158,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J

--- a/SRC/dpoequb.f
+++ b/SRC/dpoequb.f
@@ -130,8 +130,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ZERO, ONE
-      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
+      DOUBLE PRECISION   ZERO, HALF, ONE
+      PARAMETER          ( ZERO = 0.0D+0, HALF = 0.5D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I
@@ -173,7 +173,7 @@
       END IF
 
       BASE = DLAMCH( 'B' )
-      TMP = -0.5D+0 / LOG ( BASE )
+      TMP = -HALF / LOG ( BASE )
 *
 *     Find the minimum and maximum diagonal elements.
 *

--- a/SRC/dsyequb.f
+++ b/SRC/dsyequb.f
@@ -145,8 +145,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE, TWO
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0, TWO = 2.0D0 )
       INTEGER            MAX_ITER
       PARAMETER          ( MAX_ITER = 100 )
 *     ..
@@ -222,14 +222,14 @@
          END DO
       END IF
       DO J = 1, N
-         S( J ) = 1.0D0 / S( J )
+         S( J ) = ONE / S( J )
       END DO
 
-      TOL = ONE / SQRT( 2.0D0 * N )
+      TOL = ONE / SQRT( TWO * N )
 
       DO ITER = 1, MAX_ITER
-         SCALE = 0.0D0
-         SUMSQ = 0.0D0
+         SCALE = ZERO
+         SUMSQ = ZERO
 *        beta = |A|s
          DO I = 1, N
             WORK( I ) = ZERO
@@ -253,13 +253,13 @@
          END IF
 
 *        avg = s^T beta / n
-         AVG = 0.0D0
+         AVG = ZERO
          DO I = 1, N
             AVG = AVG + S( I )*WORK( I )
          END DO
          AVG = AVG / N
 
-         STD = 0.0D0
+         STD = ZERO
          DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO

--- a/SRC/sgbequb.f
+++ b/SRC/sgbequb.f
@@ -173,8 +173,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J, KD

--- a/SRC/sgeequb.f
+++ b/SRC/sgeequb.f
@@ -158,8 +158,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J

--- a/SRC/spoequb.f
+++ b/SRC/spoequb.f
@@ -130,8 +130,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ZERO, ONE
-      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
+      REAL               ZERO, HALF, ONE
+      PARAMETER          ( ZERO = 0.0E+0, HALF = 0.5E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I
@@ -173,7 +173,7 @@
       END IF
 
       BASE = SLAMCH( 'B' )
-      TMP = -0.5 / LOG ( BASE )
+      TMP = -HALF / LOG ( BASE )
 *
 *     Find the minimum and maximum diagonal elements.
 *

--- a/SRC/ssyequb.f
+++ b/SRC/ssyequb.f
@@ -145,8 +145,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE, TWO
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0, TWO = 2.0E0 )
       INTEGER            MAX_ITER
       PARAMETER          ( MAX_ITER = 100 )
 *     ..
@@ -222,14 +222,14 @@
          END DO
       END IF
       DO J = 1, N
-         S( J ) = 1.0E0 / S( J )
+         S( J ) = ONE / S( J )
       END DO
 
-      TOL = ONE / SQRT( 2.0E0 * REAL( N ) )
+      TOL = ONE / SQRT( TWO * REAL( N ) )
 
       DO ITER = 1, MAX_ITER
-         SCALE = 0.0E0
-         SUMSQ = 0.0E0
+         SCALE = ZERO
+         SUMSQ = ZERO
 *        beta = |A|s
          DO I = 1, N
             WORK( I ) = ZERO
@@ -253,13 +253,13 @@
          END IF
 
 *        avg = s^T beta / n
-         AVG = 0.0E0
+         AVG = ZERO
          DO I = 1, N
             AVG = AVG + S( I )*WORK( I )
          END DO
          AVG = AVG / REAL( N )
 
-         STD = 0.0E0
+         STD = ZERO
          DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO

--- a/SRC/zgbequb.f
+++ b/SRC/zgbequb.f
@@ -175,8 +175,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J, KD

--- a/SRC/zgeequb.f
+++ b/SRC/zgeequb.f
@@ -160,8 +160,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, J

--- a/SRC/zheequb.f
+++ b/SRC/zheequb.f
@@ -147,8 +147,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE, TWO
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0, TWO = 2.0D0 )
       INTEGER            MAX_ITER
       PARAMETER          ( MAX_ITER = 100 )
 *     ..
@@ -231,14 +231,14 @@
          END DO
       END IF
       DO J = 1, N
-         S( J ) = 1.0D0 / S( J )
+         S( J ) = ONE / S( J )
       END DO
 
-      TOL = ONE / SQRT( 2.0D0 * N )
+      TOL = ONE / SQRT( TWO * N )
 
       DO ITER = 1, MAX_ITER
-         SCALE = 0.0D0
-         SUMSQ = 0.0D0
+         SCALE = ZERO
+         SUMSQ = ZERO
 *        beta = |A|s
          DO I = 1, N
             WORK( I ) = ZERO
@@ -262,13 +262,13 @@
          END IF
 
 *        avg = s^T beta / n
-         AVG = 0.0D0
+         AVG = ZERO
          DO I = 1, N
             AVG = AVG + DBLE( S( I )*WORK( I ) )
          END DO
          AVG = AVG / N
 
-         STD = 0.0D0
+         STD = ZERO
          DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO

--- a/SRC/zpoequb.f
+++ b/SRC/zpoequb.f
@@ -132,8 +132,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ZERO, ONE
-      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
+      DOUBLE PRECISION   ZERO, HALF, ONE
+      PARAMETER          ( ZERO = 0.0D+0, HALF = 0.5D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I
@@ -175,7 +175,7 @@
       END IF
 
       BASE = DLAMCH( 'B' )
-      TMP = -0.5D+0 / LOG ( BASE )
+      TMP = -HALF / LOG ( BASE )
 *
 *     Find the minimum and maximum diagonal elements.
 *

--- a/SRC/zsyequb.f
+++ b/SRC/zsyequb.f
@@ -147,8 +147,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE, TWO
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0, TWO = 2.0D0 )
       INTEGER            MAX_ITER
       PARAMETER          ( MAX_ITER = 100 )
 *     ..
@@ -231,14 +231,14 @@
          END DO
       END IF
       DO J = 1, N
-         S( J ) = 1.0D0 / S( J )
+         S( J ) = ONE / S( J )
       END DO
 
-      TOL = ONE / SQRT( 2.0D0 * N )
+      TOL = ONE / SQRT( TWO * N )
 
       DO ITER = 1, MAX_ITER
-         SCALE = 0.0D0
-         SUMSQ = 0.0D0
+         SCALE = ZERO
+         SUMSQ = ZERO
 *        beta = |A|s
          DO I = 1, N
             WORK( I ) = ZERO
@@ -262,13 +262,13 @@
          END IF
 
 *        avg = s^T beta / n
-         AVG = 0.0D0
+         AVG = ZERO
          DO I = 1, N
             AVG = AVG + S( I ) * DBLE( WORK( I ) )
          END DO
          AVG = AVG / N
 
-         STD = 0.0D0
+         STD = ZERO
          DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO


### PR DESCRIPTION
## Summary

This PR continues the named-constant cleanup in LAPACK by normalizing
constant declarations and replacing hard-coded numeric literals in the
affected `*equb` routines.

In particular, it:

* normalizes parameter declaration order such as `ZERO, ONE`
* introduces `HALF` and `TWO` where needed
* replaces hard-coded `0.0`, `0.5`, `1.0`, and `2.0` literals with
  the corresponding named constants in routine bodies

The updates are applied consistently across the affected real/complex
and single/double-precision `*equb` variants.

No functional change is intended.

## Rationale

These routines already use named constants, but the usage was not fully
consistent across variants. Normalizing the declarations and using the
same named constants in expressions makes the source easier to compare,
review, and maintain across typed implementations.

## Affected routines

`cgbequb`, `cgeequb`, `cheequb`, `cpoequb`, `csyequb`,
`dgbequb`, `dgeequb`, `dpoequb`, `dsyequb`,
`sgbequb`, `sgeequb`, `spoequb`, `ssyequb`,
`zgbequb`, `zgeequb`, `zheequb`, `zpoequb`, `zsyequb`.
