### PR TITLE
TESTING/EIG: use named ONE constants in several error-exit tests

### DIFF
--- a/TESTING/EIG/cerrbd.f
+++ b/TESTING/EIG/cerrbd.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX )
+      REAL               ONE
+      PARAMETER          ( ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -108,7 +110,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
    20 CONTINUE
       OK = .TRUE.

--- a/TESTING/EIG/cerrhs.f
+++ b/TESTING/EIG/cerrhs.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = NMAX*NMAX )
+      REAL               ONE
+      PARAMETER          ( ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -111,7 +113,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
          SEL( J ) = .TRUE.
    20 CONTINUE

--- a/TESTING/EIG/derrbd.f
+++ b/TESTING/EIG/derrbd.f
@@ -112,7 +112,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
    20 CONTINUE
       OK = .TRUE.

--- a/TESTING/EIG/derrhs.f
+++ b/TESTING/EIG/derrhs.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = ( NMAX+2 )*( NMAX+2 )+NMAX )
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -111,7 +113,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
          WI( J ) = DBLE( J )
          SEL( J ) = .TRUE.

--- a/TESTING/EIG/serrbd.f
+++ b/TESTING/EIG/serrbd.f
@@ -112,7 +112,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
    20 CONTINUE
       OK = .TRUE.

--- a/TESTING/EIG/serrhs.f
+++ b/TESTING/EIG/serrhs.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = ( NMAX+2 )*( NMAX+2 )+NMAX )
+      REAL               ONE
+      PARAMETER          ( ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/serrhs.f
+++ b/TESTING/EIG/serrhs.f
@@ -110,7 +110,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1. / REAL( I+J )
+            A( I, J ) = ONE / REAL( I+J )
    10    CONTINUE
          WI( J ) = REAL( J )
          SEL( J ) = .TRUE.

--- a/TESTING/EIG/zerrbd.f
+++ b/TESTING/EIG/zerrbd.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX )
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -108,7 +110,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
    20 CONTINUE
       OK = .TRUE.


### PR DESCRIPTION
## Summary

This PR replaces hard-coded `1.` / `1.D0` literals with the named
constant `ONE` in several `TESTING/EIG` error-exit test routines.

Where needed, it also adds missing `ONE` parameter declarations so
the setup code follows the surrounding named-constant style.

No functional change is intended.

## Details

Several `TESTING/EIG` error-exit tests initialize matrices with
expressions such as:

- `1. / REAL(I+J)`
- `1.D0 / DBLE(I+J)`

This change rewrites those initializations to use `ONE` instead.
The goal is simply to make constant usage more consistent across
the test sources and to reduce hard-coded numeric literals in the
setup code.

## Testing

- Not run (cleanup only)