### PR TITLE
cleanup: separate real and complex zero/one constants in {c,z}csdts

### DIFF
--- a/TESTING/EIG/ccsdts.f
+++ b/TESTING/EIG/ccsdts.f
@@ -246,10 +246,10 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               REALONE, REALZERO
-      PARAMETER          ( REALONE = 1.0E0, REALZERO = 0.0E0 )
-      COMPLEX            ZERO, ONE
-      PARAMETER          ( ZERO = (0.0E0,0.0E0), ONE = (1.0E0,0.0E0) )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0 )
+      COMPLEX            CZERO, CONE
+      PARAMETER          ( CZERO = (0.0E0,0.0E0), CONE = (1.0E0,0.0E0) )
       REAL               PIOVER2
       PARAMETER ( PIOVER2 = 1.57079632679489661923132169163975144210E0 )
 *     ..
@@ -271,13 +271,13 @@
 *     .. Executable Statements ..
 *
       ULP = SLAMCH( 'Precision' )
-      ULPINV = REALONE / ULP
+      ULPINV = ONE / ULP
 *
 *     The first half of the routine checks the 2-by-2 CSD
 *
-      CALL CLASET( 'Full', M, M, ZERO, ONE, WORK, LDX )
-      CALL CHERK( 'Upper', 'Conjugate transpose', M, M, -REALONE,
-     $            X, LDX, REALONE, WORK, LDX )
+      CALL CLASET( 'Full', M, M, CZERO, CONE, WORK, LDX )
+      CALL CHERK( 'Upper', 'Conjugate transpose', M, M, -ONE,
+     $            X, LDX, ONE, WORK, LDX )
       IF (M.GT.0) THEN
          EPS2 = MAX( ULP,
      $               CLANGE( '1', M, M, WORK, LDX, RWORK ) / REAL( M ) )
@@ -301,64 +301,64 @@
 *
       CALL CLACPY( 'Full', M, M, X, LDX, XF, LDX )
 *
-      CALL CGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, ONE,
-     $            XF, LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL CGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, CONE,
+     $            XF, LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
-      CALL CGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, ONE,
-     $            U1, LDU1, WORK, LDX, ZERO, XF, LDX )
+      CALL CGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, CONE,
+     $            U1, LDU1, WORK, LDX, CZERO, XF, LDX )
 *
       DO I = 1, MIN(P,Q)-R
-         XF(I,I) = XF(I,I) - ONE
+         XF(I,I) = XF(I,I) - CONE
       END DO
       DO I = 1, R
          XF(MIN(P,Q)-R+I,MIN(P,Q)-R+I) =
-     $           XF(MIN(P,Q)-R+I,MIN(P,Q)-R+I) - CMPLX( COS(THETA(I)),
-     $              0.0E0 )
+     $           XF(MIN(P,Q)-R+I,MIN(P,Q)-R+I) -
+     $           CMPLX( COS(THETA(I)), ZERO )
       END DO
 *
       CALL CGEMM( 'No transpose', 'Conjugate transpose', P, M-Q, M-Q,
-     $            ONE, XF(1,Q+1), LDX, V2T, LDV2T, ZERO, WORK, LDX )
+     $            CONE, XF(1,Q+1), LDX, V2T, LDV2T, CZERO, WORK, LDX )
 *
       CALL CGEMM( 'Conjugate transpose', 'No transpose', P, M-Q, P,
-     $            ONE, U1, LDU1, WORK, LDX, ZERO, XF(1,Q+1), LDX )
+     $            CONE, U1, LDU1, WORK, LDX, CZERO, XF(1,Q+1), LDX )
 *
       DO I = 1, MIN(P,M-Q)-R
-         XF(P-I+1,M-I+1) = XF(P-I+1,M-I+1) + ONE
+         XF(P-I+1,M-I+1) = XF(P-I+1,M-I+1) + CONE
       END DO
       DO I = 1, R
          XF(P-(MIN(P,M-Q)-R)+1-I,M-(MIN(P,M-Q)-R)+1-I) =
      $      XF(P-(MIN(P,M-Q)-R)+1-I,M-(MIN(P,M-Q)-R)+1-I) +
