### PR TITLE
Testing: initialize ISPEC=9 before running DMD tests

### DIFF
--- a/TESTING/EIG/CMakeLists.txt
+++ b/TESTING/EIG/CMakeLists.txt
@@ -111,22 +111,22 @@ endmacro()
 
 if(BUILD_SINGLE)
 add_eig_executable(xeigtsts ${SEIGTST} ${SCIGTST} ${AEIGTST})
-add_eig_executable(xdmdeigtsts ${SDMDEIGTST})
+add_eig_executable(xdmdeigtsts ${SDMDEIGTST} ${AEIGTST})
 endif()
 
 if(BUILD_COMPLEX)
 add_eig_executable(xeigtstc ${CEIGTST} ${SCIGTST} ${AEIGTST})
-add_eig_executable(xdmdeigtstc ${CDMDEIGTST})
+add_eig_executable(xdmdeigtstc ${CDMDEIGTST} ${AEIGTST})
 endif()
 
 
 if(BUILD_DOUBLE)
 add_eig_executable(xeigtstd ${DEIGTST} ${DZIGTST} ${AEIGTST})
-add_eig_executable(xdmdeigtstd ${DDMDEIGTST})
+add_eig_executable(xdmdeigtstd ${DDMDEIGTST} ${AEIGTST})
 endif()
 
 if(BUILD_COMPLEX16)
 add_eig_executable(xeigtstz ${ZEIGTST} ${DZIGTST} ${AEIGTST})
-add_eig_executable(xdmdeigtstz ${ZDMDEIGTST})
+add_eig_executable(xdmdeigtstz ${ZDMDEIGTST} ${AEIGTST})
 add_eig_executable(test_wq_zrwork test_wq_rwork.f)
 endif()

--- a/TESTING/EIG/Makefile
+++ b/TESTING/EIG/Makefile
@@ -135,16 +135,16 @@ complex: xeigtstc xdmdeigtstc
 double: xeigtstd xdmdeigtstd
 complex16: xeigtstz xdmdeigtstz
 
-xdmdeigtsts: $(SDMDEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
+xdmdeigtsts: $(SDMDEIGTST) $(AEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
 	$(FC) $(FFLAGS) $(LDFLAGS) -o $@ $^
 
-xdmdeigtstc: $(CDMDEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
+xdmdeigtstc: $(CDMDEIGTST) $(AEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
 	$(FC) $(FFLAGS) $(LDFLAGS) -o $@ $^
 
-xdmdeigtstd: $(DDMDEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
+xdmdeigtstd: $(DDMDEIGTST) $(AEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
 	$(FC) $(FFLAGS) $(LDFLAGS) -o $@ $^
 
-xdmdeigtstz: $(ZDMDEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
+xdmdeigtstz: $(ZDMDEIGTST) $(AEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)
 	$(FC) $(FFLAGS) $(LDFLAGS) -o $@ $^
 
 xeigtsts: $(SEIGTST) $(SCIGTST) $(AEIGTST) $(TMGLIB) $(LAPACKLIB) $(BLASLIB)

--- a/TESTING/EIG/cchkdmd.f90
+++ b/TESTING/EIG/cchkdmd.f90
@@ -82,7 +82,7 @@
       LOGICAL :: TEST_QRDMD
 
 !..... external subroutines (BLAS and LAPACK)
-      EXTERNAL CAXPY, CGEEV, CGEMM, CGEMV, CLASCL
+      EXTERNAL CAXPY, CGEEV, CGEMM, CGEMV, CLASCL, XLAENV
 !.....external subroutines DMD package
 !     subroutines under test
       EXTERNAL CGEDMD, CGEDMDQ
@@ -112,6 +112,8 @@
 
       WANTQ = 'Q'
       WANTR = 'R'
+      ! Initialize the divide-and-conquer cutoff used by xGESDD/xBDSDC.
+      CALL XLAENV( 9, 25 )
 !.................................................................................
 
       EPS = SLAMCH( 'P' )  ! machine precision WP

--- a/TESTING/EIG/dchkdmd.f90
+++ b/TESTING/EIG/dchkdmd.f90
@@ -95,7 +95,7 @@
       LOGICAL  TEST_QRDMD
 !..... external subroutines (BLAS and LAPACK)
       EXTERNAL DAXPY,  DGEEV, DGEMM, DGEMV, DLACPY, DLASCL
-      EXTERNAL DLARNV, DLATMR
+      EXTERNAL DLARNV, DLATMR, XLAENV
 !.....external subroutines DMD package, part 1
 !     subroutines under test
       EXTERNAL DGEDMD, DGEDMDQ
@@ -118,6 +118,8 @@
                           ! be performed with xGEDMDQ.
       WANTQ = 'Q'
       WANTR = 'R'
+      ! Initialize the divide-and-conquer cutoff used by xGESDD/xBDSDC.
+      CALL XLAENV( 9, 25 )
 !.................................................................................
 
       EPS = DLAMCH( 'P' )  ! machine precision DP

--- a/TESTING/EIG/schkdmd.f90
+++ b/TESTING/EIG/schkdmd.f90
@@ -95,7 +95,7 @@
       LOGICAL          TEST_QRDMD
 !..... external subroutines (BLAS and LAPACK)
       EXTERNAL SAXPY,  SGEEV, SGEMM, SGEMV, SLACPY, SLASCL
-      EXTERNAL SLARNV, SLATMR
+      EXTERNAL SLARNV, SLATMR, XLAENV
 !.....external subroutines DMD package, part 1
 !     subroutines under test
       EXTERNAL SGEDMD, SGEDMDQ
@@ -118,6 +118,8 @@
                           ! be performed with xGEDMDQ.
       WANTQ = 'Q'
       WANTR = 'R'
+      ! Initialize the divide-and-conquer cutoff used by xGESDD/xBDSDC.
+      CALL XLAENV( 9, 25 )
 !.................................................................................
 
       EPS = SLAMCH( 'P' )  ! machine precision SP

--- a/TESTING/EIG/zchkdmd.f90
+++ b/TESTING/EIG/zchkdmd.f90
@@ -86,7 +86,7 @@
 !.....external subroutines (BLAS and LAPACK)
       EXTERNAL DAXPY,  DGEEV, DGEMM, DGEMV, DLACPY, DLASCL
       EXTERNAL ZGEEV,  ZGEMV, ZLASCL
-      EXTERNAL ZLARNV, ZLATMR
+      EXTERNAL ZLARNV, ZLATMR, XLAENV
       EXTERNAL ZAXPY,  ZGEMM
 !.....external subroutines DMD package, part 1
 !     subroutines under test
@@ -112,6 +112,8 @@
                           ! be performed with xGEDMDQ.
       WANTQ = 'Q'
       WANTR = 'R'
+      ! Initialize the divide-and-conquer cutoff used by xGESDD/xBDSDC.
+      CALL XLAENV( 9, 25 )
 !.................................................................................
 
       EPS = DLAMCH( 'P' )  ! machine precision DP


### PR DESCRIPTION
The DMD test drivers use the testing ILAENV from TESTING/EIG, where ISPEC=9 returns IPARMS(9). The drivers never initialized that entry, so the xGESDD/xBDSDC divide-and-conquer cutoff came from undefined state.

This undefined test state can lead to invalid xLASD0 calls and a large number of false failures. In this patch we initialize XLAENV(9,25) in the s/c/d/z DMD test drivers so the tests start from a defined ILAENV configuration.

**Description**

**Checklist**

- [ ] The documentation has been updated  -- no docs update required
- [ ] If the PR solves a specific issue, it is set to be closed on merge   -- no matching issue