### PR TITLE
TESTING/LIN: use ZERO/ONE/CZERO in LQ/QL/QR/RQ error-exit tests

### DIFF
--- a/TESTING/LIN/cerrlq.f
+++ b/TESTING/LIN/cerrlq.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +105,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
-            AF( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
+            A( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
+            AF( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/cerrlqt.f
+++ b/TESTING/LIN/cerrlqt.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.E0 / CMPLX( REAL( I+J ), 0.E0 )
-            C( I, J ) = 1.E0 / CMPLX( REAL( I+J ), 0.E0 )
-            T( I, J ) = 1.E0 / CMPLX( REAL( I+J ), 0.E0 )
+            A( I, J ) = ONE / CMPLX( REAL( I+J ), ZERO )
+            C( I, J ) = ONE / CMPLX( REAL( I+J ), ZERO )
+            T( I, J ) = ONE / CMPLX( REAL( I+J ), ZERO )
          END DO
-         W( J ) = 0.E0
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/cerrlqtp.f
+++ b/TESTING/LIN/cerrlqtp.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.E0 / CMPLX( REAL( I+J ), 0.E0 )
-            C( I, J ) = 1.E0 / CMPLX( REAL( I+J ), 0.E0 )
-            T( I, J ) = 1.E0 / CMPLX( REAL( I+J ), 0.E0 )
+            A( I, J ) = ONE / CMPLX( REAL( I+J ), ZERO )
+            C( I, J ) = ONE / CMPLX( REAL( I+J ), ZERO )
+            T( I, J ) = ONE / CMPLX( REAL( I+J ), ZERO )
          END DO
-         W( J ) = 0.E0
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/cerrql.f
+++ b/TESTING/LIN/cerrql.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +105,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
-            AF( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
+            A( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
+            AF( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/cerrqr.f
+++ b/TESTING/LIN/cerrqr.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -102,12 +106,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
-            AF( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
+            A( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
+            AF( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/cerrqrt.f
+++ b/TESTING/LIN/cerrqrt.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.0 / CMPLX( FLOAT(I+J), 0.0 )
-            C( I, J ) = 1.0 / CMPLX( FLOAT(I+J), 0.0 )
-            T( I, J ) = 1.0 / CMPLX( FLOAT(I+J), 0.0 )
+            A( I, J ) = ONE / CMPLX( FLOAT( I+J ), ZERO )
+            C( I, J ) = ONE / CMPLX( FLOAT( I+J ), ZERO )
+            T( I, J ) = ONE / CMPLX( FLOAT( I+J ), ZERO )
          END DO
-         W( J ) = 0.0
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/cerrqrtp.f
+++ b/TESTING/LIN/cerrqrtp.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.0 / CMPLX(FLOAT( I+J ),0.0)
-            C( I, J ) = 1.0 / CMPLX(FLOAT( I+J ),0.0)
-            T( I, J ) = 1.0 / CMPLX(FLOAT( I+J ),0.0)
+            A( I, J ) = ONE / CMPLX( FLOAT( I+J ), ZERO )
+            C( I, J ) = ONE / CMPLX( FLOAT( I+J ), ZERO )
+            T( I, J ) = ONE / CMPLX( FLOAT( I+J ), ZERO )
          END DO
-         W( J ) = CMPLX(0.0,0.0)
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/cerrrq.f
+++ b/TESTING/LIN/cerrrq.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX            CZERO
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +105,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
-            AF( I, J ) = CMPLX( 1. / REAL( I+J ), -1. / REAL( I+J ) )
+            A( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
+            AF( I, J ) = CMPLX( ONE / REAL( I+J ), -ONE / REAL( I+J ) )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrlq.f
+++ b/TESTING/LIN/derrlq.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +103,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            AF( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            AF( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrlqt.f
+++ b/TESTING/LIN/derrlqt.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            C( I, J ) = 1.D0 / DBLE( I+J )
-            T( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            C( I, J ) = ONE / DBLE( I+J )
+            T( I, J ) = ONE / DBLE( I+J )
          END DO
-         W( J ) = 0.D0
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrlqtp.f
+++ b/TESTING/LIN/derrlqtp.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            C( I, J ) = 1.D0 / DBLE( I+J )
-            T( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            C( I, J ) = ONE / DBLE( I+J )
+            T( I, J ) = ONE / DBLE( I+J )
          END DO
-         W( J ) = 0.0
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrql.f
+++ b/TESTING/LIN/derrql.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +103,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            AF( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            AF( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrqr.f
+++ b/TESTING/LIN/derrqr.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -102,12 +104,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            AF( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            AF( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrqrt.f
+++ b/TESTING/LIN/derrqrt.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            C( I, J ) = 1.D0 / DBLE( I+J )
-            T( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            C( I, J ) = ONE / DBLE( I+J )
+            T( I, J ) = ONE / DBLE( I+J )
          END DO
-         W( J ) = 0.D0
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrqrtp.f
+++ b/TESTING/LIN/derrqrtp.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            C( I, J ) = 1.D0 / DBLE( I+J )
-            T( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            C( I, J ) = ONE / DBLE( I+J )
+            T( I, J ) = ONE / DBLE( I+J )
          END DO
-         W( J ) = 0.0
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/derrrq.f
+++ b/TESTING/LIN/derrrq.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +103,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
-            AF( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
+            AF( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrlq.f
+++ b/TESTING/LIN/serrlq.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +103,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
-            AF( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
+            AF( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrlqt.f
+++ b/TESTING/LIN/serrlqt.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
-            C( I, J ) = 1. / REAL( I+J )
-            T( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
+            C( I, J ) = ONE / REAL( I+J )
+            T( I, J ) = ONE / REAL( I+J )
          END DO
-         W( J ) = 0.
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrlqtp.f
+++ b/TESTING/LIN/serrlqtp.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
-            C( I, J ) = 1. / REAL( I+J )
-            T( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
+            C( I, J ) = ONE / REAL( I+J )
+            T( I, J ) = ONE / REAL( I+J )
          END DO
-         W( J ) = 0.
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrql.f
+++ b/TESTING/LIN/serrql.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +103,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
-            AF( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
+            AF( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrqr.f
+++ b/TESTING/LIN/serrqr.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -102,12 +104,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
-            AF( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
+            AF( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrqrt.f
+++ b/TESTING/LIN/serrqrt.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.0 / FLOAT( I+J )
-            C( I, J ) = 1.0 / FLOAT( I+J )
-            T( I, J ) = 1.0 / FLOAT( I+J )
+            A( I, J ) = ONE / FLOAT( I+J )
+            C( I, J ) = ONE / FLOAT( I+J )
+            T( I, J ) = ONE / FLOAT( I+J )
          END DO
-         W( J ) = 0.0
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrqrtp.f
+++ b/TESTING/LIN/serrqrtp.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +103,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.0 / FLOAT( I+J )
-            C( I, J ) = 1.0 / FLOAT( I+J )
-            T( I, J ) = 1.0 / FLOAT( I+J )
+            A( I, J ) = ONE / FLOAT( I+J )
+            C( I, J ) = ONE / FLOAT( I+J )
+            T( I, J ) = ONE / FLOAT( I+J )
          END DO
-         W( J ) = 0.0
+         W( J ) = ZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/serrrq.f
+++ b/TESTING/LIN/serrrq.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,12 +103,12 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
-            AF( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
+            AF( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
-         B( J ) = 0.
-         W( J ) = 0.
-         X( J ) = 0.
+         B( J ) = ZERO
+         W( J ) = ZERO
+         X( J ) = ZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrlq.f
+++ b/TESTING/LIN/zerrlq.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,14 +105,14 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                  -1.D0 / DBLE( I+J ) )
-            AF( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                   -1.D0 / DBLE( I+J ) )
+            A( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                  -ONE / DBLE( I+J ) )
+            AF( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                   -ONE / DBLE( I+J ) )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrlqt.f
+++ b/TESTING/LIN/zerrlqt.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
-            C( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
-            T( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
+            A( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            C( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            T( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
          END DO
-         W( J ) = 0.D0
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrlqtp.f
+++ b/TESTING/LIN/zerrlqtp.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
-            C( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
-            T( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
+            A( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            C( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            T( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
          END DO
-         W( J ) = 0.0
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrql.f
+++ b/TESTING/LIN/zerrql.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,14 +105,14 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                  -1.D0 / DBLE( I+J ) )
-            AF( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                   -1.D0 / DBLE( I+J ) )
+            A( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                  -ONE / DBLE( I+J ) )
+            AF( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                   -ONE / DBLE( I+J ) )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrqr.f
+++ b/TESTING/LIN/zerrqr.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -102,14 +106,14 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                  -1.D0 / DBLE( I+J ) )
-            AF( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                   -1.D0 / DBLE( I+J ) )
+            A( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                  -ONE / DBLE( I+J ) )
+            AF( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                   -ONE / DBLE( I+J ) )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrqrt.f
+++ b/TESTING/LIN/zerrqrt.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
-            C( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
-            T( I, J ) = 1.D0 / DCMPLX( DBLE( I+J ), 0.D0 )
+            A( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            C( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            T( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
          END DO
-         W( J ) = 0.D0
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrqrtp.f
+++ b/TESTING/LIN/zerrqrtp.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,11 +105,11 @@
 *
       DO J = 1, NMAX
          DO I = 1, NMAX
-            A( I, J ) = 1.D0 / DCMPLX(DBLE( I+J ),0.D0)
-            C( I, J ) = 1.D0 / DCMPLX(DBLE( I+J ),0.D0)
-            T( I, J ) = 1.D0 / DCMPLX(DBLE( I+J ),0.D0)
+            A( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            C( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
+            T( I, J ) = ONE / DCMPLX( DBLE( I+J ), ZERO )
          END DO
-         W( J ) = DCMPLX(0.D0,0.D0)
+         W( J ) = CZERO
       END DO
       OK = .TRUE.
 *

--- a/TESTING/LIN/zerrrq.f
+++ b/TESTING/LIN/zerrrq.f
@@ -68,6 +68,10 @@
 *     .. Parameters ..
       INTEGER            NMAX
       PARAMETER          ( NMAX = 2 )
+      COMPLEX*16         CZERO
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, INFO, J
@@ -101,14 +105,14 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                  -1.D0 / DBLE( I+J ) )
-            AF( I, J ) = DCMPLX( 1.D0 / DBLE( I+J ),
-     $                   -1.D0 / DBLE( I+J ) )
+            A( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                  -ONE / DBLE( I+J ) )
+            AF( I, J ) = DCMPLX( ONE / DBLE( I+J ),
+     $                   -ONE / DBLE( I+J ) )
    10    CONTINUE
-         B( J ) = 0.D0
-         W( J ) = 0.D0
-         X( J ) = 0.D0
+         B( J ) = CZERO
+         W( J ) = CZERO
+         X( J ) = CZERO
    20 CONTINUE
       OK = .TRUE.
 *


### PR DESCRIPTION
## Summary

This PR replaces hard-coded `0`/`1` literals in the TESTING/LIN
error-exit drivers for the LQ/QL/QR/RQ families with typed named
constants.

For the real variants, it introduces `ZERO` and `ONE`.
For the complex variants, it also introduces `CZERO` and uses it for
complex zero initialization.

This is a mechanical cleanup only; no functional change is intended.

## Scope

The change is limited to the following TESTING/LIN error-exit drivers:

- `{s,d,c,z}err{lq,lqt,lqtp,ql,qr,qrt,qrtp,rq}`

## What changed

- added typed `ZERO` / `ONE` parameter constants
- replaced scattered hard-coded `0` / `1` literals in test-data setup
- added `CZERO` in the complex variants
- replaced complex zero initializers with `CZERO` for consistency

## Why

These files used a mix of literal forms such as `0.`, `0.0`, `0.D0`,
`1.`, `1.E0`, and `1.D0`, plus ad hoc complex zero initializers.

Using typed named constants makes the initialization code more uniform
and easier to maintain, without changing behavior.

## Testing

Not run.  
This is a mechanical source cleanup in the error-exit test drivers only.