-     $      CMPLX( SIN(THETA(R-I+1)), 0.0E0 )
+     $      CMPLX( SIN(THETA(R-I+1)), ZERO )
       END DO
 *
-      CALL CGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q, ONE,
-     $            XF(P+1,1), LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL CGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q,
+     $            CONE, XF(P+1,1), LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
       CALL CGEMM( 'Conjugate transpose', 'No transpose', M-P, Q, M-P,
-     $            ONE, U2, LDU2, WORK, LDX, ZERO, XF(P+1,1), LDX )
+     $            CONE, U2, LDU2, WORK, LDX, CZERO, XF(P+1,1), LDX )
 *
       DO I = 1, MIN(M-P,Q)-R
-         XF(M-I+1,Q-I+1) = XF(M-I+1,Q-I+1) - ONE
+         XF(M-I+1,Q-I+1) = XF(M-I+1,Q-I+1) - CONE
       END DO
       DO I = 1, R
          XF(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) =
      $             XF(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) -
-     $             CMPLX( SIN(THETA(R-I+1)), 0.0E0 )
+     $             CMPLX( SIN(THETA(R-I+1)), ZERO )
       END DO
 *
       CALL CGEMM( 'No transpose', 'Conjugate transpose', M-P, M-Q, M-Q,
-     $            ONE, XF(P+1,Q+1), LDX, V2T, LDV2T, ZERO, WORK, LDX )
+     $            CONE, XF(P+1,Q+1), LDX, V2T, LDV2T, CZERO, WORK, LDX )
 *
       CALL CGEMM( 'Conjugate transpose', 'No transpose', M-P, M-Q, M-P,
-     $            ONE, U2, LDU2, WORK, LDX, ZERO, XF(P+1,Q+1), LDX )
+     $            CONE, U2, LDU2, WORK, LDX, CZERO, XF(P+1,Q+1), LDX )
 *
       DO I = 1, MIN(M-P,M-Q)-R
-         XF(P+I,Q+I) = XF(P+I,Q+I) - ONE
+         XF(P+I,Q+I) = XF(P+I,Q+I) - CONE
       END DO
       DO I = 1, R
          XF(P+(MIN(M-P,M-Q)-R)+I,Q+(MIN(M-P,M-Q)-R)+I) =
      $      XF(P+(MIN(M-P,M-Q)-R)+I,Q+(MIN(M-P,M-Q)-R)+I) -
