### PR TITLE
TESTING/LIN: use named constants in drvrf tests

### DIFF
--- a/TESTING/LIN/cdrvrf3.f
+++ b/TESTING/LIN/cdrvrf3.f
@@ -138,8 +138,10 @@
 *     ..
 *     .. Parameters ..
       COMPLEX            ZERO, ONE
+      REAL               TWO
       PARAMETER          ( ZERO = ( 0.0E+0, 0.0E+0 ) ,
      +                     ONE  = ( 1.0E+0, 0.0E+0 ) )
+      PARAMETER          ( TWO  = 2.0E+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 1 )
 *     ..
@@ -287,7 +289,7 @@
                                     DO J = 1, NA
                                        DO I = 1, J
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( J, J ) )
+     +                                            ( TWO * A( J, J ) )
                                        END DO
                                     END DO
                                  END IF
@@ -310,7 +312,7 @@
                                     DO I = 1, NA
                                        DO J = 1, I
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( I, I ) )
+     +                                            ( TWO * A( I, I ) )
                                        END DO
                                     END DO
                                  END IF

--- a/TESTING/LIN/cdrvrfp.f
+++ b/TESTING/LIN/cdrvrfp.f
@@ -276,8 +276,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 4 )
 *     ..

--- a/TESTING/LIN/ddrvrf3.f
+++ b/TESTING/LIN/ddrvrf3.f
@@ -135,9 +135,10 @@
 *  =====================================================================
 *     ..
 *     .. Parameters ..
-      DOUBLE PRECISION   ZERO, ONE
+      DOUBLE PRECISION   ZERO, ONE, TWO
       PARAMETER          ( ZERO = ( 0.0D+0, 0.0D+0 ) ,
-     +                     ONE  = ( 1.0D+0, 0.0D+0 ) )
+     +                     ONE  = ( 1.0D+0, 0.0D+0 ),
+     +                     TWO  = 2.0D+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 1 )
 *     ..
@@ -283,7 +284,7 @@
                                     DO J = 1, NA
                                        DO I = 1, J
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( J, J ) )
+     +                                            ( TWO * A( J, J ) )
                                        END DO
                                     END DO
                                  END IF
@@ -306,7 +307,7 @@
                                     DO I = 1, NA
                                        DO J = 1, I
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( I, I ) )
+     +                                            ( TWO * A( I, I ) )
                                        END DO
                                     END DO
                                  END IF

--- a/TESTING/LIN/ddrvrfp.f
+++ b/TESTING/LIN/ddrvrfp.f
@@ -269,8 +269,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 4 )
 *     ..

--- a/TESTING/LIN/sdrvrf3.f
+++ b/TESTING/LIN/sdrvrf3.f
@@ -135,9 +135,10 @@
 *  =====================================================================
 *     ..
 *     .. Parameters ..
-      REAL               ZERO, ONE
+      REAL               ZERO, ONE, TWO
       PARAMETER          ( ZERO = ( 0.0E+0, 0.0E+0 ) ,
-     +                     ONE  = ( 1.0E+0, 0.0E+0 ) )
+     +                     ONE  = ( 1.0E+0, 0.0E+0 ),
+     +                     TWO  = 2.0E+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 1 )
 *     ..
@@ -283,7 +284,7 @@
                                     DO J = 1, NA
                                        DO I = 1, J
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( J, J ) )
+     +                                            ( TWO * A( J, J ) )
                                        END DO
                                     END DO
                                  END IF
@@ -306,7 +307,7 @@
                                     DO I = 1, NA
                                        DO J = 1, I
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( I, I ) )
+     +                                            ( TWO * A( I, I ) )
                                        END DO
                                     END DO
                                  END IF

--- a/TESTING/LIN/sdrvrfp.f
+++ b/TESTING/LIN/sdrvrfp.f
@@ -269,8 +269,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 4 )
 *     ..

--- a/TESTING/LIN/zdrvrf3.f
+++ b/TESTING/LIN/zdrvrf3.f
@@ -138,8 +138,10 @@
 *     ..
 *     .. Parameters ..
       COMPLEX*16         ZERO, ONE
+      DOUBLE PRECISION   TWO
       PARAMETER          ( ZERO = ( 0.0D+0, 0.0D+0 ) ,
      +                     ONE  = ( 1.0D+0, 0.0D+0 ) )
+      PARAMETER          ( TWO  = 2.0D+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 1 )
 *     ..
@@ -287,7 +289,7 @@
                                     DO J = 1, NA
                                        DO I = 1, J
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( J, J ) )
+     +                                            ( TWO * A( J, J ) )
                                        END DO
                                     END DO
                                  END IF
@@ -310,7 +312,7 @@
                                     DO I = 1, NA
                                        DO J = 1, I
                                           A( I, J ) = A( I, J ) /
-     +                                            ( 2.0 * A( I, I ) )
+     +                                            ( TWO * A( I, I ) )
                                        END DO
                                     END DO
                                  END IF

--- a/TESTING/LIN/zdrvrfp.f
+++ b/TESTING/LIN/zdrvrfp.f
@@ -276,8 +276,8 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
       INTEGER            NTESTS
       PARAMETER          ( NTESTS = 4 )
 *     ..


### PR DESCRIPTION
  This PR replaces hard-coded floating-point constants in the TESTING/LIN drvrf test drivers with named constants.

  Files updated:
  ```text
  TESTING/LIN/cdrvrf3.f
  TESTING/LIN/ddrvrf3.f
  TESTING/LIN/sdrvrf3.f
  TESTING/LIN/zdrvrf3.f
  TESTING/LIN/cdrvrfp.f
  TESTING/LIN/ddrvrfp.f
  TESTING/LIN/sdrvrfp.f
  TESTING/LIN/zdrvrfp.f

  Summary:

  - Replace hard-coded 2.0 divisors in *drvrf3.f with TWO.
  - Normalize ZERO, ONE parameter ordering in *drvrfp.f.

  Validation:

  - Checked that no additional executable floating-point constants such as 0.5, 0.25, or -0.125 remain in these files.
  - Ran git diff --check for the updated files.