-     $      CMPLX( COS(THETA(I)), 0.0E0 )
+     $      CMPLX( COS(THETA(I)), ZERO )
       END DO
 *
 *     Compute norm( U1'*X11*V1 - D11 ) / ( MAX(1,P,Q)*EPS2 ) .
@@ -383,9 +383,9 @@
 *
 *     Compute I - U1'*U1
 *
-      CALL CLASET( 'Full', P, P, ZERO, ONE, WORK, LDU1 )
-      CALL CHERK( 'Upper', 'Conjugate transpose', P, P, -REALONE,
-     $            U1, LDU1, REALONE, WORK, LDU1 )
+      CALL CLASET( 'Full', P, P, CZERO, CONE, WORK, LDU1 )
+      CALL CHERK( 'Upper', 'Conjugate transpose', P, P, -ONE,
+     $            U1, LDU1, ONE, WORK, LDU1 )
 *
 *     Compute norm( I - U'*U ) / ( MAX(1,P) * ULP ) .
 *
@@ -394,9 +394,9 @@
 *
 *     Compute I - U2'*U2
 *
-      CALL CLASET( 'Full', M-P, M-P, ZERO, ONE, WORK, LDU2 )
-      CALL CHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -REALONE,
-     $            U2, LDU2, REALONE, WORK, LDU2 )
+      CALL CLASET( 'Full', M-P, M-P, CZERO, CONE, WORK, LDU2 )
+      CALL CHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -ONE,
+     $            U2, LDU2, ONE, WORK, LDU2 )
 *
 *     Compute norm( I - U2'*U2 ) / ( MAX(1,M-P) * ULP ) .
 *
@@ -405,9 +405,9 @@
 *
 *     Compute I - V1T*V1T'
 *
-      CALL CLASET( 'Full', Q, Q, ZERO, ONE, WORK, LDV1T )
-      CALL CHERK( 'Upper', 'No transpose', Q, Q, -REALONE,
-     $            V1T, LDV1T, REALONE, WORK, LDV1T )
+      CALL CLASET( 'Full', Q, Q, CZERO, CONE, WORK, LDV1T )
+      CALL CHERK( 'Upper', 'No transpose', Q, Q, -ONE,
+     $            V1T, LDV1T, ONE, WORK, LDV1T )
 *
 *     Compute norm( I - V1T*V1T' ) / ( MAX(1,Q) * ULP ) .
 *
@@ -416,9 +416,9 @@
 *
 *     Compute I - V2T*V2T'
 *
-      CALL CLASET( 'Full', M-Q, M-Q, ZERO, ONE, WORK, LDV2T )
-      CALL CHERK( 'Upper', 'No transpose', M-Q, M-Q, -REALONE,
-     $            V2T, LDV2T, REALONE, WORK, LDV2T )
+      CALL CLASET( 'Full', M-Q, M-Q, CZERO, CONE, WORK, LDV2T )
+      CALL CHERK( 'Upper', 'No transpose', M-Q, M-Q, -ONE,
+     $            V2T, LDV2T, ONE, WORK, LDV2T )
 *
 *     Compute norm( I - V2T*V2T' ) / ( MAX(1,M-Q) * ULP ) .
 *
@@ -427,9 +427,9 @@
 *
 *     Check sorting
 *
-      RESULT( 9 ) = REALZERO
+      RESULT( 9 ) = ZERO
       DO I = 1, R
-         IF( THETA(I).LT.REALZERO .OR. THETA(I).GT.PIOVER2 ) THEN
+         IF( THETA(I).LT.ZERO .OR. THETA(I).GT.PIOVER2 ) THEN
             RESULT( 9 ) = ULPINV
          END IF
          IF( I.GT.1) THEN
@@ -441,9 +441,9 @@
 *
 *     The second half of the routine checks the 2-by-1 CSD
 *
-      CALL CLASET( 'Full', Q, Q, ZERO, ONE, WORK, LDX )
-      CALL CHERK( 'Upper', 'Conjugate transpose', Q, M, -REALONE,
-     $            X, LDX, REALONE, WORK, LDX )
+      CALL CLASET( 'Full', Q, Q, CZERO, CONE, WORK, LDX )
+      CALL CHERK( 'Upper', 'Conjugate transpose', Q, M, -ONE,
+     $            X, LDX, ONE, WORK, LDX )
       IF (M.GT.0) THEN
          EPS2 = MAX( ULP,
      $               CLANGE( '1', Q, Q, WORK, LDX, RWORK ) / REAL( M ) )
@@ -464,34 +464,34 @@
 *
 *     Compute [X11;X21] := diag(U1,U2)'*[X11;X21]*V1 - [D11;D21]
 *
-      CALL CGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, ONE,
-     $            X, LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL CGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, CONE,
+     $            X, LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
-      CALL CGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, ONE,
-     $            U1, LDU1, WORK, LDX, ZERO, X, LDX )
+      CALL CGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, CONE,
+     $            U1, LDU1, WORK, LDX, CZERO, X, LDX )
 *
       DO I = 1, MIN(P,Q)-R
-         X(I,I) = X(I,I) - ONE
+         X(I,I) = X(I,I) - CONE
       END DO
       DO I = 1, R
          X(MIN(P,Q)-R+I,MIN(P,Q)-R+I) =
-     $           X(MIN(P,Q)-R+I,MIN(P,Q)-R+I) - CMPLX( COS(THETA(I)),
-     $              0.0E0 )
+     $           X(MIN(P,Q)-R+I,MIN(P,Q)-R+I) -
+     $           CMPLX( COS(THETA(I)), ZERO )
       END DO
 *
-      CALL CGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q, ONE,
-     $            X(P+1,1), LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL CGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q,
+     $            CONE, X(P+1,1), LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
       CALL CGEMM( 'Conjugate transpose', 'No transpose', M-P, Q, M-P,
-     $            ONE, U2, LDU2, WORK, LDX, ZERO, X(P+1,1), LDX )
+     $            CONE, U2, LDU2, WORK, LDX, CZERO, X(P+1,1), LDX )
 *
       DO I = 1, MIN(M-P,Q)-R
-         X(M-I+1,Q-I+1) = X(M-I+1,Q-I+1) - ONE
+         X(M-I+1,Q-I+1) = X(M-I+1,Q-I+1) - CONE
       END DO
       DO I = 1, R
          X(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) =
      $             X(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) -
-     $             CMPLX( SIN(THETA(R-I+1)), 0.0E0 )
+     $             CMPLX( SIN(THETA(R-I+1)), ZERO )
       END DO
 *
 *     Compute norm( U1'*X11*V1 - D11 ) / ( MAX(1,P,Q)*EPS2 ) .
@@ -506,9 +506,9 @@
 *
 *     Compute I - U1'*U1
 *
-      CALL CLASET( 'Full', P, P, ZERO, ONE, WORK, LDU1 )
-      CALL CHERK( 'Upper', 'Conjugate transpose', P, P, -REALONE,
-     $            U1, LDU1, REALONE, WORK, LDU1 )
+      CALL CLASET( 'Full', P, P, CZERO, CONE, WORK, LDU1 )
+      CALL CHERK( 'Upper', 'Conjugate transpose', P, P, -ONE,
+     $            U1, LDU1, ONE, WORK, LDU1 )
 *
 *     Compute norm( I - U1'*U1 ) / ( MAX(1,P) * ULP ) .
 *
@@ -517,9 +517,9 @@
 *
 *     Compute I - U2'*U2
 *
-      CALL CLASET( 'Full', M-P, M-P, ZERO, ONE, WORK, LDU2 )
-      CALL CHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -REALONE,
-     $            U2, LDU2, REALONE, WORK, LDU2 )
+      CALL CLASET( 'Full', M-P, M-P, CZERO, CONE, WORK, LDU2 )
+      CALL CHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -ONE,
+     $            U2, LDU2, ONE, WORK, LDU2 )
 *
 *     Compute norm( I - U2'*U2 ) / ( MAX(1,M-P) * ULP ) .
 *
@@ -528,9 +528,9 @@
 *
 *     Compute I - V1T*V1T'
 *
-      CALL CLASET( 'Full', Q, Q, ZERO, ONE, WORK, LDV1T )
-      CALL CHERK( 'Upper', 'No transpose', Q, Q, -REALONE,
-     $            V1T, LDV1T, REALONE, WORK, LDV1T )
+      CALL CLASET( 'Full', Q, Q, CZERO, CONE, WORK, LDV1T )
+      CALL CHERK( 'Upper', 'No transpose', Q, Q, -ONE,
+     $            V1T, LDV1T, ONE, WORK, LDV1T )
 *
 *     Compute norm( I - V1T*V1T' ) / ( MAX(1,Q) * ULP ) .
 *
@@ -539,9 +539,9 @@
 *
 *     Check sorting
 *
-      RESULT( 15 ) = REALZERO
+      RESULT( 15 ) = ZERO
       DO I = 1, R
-         IF( THETA(I).LT.REALZERO .OR. THETA(I).GT.PIOVER2 ) THEN
+         IF( THETA(I).LT.ZERO .OR. THETA(I).GT.PIOVER2 ) THEN
             RESULT( 15 ) = ULPINV
          END IF
          IF( I.GT.1) THEN

--- a/TESTING/EIG/zcsdts.f
+++ b/TESTING/EIG/zcsdts.f
@@ -246,10 +246,10 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   REALONE, REALZERO
-      PARAMETER          ( REALONE = 1.0D0, REALZERO = 0.0D0 )
-      COMPLEX*16         ZERO, ONE
-      PARAMETER          ( ZERO = (0.0D0,0.0D0), ONE = (1.0D0,0.0D0) )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0 )
+      COMPLEX*16         CZERO, CONE
+      PARAMETER          ( CZERO = (0.0D0,0.0D0), CONE = (1.0D0,0.0D0) )
       DOUBLE PRECISION   PIOVER2
       PARAMETER ( PIOVER2 = 1.57079632679489661923132169163975144210D0 )
 *     ..
@@ -271,13 +271,13 @@
 *     .. Executable Statements ..
 *
       ULP = DLAMCH( 'Precision' )
-      ULPINV = REALONE / ULP
+      ULPINV = ONE / ULP
 *
 *     The first half of the routine checks the 2-by-2 CSD
 *
-      CALL ZLASET( 'Full', M, M, ZERO, ONE, WORK, LDX )
-      CALL ZHERK( 'Upper', 'Conjugate transpose', M, M, -REALONE,
-     $            X, LDX, REALONE, WORK, LDX )
+      CALL ZLASET( 'Full', M, M, CZERO, CONE, WORK, LDX )
+      CALL ZHERK( 'Upper', 'Conjugate transpose', M, M, -ONE,
+     $            X, LDX, ONE, WORK, LDX )
       IF (M.GT.0) THEN
          EPS2 = MAX( ULP,
      $               ZLANGE( '1', M, M, WORK, LDX, RWORK ) / DBLE( M ) )
@@ -301,64 +301,64 @@
 *
       CALL ZLACPY( 'Full', M, M, X, LDX, XF, LDX )
 *
-      CALL ZGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, ONE,
-     $            XF, LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL ZGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, CONE,
+     $            XF, LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
-      CALL ZGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, ONE,
-     $            U1, LDU1, WORK, LDX, ZERO, XF, LDX )
+      CALL ZGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, CONE,
+     $            U1, LDU1, WORK, LDX, CZERO, XF, LDX )
 *
       DO I = 1, MIN(P,Q)-R
-         XF(I,I) = XF(I,I) - ONE
+         XF(I,I) = XF(I,I) - CONE
       END DO
       DO I = 1, R
          XF(MIN(P,Q)-R+I,MIN(P,Q)-R+I) =
-     $           XF(MIN(P,Q)-R+I,MIN(P,Q)-R+I) - DCMPLX( COS(THETA(I)),
-     $              0.0D0 )
+     $           XF(MIN(P,Q)-R+I,MIN(P,Q)-R+I) -
+     $           DCMPLX( COS(THETA(I)), ZERO )
       END DO
 *
       CALL ZGEMM( 'No transpose', 'Conjugate transpose', P, M-Q, M-Q,
-     $            ONE, XF(1,Q+1), LDX, V2T, LDV2T, ZERO, WORK, LDX )
+     $            CONE, XF(1,Q+1), LDX, V2T, LDV2T, CZERO, WORK, LDX )
 *
       CALL ZGEMM( 'Conjugate transpose', 'No transpose', P, M-Q, P,
-     $            ONE, U1, LDU1, WORK, LDX, ZERO, XF(1,Q+1), LDX )
+     $            CONE, U1, LDU1, WORK, LDX, CZERO, XF(1,Q+1), LDX )
 *
       DO I = 1, MIN(P,M-Q)-R
-         XF(P-I+1,M-I+1) = XF(P-I+1,M-I+1) + ONE
+         XF(P-I+1,M-I+1) = XF(P-I+1,M-I+1) + CONE
       END DO
       DO I = 1, R
          XF(P-(MIN(P,M-Q)-R)+1-I,M-(MIN(P,M-Q)-R)+1-I) =
      $      XF(P-(MIN(P,M-Q)-R)+1-I,M-(MIN(P,M-Q)-R)+1-I) +
-     $      DCMPLX( SIN(THETA(R-I+1)), 0.0D0 )
+     $      DCMPLX( SIN(THETA(R-I+1)), ZERO )
       END DO
 *
-      CALL ZGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q, ONE,
-     $            XF(P+1,1), LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL ZGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q,
+     $            CONE, XF(P+1,1), LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
       CALL ZGEMM( 'Conjugate transpose', 'No transpose', M-P, Q, M-P,
-     $            ONE, U2, LDU2, WORK, LDX, ZERO, XF(P+1,1), LDX )
+     $            CONE, U2, LDU2, WORK, LDX, CZERO, XF(P+1,1), LDX )
 *
       DO I = 1, MIN(M-P,Q)-R
-         XF(M-I+1,Q-I+1) = XF(M-I+1,Q-I+1) - ONE
+         XF(M-I+1,Q-I+1) = XF(M-I+1,Q-I+1) - CONE
       END DO
       DO I = 1, R
          XF(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) =
      $             XF(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) -
-     $             DCMPLX( SIN(THETA(R-I+1)), 0.0D0 )
+     $             DCMPLX( SIN(THETA(R-I+1)), ZERO )
       END DO
 *
       CALL ZGEMM( 'No transpose', 'Conjugate transpose', M-P, M-Q, M-Q,
-     $            ONE, XF(P+1,Q+1), LDX, V2T, LDV2T, ZERO, WORK, LDX )
+     $            CONE, XF(P+1,Q+1), LDX, V2T, LDV2T, CZERO, WORK, LDX )
 *
       CALL ZGEMM( 'Conjugate transpose', 'No transpose', M-P, M-Q, M-P,
-     $            ONE, U2, LDU2, WORK, LDX, ZERO, XF(P+1,Q+1), LDX )
+     $            CONE, U2, LDU2, WORK, LDX, CZERO, XF(P+1,Q+1), LDX )
 *
       DO I = 1, MIN(M-P,M-Q)-R
-         XF(P+I,Q+I) = XF(P+I,Q+I) - ONE
+         XF(P+I,Q+I) = XF(P+I,Q+I) - CONE
       END DO
       DO I = 1, R
          XF(P+(MIN(M-P,M-Q)-R)+I,Q+(MIN(M-P,M-Q)-R)+I) =
      $      XF(P+(MIN(M-P,M-Q)-R)+I,Q+(MIN(M-P,M-Q)-R)+I) -
-     $      DCMPLX( COS(THETA(I)), 0.0D0 )
+     $      DCMPLX( COS(THETA(I)), ZERO )
       END DO
 *
 *     Compute norm( U1'*X11*V1 - D11 ) / ( MAX(1,P,Q)*EPS2 ) .
@@ -383,9 +383,9 @@
 *
 *     Compute I - U1'*U1
 *
-      CALL ZLASET( 'Full', P, P, ZERO, ONE, WORK, LDU1 )
-      CALL ZHERK( 'Upper', 'Conjugate transpose', P, P, -REALONE,
-     $            U1, LDU1, REALONE, WORK, LDU1 )
+      CALL ZLASET( 'Full', P, P, CZERO, CONE, WORK, LDU1 )
+      CALL ZHERK( 'Upper', 'Conjugate transpose', P, P, -ONE,
+     $            U1, LDU1, ONE, WORK, LDU1 )
 *
 *     Compute norm( I - U'*U ) / ( MAX(1,P) * ULP ) .
 *
@@ -394,9 +394,9 @@
 *
 *     Compute I - U2'*U2
 *
-      CALL ZLASET( 'Full', M-P, M-P, ZERO, ONE, WORK, LDU2 )
-      CALL ZHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -REALONE,
-     $            U2, LDU2, REALONE, WORK, LDU2 )
+      CALL ZLASET( 'Full', M-P, M-P, CZERO, CONE, WORK, LDU2 )
+      CALL ZHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -ONE,
+     $            U2, LDU2, ONE, WORK, LDU2 )
 *
 *     Compute norm( I - U2'*U2 ) / ( MAX(1,M-P) * ULP ) .
 *
@@ -405,9 +405,9 @@
 *
 *     Compute I - V1T*V1T'
 *
-      CALL ZLASET( 'Full', Q, Q, ZERO, ONE, WORK, LDV1T )
-      CALL ZHERK( 'Upper', 'No transpose', Q, Q, -REALONE,
-     $            V1T, LDV1T, REALONE, WORK, LDV1T )
+      CALL ZLASET( 'Full', Q, Q, CZERO, CONE, WORK, LDV1T )
+      CALL ZHERK( 'Upper', 'No transpose', Q, Q, -ONE,
+     $            V1T, LDV1T, ONE, WORK, LDV1T )
 *
 *     Compute norm( I - V1T*V1T' ) / ( MAX(1,Q) * ULP ) .
 *
@@ -416,9 +416,9 @@
 *
 *     Compute I - V2T*V2T'
 *
-      CALL ZLASET( 'Full', M-Q, M-Q, ZERO, ONE, WORK, LDV2T )
-      CALL ZHERK( 'Upper', 'No transpose', M-Q, M-Q, -REALONE,
-     $            V2T, LDV2T, REALONE, WORK, LDV2T )
+      CALL ZLASET( 'Full', M-Q, M-Q, CZERO, CONE, WORK, LDV2T )
+      CALL ZHERK( 'Upper', 'No transpose', M-Q, M-Q, -ONE,
+     $            V2T, LDV2T, ONE, WORK, LDV2T )
 *
 *     Compute norm( I - V2T*V2T' ) / ( MAX(1,M-Q) * ULP ) .
 *
@@ -427,9 +427,9 @@
 *
 *     Check sorting
 *
-      RESULT( 9 ) = REALZERO
+      RESULT( 9 ) = ZERO
       DO I = 1, R
-         IF( THETA(I).LT.REALZERO .OR. THETA(I).GT.PIOVER2 ) THEN
+         IF( THETA(I).LT.ZERO .OR. THETA(I).GT.PIOVER2 ) THEN
             RESULT( 9 ) = ULPINV
          END IF
          IF( I.GT.1) THEN
@@ -441,9 +441,9 @@
 *
 *     The second half of the routine checks the 2-by-1 CSD
 *
-      CALL ZLASET( 'Full', Q, Q, ZERO, ONE, WORK, LDX )
-      CALL ZHERK( 'Upper', 'Conjugate transpose', Q, M, -REALONE,
-     $            X, LDX, REALONE, WORK, LDX )
+      CALL ZLASET( 'Full', Q, Q, CZERO, CONE, WORK, LDX )
+      CALL ZHERK( 'Upper', 'Conjugate transpose', Q, M, -ONE,
+     $            X, LDX, ONE, WORK, LDX )
       IF (M.GT.0) THEN
          EPS2 = MAX( ULP,
      $               ZLANGE( '1', Q, Q, WORK, LDX, RWORK ) / DBLE( M ) )
@@ -464,34 +464,34 @@
 *
 *     Compute [X11;X21] := diag(U1,U2)'*[X11;X21]*V1 - [D11;D21]
 *
-      CALL ZGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, ONE,
-     $            X, LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL ZGEMM( 'No transpose', 'Conjugate transpose', P, Q, Q, CONE,
+     $            X, LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
-      CALL ZGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, ONE,
-     $            U1, LDU1, WORK, LDX, ZERO, X, LDX )
+      CALL ZGEMM( 'Conjugate transpose', 'No transpose', P, Q, P, CONE,
+     $            U1, LDU1, WORK, LDX, CZERO, X, LDX )
 *
       DO I = 1, MIN(P,Q)-R
-         X(I,I) = X(I,I) - ONE
+         X(I,I) = X(I,I) - CONE
       END DO
       DO I = 1, R
          X(MIN(P,Q)-R+I,MIN(P,Q)-R+I) =
-     $           X(MIN(P,Q)-R+I,MIN(P,Q)-R+I) - DCMPLX( COS(THETA(I)),
-     $              0.0D0 )
+     $           X(MIN(P,Q)-R+I,MIN(P,Q)-R+I) -
+     $           DCMPLX( COS(THETA(I)), ZERO )
       END DO
 *
-      CALL ZGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q, ONE,
-     $            X(P+1,1), LDX, V1T, LDV1T, ZERO, WORK, LDX )
+      CALL ZGEMM( 'No transpose', 'Conjugate transpose', M-P, Q, Q,
+     $            CONE, X(P+1,1), LDX, V1T, LDV1T, CZERO, WORK, LDX )
 *
       CALL ZGEMM( 'Conjugate transpose', 'No transpose', M-P, Q, M-P,
-     $            ONE, U2, LDU2, WORK, LDX, ZERO, X(P+1,1), LDX )
+     $            CONE, U2, LDU2, WORK, LDX, CZERO, X(P+1,1), LDX )
 *
       DO I = 1, MIN(M-P,Q)-R
-         X(M-I+1,Q-I+1) = X(M-I+1,Q-I+1) - ONE
+         X(M-I+1,Q-I+1) = X(M-I+1,Q-I+1) - CONE
       END DO
       DO I = 1, R
          X(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) =
      $             X(M-(MIN(M-P,Q)-R)+1-I,Q-(MIN(M-P,Q)-R)+1-I) -
-     $             DCMPLX( SIN(THETA(R-I+1)), 0.0D0 )
+     $             DCMPLX( SIN(THETA(R-I+1)), ZERO )
       END DO
 *
 *     Compute norm( U1'*X11*V1 - D11 ) / ( MAX(1,P,Q)*EPS2 ) .
@@ -506,9 +506,9 @@
 *
 *     Compute I - U1'*U1
 *
-      CALL ZLASET( 'Full', P, P, ZERO, ONE, WORK, LDU1 )
-      CALL ZHERK( 'Upper', 'Conjugate transpose', P, P, -REALONE,
-     $            U1, LDU1, REALONE, WORK, LDU1 )
+      CALL ZLASET( 'Full', P, P, CZERO, CONE, WORK, LDU1 )
+      CALL ZHERK( 'Upper', 'Conjugate transpose', P, P, -ONE,
+     $            U1, LDU1, ONE, WORK, LDU1 )
 *
 *     Compute norm( I - U'*U ) / ( MAX(1,P) * ULP ) .
 *
@@ -517,9 +517,9 @@
 *
 *     Compute I - U2'*U2
 *
-      CALL ZLASET( 'Full', M-P, M-P, ZERO, ONE, WORK, LDU2 )
-      CALL ZHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -REALONE,
-     $            U2, LDU2, REALONE, WORK, LDU2 )
+      CALL ZLASET( 'Full', M-P, M-P, CZERO, CONE, WORK, LDU2 )
+      CALL ZHERK( 'Upper', 'Conjugate transpose', M-P, M-P, -ONE,
+     $            U2, LDU2, ONE, WORK, LDU2 )
 *
 *     Compute norm( I - U2'*U2 ) / ( MAX(1,M-P) * ULP ) .
 *
@@ -528,9 +528,9 @@
 *
 *     Compute I - V1T*V1T'
 *
-      CALL ZLASET( 'Full', Q, Q, ZERO, ONE, WORK, LDV1T )
-      CALL ZHERK( 'Upper', 'No transpose', Q, Q, -REALONE,
-     $            V1T, LDV1T, REALONE, WORK, LDV1T )
+      CALL ZLASET( 'Full', Q, Q, CZERO, CONE, WORK, LDV1T )
+      CALL ZHERK( 'Upper', 'No transpose', Q, Q, -ONE,
+     $            V1T, LDV1T, ONE, WORK, LDV1T )
 *
 *     Compute norm( I - V1T*V1T' ) / ( MAX(1,Q) * ULP ) .
 *
@@ -539,9 +539,9 @@
 *
 *     Check sorting
 *
-      RESULT( 15 ) = REALZERO
+      RESULT( 15 ) = ZERO
       DO I = 1, R
-         IF( THETA(I).LT.REALZERO .OR. THETA(I).GT.PIOVER2 ) THEN
+         IF( THETA(I).LT.ZERO .OR. THETA(I).GT.PIOVER2 ) THEN
             RESULT( 15 ) = ULPINV
          END IF
          IF( I.GT.1) THEN
@@ -556,4 +556,3 @@
 *     End of ZCSDTS
 *
       END
-


### PR DESCRIPTION
## Summary

This cleanup makes the scalar and complex constants explicit in the CSD
test routines.

`ccsdts.f` and `zcsdts.f` previously used separate real constants
(`REALZERO`/`REALONE`) alongside complex `ZERO`/`ONE`. This change
switches to real `ZERO`/`ONE` and complex `CZERO`/`CONE`, then updates
the affected call sites to use constants with the intended type.

## Changes

- define real `ZERO`/`ONE` and complex `CZERO`/`CONE`
- update `{C,Z}LASET`, `{C,Z}GEMM`, and `{C,Z}HERK` call sites to use
  the matching real or complex constants
- replace literal imaginary-zero arguments in `CMPLX`/`DCMPLX` with the
  named real `ZERO` constant
- remove the now-redundant `REALZERO`/`REALONE` naming in these routines

## Notes

No functional change intended.

This is a test-code cleanup that makes the constant usage more explicit
and avoids mixing real and complex meanings under the same `ZERO`/`ONE`
names.