### PR TITLE
Add a new algorithm for the generalized eigenvalue problem

### DIFF
--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -85,6 +85,7 @@ set(DZLAUX
    ../INSTALL/dlamch.f ${DSECOND_SRC})
 
 set(SLASRC
+   sggdef.f	sggev4.f sgghd4.f sggprp.f slarev.f slatrn.f
    sgbbrd.f sgbcon.f sgbequ.f sgbrfs.f sgbsv.f
    sgbsvx.f sgbtf2.f sgbtrf.f sgbtrs.f sgebak.f sgebal.f sgebd2.f
    sgebrd.f sgecon.f sgeequ.f sgees.f  sgeesx.f sgeev.f  sgeevx.f
@@ -176,6 +177,7 @@ set(SXLASRC sgesvxx.f sgerfsx.f sla_gerfsx_extended.f sla_geamv.f
    slascl2.f sla_wwaddw.f)
 
 set(CLASRC
+   cggdef.f	cggev4.f cgghd4.f cggprp.f clarev.f clatrn.f
    cbdsqr.f cgbbrd.f cgbcon.f cgbequ.f cgbrfs.f cgbsv.f  cgbsvx.f
    cgbtf2.f cgbtrf.f cgbtrs.f cgebak.f cgebal.f cgebd2.f cgebrd.f
    cgecon.f cgeequ.f cgees.f  cgeesx.f cgeev.f  cgeevx.f
@@ -286,6 +288,7 @@ set(ZCLASRC
     sisnan.f slaisnan.f)
 
 set(DLASRC
+   dggdef.f	dggev4.f dgghd4.f dggprp.f dlarev.f dlatrn.f
    dbdsvdx.f dgbbrd.f dgbcon.f dgbequ.f dgbrfs.f dgbsv.f
    dgbsvx.f dgbtf2.f dgbtrf.f dgbtrs.f dgebak.f dgebal.f dgebd2.f
    dgebrd.f dgecon.f dgeequ.f dgees.f  dgeesx.f dgeev.f  dgeevx.f
@@ -375,6 +378,7 @@ set(DXLASRC dgesvxx.f dgerfsx.f dla_gerfsx_extended.f dla_geamv.f
    dlascl2.f dla_wwaddw.f)
 
 set(ZLASRC
+   zggdef.f	zggev4.f zgghd4.f zggprp.f zlarev.f zlatrn.f
    zbdsqr.f zgbbrd.f zgbcon.f zgbequ.f zgbrfs.f zgbsv.f  zgbsvx.f
    zgbtf2.f zgbtrf.f zgbtrs.f zgebak.f zgebal.f zgebd2.f zgebrd.f
    zgecon.f zgeequ.f zgees.f  zgeesx.f zgeev.f  zgeevx.f

--- a/SRC/cggdef.f
+++ b/SRC/cggdef.f
@@ -1,0 +1,315 @@
+*> \brief \b CGGDEF
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> CGGDEF performs the deflation of infinite eigenvalues in the generalized
+*> eigenvalue problem.
+*> It applies QR and RQ factorizations to 
+*> sub-blocks of A and B to properly isolate and deflate these eigenvalues.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPVL
+*> \verbatim
+*>          COMPVL is LOGICAL
+*>          = .TRUE.:  Compute the left Schur vectors (VL).
+*>          = .FALSE.: Do not compute the left Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] COMPVR
+*> \verbatim
+*>          COMPVR is LOGICAL
+*>          = .TRUE.:  Compute the right Schur vectors (VR).
+*>          = .FALSE.: Do not compute the right Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.
+*>          N >= 0.
+*> \endverbatim
+*>
+*> \param[in] K
+*> \verbatim
+*>          K is INTEGER
+*>          The number of infinite eigenvalues to deflate (the block size).
+*>          0 <= K <= N.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension (LDA, N)
+*>          On entry, the matrix A to be deflated.
+*>          On exit, A has been updated by the unitary transformations.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX array, dimension (LDB, N)
+*>          On entry, the matrix B to be deflated.
+*>          On exit, B has been updated by the unitary transformations.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VL
+*> \verbatim
+*>          VL is COMPLEX array, dimension (LDVL, N)
+*>          If COMPVL = .TRUE., the left Schur vectors are accumulated in VL.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL.
+*>          If COMPVL = .TRUE., LDVL >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VR
+*> \verbatim
+*>          VR is COMPLEX array, dimension (LDVR, N)
+*>          If COMPVR = .TRUE., the right Schur vectors are accumulated in VR.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR.
+*>          If COMPVR = .TRUE., LDVR >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          LWORK >= max(1, 2*N).
+*>          If LWORK = -1, then a workspace query is assumed;
+*>          the routine
+*>          only calculates the optimal size of the WORK array.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE CGGDEF( COMPVL, COMPVR, N, K, A, LDA, B, LDB, VL,
+     $                   LDVL, VR, LDVR, WORK, LWORK, INFO )
+*
+* -- LAPACK-style Code --
+*
+* .. Scalar Arguments ..
+      LOGICAL            COMPVL, COMPVR
+      INTEGER            INFO, K, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      COMPLEX         A( LDA, * ), B( LDB, * ), VL( LDVL, * ),
+     $                   VR( LDVR, * ), WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IINFO, J, LWKOPT
+* ..
+* .. External Subroutines ..
+      EXTERNAL           CGEQRF, CGERQF, CUNMQR, CUNMRQ, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          REAL, CMPLX, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input parameters.
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( K.LT.0 .OR. K.GT.N ) THEN
+         INFO = -4
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -6
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -8
+      ELSE IF( COMPVL .AND. LDVL.LT.MAX( 1, N ) ) THEN
+         INFO = -10
+      ELSE IF( COMPVR .AND. LDVR.LT.MAX( 1, N ) ) THEN
+         INFO = -12
+      ELSE IF( LWORK.LT.MAX( 1, 2*N ) .AND. .NOT.LQUERY ) THEN
+* Minimum workspace is N elements for TAU arrays + N elements for routines
+         INFO = -14
+      END IF
+*
+      IF( INFO.EQ.0 ) THEN
+*
+* Compute optimal workspace
+*
+         LWKOPT = MAX( 1, 2*N )
+         IF( K.GT.0 ) THEN
+            CALL CGEQRF( N, K, A, LDA, WORK, WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( REAL( WORK( 1 ) ) ) )
+*
+            IF( N.GT.K ) THEN
+               CALL CUNMQR( 'L', 'C', N, N - K, K, A, LDA, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( REAL( WORK( 1 ) ) ) )
+            END IF
+*
+            IF( COMPVL ) THEN
+               CALL CUNMQR( 'R', 'N', N, N, K, A, LDA, WORK, VL,
+     $                      LDVL, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( REAL( WORK( 1 ) ) ) )
+            END IF
+         END IF
+*
+         IF( N.GT.K ) THEN
+            CALL CGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB, WORK,
+     $                   WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( REAL( WORK( 1 ) ) ) )
+*
+            IINFO = -1
+            CALL CUNMRQ( 'R', 'C', N, N - K, N - K, 
+     $                   B( K + 1, K + 1 ),
+     $                   LDB, WORK, A( 1, K + 1 ), LDA, WORK, -1,
+     $                   IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( REAL( WORK( 1 ) ) ) )
+*
+            IF( K.GT.0 ) THEN
+               CALL CUNMRQ( 'R', 'C', K, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( REAL( WORK( 1 ) ) ) )
+            END IF
+*
+            IF( COMPVR ) THEN
+               CALL CUNMRQ( 'R', 'C', N, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      VR( 1, K + 1 ), LDVR, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( REAL( WORK( 1 ) ) ) )
+            END IF
+         END IF
+*
+         WORK( 1 ) = CMPLX( REAL( LWKOPT ), 0.0E0 )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'CGGDEF', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+* QR portion
+* Factorize A(1:N, 1:K)
+* WORK(1:K) holds the TAU scalar factors for A
+*
+      IF( K.GT.0 ) THEN
+         CALL CGEQRF( N, K, A, LDA, WORK( 1 ), WORK( N + 1 ),
+     $                LWORK - N, IINFO )
+*
+* Apply Q^H to A(1:N, K+1:N)
+*
+         IF( N.GT.K ) THEN
+            CALL CUNMQR( 'L', 'C', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   A( 1, K + 1 ), LDA, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+*
+* Apply Q^H to B(1:N, K+1:N)
+*
+            CALL CUNMQR( 'L', 'C', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVL ) THEN
+* Accumulate Q in VL: VL = VL * Q
+            CALL CUNMQR( 'R', 'N', N, N, K, A, LDA, WORK( 1 ), VL,
+     $                   LDVL, WORK( N + 1 ), LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* RQ portion
+* Factorize B(K+1:N, K+1:N)
+* WORK(K+1:N) holds the TAU scalar factors for B
+*
+      IF( N.GT.K ) THEN
+         CALL CGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB,
+     $                WORK( K + 1 ), WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^H to A(1:N, K+1:N) from the right: A = A * Q^H
+*
+         CALL CUNMRQ( 'R', 'C', N, N - K, N - K, B( K + 1, K + 1 ),
+     $                LDB, WORK( K + 1 ), A( 1, K + 1 ), LDA,
+     $                WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^H to B(1:K, K+1:N) from the right: B = B * Q^H
+*
+         IF( K.GT.0 ) THEN
+            CALL CUNMRQ( 'R', 'C', K, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVR ) THEN
+* Accumulate Q^H in VR: VR(1:N, K+1:N) = VR(1:N, K+1:N) * Q^H
+            CALL CUNMRQ( 'R', 'C', N, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   VR( 1, K + 1 ), LDVR, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* Zero out strictly lower triangular parts
+*
+      DO J = 1, K
+         DO I = J + 1, N
+            A( I, J ) = ( 0.0E0, 0.0E0 )
+         END DO
+      END DO
+*
+      DO J = K + 1, N
+         DO I = J + 1, N
+            B( I, J ) = ( 0.0E0, 0.0E0 )
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of CGGDEF
+*
+      END

--- a/SRC/cggev4.f
+++ b/SRC/cggev4.f
@@ -1,0 +1,379 @@
+*> \brief \b CGGEV4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> CGGEV4 computes for a pair of N-by-N complex nonsymmetric matrices 
+*> (A,B) the generalized eigenvalues, and optionally, the left and/or 
+*> right generalized eigenvectors.
+*> 
+*> This routine performs the following steps:
+*> 1) Preprocessing (CGGPRP) 
+*> 2) Deflation of infinite eigenvalues (CGGDEF) 
+*> 3) Blocked Hessenberg-Triangular Reduction (CGGHD4) 
+*> 4) QZ algorithm (CLAQZ0) 
+*> 5) Eigenvector computation and normalization.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] JOBVL
+*> \verbatim
+*>          JOBVL is CHARACTER*1
+*>          = 'N':  do not compute the left generalized eigenvectors;
+*>          = 'V':  compute the left generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] JOBVR
+*> \verbatim
+*>          JOBVR is CHARACTER*1
+*>          = 'N':  do not compute the right generalized eigenvectors;
+*>          = 'V':  compute the right generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.
+*>          N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] ALPHA
+*> \verbatim
+*>          ALPHA is COMPLEX array, dimension (N)
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is COMPLEX array, dimension (N)
+*>          ALPHA(j)/BETA(j), j=1,...,N, will be the
+*>          generalized eigenvalues.
+*>          Deflated infinite eigenvalues will set BETA to zero.
+*> \endverbatim
+*>
+*> \param[out] VL
+*> \verbatim
+*>          VL is COMPLEX array, dimension (LDVL, N)
+*>          If JOBVL = 'V', the left eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL.
+*>          LDVL >= 1, and if JOBVL = 'V', LDVL >= N.
+*> \endverbatim
+*>
+*> \param[out] VR
+*> \verbatim
+*>          VR is COMPLEX array, dimension (LDVR, N)
+*>          If JOBVR = 'V', the right eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR.
+*>          LDVR >= 1, and if JOBVR = 'V', LDVR >= N.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the number of deflated 
+*>          infinite eigenvalues.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is REAL array, dimension (MAX(1, 8*N))
+*>          Workspace required for real magnitudes and operations.
+*> \endverbatim
+*>
+*> \param[out] IWORK
+*> \verbatim
+*>          IWORK is INTEGER array, dimension (N)
+*>          Pivot indices from preprocessing.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE CGGEV4( JOBVL, JOBVR, N, A, LDA, B, LDB, ALPHA,
+     $                   BETA, VL, LDVL, VR, LDVR, WORK,
+     $                   LWORK, RWORK, IWORK, INFO )
+*
+* .. Scalar Arguments ..
+      CHARACTER          JOBVL, JOBVR
+      INTEGER            INFO, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            IWORK( * )
+      REAL   RWORK( * )
+      COMPLEX         A( LDA, * ), ALPHA( * ), B( LDB, * ),
+     $                   BETA( * ), VL( LDVL, * ), VR( LDVR, * ),
+     $                   WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      REAL   RZERO, RONE
+      PARAMETER          ( RZERO = 0.0E+0, RONE = 1.0E+0 )
+      COMPLEX         CZERO, CONE, X
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ), 
+     $                     CONE  = ( 1.0E+0, 0.0E+0 ) )
+* ..
+* .. Local Scalars ..
+      LOGICAL            COMPVL, COMPVR, LQUERY
+      CHARACTER          JOBQZ, JOBVEC
+*
+* IHI is added to support balancing: CGGBAL sets ILO and IHI to
+* indicate the submatrix that was balanced. IHI is not needed by
+* the existing pipeline but is required by CGGBAK.
+*
+      INTEGER            I, IN, J, K, NINFINITE, WORKNEEDED, ILO
+      REAL   RTMP, TOL
+* ..
+* .. Local Arrays ..
+      LOGICAL            LDUMMY( 1 )
+      COMPLEX         DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      EXTERNAL           LSAME
+* ..
+* .. External Subroutines ..
+*
+* CGGBAL / CGGBAK added for balancing (same as ZGGEV3).
+*
+      EXTERNAL           CGEQRF, CGERQF, CGGBAL, CGGBAK, CGGDEF,
+     $                   CGGHD4, CGGPRP, CLAQZ0, CUNMQR, CUNMRQ,
+     $                   CTGEVC, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, REAL, CMPLX, INT, MAX, MIN
+* ..
+* .. Executable Statements ..
+*
+      REAL ABS1
+      ABS1( X ) = ABS( REAL( X ) ) + ABS( AIMAG( X ) )
+
+      COMPVL = LSAME( JOBVL, 'V' )
+      COMPVR = LSAME( JOBVR, 'V' )
+      IF( COMPVL .OR. COMPVR ) THEN
+         JOBQZ = 'S'
+      ELSE
+         JOBQZ = 'E'
+      END IF
+*
+* LAPACK style argument checks
+      INFO = 0
+      IF( .NOT.COMPVL .AND. .NOT.LSAME( JOBVL, 'N' ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.COMPVR .AND. .NOT.LSAME( JOBVR, 'N' ) ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDVL.LT.1 .OR. ( COMPVL .AND. LDVL.LT.N ) ) THEN
+         INFO = -11
+      ELSE IF( LDVR.LT.1 .OR. ( COMPVR .AND. LDVR.LT.N ) ) THEN
+         INFO = -13
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'CGGEV4', -INFO )
+         RETURN
+       END IF
+*
+      IF( COMPVL .AND. COMPVR ) THEN
+         JOBVEC = 'B'
+      ELSE IF( COMPVL ) THEN
+         JOBVEC = 'L'
+      ELSE IF( COMPVR ) THEN
+         JOBVEC = 'R'
+      ELSE
+         JOBVEC = 'N'
+      END IF
+*
+* Workspace queries
+      LQUERY = ( LWORK.EQ.-1 )
+      WORKNEEDED = 0
+*
+      CALL CGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, DUMMY, -1, RWORK, IWORK, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( REAL( DUMMY( 1 ) ) ) )
+      CALL CGGHD4( JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB, VL, LDVL,
+     $             VR, LDVR, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( REAL( DUMMY( 1 ) ) ) )
+      CALL CGEQRF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( REAL( DUMMY( 1 ) ) ) )
+      CALL CUNMQR( 'L', 'C', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( REAL( DUMMY( 1 ) ) ) )
+      CALL CGERQF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( REAL( DUMMY( 1 ) ) ) )
+      CALL CUNMRQ( 'L', 'C', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( REAL( DUMMY( 1 ) ) ) )
+      CALL CLAQZ0( JOBQZ, JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB,
+     $             ALPHA, BETA, VL, LDVL, VR, LDVR, DUMMY,
+     $             -1, RWORK, 0, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( REAL( DUMMY( 1 ) ) ) )
+*
+* CGGBAL does not use a workspace query; it always needs 6*N
+* elements. Ensure the workspace is large enough to accommodate it.
+*
+      WORKNEEDED = MAX( WORKNEEDED, 6*N )
+*
+      IF( LQUERY ) THEN
+         WORK( 1 ) = CMPLX( REAL( WORKNEEDED ), 0.0E+0 )
+         RETURN
+      END IF
+
+* ---------------------------------------------------------------
+*
+* Step 1: Preprocessing
+      CALL CGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, WORK, LWORK, RWORK, IWORK, INFO )
+
+      TOL = RWORK( 2 )
+      NINFINITE = 0
+      DO K = 1, N
+         IF (TOL.LT.ABS(B(K, K))) THEN
+            EXIT
+         END IF
+         NINFINITE = NINFINITE + 1
+         DO I = 1, NINFINITE
+            B(I, K) = CZERO
+         END DO
+      END DO
+
+*
+* Step 2: Deflation of infinite eigenvalues
+      IF( NINFINITE.GT.0 ) THEN
+         CALL CGGDEF( COMPVL, COMPVR, N, NINFINITE, A, LDA, B, LDB,
+     $                VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+      END IF
+
+      DO I = 1, NINFINITE
+         ALPHA(I) = A(I, I)
+         BETA(I) = CZERO
+      END DO
+
+*
+* Add small perturbation to B if needed
+      DO I = NINFINITE + 1, N
+         IF (ABS(B(I, I)).LE.TOL) THEN
+            B(I, I) = CMPLX( TOL, RZERO )
+         END IF
+      END DO
+*
+* ---------------------------------------------------------------
+*
+* Step 3: Hessenberg-Triangular Reduction
+*
+      ILO = MIN( N, NINFINITE + 1 )
+      CALL CGGHD4( JOBVL, JOBVR, N, ILO, N, A, LDA, B, LDB,
+     $             VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+
+*
+* ---------------------------------------------------------------
+*
+* Step 4: QZ
+* Use the balanced ILO (not the raw NINFINITE+1) so that CLAQZ0
+* operates on exactly the same submatrix that CGGHD4 reduced to
+* Hessenberg-triangular form. Rows NINFINITE+1..ILO-1 were
+* identified by CGGBAL as already decoupled and were skipped by
+* CGGHD4; passing NINFINITE+1 here would hand CLAQZ0 a
+* non-Hessenberg leading block.
+      IF( NINFINITE.NE.N ) THEN
+         CALL CLAQZ0( JOBQZ, JOBVL, JOBVR, N, ILO, N, A, LDA,
+     $                B, LDB, ALPHA, BETA, VL, LDVL, VR, LDVR,
+     $                WORK, LWORK, RWORK, 0, INFO )
+      END IF
+*
+* Step 5: Eigenvectors
+      IF( COMPVL .OR. COMPVR ) THEN
+         CALL CTGEVC( JOBVEC, 'B', LDUMMY, N, A, LDA, B, LDB, VL, LDVL,
+     $                VR, LDVR, N, IN, WORK, RWORK, INFO )
+      END IF
+*
+* ---------------------------------------------------------------
+*
+* Normalise left eigenvectors
+      IF( COMPVL ) THEN
+         DO I = 1, N
+            RTMP = RZERO
+            DO J = 1, N
+               RTMP = MAX( RTMP, ABS1( VL( J, I ) ) )
+            END DO
+            RTMP = RONE / RTMP
+            DO J = 1, N
+               VL( J, I ) = VL( J, I ) * CMPLX( RTMP, RZERO )
+            END DO
+         END DO
+      END IF
+*
+* Normalise right eigenvectors
+      IF( COMPVR ) THEN
+         DO I = 1, N
+            RTMP = RZERO
+            DO J = 1, N
+               RTMP = MAX( RTMP, ABS1( VR( J, I ) ) )
+            END DO
+            RTMP = RONE / RTMP
+            DO J = 1, N
+               VR( J, I ) = VR( J, I ) * CMPLX( RTMP, RZERO )
+            END DO
+         END DO
+      END IF
+*
+      WORK( 1 ) = CMPLX( REAL( NINFINITE ), RZERO )
+      RETURN
+      END SUBROUTINE CGGEV4

--- a/SRC/cgghd4.f
+++ b/SRC/cgghd4.f
@@ -1,0 +1,369 @@
+*> \brief \b CGGHD4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> CGGHD4 reduces a pair of complex matrices (A,B) to generalized upper
+*> Hessenberg form using unitary transformations, where A is a
+*> Hessenberg matrix and B is upper triangular. This routine
+*> employs a blocked algorithm (Steel et al) to improve efficiency
+*> and scalability.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPQ
+*> \verbatim
+*>          COMPQ is CHARACTER*1
+*>          = 'N': do not compute Q;
+*>          = 'I': Q is initialized to the unit matrix, and the
+*>                 unitary matrix Q is returned;
+*>          = 'V': Q must contain a unitary matrix Q1 on entry,
+*>                 and the product Q1*Q is returned.
+*> \endverbatim
+*>
+*> \param[in] COMPZ
+*> \verbatim
+*>          COMPZ is CHARACTER*1
+*>          = 'N': do not compute Z;
+*>          = 'I': Z is initialized to the unit matrix, and the
+*>                 unitary matrix Z is returned;
+*>          = 'V': Z must contain a unitary matrix Z1 on entry,
+*>                 and the product Z1*Z is returned.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] ILO
+*> \param[in] IHI
+*> \verbatim
+*>          ILO and IHI are INTEGER
+*>          It is assumed that A is already upper triangular in rows
+*>          and columns 1:ILO-1 and IHI+1:N. ILO and IHI are normally
+*>          set by a previous call to CGGBAL.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension (LDA, N)
+*>          On entry, the N-by-N general matrix to be reduced.
+*>          On exit, the upper triangle and the first subdiagonal of A
+*>          are overwritten with the upper Hessenberg matrix H.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX array, dimension (LDB, N)
+*>          On entry, the N-by-N upper triangular matrix B.
+*>          On exit, the upper triangular matrix T = Q**H B Z.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] Q
+*> \verbatim
+*>          Q is COMPLEX array, dimension (LDQ, N)
+*>          If COMPQ='N', then Q is not referenced.
+*>          If COMPQ='V', on entry Q must contain a unitary matrix.
+*>          If COMPQ='I', on exit Q contains the unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          LDQ >= N if COMPQ='V' or 'I'; LDQ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[in,out] Z
+*> \verbatim
+*>          Z is COMPLEX array, dimension (LDZ, N)
+*>          If COMPZ='N', then Z is not referenced.
+*>          If COMPZ='V', on entry Z must contain a unitary matrix.
+*>          If COMPZ='I', on exit Z contains the unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          LDZ >= N if COMPZ='V' or 'I'; LDZ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE CGGHD4( COMPQ, COMPZ, N, ILO, IHI, A, LDA, B, LDB,
+     $                   Q, LDQ, Z, LDZ, WORK, LWORK, INFO )
+*
+* -- LAPACK-like routine --
+*
+* .. Scalar Arguments ..
+      CHARACTER          COMPQ, COMPZ
+      INTEGER            IHI, ILO, INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      COMPLEX         A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            ILQ, ILZ, LQUERY
+      INTEGER            I, J, IERR, IWORK, K, LWKOPT, NCOLS,
+     $                   NITER, COL_LEN, LMIN
+      REAL   EPS, NORM, NORMA, TOL, AMAX
+* ..
+* .. Local Arrays ..
+      REAL   RWORK( 1 )
+      COMPLEX         DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      REAL   SLAMCH, CLANGE
+      EXTERNAL           LSAME, SLAMCH, CLANGE
+* ..
+* .. External Subroutines ..
+      EXTERNAL           CGEHRD, CGERQF, CLACPY, CLASET, CUNMHR,
+     $                   CUNMRQ, CTRSM, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, REAL, CMPLX, MAX, MIN
+* ..
+* .. Parameters ..
+      COMPLEX         CZERO, CONE
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ), 
+     $                     CONE  = ( 1.0E+0, 0.0E+0 ) )
+      REAL   RZERO, RONE
+      PARAMETER          ( RZERO = 0.0E+0, RONE = 1.0E+0 )
+* ..
+* .. Executable Statements ..
+*
+* Decode and test the input parameters.
+*
+      INFO = 0
+      ILQ = LSAME( COMPQ, 'V' ) .OR. LSAME( COMPQ, 'I' )
+      ILZ = LSAME( COMPZ, 'V' ) .OR. LSAME( COMPZ, 'I' )
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( .NOT.LSAME( COMPQ, 'N' ) .AND. .NOT.ILQ ) THEN
+         INFO = -1
+      ELSE IF( .NOT.LSAME( COMPZ, 'N' ) .AND. .NOT.ILZ ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( ILO.LT.1 .OR. ILO.GT.MAX( 1, N ) ) THEN
+         INFO = -4
+      ELSE IF( IHI.LT.MIN( ILO, N ) .OR. IHI.GT.N ) THEN
+         INFO = -5
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( ILQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      ELSE IF( ILZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -13
+      END IF
+*
+* Compute optimal workspace.
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 2*( N + 1 )
+         CALL CGEHRD( N, 1, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( REAL( WORK( 1 ) ) ) )
+         CALL CUNMHR( 'L', 'C', N, N, 1, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( REAL( WORK( 1 ) ) ) )
+         CALL CGERQF( N, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( REAL( WORK( 1 ) ) ) )
+         CALL CUNMRQ( 'R', 'C', N, N, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( REAL( WORK( 1 ) ) ) )
+         LWKOPT = LWKOPT + N*( N + 1 )
+         LMIN = LWKOPT
+         WORK( 1 ) = CMPLX( REAL( LWKOPT ), 0.0E+0 )
+         IF( LWORK.LT.LMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -15
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'CGGHD4', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Initialize Q and Z if requested.
+*
+      IF( LSAME( COMPQ, 'I' ) ) THEN
+         CALL CLASET( 'F', N, N, CZERO, CONE, Q, LDQ )
+      END IF
+      IF( LSAME( COMPZ, 'I' ) ) THEN
+         CALL CLASET( 'F', N, N, CZERO, CONE, Z, LDZ )
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.LE.1 ) RETURN
+*
+      NORMA = CLANGE( 'F', N, N, A, LDA, RWORK )
+      EPS = SLAMCH( 'E' )
+      TOL = EPS * NORMA
+      NITER = 0
+      K = ILO
+      IWORK = N*N + 1
+
+      AMAX = RZERO
+      DO J = 1, N
+         DO I = 1, N
+            AMAX = MAX( AMAX, ABS(A(I, J)) )
+         END DO
+      END DO
+      IF (AMAX.EQ.RZERO) THEN
+         AMAX = RONE
+      END IF
+      TOL = EPS * AMAX
+
+*
+* Outer reduction loop: iterate until K reaches IHI or NITER hits 50.
+*
+      DO WHILE( K.LT.IHI .AND. NITER.LT.50 )
+*
+* Inner deflation loop: advance K while subdiagonal entries are small.
+*
+         DO WHILE( K.LT.IHI )
+            COL_LEN = IHI - K - 1
+            
+            IF( COL_LEN.LE.0 ) THEN
+               K = K + 1
+               CYCLE
+            END IF
+            
+            NORM = RZERO
+            DO I = 1, COL_LEN
+               NORM = MAX( NORM, ABS( A( K + 1 + I, K ) ) )
+            END DO
+            
+            IF( NORM.GT.TOL ) THEN
+               EXIT
+            END IF
+
+*
+* Deflate strictly bounded values
+*
+            DO I = 1, COL_LEN
+               A( K + 1 + I, K ) = CZERO
+            END DO
+            K = K + 1
+         END DO
+
+         IF (K.GE.IHI) THEN
+            EXIT
+         END IF
+
+         NITER = NITER + 1
+         NCOLS = IHI - K + 1
+*
+* Copy A(K:IHI, K:IHI) into X (stored at WORK(1))
+*
+         CALL CLACPY( 'A', NCOLS, NCOLS, A( K, K ), LDA, WORK, NCOLS )
+*
+* CTRSM to solve X * B = A
+*
+         CALL CTRSM( 'R', 'U', 'N', 'N', NCOLS, NCOLS, 
+     $               CMPLX( RONE / AMAX, RZERO ), B( K, K ), LDB, 
+     $               WORK, NCOLS )
+*
+* Hessenberg reduction of X
+*
+         CALL CGEHRD( NCOLS, 1, NCOLS, WORK, NCOLS, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Qc**H to A and B from the left
+*
+         CALL CUNMHR( 'L', 'C', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), A( K, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         CALL CUNMHR( 'L', 'C', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), B( K, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILQ ) THEN
+            CALL CUNMHR( 'R', 'N', N, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                   WORK( IWORK ), Q( 1, K ), LDQ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+
+*
+* RQ factorization of B(K:IHI, K:IHI)
+*
+         CALL CGERQF( NCOLS, NCOLS, B( K, K ), LDB, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**H to A from the right (Updates rows 1:IHI)
+*
+         CALL CUNMRQ( 'R', 'C', IHI, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), A( 1, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**H to B from the right (CRITICAL FIX: Updates rows 1:K-1)
+*
+         CALL CUNMRQ( 'R', 'C', K-1, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), B( 1, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILZ ) THEN
+            CALL CUNMRQ( 'R', 'C', N, NCOLS, NCOLS, B( K, K ), LDB,
+     $                   WORK( IWORK ), Z( 1, K ), LDZ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+*
+* Zero lower triangle of B globally
+*
+         CALL CLASET( 'L', N-1, N-1, CZERO, CZERO, B( 2, 1 ), LDB )
+
+*
+      END DO
+*
+* End of CGGHD4
+*
+      END SUBROUTINE CGGHD4

--- a/SRC/cggprp.f
+++ b/SRC/cggprp.f
@@ -1,0 +1,308 @@
+*> \brief \b CGGPRP
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> CGGPRP is a preprocessing routine for the generalized 
+*> eigenvalue problem.
+*> It prepares the matrices A and B by applying 
+*> an initial Rank-Revealing QR (RRQR) factorization on B, transposing
+*> and reversing arrays, and initializing unitary transformation 
+*> matrices Q and Z if requested.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WANTQ
+*> \verbatim
+*>          WANTQ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the unitary matrix Q.
+*>          = .FALSE.: Do not compute Q.
+*> \endverbatim
+*>
+*> \param[in] WANTZ
+*> \verbatim
+*>          WANTZ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the unitary matrix Z.
+*>          = .FALSE.: Do not compute Z.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A is overwritten by the preprocessed matrix.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B is overwritten by the preprocessed upper 
+*>          triangular matrix from the RRQR factorization.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is COMPLEX array, dimension (LDQ, N)
+*>          If WANTQ = .TRUE., contains the initialized unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          If WANTQ = .TRUE., LDQ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is COMPLEX array, dimension (LDZ, N)
+*>          If WANTZ = .TRUE., contains the initialized unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          If WANTZ = .TRUE., LDZ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is REAL array, dimension (MAX(1, 2*N))
+*>          On exit, if INFO = 0, RWORK(1) returns the norm of B, and 
+*>          RWORK(2) returns the tolerance computed.
+*> \endverbatim
+*>
+*> \param[out] JPVT
+*> \verbatim
+*>          JPVT is INTEGER array, dimension (N)
+*>          On exit, contains the pivot indices from CGEQP3.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim      
+      SUBROUTINE CGGPRP( WANTQ, WANTZ, N, A, LDA, B, LDB, Q, LDQ,
+     $                   Z, LDZ, WORK, LWORK, RWORK, JPVT, INFO )
+*
+* -- LAPACK-style preprocessing routine --
+*
+* .. Scalar Arguments ..
+      LOGICAL            WANTQ, WANTZ
+      INTEGER            INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            JPVT( * )
+      REAL   RWORK( * )
+      COMPLEX         A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IERR, J, LWKOPT, WORKNEEDED
+      REAL   NORMB, TOL
+* ..
+* .. Local Arrays ..
+      COMPLEX         DUMMY( 1 )
+* ..
+* .. External Subroutines ..
+      EXTERNAL           CGEQP3, CLAREV, CLAPMR, CLATRN, CUNGQR, CUNMQR,
+     $                   XERBLA
+* ..
+* .. External Functions ..
+      REAL   SLAMCH, CLANGE
+      EXTERNAL           SLAMCH, CLANGE
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          REAL, CMPLX, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input arguments
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( WANTQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( WANTZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      END IF
+*
+* Compute workspace if no argument errors occurred
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 0
+         CALL CGEQP3( N, N, B, LDB, JPVT, DUMMY, DUMMY, -1, RWORK, 
+     $                IERR )
+         LWKOPT = MAX( LWKOPT, INT( REAL( DUMMY( 1 ) ) ) )
+*
+         CALL CUNMQR( 'R', 'N', N, N, N, B, LDB, DUMMY, A, LDA,
+     $                DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( REAL( DUMMY( 1 ) ) ) )
+*
+         CALL CUNGQR( N, N, N, Z, LDZ, DUMMY, DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( REAL( DUMMY( 1 ) ) ) )
+*
+* Total workspace must accommodate TAU (size N) plus the optimal
+* workspace sizes requested by the underlying routines.
+*
+         WORKNEEDED = N + LWKOPT
+*
+         IF( LWORK.LT.WORKNEEDED .AND. .NOT.LQUERY ) THEN
+            INFO = -13
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'CGGPRP', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         WORK( 1 ) = CMPLX( REAL( WORKNEEDED ), 0.0E0 )
+         RETURN
+      END IF
+*
+* Compute norm of B and tolerance
+*
+      NORMB = CLANGE( 'F', N, N, B, LDB, RWORK )
+      TOL = NORMB * SLAMCH( 'E' )
+*
+* B = B^T
+*
+      CALL CLATRN( N, B, LDB )
+*
+* B = B[:, ::-1]
+*
+      CALL CLAREV( 'C', N, N, B, LDB )
+*
+* RRQR(B)
+*
+      DO I = 1, N
+         JPVT( I ) = 0
+      END DO
+      CALL CGEQP3( N, N, B, LDB, JPVT, WORK, WORK( N + 1 ),
+     $             LWORK - N, RWORK, IERR )
+*
+* A = A[::-1]
+*
+      CALL CLAREV( 'R', N, N, A, LDA )
+*
+* A = A[p]
+*
+      CALL CLAPMR( .TRUE., N, N, A, LDA, JPVT )
+*
+* A = A * Q
+*
+      CALL CUNMQR( 'R', 'N', N, N, N, B, LDB, WORK, A, LDA,
+     $             WORK( N + 1 ), LWORK - N, IERR )
+*
+      IF( WANTQ ) THEN
+*
+* Initialize Q = J P J
+* (J is the column index, I is the row index)
+*
+         DO J = 1, N
+            DO I = 1, N
+               Q( I, J ) = ( 0.0E0, 0.0E0 )
+            END DO
+         END DO
+         DO J = 1, N
+            I = N - JPVT( N - J + 1 ) + 1
+            Q( I, J ) = ( 1.0E0, 0.0E0 )
+         END DO
+      END IF
+*
+      IF( WANTZ ) THEN
+*
+* Copy B into Z
+*
+         DO J = 1, N
+            DO I = 1, N
+               Z( I, J ) = B( I, J )
+            END DO
+         END DO
+         CALL CUNGQR( N, N, N, Z, LDZ, WORK, WORK( N + 1 ),
+     $                LWORK - N, IERR )
+         CALL CLAREV( 'C', N, N, Z, LDZ )
+      END IF
+*
+* A = A[::-1][:, ::-1]
+*
+      CALL CLAREV( 'B', N, N, A, LDA )
+*
+* B = B.T[::-1][:, ::-1]
+* (Zero strictly lower triangle to preserve the R matrix from CGEQP3.
+* J is the column, I is the row.)
+*
+      DO J = 1, N - 1
+         DO I = J + 1, N
+            B( I, J ) = ( 0.0E0, 0.0E0 )
+         END DO
+      END DO
+*
+      CALL CLATRN( N, B, LDB )
+      CALL CLAREV( 'B', N, N, B, LDB )
+*
+* Store norm and tolerance in the first two elements of RWORK, 
+* and optimal LWORK in WORK(1)
+*
+      RWORK( 1 ) = NORMB
+      RWORK( 2 ) = TOL
+      WORK( 1 )  = CMPLX( REAL( WORKNEEDED ), 0.0E0 )
+*
+      RETURN
+*
+* End of CGGPRP
+*
+      END

--- a/SRC/clarev.f
+++ b/SRC/clarev.f
@@ -1,0 +1,115 @@
+*> \brief \b CLAREV
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> CLAREV reverses the order of the rows and/or columns of a given
+*> M-by-N complex*16 matrix A.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WHICH
+*> \verbatim
+*>          WHICH is CHARACTER*1
+*>          Specifies whether to reverse rows, columns, or both:
+*>          = 'B': Reverse both rows and columns.
+*>          = 'R': Reverse rows only.
+*>          = 'C': Reverse columns only.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension (LDA, N)
+*>          On entry, the matrix A to be reversed.
+*>          On exit, the elements of A have been swapped according to WHICH.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.
+*> \endverbatim
+      SUBROUTINE CLAREV( WHICH, M, N, A, LDA )
+* .. Scalar Arguments ..
+      CHARACTER          WHICH
+      INTEGER            M, N, LDA
+* .. Array Arguments ..
+      COMPLEX         A( LDA, * )
+* .. Local Scalars ..
+      INTEGER            I, J, M2, N2
+      LOGICAL            ROWODD, COLODD
+      COMPLEX         TMPA, TMPB, TMPC, TMPD
+* .. Executable Statements ..
+
+      M2 = M / 2
+      N2 = N / 2
+      ROWODD = MOD(M, 2) .NE. 0
+      COLODD = MOD(N, 2) .NE. 0
+
+      IF ( WHICH .EQ. 'B' ) THEN
+         DO I = 1, N2
+            DO J = 1, M2
+               TMPA = A( J, I )
+               TMPB = A( J, N - I + 1 )
+               TMPC = A( M - J + 1, I )
+               TMPD = A( M - J + 1, N - I + 1 )
+               
+               A( J, I ) = TMPD
+               A( J, N - I + 1 ) = TMPC
+               A( M - J + 1, I ) = TMPB
+               A( M - J + 1, N - I + 1 ) = TMPA
+            END DO
+            IF ( ROWODD ) THEN
+               TMPA = A( M2 + 1, I )
+               A( M2 + 1, I ) = A( M2 + 1, N - I + 1 )
+               A( M2 + 1, N - I + 1 ) = TMPA
+            END IF
+         END DO
+         IF ( COLODD ) THEN
+            DO J = 1, M2
+               TMPA = A( J, N2 + 1 )
+               A( J, N2 + 1 ) = A( M - J + 1, N2 + 1 )
+               A( M - J + 1, N2 + 1 ) = TMPA
+            END DO
+         END IF
+
+      ELSE IF ( WHICH .EQ. 'R' ) THEN
+         DO I = 1, N
+            DO J = 1, M2
+               TMPA = A( J, I )
+               A( J, I ) = A( M - J + 1, I )
+               A( M - J + 1, I ) = TMPA
+            END DO
+         END DO
+
+      ELSE IF ( WHICH .EQ. 'C' ) THEN
+         DO I = 1, N2
+            DO J = 1, M
+               TMPA = A( J, I )
+               A( J, I ) = A( J, N - I + 1 )
+               A( J, N - I + 1 ) = TMPA
+            END DO
+         END DO
+      END IF
+
+      RETURN
+      END

--- a/SRC/clatrn.f
+++ b/SRC/clatrn.f
@@ -1,0 +1,125 @@
+*> \brief \b CLATRN
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> CLATRN performs an in-place conjugate transpose of an N-by-N complex*16
+*> matrix A. It utilizes OpenMP parallelization and a blocked iteration 
+*> scheme to optimize cache usage during the transposition process.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension (LDA, N)
+*>          On entry, the N-by-N matrix to be conjugate transposed.
+*>          On exit, A is overwritten by its conjugate transpose.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+      SUBROUTINE CLATRN( N, A, LDA )
+
+#if defined(_OPENMP)
+      use omp_lib
+#endif
+*
+* -- LAPACK auxiliary routine --
+*
+* .. Scalar Arguments ..
+      INTEGER            LDA, N
+* ..
+* .. Array Arguments ..
+      COMPLEX         A( LDA, * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      INTEGER            SIZE
+      PARAMETER          ( SIZE = 8 )
+* ..
+* .. Local Scalars ..
+      INTEGER            BLOCK, I, J, NUM_THREADS, TAIL_START
+      COMPLEX         TEMP
+* ..
+* .. External Functions ..
+#if defined(_OPENMP)
+      INTEGER            OMP_GET_MAX_THREADS
+      EXTERNAL           OMP_GET_MAX_THREADS
+#endif
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          MIN, CONJG
+* ..
+* .. Executable Statements ..
+*
+#if defined(_OPENMP)
+      IF( N.GE.256 ) THEN
+         NUM_THREADS = N / 64
+      ELSE
+         NUM_THREADS = 1
+      END IF
+      NUM_THREADS = MIN( NUM_THREADS, OMP_GET_MAX_THREADS() )
+#else
+      NUM_THREADS = 1
+#endif
+   
+!$OMP PARALLEL DO PRIVATE( BLOCK, I, J, TEMP )
+!$OMP+            NUM_THREADS( NUM_THREADS ) SCHEDULE( DYNAMIC, 1 )
+      DO BLOCK = 1, N - SIZE + 1, SIZE
+*
+* This pair takes care of the main diagonal block
+         DO I = BLOCK, BLOCK + SIZE - 1
+            DO J = I + 0, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = CONJG(A( J, I ))
+               A( J, I ) = CONJG(TEMP)
+            END DO
+         END DO
+*
+* Transpose sub-matrices not on the main diagonal
+         DO I = BLOCK + SIZE, N
+            DO J = BLOCK, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = CONJG(A( J, I ))
+               A( J, I ) = CONJG(TEMP)
+            END DO
+         END DO
+*
+      END DO
+!$OMP END PARALLEL DO
+*
+* Transpose remaining elements along the main diagonal
+* Note: TAIL_START is explicitly calculated because BLOCK is 
+* undefined outside the OpenMP parallel construct.
+      TAIL_START = ( N / SIZE ) * SIZE + 1
+      DO I = TAIL_START, N
+         DO J = I + 0, N
+            TEMP      = A( I, J )
+            A( I, J ) = CONJG(A( J, I ))
+            A( J, I ) = CONJG(TEMP)
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of CLATRN
+*
+      END

--- a/SRC/dggdef.f
+++ b/SRC/dggdef.f
@@ -1,0 +1,311 @@
+*> \brief \b DGGDEF
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> DGGDEF performs the deflation of infinite eigenvalues in the generalized
+*> eigenvalue problem. It applies QR and RQ factorizations to 
+*> sub-blocks of A and B to properly isolate and deflate these eigenvalues.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPVL
+*> \verbatim
+*>          COMPVL is LOGICAL
+*>          = .TRUE.:  Compute the left Schur vectors (VL).
+*>          = .FALSE.: Do not compute the left Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] COMPVR
+*> \verbatim
+*>          COMPVR is LOGICAL
+*>          = .TRUE.:  Compute the right Schur vectors (VR).
+*>          = .FALSE.: Do not compute the right Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] K
+*> \verbatim
+*>          K is INTEGER
+*>          The number of infinite eigenvalues to deflate (the block size). 
+*>          0 <= K <= N.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA, N)
+*>          On entry, the matrix A to be deflated.
+*>          On exit, A has been updated by the orthogonal transformations.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is DOUBLE PRECISION array, dimension (LDB, N)
+*>          On entry, the matrix B to be deflated.
+*>          On exit, B has been updated by the orthogonal transformations.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VL
+*> \verbatim
+*>          VL is DOUBLE PRECISION array, dimension (LDVL, N)
+*>          If COMPVL = .TRUE., the left Schur vectors are accumulated in VL.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL.  
+*>          If COMPVL = .TRUE., LDVL >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VR
+*> \verbatim
+*>          VR is DOUBLE PRECISION array, dimension (LDVR, N)
+*>          If COMPVR = .TRUE., the right Schur vectors are accumulated in VR.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR.  
+*>          If COMPVR = .TRUE., LDVR >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK. LWORK >= max(1, 2*N).
+*>          If LWORK = -1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the WORK array.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE DGGDEF( COMPVL, COMPVR, N, K, A, LDA, B, LDB, VL,
+     $                   LDVL, VR, LDVR, WORK, LWORK, INFO )
+*
+* -- LAPACK-style Code --
+*
+* .. Scalar Arguments ..
+      LOGICAL            COMPVL, COMPVR
+      INTEGER            INFO, K, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), VL( LDVL, * ),
+     $                   VR( LDVR, * ), WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IINFO, J, LWKOPT
+* ..
+* .. External Subroutines ..
+      EXTERNAL           DGEQRF, DGERQF, DORMQR, DORMRQ, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          DBLE, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input parameters.
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( K.LT.0 .OR. K.GT.N ) THEN
+         INFO = -4
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -6
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -8
+      ELSE IF( COMPVL .AND. LDVL.LT.MAX( 1, N ) ) THEN
+         INFO = -10
+      ELSE IF( COMPVR .AND. LDVR.LT.MAX( 1, N ) ) THEN
+         INFO = -12
+      ELSE IF( LWORK.LT.MAX( 1, 2*N ) .AND. .NOT.LQUERY ) THEN
+* Minimum workspace is N elements for TAU arrays + N elements for routines
+         INFO = -14
+      END IF
+*
+      IF( INFO.EQ.0 ) THEN
+*
+* Compute optimal workspace
+*
+         LWKOPT = MAX( 1, 2*N )
+         IF( K.GT.0 ) THEN
+            CALL DGEQRF( N, K, A, LDA, WORK, WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+*
+            IF( N.GT.K ) THEN
+               CALL DORMQR( 'L', 'T', N, N - K, K, A, LDA, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+*
+            IF( COMPVL ) THEN
+               CALL DORMQR( 'R', 'N', N, N, K, A, LDA, WORK, VL,
+     $                      LDVL, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+         END IF
+*
+         IF( N.GT.K ) THEN
+            CALL DGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB, WORK,
+     $                   WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+*
+            IINFO = -1
+            CALL DORMRQ( 'R', 'T', N, N - K, N - K, 
+     $                   B( K + 1, K + 1 ),
+     $                   LDB, WORK, A( 1, K + 1 ), LDA, WORK, -1,
+     $                   IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+*
+            IF( K.GT.0 ) THEN
+               CALL DORMRQ( 'R', 'T', K, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+*
+            IF( COMPVR ) THEN
+               CALL DORMRQ( 'R', 'T', N, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      VR( 1, K + 1 ), LDVR, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+         END IF
+*
+         WORK( 1 ) = DBLE( LWKOPT )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DGGDEF', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+* QR portion
+* Factorize A(1:N, 1:K)
+* WORK(1:K) holds the TAU scalar factors for A
+*
+      IF( K.GT.0 ) THEN
+         CALL DGEQRF( N, K, A, LDA, WORK( 1 ), WORK( N + 1 ),
+     $                LWORK - N, IINFO )
+*
+* Apply Q^T to A(1:N, K+1:N)
+*
+         IF( N.GT.K ) THEN
+            CALL DORMQR( 'L', 'T', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   A( 1, K + 1 ), LDA, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+*
+* Apply Q^T to B(1:N, K+1:N)
+*
+            CALL DORMQR( 'L', 'T', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVL ) THEN
+* Accumulate Q in VL: VL = VL * Q
+            CALL DORMQR( 'R', 'N', N, N, K, A, LDA, WORK( 1 ), VL,
+     $                   LDVL, WORK( N + 1 ), LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* RQ portion
+* Factorize B(K+1:N, K+1:N)
+* WORK(K+1:N) holds the TAU scalar factors for B
+*
+      IF( N.GT.K ) THEN
+         CALL DGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB,
+     $                WORK( K + 1 ), WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^T to A(1:N, K+1:N) from the right: A = A * Q^T
+*
+         CALL DORMRQ( 'R', 'T', N, N - K, N - K, B( K + 1, K + 1 ),
+     $                LDB, WORK( K + 1 ), A( 1, K + 1 ), LDA,
+     $                WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^T to B(1:K, K+1:N) from the right: B = B * Q^T
+*
+         IF( K.GT.0 ) THEN
+            CALL DORMRQ( 'R', 'T', K, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVR ) THEN
+* Accumulate Q^T in VR: VR(1:N, K+1:N) = VR(1:N, K+1:N) * Q^T
+            CALL DORMRQ( 'R', 'T', N, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   VR( 1, K + 1 ), LDVR, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* Zero out strictly lower triangular parts
+*
+      DO J = 1, K
+         DO I = J + 1, N
+            A( I, J ) = 0.0D0
+         END DO
+      END DO
+*
+      DO J = K + 1, N
+         DO I = J + 1, N
+            B( I, J ) = 0.0D0
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of DGGDEF
+*
+      END

--- a/SRC/dggev4.f
+++ b/SRC/dggev4.f
@@ -1,0 +1,403 @@
+*> \brief \b DGGEV4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> DGGEV4 computes for a pair of N-by-N real nonsymmetric matrices (A,B)
+*> the generalized eigenvalues, and optionally, the left and/or right
+*> generalized eigenvectors.
+*> 
+*> This routine performs the following steps:
+*> 1) Preprocessing (DGGPRP) 
+*> 2) Deflation of infinite eigenvalues (DGGDEF) 
+*> 3) Blocked Hessenberg-Triangular Reduction (DGGHD4) 
+*> 4) QZ algorithm (DLAQZ0) 
+*> 5) Eigenvector computation and normalization.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] JOBVL
+*> \verbatim
+*>          JOBVL is CHARACTER*1
+*>          = 'N':  do not compute the left generalized eigenvectors;
+*>          = 'V':  compute the left generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] JOBVR
+*> \verbatim
+*>          JOBVR is CHARACTER*1
+*>          = 'N':  do not compute the right generalized eigenvectors;
+*>          = 'V':  compute the right generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is DOUBLE PRECISION array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] ALPHAR
+*> \verbatim
+*>          ALPHAR is DOUBLE PRECISION array, dimension (N)
+*> \endverbatim
+*>
+*> \param[out] ALPHAI
+*> \verbatim
+*>          ALPHAI is DOUBLE PRECISION array, dimension (N)
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is DOUBLE PRECISION array, dimension (N)
+*>          (ALPHAR(j) + ALPHAI(j)*i)/BETA(j), j=1,...,N, will be the
+*>          generalized eigenvalues. Deflated infinite eigenvalues 
+*>          will set BETA to zero.
+*> \endverbatim
+*>
+*> \param[out] VL
+*> \verbatim
+*>          VL is DOUBLE PRECISION array, dimension (LDVL, N)
+*>          If JOBVL = 'V', the left eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL. LDVL >= 1, and
+*>          if JOBVL = 'V', LDVL >= N.
+*> \endverbatim
+*>
+*> \param[out] VR
+*> \verbatim
+*>          VR is DOUBLE PRECISION array, dimension (LDVR, N)
+*>          If JOBVR = 'V', the right eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR. LDVR >= 1, and
+*>          if JOBVR = 'V', LDVR >= N.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the number of deflated 
+*>          infinite eigenvalues.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] JPVT
+*> \verbatim
+*>          JPVT is INTEGER array, dimension (N)
+*>          Pivot indices from preprocessing.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE DGGEV4( JOBVL, JOBVR, N, A, LDA, B, LDB, ALPHAR,
+     $                   ALPHAI, BETA, VL, LDVL, VR, LDVR, WORK,
+     $                   LWORK, IWORK, INFO )
+*
+* .. Scalar Arguments ..
+      CHARACTER          JOBVL, JOBVR
+      INTEGER            INFO, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            IWORK( * )
+      DOUBLE PRECISION   A( LDA, * ), ALPHAI( * ), ALPHAR( * ),
+     $                   B( LDB, * ), BETA( * ), VL( LDVL, * ),
+     $                   VR( LDVR, * ), WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
+* ..
+* .. Local Scalars ..
+      LOGICAL            COMPVL, COMPVR, LQUERY
+      CHARACTER          JOBQZ, JOBVEC
+*
+*     IHI is added to support balancing: DGGBAL sets ILO and IHI to
+*     indicate the submatrix that was balanced.  IHI is not needed by
+*     the existing pipeline but is required by DGGBAK.
+*
+      INTEGER            I, IN, J, K, NINFINITE, WORKNEEDED, ILO
+      DOUBLE PRECISION   TMP, TOL
+* ..
+* .. Local Arrays ..
+      LOGICAL            LDUMMY( 1 )
+      DOUBLE PRECISION   DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      EXTERNAL           LSAME
+* ..
+* .. External Subroutines ..
+*
+*     DGGBAL / DGGBAK added for balancing (same as DGGEV3).
+*
+      EXTERNAL           DGEQRF, DGERQF, DGGBAL, DGGBAK, DGGDEF,
+     $                   DGGHD4, DGGPRP, DLAQZ0, DORMQR, DORMRQ,
+     $                   DTGEVC, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, DBLE, INT, MAX, SQRT, MIN
+* ..
+* .. Executable Statements ..
+*
+      COMPVL = LSAME( JOBVL, 'V' )
+      COMPVR = LSAME( JOBVR, 'V' )
+      IF( COMPVL .OR. COMPVR ) THEN
+         JOBQZ = 'S'
+      ELSE
+         JOBQZ = 'E'
+      END IF
+*
+* LAPACK style argument checks
+      INFO = 0
+      IF( .NOT.COMPVL .AND. .NOT.LSAME( JOBVL, 'N' ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.COMPVR .AND. .NOT.LSAME( JOBVR, 'N' ) ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDVL.LT.1 .OR. ( COMPVL .AND. LDVL.LT.N ) ) THEN
+         INFO = -12
+      ELSE IF( LDVR.LT.1 .OR. ( COMPVR .AND. LDVR.LT.N ) ) THEN
+         INFO = -14
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DGGEV4', -INFO )
+         RETURN
+      END IF
+*
+      IF( COMPVL .AND. COMPVR ) THEN
+         JOBVEC = 'B'
+      ELSE IF( COMPVL ) THEN
+         JOBVEC = 'L'
+      ELSE IF( COMPVR ) THEN
+         JOBVEC = 'R'
+      ELSE
+         JOBVEC = 'N'
+      END IF
+*
+* Workspace queries
+      LQUERY = ( LWORK.EQ.-1 )
+      WORKNEEDED = 0
+*
+      CALL DGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, DUMMY, -1, IWORK, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL DGGHD4( JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB, VL, LDVL,
+     $             VR, LDVR, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL DGEQRF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL DORMQR( 'L', 'T', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL DGERQF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL DORMRQ( 'L', 'T', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL DLAQZ0( JOBQZ, JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB,
+     $             ALPHAR, ALPHAI, BETA, VL, LDVL, VR, LDVR, DUMMY,
+     $             -1, 0, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+*
+*     DGGBAL does not use a workspace query; it always needs 6*N
+*     elements.  Ensure the workspace is large enough to accommodate it.
+*
+      WORKNEEDED = MAX( WORKNEEDED, 6*N )
+*
+      IF( LQUERY ) THEN
+         WORK( 1 ) = DBLE( WORKNEEDED )
+         RETURN
+      END IF
+
+* ---------------------------------------------------------------
+*
+* Step 1: Preprocessing
+      CALL DGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, WORK, LWORK, IWORK, INFO )
+
+      TOL = WORK( 2 )
+      NINFINITE = 0
+      DO K = 1, N
+         IF (TOL.LT.ABS(B(K, K))) THEN
+            EXIT
+         END IF
+         NINFINITE = NINFINITE + 1
+         DO I = 1, NINFINITE
+            B(I, K) = ZERO
+         END DO
+      END DO
+
+*
+* Step 2: Deflation of infinite eigenvalues
+      IF( NINFINITE.GT.0 ) THEN
+         CALL DGGDEF( COMPVL, COMPVR, N, NINFINITE, A, LDA, B, LDB,
+     $                VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+      END IF
+
+      DO I = 1, NINFINITE
+         ALPHAR(I) = A(I, I)
+         ALPHAI(I) = ZERO
+         BETA(I) = ZERO
+      END DO
+
+*
+* Add small perturbation to B if needed
+      DO I = NINFINITE + 1, N
+         IF (ABS(B(I, I)).LE.TOL) THEN
+            B(I, I) = TOL
+         END IF
+      END DO
+*
+* ---------------------------------------------------------------
+*
+* Step 3: Hessenberg-Triangular Reduction
+*
+      ILO = MIN( N, NINFINITE + 1 )
+      CALL DGGHD4( JOBVL, JOBVR, N, ILO, N, A, LDA, B, LDB,
+     $             VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+
+*
+* ---------------------------------------------------------------
+*
+* Step 4: QZ
+*     Use the balanced ILO (not the raw NINFINITE+1) so that DLAQZ0
+*     operates on exactly the same submatrix that DGGHD4 reduced to
+*     Hessenberg-triangular form.  Rows NINFINITE+1..ILO-1 were
+*     identified by DGGBAL as already decoupled and were skipped by
+*     DGGHD4; passing NINFINITE+1 here would hand DLAQZ0 a
+*     non-Hessenberg leading block.
+      IF( NINFINITE.NE.N ) THEN
+         CALL DLAQZ0( JOBQZ, JOBVL, JOBVR, N, ILO, N, A, LDA,
+     $                B, LDB, ALPHAR, ALPHAI, BETA, VL, LDVL, VR, LDVR,
+     $                WORK, LWORK, 0, INFO )
+      END IF
+*
+* Step 5: Eigenvectors
+      IF( COMPVL .OR. COMPVR ) THEN
+         CALL DTGEVC( JOBVEC, 'B', LDUMMY, N, A, LDA, B, LDB, VL, LDVL,
+     $                VR, LDVR, N, IN, WORK, INFO )
+      END IF
+*
+* ---------------------------------------------------------------
+*
+* Normalise left eigenvectors
+      IF( COMPVL ) THEN
+         I = 1
+         DO WHILE( I.LE.N )
+            TMP = ZERO
+            IF( ALPHAI( I ).NE.ZERO ) THEN
+* Complex case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VL(J, I)) + ABS(VL(J, I + 1)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VL( J, I )   = VL( J, I ) * TMP
+                  VL( J, I+1 ) = VL( J, I+1 ) * TMP
+               END DO
+               I = I + 2
+            ELSE
+* Real case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VL(J, I)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VL( J, I ) = VL( J, I ) * TMP
+               END DO
+               I = I + 1
+            END IF
+         END DO
+      END IF
+*
+* Normalise right eigenvectors
+      IF( COMPVR ) THEN
+         I = 1
+         DO WHILE( I.LE.N )
+            TMP = ZERO
+            IF( ALPHAI( I ).NE.ZERO ) THEN
+* Complex case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VR(J, I)) + ABS(VR(J, I + 1)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VR( J, I )   = VR( J, I ) * TMP
+                  VR( J, I+1 ) = VR( J, I+1 ) * TMP
+               END DO
+               I = I + 2
+            ELSE
+* Real case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VR(J, I)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VR( J, I ) = VR( J, I ) * TMP
+               END DO
+               I = I + 1
+            END IF
+         END DO
+      END IF
+*
+      WORK( 1 ) = DBLE( NINFINITE )
+      RETURN
+      END SUBROUTINE DGGEV4

--- a/SRC/dgghd4.f
+++ b/SRC/dgghd4.f
@@ -1,0 +1,363 @@
+*> \brief \b DGGHD4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> DGGHD4 reduces a pair of real matrices (A,B) to generalized upper
+*> Hessenberg form using orthogonal transformations, where A is a
+*> Hessenberg matrix and B is upper triangular. This routine
+*> employs a blocked algorithm (Steel et al) to improve efficiency
+*> and scalability.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPQ
+*> \verbatim
+*>          COMPQ is CHARACTER*1
+*>          = 'N': do not compute Q;
+*>          = 'I': Q is initialized to the unit matrix, and the
+*>                 orthogonal matrix Q is returned;
+*>          = 'V': Q must contain an orthogonal matrix Q1 on entry,
+*>                 and the product Q1*Q is returned.
+*> \endverbatim
+*>
+*> \param[in] COMPZ
+*> \verbatim
+*>          COMPZ is CHARACTER*1
+*>          = 'N': do not compute Z;
+*>          = 'I': Z is initialized to the unit matrix, and the
+*>                 orthogonal matrix Z is returned;
+*>          = 'V': Z must contain an orthogonal matrix Z1 on entry,
+*>                 and the product Z1*Z is returned.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] ILO
+*> \param[in] IHI
+*> \verbatim
+*>          ILO and IHI are INTEGER
+*>          It is assumed that A is already upper triangular in rows
+*>          and columns 1:ILO-1 and IHI+1:N. ILO and IHI are normally
+*>          set by a previous call to DGGBAL.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA, N)
+*>          On entry, the N-by-N general matrix to be reduced.
+*>          On exit, the upper triangle and the first subdiagonal of A
+*>          are overwritten with the upper Hessenberg matrix H.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is DOUBLE PRECISION array, dimension (LDB, N)
+*>          On entry, the N-by-N upper triangular matrix B.
+*>          On exit, the upper triangular matrix T = Q**T B Z.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] Q
+*> \verbatim
+*>          Q is DOUBLE PRECISION array, dimension (LDQ, N)
+*>          If COMPQ='N', then Q is not referenced.
+*>          If COMPQ='V', on entry Q must contain an orthogonal matrix.
+*>          If COMPQ='I', on exit Q contains the orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          LDQ >= N if COMPQ='V' or 'I'; LDQ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[in,out] Z
+*> \verbatim
+*>          Z is DOUBLE PRECISION array, dimension (LDZ, N)
+*>          If COMPZ='N', then Z is not referenced.
+*>          If COMPZ='V', on entry Z must contain an orthogonal matrix.
+*>          If COMPZ='I', on exit Z contains the orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          LDZ >= N if COMPZ='V' or 'I'; LDZ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE DGGHD4( COMPQ, COMPZ, N, ILO, IHI, A, LDA, B, LDB,
+     $                   Q, LDQ, Z, LDZ, WORK, LWORK, INFO )
+*
+* -- LAPACK-like routine --
+*
+* .. Scalar Arguments ..
+      CHARACTER          COMPQ, COMPZ
+      INTEGER            IHI, ILO, INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            ILQ, ILZ, LQUERY
+      INTEGER            I, J, IERR, IWORK, K, LWKOPT, NCOLS,
+     $                   NITER, COL_LEN, LMIN
+      DOUBLE PRECISION   EPS, NORM, NORMA, TOL, AMAX
+* ..
+* .. Local Arrays ..
+      DOUBLE PRECISION   DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      DOUBLE PRECISION   DLAMCH, DLANGE
+      EXTERNAL           LSAME, DLAMCH, DLANGE
+* ..
+* .. External Subroutines ..
+      EXTERNAL           DGEHRD, DGERQF, DLACPY, DLASET, DORMHR,
+     $                   DORMRQ, DTRSM, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, DBLE, MAX, MIN
+
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
+* ..
+* .. Executable Statements ..
+*
+* Decode and test the input parameters.
+*
+      INFO = 0
+      ILQ = LSAME( COMPQ, 'V' ) .OR. LSAME( COMPQ, 'I' )
+      ILZ = LSAME( COMPZ, 'V' ) .OR. LSAME( COMPZ, 'I' )
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( .NOT.LSAME( COMPQ, 'N' ) .AND. .NOT.ILQ ) THEN
+         INFO = -1
+      ELSE IF( .NOT.LSAME( COMPZ, 'N' ) .AND. .NOT.ILZ ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( ILO.LT.1 .OR. ILO.GT.MAX( 1, N ) ) THEN
+         INFO = -4
+      ELSE IF( IHI.LT.MIN( ILO, N ) .OR. IHI.GT.N ) THEN
+         INFO = -5
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( ILQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      ELSE IF( ILZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -13
+      END IF
+*
+* Compute optimal workspace.
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 2*( N + 1 )
+         CALL DGEHRD( N, 1, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         CALL DORMHR( 'L', 'T', N, N, 1, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         CALL DGERQF( N, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         CALL DORMRQ( 'R', 'T', N, N, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         LWKOPT = LWKOPT + N*( N + 1 )
+         LMIN = LWKOPT
+         WORK( 1 ) = DBLE( LWKOPT )
+         IF( LWORK.LT.LMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -15
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DGGHD4', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Initialize Q and Z if requested.
+*
+      IF( LSAME( COMPQ, 'I' ) ) THEN
+         CALL DLASET( 'F', N, N, 0.0D0, 1.0D0, Q, LDQ )
+      END IF
+      IF( LSAME( COMPZ, 'I' ) ) THEN
+         CALL DLASET( 'F', N, N, 0.0D0, 1.0D0, Z, LDZ )
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.LE.1 ) RETURN
+*
+      NORMA = DLANGE( 'F', N, N, A, LDA, WORK )
+      EPS = DLAMCH( 'E' )
+      TOL = EPS * NORMA
+      NITER = 0
+      K = ILO
+      IWORK = N*N + 1
+
+      AMAX = ZERO
+      DO J = 1, N
+         DO I = 1, N
+            AMAX = MAX( AMAX, ABS(A(I, J)) )
+         END DO
+      END DO
+      IF (AMAX.EQ.ZERO) THEN
+         AMAX = ONE
+      END IF
+      TOL = EPS * AMAX
+
+*
+* Outer reduction loop: iterate until K reaches IHI or NITER hits 50.
+*
+      DO WHILE( K.LT.IHI .AND. NITER.LT.50 )
+*
+* Inner deflation loop: advance K while subdiagonal entries are small.
+*
+         DO WHILE( K.LT.IHI )
+            COL_LEN = IHI - K - 1
+            
+            IF( COL_LEN.LE.0 ) THEN
+               K = K + 1
+               CYCLE
+            END IF
+            
+            NORM = 0.0D0
+            DO I = 1, COL_LEN
+               NORM = MAX( NORM, ABS( A( K + 1 + I, K ) ) )
+            END DO
+            
+            IF( NORM.GT.TOL ) THEN
+               EXIT
+            END IF
+
+*
+* Deflate strictly bounded values
+*
+            DO I = 1, COL_LEN
+               A( K + 1 + I, K ) = 0.0D0
+            END DO
+            K = K + 1
+         END DO
+
+         IF (K.GE.IHI) THEN
+            EXIT
+         END IF
+
+         NITER = NITER + 1
+         NCOLS = IHI - K + 1
+*
+* Copy A(K:IHI, K:IHI) into X (stored at WORK(1))
+*
+         CALL DLACPY( 'A', NCOLS, NCOLS, A( K, K ), LDA, WORK, NCOLS )
+*
+* DTRSM to solve X * B = A
+*
+         CALL DTRSM( 'R', 'U', 'N', 'N', NCOLS, NCOLS, ONE / AMAX,
+     $               B( K, K ), LDB, WORK, NCOLS )
+*
+* Hessenberg reduction of X
+*
+         CALL DGEHRD( NCOLS, 1, NCOLS, WORK, NCOLS, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Qc**T to A and B from the left
+*
+         CALL DORMHR( 'L', 'T', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), A( K, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         CALL DORMHR( 'L', 'T', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), B( K, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILQ ) THEN
+            CALL DORMHR( 'R', 'N', N, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                   WORK( IWORK ), Q( 1, K ), LDQ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+
+*
+* RQ factorization of B(K:IHI, K:IHI)
+*
+         CALL DGERQF( NCOLS, NCOLS, B( K, K ), LDB, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**T to A from the right (Updates rows 1:IHI)
+*
+         CALL DORMRQ( 'R', 'T', IHI, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), A( 1, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**T to B from the right (CRITICAL FIX: Updates rows 1:K-1)
+*
+         CALL DORMRQ( 'R', 'T', K-1, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), B( 1, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILZ ) THEN
+            CALL DORMRQ( 'R', 'T', N, NCOLS, NCOLS, B( K, K ), LDB,
+     $                   WORK( IWORK ), Z( 1, K ), LDZ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+*
+* Zero lower triangle of B globally
+*
+         CALL DLASET( 'L', N-1, N-1, 0.0D0, 0.0D0, B( 2, 1 ), LDB )
+
+*
+      END DO
+*
+* End of DGGHD4
+*
+      END SUBROUTINE DGGHD4

--- a/SRC/dggprp.f
+++ b/SRC/dggprp.f
@@ -1,0 +1,297 @@
+*> \brief \b DGGPRP
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> DGGPRP is a preprocessing routine for the generalized 
+*> eigenvalue problem. It prepares the matrices A and B by applying 
+*> an initial Rank-Revealing QR (RRQR) factorization on B, transposing
+*> and reversing arrays, and initializing orthogonal transformation 
+*> matrices Q and Z if requested.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WANTQ
+*> \verbatim
+*>          WANTQ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the orthogonal matrix Q.
+*>          = .FALSE.: Do not compute Q.
+*> \endverbatim
+*>
+*> \param[in] WANTZ
+*> \verbatim
+*>          WANTZ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the orthogonal matrix Z.
+*>          = .FALSE.: Do not compute Z.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A is overwritten by the preprocessed matrix.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is DOUBLE PRECISION array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B is overwritten by the preprocessed upper 
+*>          triangular matrix from the RRQR factorization.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is DOUBLE PRECISION array, dimension (LDQ, N)
+*>          If WANTQ = .TRUE., contains the initialized orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          If WANTQ = .TRUE., LDQ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is DOUBLE PRECISION array, dimension (LDZ, N)
+*>          If WANTZ = .TRUE., contains the initialized orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          If WANTZ = .TRUE., LDZ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is DOUBLE PRECISION array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the norm of B, and 
+*>          WORK(2) returns the tolerance computed.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] JPVT
+*> \verbatim
+*>          JPVT is INTEGER array, dimension (N)
+*>          On exit, contains the pivot indices from DGEQP3.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim      
+      SUBROUTINE DGGPRP( WANTQ, WANTZ, N, A, LDA, B, LDB, Q, LDQ,
+     $                   Z, LDZ, WORK, LWORK, JPVT, INFO )
+*
+* -- LAPACK-style preprocessing routine --
+*
+* .. Scalar Arguments ..
+      LOGICAL            WANTQ, WANTZ
+      INTEGER            INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            JPVT( * )
+      DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IERR, J, LWKOPT, WORKNEEDED
+      DOUBLE PRECISION   NORMB, TOL
+* ..
+* .. Local Arrays ..
+      DOUBLE PRECISION   DUMMY( 1 )
+* ..
+* .. External Subroutines ..
+      EXTERNAL           DGEQP3, DLAREV, DLAPMR, DLATRN, DORGQR, DORMQR,
+     $                   XERBLA
+* ..
+* .. External Functions ..
+      DOUBLE PRECISION   DLAMCH, DLANGE
+      EXTERNAL           DLAMCH, DLANGE
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          DBLE, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input arguments
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( WANTQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( WANTZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      END IF
+*
+* Compute workspace if no argument errors occurred
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 0
+         CALL DGEQP3( N, N, B, LDB, JPVT, DUMMY, DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DUMMY( 1 ) ) )
+*
+         CALL DORMQR( 'R', 'N', N, N, N, B, LDB, DUMMY, A, LDA,
+     $                DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DUMMY( 1 ) ) )
+*
+         CALL DORGQR( N, N, N, Z, LDZ, DUMMY, DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DUMMY( 1 ) ) )
+*
+* Total workspace must accommodate TAU (size N) plus the optimal
+* workspace sizes requested by the underlying routines.
+*
+         WORKNEEDED = N + LWKOPT
+*
+         IF( LWORK.LT.WORKNEEDED .AND. .NOT.LQUERY ) THEN
+            INFO = -13
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DGGPRP', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         WORK( 1 ) = DBLE( WORKNEEDED )
+         RETURN
+      END IF
+*
+* Compute norm of B and tolerance
+*
+      NORMB = DLANGE( 'F', N, N, B, LDB, WORK )
+      TOL = NORMB * DLAMCH( 'E' )
+*
+* B = B^T
+*
+      CALL DLATRN( N, B, LDB )
+*
+* B = B[:, ::-1]
+*
+      CALL DLAREV( 'C', N, N, B, LDB )
+*
+* RRQR(B)
+*
+      DO I = 1, N
+         JPVT( I ) = 0
+      END DO
+      CALL DGEQP3( N, N, B, LDB, JPVT, WORK, WORK( N + 1 ),
+     $             LWORK - N, IERR )
+*
+* A = A[::-1]
+*
+      CALL DLAREV( 'R', N, N, A, LDA )
+*
+* A = A[p]
+*
+      CALL DLAPMR( .TRUE., N, N, A, LDA, JPVT )
+*
+* A = A * Q
+*
+      CALL DORMQR( 'R', 'N', N, N, N, B, LDB, WORK, A, LDA,
+     $             WORK( N + 1 ), LWORK - N, IERR )
+*
+      IF( WANTQ ) THEN
+*
+* Initialize Q = J P J
+* (J is the column index, I is the row index)
+*
+         DO J = 1, N
+            DO I = 1, N
+               Q( I, J ) = 0.0D0
+            END DO
+         END DO
+         DO J = 1, N
+            I = N - JPVT( N - J + 1 ) + 1
+            Q( I, J ) = 1.0D0
+         END DO
+      END IF
+*
+      IF( WANTZ ) THEN
+*
+* Copy B into Z
+*
+         DO J = 1, N
+            DO I = 1, N
+               Z( I, J ) = B( I, J )
+            END DO
+         END DO
+         CALL DORGQR( N, N, N, Z, LDZ, WORK, WORK( N + 1 ),
+     $                LWORK - N, IERR )
+         CALL DLAREV( 'C', N, N, Z, LDZ )
+      END IF
+*
+* A = A[::-1][:, ::-1]
+*
+      CALL DLAREV( 'B', N, N, A, LDA )
+*
+* B = B.T[::-1][:, ::-1]
+* (Zero strictly lower triangle to preserve the R matrix from DGEQP3.
+* J is the column, I is the row.)
+*
+      DO J = 1, N - 1
+         DO I = J + 1, N
+            B( I, J ) = 0.0D0
+         END DO
+      END DO
+*
+      CALL DLATRN( N, B, LDB )
+      CALL DLAREV( 'B', N, N, B, LDB )
+*
+* Store norm and tolerance in the first two elements of WORK
+*
+      WORK( 1 ) = NORMB
+      WORK( 2 ) = TOL
+*
+      RETURN
+*
+* End of DGGPRP
+*
+      END

--- a/SRC/dlarev.f
+++ b/SRC/dlarev.f
@@ -1,0 +1,115 @@
+*> \brief \b DLAREV
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> DLAREV reverses the order of the rows and/or columns of a given
+*> M-by-N double precision matrix A.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WHICH
+*> \verbatim
+*>          WHICH is CHARACTER*1
+*>          Specifies whether to reverse rows, columns, or both:
+*>          = 'B': Reverse both rows and columns.
+*>          = 'R': Reverse rows only.
+*>          = 'C': Reverse columns only.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA, N)
+*>          On entry, the matrix A to be reversed.
+*>          On exit, the elements of A have been swapped according to WHICH.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.
+*> \endverbatim
+      SUBROUTINE DLAREV( WHICH, M, N, A, LDA )
+*     .. Scalar Arguments ..
+      CHARACTER          WHICH
+      INTEGER            M, N, LDA
+*     .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * )
+*     .. Local Scalars ..
+      INTEGER            I, J, M2, N2
+      LOGICAL            ROWODD, COLODD
+      DOUBLE PRECISION   TMPA, TMPB, TMPC, TMPD
+*     .. Executable Statements ..
+
+      M2 = M / 2
+      N2 = N / 2
+      ROWODD = MOD(M, 2) .NE. 0
+      COLODD = MOD(N, 2) .NE. 0
+
+      IF ( WHICH .EQ. 'B' ) THEN
+         DO I = 1, N2
+            DO J = 1, M2
+               TMPA = A( J, I )
+               TMPB = A( J, N - I + 1 )
+               TMPC = A( M - J + 1, I )
+               TMPD = A( M - J + 1, N - I + 1 )
+               
+               A( J, I ) = TMPD
+               A( J, N - I + 1 ) = TMPC
+               A( M - J + 1, I ) = TMPB
+               A( M - J + 1, N - I + 1 ) = TMPA
+            END DO
+            IF ( ROWODD ) THEN
+               TMPA = A( M2 + 1, I )
+               A( M2 + 1, I ) = A( M2 + 1, N - I + 1 )
+               A( M2 + 1, N - I + 1 ) = TMPA
+            END IF
+         END DO
+         IF ( COLODD ) THEN
+            DO J = 1, M2
+               TMPA = A( J, N2 + 1 )
+               A( J, N2 + 1 ) = A( M - J + 1, N2 + 1 )
+               A( M - J + 1, N2 + 1 ) = TMPA
+            END DO
+         END IF
+
+      ELSE IF ( WHICH .EQ. 'R' ) THEN
+         DO I = 1, N
+            DO J = 1, M2
+               TMPA = A( J, I )
+               A( J, I ) = A( M - J + 1, I )
+               A( M - J + 1, I ) = TMPA
+            END DO
+         END DO
+
+      ELSE IF ( WHICH .EQ. 'C' ) THEN
+         DO I = 1, N2
+            DO J = 1, M
+               TMPA = A( J, I )
+               A( J, I ) = A( J, N - I + 1 )
+               A( J, N - I + 1 ) = TMPA
+            END DO
+         END DO
+      END IF
+
+      RETURN
+      END

--- a/SRC/dlatrn.f
+++ b/SRC/dlatrn.f
@@ -1,0 +1,125 @@
+*> \brief \b DLATRN
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> DLATRN performs an in-place transpose of an N-by-N double precision
+*> matrix A. It utilizes OpenMP parallelization and a blocked iteration 
+*> scheme to optimize cache usage during the transposition process.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA, N)
+*>          On entry, the N-by-N matrix to be transposed.
+*>          On exit, A is overwritten by its transpose.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+      SUBROUTINE DLATRN( N, A, LDA )
+
+#if defined(_OPENMP)
+      use omp_lib
+#endif
+*
+* -- LAPACK auxiliary routine --
+*
+* .. Scalar Arguments ..
+      INTEGER            LDA, N
+* ..
+* .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      INTEGER            SIZE
+      PARAMETER          ( SIZE = 8 )
+* ..
+* .. Local Scalars ..
+      INTEGER            BLOCK, I, J, NUM_THREADS, TAIL_START
+      DOUBLE PRECISION   TEMP
+* ..
+* .. External Functions ..
+#if defined(_OPENMP)
+      INTEGER            OMP_GET_MAX_THREADS
+      EXTERNAL           OMP_GET_MAX_THREADS
+#endif
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          MIN
+* ..
+* .. Executable Statements ..
+*
+#if defined(_OPENMP)
+      IF( N.GE.256 ) THEN
+         NUM_THREADS = N / 64
+      ELSE
+         NUM_THREADS = 1
+      END IF
+      NUM_THREADS = MIN( NUM_THREADS, OMP_GET_MAX_THREADS() )
+#else
+      NUM_THREADS = 1
+#endif
+   
+!$OMP PARALLEL DO PRIVATE( BLOCK, I, J, TEMP )
+!$OMP+            NUM_THREADS( NUM_THREADS ) SCHEDULE( DYNAMIC, 1 )
+      DO BLOCK = 1, N - SIZE + 1, SIZE
+*
+* This pair takes care of the main diagonal block
+         DO I = BLOCK, BLOCK + SIZE - 1
+            DO J = I + 1, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = A( J, I )
+               A( J, I ) = TEMP
+            END DO
+         END DO
+*
+* Transpose sub-matrices not on the main diagonal
+         DO I = BLOCK + SIZE, N
+            DO J = BLOCK, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = A( J, I )
+               A( J, I ) = TEMP
+            END DO
+         END DO
+*
+      END DO
+!$OMP END PARALLEL DO
+*
+* Transpose remaining elements along the main diagonal
+* Note: TAIL_START is explicitly calculated because BLOCK is 
+* undefined outside the OpenMP parallel construct.
+      TAIL_START = ( N / SIZE ) * SIZE + 1
+      DO I = TAIL_START, N
+         DO J = I + 1, N
+            TEMP      = A( I, J )
+            A( I, J ) = A( J, I )
+            A( J, I ) = TEMP
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of DLATRN
+*
+      END

--- a/SRC/sggdef.f
+++ b/SRC/sggdef.f
@@ -1,0 +1,311 @@
+*> \brief \b SGGDEF
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> SGGDEF performs the deflation of infinite eigenvalues in the generalized
+*> eigenvalue problem. It applies QR and RQ factorizations to 
+*> sub-blocks of A and B to properly isolate and deflate these eigenvalues.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPVL
+*> \verbatim
+*>          COMPVL is LOGICAL
+*>          = .TRUE.:  Compute the left Schur vectors (VL).
+*>          = .FALSE.: Do not compute the left Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] COMPVR
+*> \verbatim
+*>          COMPVR is LOGICAL
+*>          = .TRUE.:  Compute the right Schur vectors (VR).
+*>          = .FALSE.: Do not compute the right Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] K
+*> \verbatim
+*>          K is INTEGER
+*>          The number of infinite eigenvalues to deflate (the block size). 
+*>          0 <= K <= N.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array, dimension (LDA, N)
+*>          On entry, the matrix A to be deflated.
+*>          On exit, A has been updated by the orthogonal transformations.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is REAL array, dimension (LDB, N)
+*>          On entry, the matrix B to be deflated.
+*>          On exit, B has been updated by the orthogonal transformations.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VL
+*> \verbatim
+*>          VL is REAL array, dimension (LDVL, N)
+*>          If COMPVL = .TRUE., the left Schur vectors are accumulated in VL.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL.  
+*>          If COMPVL = .TRUE., LDVL >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VR
+*> \verbatim
+*>          VR is REAL array, dimension (LDVR, N)
+*>          If COMPVR = .TRUE., the right Schur vectors are accumulated in VR.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR.  
+*>          If COMPVR = .TRUE., LDVR >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK. LWORK >= max(1, 2*N).
+*>          If LWORK = -1, then a workspace query is assumed; the routine
+*>          only calculates the optimal size of the WORK array.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE SGGDEF( COMPVL, COMPVR, N, K, A, LDA, B, LDB, VL,
+     $                   LDVL, VR, LDVR, WORK, LWORK, INFO )
+*
+* -- LAPACK-style Code --
+*
+* .. Scalar Arguments ..
+      LOGICAL            COMPVL, COMPVR
+      INTEGER            INFO, K, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      REAL   A( LDA, * ), B( LDB, * ), VL( LDVL, * ),
+     $                   VR( LDVR, * ), WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IINFO, J, LWKOPT
+* ..
+* .. External Subroutines ..
+      EXTERNAL           SGEQRF, SGERQF, SORMQR, SORMRQ, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          REAL, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input parameters.
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( K.LT.0 .OR. K.GT.N ) THEN
+         INFO = -4
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -6
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -8
+      ELSE IF( COMPVL .AND. LDVL.LT.MAX( 1, N ) ) THEN
+         INFO = -10
+      ELSE IF( COMPVR .AND. LDVR.LT.MAX( 1, N ) ) THEN
+         INFO = -12
+      ELSE IF( LWORK.LT.MAX( 1, 2*N ) .AND. .NOT.LQUERY ) THEN
+* Minimum workspace is N elements for TAU arrays + N elements for routines
+         INFO = -14
+      END IF
+*
+      IF( INFO.EQ.0 ) THEN
+*
+* Compute optimal workspace
+*
+         LWKOPT = MAX( 1, 2*N )
+         IF( K.GT.0 ) THEN
+            CALL SGEQRF( N, K, A, LDA, WORK, WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+*
+            IF( N.GT.K ) THEN
+               CALL SORMQR( 'L', 'T', N, N - K, K, A, LDA, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+*
+            IF( COMPVL ) THEN
+               CALL SORMQR( 'R', 'N', N, N, K, A, LDA, WORK, VL,
+     $                      LDVL, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+         END IF
+*
+         IF( N.GT.K ) THEN
+            CALL SGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB, WORK,
+     $                   WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+*
+            IINFO = -1
+            CALL SORMRQ( 'R', 'T', N, N - K, N - K, 
+     $                   B( K + 1, K + 1 ),
+     $                   LDB, WORK, A( 1, K + 1 ), LDA, WORK, -1,
+     $                   IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+*
+            IF( K.GT.0 ) THEN
+               CALL SORMRQ( 'R', 'T', K, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+*
+            IF( COMPVR ) THEN
+               CALL SORMRQ( 'R', 'T', N, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      VR( 1, K + 1 ), LDVR, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( WORK( 1 ) ) )
+            END IF
+         END IF
+*
+         WORK( 1 ) = REAL( LWKOPT )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'SGGDEF', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+* QR portion
+* Factorize A(1:N, 1:K)
+* WORK(1:K) holds the TAU scalar factors for A
+*
+      IF( K.GT.0 ) THEN
+         CALL SGEQRF( N, K, A, LDA, WORK( 1 ), WORK( N + 1 ),
+     $                LWORK - N, IINFO )
+*
+* Apply Q^T to A(1:N, K+1:N)
+*
+         IF( N.GT.K ) THEN
+            CALL SORMQR( 'L', 'T', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   A( 1, K + 1 ), LDA, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+*
+* Apply Q^T to B(1:N, K+1:N)
+*
+            CALL SORMQR( 'L', 'T', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVL ) THEN
+* Accumulate Q in VL: VL = VL * Q
+            CALL SORMQR( 'R', 'N', N, N, K, A, LDA, WORK( 1 ), VL,
+     $                   LDVL, WORK( N + 1 ), LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* RQ portion
+* Factorize B(K+1:N, K+1:N)
+* WORK(K+1:N) holds the TAU scalar factors for B
+*
+      IF( N.GT.K ) THEN
+         CALL SGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB,
+     $                WORK( K + 1 ), WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^T to A(1:N, K+1:N) from the right: A = A * Q^T
+*
+         CALL SORMRQ( 'R', 'T', N, N - K, N - K, B( K + 1, K + 1 ),
+     $                LDB, WORK( K + 1 ), A( 1, K + 1 ), LDA,
+     $                WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^T to B(1:K, K+1:N) from the right: B = B * Q^T
+*
+         IF( K.GT.0 ) THEN
+            CALL SORMRQ( 'R', 'T', K, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVR ) THEN
+* Accumulate Q^T in VR: VR(1:N, K+1:N) = VR(1:N, K+1:N) * Q^T
+            CALL SORMRQ( 'R', 'T', N, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   VR( 1, K + 1 ), LDVR, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* Zero out strictly lower triangular parts
+*
+      DO J = 1, K
+         DO I = J + 1, N
+            A( I, J ) = 0.0E0
+         END DO
+      END DO
+*
+      DO J = K + 1, N
+         DO I = J + 1, N
+            B( I, J ) = 0.0E0
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of SGGDEF
+*
+      END

--- a/SRC/sggev4.f
+++ b/SRC/sggev4.f
@@ -1,0 +1,403 @@
+*> \brief \b SGGEV4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> SGGEV4 computes for a pair of N-by-N real nonsymmetric matrices (A,B)
+*> the generalized eigenvalues, and optionally, the left and/or right
+*> generalized eigenvectors.
+*> 
+*> This routine performs the following steps:
+*> 1) Preprocessing (SGGPRP) 
+*> 2) Deflation of infinite eigenvalues (SGGDEF) 
+*> 3) Blocked Hessenberg-Triangular Reduction (SGGHD4) 
+*> 4) QZ algorithm (SLAQZ0) 
+*> 5) Eigenvector computation and normalization.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] JOBVL
+*> \verbatim
+*>          JOBVL is CHARACTER*1
+*>          = 'N':  do not compute the left generalized eigenvectors;
+*>          = 'V':  compute the left generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] JOBVR
+*> \verbatim
+*>          JOBVR is CHARACTER*1
+*>          = 'N':  do not compute the right generalized eigenvectors;
+*>          = 'V':  compute the right generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is REAL array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] ALPHAR
+*> \verbatim
+*>          ALPHAR is REAL array, dimension (N)
+*> \endverbatim
+*>
+*> \param[out] ALPHAI
+*> \verbatim
+*>          ALPHAI is REAL array, dimension (N)
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is REAL array, dimension (N)
+*>          (ALPHAR(j) + ALPHAI(j)*i)/BETA(j), j=1,...,N, will be the
+*>          generalized eigenvalues. Deflated infinite eigenvalues 
+*>          will set BETA to zero.
+*> \endverbatim
+*>
+*> \param[out] VL
+*> \verbatim
+*>          VL is REAL array, dimension (LDVL, N)
+*>          If JOBVL = 'V', the left eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL. LDVL >= 1, and
+*>          if JOBVL = 'V', LDVL >= N.
+*> \endverbatim
+*>
+*> \param[out] VR
+*> \verbatim
+*>          VR is REAL array, dimension (LDVR, N)
+*>          If JOBVR = 'V', the right eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR. LDVR >= 1, and
+*>          if JOBVR = 'V', LDVR >= N.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the number of deflated 
+*>          infinite eigenvalues.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] JPVT
+*> \verbatim
+*>          JPVT is INTEGER array, dimension (N)
+*>          Pivot indices from preprocessing.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE SGGEV4( JOBVL, JOBVR, N, A, LDA, B, LDB, ALPHAR,
+     $                   ALPHAI, BETA, VL, LDVL, VR, LDVR, WORK,
+     $                   LWORK, IWORK, INFO )
+*
+* .. Scalar Arguments ..
+      CHARACTER          JOBVL, JOBVR
+      INTEGER            INFO, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            IWORK( * )
+      REAL   A( LDA, * ), ALPHAI( * ), ALPHAR( * ),
+     $                   B( LDB, * ), BETA( * ), VL( LDVL, * ),
+     $                   VR( LDVR, * ), WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      REAL   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
+* ..
+* .. Local Scalars ..
+      LOGICAL            COMPVL, COMPVR, LQUERY
+      CHARACTER          JOBQZ, JOBVEC
+*
+*     IHI is added to support balancing: SGGBAL sets ILO and IHI to
+*     indicate the submatrix that was balanced.  IHI is not needed by
+*     the existing pipeline but is required by SGGBAK.
+*
+      INTEGER            I, IN, J, K, NINFINITE, WORKNEEDED, ILO
+      REAL   TMP, TOL
+* ..
+* .. Local Arrays ..
+      LOGICAL            LDUMMY( 1 )
+      REAL   DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      EXTERNAL           LSAME
+* ..
+* .. External Subroutines ..
+*
+*     SGGBAL / SGGBAK added for balancing (same as DGGEV3).
+*
+      EXTERNAL           SGEQRF, SGERQF, SGGBAL, SGGBAK, SGGDEF,
+     $                   SGGHD4, SGGPRP, SLAQZ0, SORMQR, SORMRQ,
+     $                   STGEVC, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, REAL, INT, MAX, SQRT, MIN
+* ..
+* .. Executable Statements ..
+*
+      COMPVL = LSAME( JOBVL, 'V' )
+      COMPVR = LSAME( JOBVR, 'V' )
+      IF( COMPVL .OR. COMPVR ) THEN
+         JOBQZ = 'S'
+      ELSE
+         JOBQZ = 'E'
+      END IF
+*
+* LAPACK style argument checks
+      INFO = 0
+      IF( .NOT.COMPVL .AND. .NOT.LSAME( JOBVL, 'N' ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.COMPVR .AND. .NOT.LSAME( JOBVR, 'N' ) ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDVL.LT.1 .OR. ( COMPVL .AND. LDVL.LT.N ) ) THEN
+         INFO = -12
+      ELSE IF( LDVR.LT.1 .OR. ( COMPVR .AND. LDVR.LT.N ) ) THEN
+         INFO = -14
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'SGGEV4', -INFO )
+         RETURN
+      END IF
+*
+      IF( COMPVL .AND. COMPVR ) THEN
+         JOBVEC = 'B'
+      ELSE IF( COMPVL ) THEN
+         JOBVEC = 'L'
+      ELSE IF( COMPVR ) THEN
+         JOBVEC = 'R'
+      ELSE
+         JOBVEC = 'N'
+      END IF
+*
+* Workspace queries
+      LQUERY = ( LWORK.EQ.-1 )
+      WORKNEEDED = 0
+*
+      CALL SGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, DUMMY, -1, IWORK, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL SGGHD4( JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB, VL, LDVL,
+     $             VR, LDVR, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL SGEQRF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL SORMQR( 'L', 'T', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL SGERQF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL SORMRQ( 'L', 'T', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+      CALL SLAQZ0( JOBQZ, JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB,
+     $             ALPHAR, ALPHAI, BETA, VL, LDVL, VR, LDVR, DUMMY,
+     $             -1, 0, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DUMMY( 1 ) ) )
+*
+*     SGGBAL does not use a workspace query; it always needs 6*N
+*     elements.  Ensure the workspace is large enough to accommodate it.
+*
+      WORKNEEDED = MAX( WORKNEEDED, 6*N )
+*
+      IF( LQUERY ) THEN
+         WORK( 1 ) = REAL( WORKNEEDED )
+         RETURN
+      END IF
+
+* ---------------------------------------------------------------
+*
+* Step 1: Preprocessing
+      CALL SGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, WORK, LWORK, IWORK, INFO )
+
+      TOL = WORK( 2 )
+      NINFINITE = 0
+      DO K = 1, N
+         IF (TOL.LT.ABS(B(K, K))) THEN
+            EXIT
+         END IF
+         NINFINITE = NINFINITE + 1
+         DO I = 1, NINFINITE
+            B(I, K) = ZERO
+         END DO
+      END DO
+
+*
+* Step 2: Deflation of infinite eigenvalues
+      IF( NINFINITE.GT.0 ) THEN
+         CALL SGGDEF( COMPVL, COMPVR, N, NINFINITE, A, LDA, B, LDB,
+     $                VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+      END IF
+
+      DO I = 1, NINFINITE
+         ALPHAR(I) = A(I, I)
+         ALPHAI(I) = ZERO
+         BETA(I) = ZERO
+      END DO
+
+*
+* Add small perturbation to B if needed
+      DO I = NINFINITE + 1, N
+         IF (ABS(B(I, I)).LE.TOL) THEN
+            B(I, I) = TOL
+         END IF
+      END DO
+*
+* ---------------------------------------------------------------
+*
+* Step 3: Hessenberg-Triangular Reduction
+*
+      ILO = MIN( N, NINFINITE + 1 )
+      CALL SGGHD4( JOBVL, JOBVR, N, ILO, N, A, LDA, B, LDB,
+     $             VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+
+*
+* ---------------------------------------------------------------
+*
+* Step 4: QZ
+*     Use the balanced ILO (not the raw NINFINITE+1) so that SLAQZ0
+*     operates on exactly the same submatrix that SGGHD4 reduced to
+*     Hessenberg-triangular form.  Rows NINFINITE+1..ILO-1 were
+*     identified by SGGBAL as already decoupled and were skipped by
+*     SGGHD4; passing NINFINITE+1 here would hand SLAQZ0 a
+*     non-Hessenberg leading block.
+      IF( NINFINITE.NE.N ) THEN
+         CALL SLAQZ0( JOBQZ, JOBVL, JOBVR, N, ILO, N, A, LDA,
+     $                B, LDB, ALPHAR, ALPHAI, BETA, VL, LDVL, VR, LDVR,
+     $                WORK, LWORK, 0, INFO )
+      END IF
+*
+* Step 5: Eigenvectors
+      IF( COMPVL .OR. COMPVR ) THEN
+         CALL STGEVC( JOBVEC, 'B', LDUMMY, N, A, LDA, B, LDB, VL, LDVL,
+     $                VR, LDVR, N, IN, WORK, INFO )
+      END IF
+*
+* ---------------------------------------------------------------
+*
+* Normalise left eigenvectors
+      IF( COMPVL ) THEN
+         I = 1
+         DO WHILE( I.LE.N )
+            TMP = ZERO
+            IF( ALPHAI( I ).NE.ZERO ) THEN
+* Complex case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VL(J, I)) + ABS(VL(J, I + 1)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VL( J, I )   = VL( J, I ) * TMP
+                  VL( J, I+1 ) = VL( J, I+1 ) * TMP
+               END DO
+               I = I + 2
+            ELSE
+* Real case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VL(J, I)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VL( J, I ) = VL( J, I ) * TMP
+               END DO
+               I = I + 1
+            END IF
+         END DO
+      END IF
+*
+* Normalise right eigenvectors
+      IF( COMPVR ) THEN
+         I = 1
+         DO WHILE( I.LE.N )
+            TMP = ZERO
+            IF( ALPHAI( I ).NE.ZERO ) THEN
+* Complex case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VR(J, I)) + ABS(VR(J, I + 1)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VR( J, I )   = VR( J, I ) * TMP
+                  VR( J, I+1 ) = VR( J, I+1 ) * TMP
+               END DO
+               I = I + 2
+            ELSE
+* Real case
+               DO J = 1, N
+                  TMP = MAX(TMP, ABS(VR(J, I)))
+               END DO
+               TMP = ONE / TMP
+               DO J = 1, N
+                  VR( J, I ) = VR( J, I ) * TMP
+               END DO
+               I = I + 1
+            END IF
+         END DO
+      END IF
+*
+      WORK( 1 ) = REAL( NINFINITE )
+      RETURN
+      END SUBROUTINE SGGEV4

--- a/SRC/sgghd4.f
+++ b/SRC/sgghd4.f
@@ -1,0 +1,363 @@
+*> \brief \b SGGHD4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> SGGHD4 reduces a pair of real matrices (A,B) to generalized upper
+*> Hessenberg form using orthogonal transformations, where A is a
+*> Hessenberg matrix and B is upper triangular. This routine
+*> employs a blocked algorithm (Steel et al) to improve efficiency
+*> and scalability.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPQ
+*> \verbatim
+*>          COMPQ is CHARACTER*1
+*>          = 'N': do not compute Q;
+*>          = 'I': Q is initialized to the unit matrix, and the
+*>                 orthogonal matrix Q is returned;
+*>          = 'V': Q must contain an orthogonal matrix Q1 on entry,
+*>                 and the product Q1*Q is returned.
+*> \endverbatim
+*>
+*> \param[in] COMPZ
+*> \verbatim
+*>          COMPZ is CHARACTER*1
+*>          = 'N': do not compute Z;
+*>          = 'I': Z is initialized to the unit matrix, and the
+*>                 orthogonal matrix Z is returned;
+*>          = 'V': Z must contain an orthogonal matrix Z1 on entry,
+*>                 and the product Z1*Z is returned.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] ILO
+*> \param[in] IHI
+*> \verbatim
+*>          ILO and IHI are INTEGER
+*>          It is assumed that A is already upper triangular in rows
+*>          and columns 1:ILO-1 and IHI+1:N. ILO and IHI are normally
+*>          set by a previous call to SGGBAL.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array, dimension (LDA, N)
+*>          On entry, the N-by-N general matrix to be reduced.
+*>          On exit, the upper triangle and the first subdiagonal of A
+*>          are overwritten with the upper Hessenberg matrix H.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is REAL array, dimension (LDB, N)
+*>          On entry, the N-by-N upper triangular matrix B.
+*>          On exit, the upper triangular matrix T = Q**T B Z.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] Q
+*> \verbatim
+*>          Q is REAL array, dimension (LDQ, N)
+*>          If COMPQ='N', then Q is not referenced.
+*>          If COMPQ='V', on entry Q must contain an orthogonal matrix.
+*>          If COMPQ='I', on exit Q contains the orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          LDQ >= N if COMPQ='V' or 'I'; LDQ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[in,out] Z
+*> \verbatim
+*>          Z is REAL array, dimension (LDZ, N)
+*>          If COMPZ='N', then Z is not referenced.
+*>          If COMPZ='V', on entry Z must contain an orthogonal matrix.
+*>          If COMPZ='I', on exit Z contains the orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          LDZ >= N if COMPZ='V' or 'I'; LDZ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE SGGHD4( COMPQ, COMPZ, N, ILO, IHI, A, LDA, B, LDB,
+     $                   Q, LDQ, Z, LDZ, WORK, LWORK, INFO )
+*
+* -- LAPACK-like routine --
+*
+* .. Scalar Arguments ..
+      CHARACTER          COMPQ, COMPZ
+      INTEGER            IHI, ILO, INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      REAL   A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            ILQ, ILZ, LQUERY
+      INTEGER            I, J, IERR, IWORK, K, LWKOPT, NCOLS,
+     $                   NITER, COL_LEN, LMIN
+      REAL   EPS, NORM, NORMA, TOL, AMAX
+* ..
+* .. Local Arrays ..
+      REAL   DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      REAL   SLAMCH, SLANGE
+      EXTERNAL           LSAME, SLAMCH, SLANGE
+* ..
+* .. External Subroutines ..
+      EXTERNAL           SGEHRD, SGERQF, SLACPY, SLASET, SORMHR,
+     $                   SORMRQ, STRSM, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, REAL, MAX, MIN
+
+      REAL   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
+* ..
+* .. Executable Statements ..
+*
+* Decode and test the input parameters.
+*
+      INFO = 0
+      ILQ = LSAME( COMPQ, 'V' ) .OR. LSAME( COMPQ, 'I' )
+      ILZ = LSAME( COMPZ, 'V' ) .OR. LSAME( COMPZ, 'I' )
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( .NOT.LSAME( COMPQ, 'N' ) .AND. .NOT.ILQ ) THEN
+         INFO = -1
+      ELSE IF( .NOT.LSAME( COMPZ, 'N' ) .AND. .NOT.ILZ ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( ILO.LT.1 .OR. ILO.GT.MAX( 1, N ) ) THEN
+         INFO = -4
+      ELSE IF( IHI.LT.MIN( ILO, N ) .OR. IHI.GT.N ) THEN
+         INFO = -5
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( ILQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      ELSE IF( ILZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -13
+      END IF
+*
+* Compute optimal workspace.
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 2*( N + 1 )
+         CALL SGEHRD( N, 1, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         CALL SORMHR( 'L', 'T', N, N, 1, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         CALL SGERQF( N, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         CALL SORMRQ( 'R', 'T', N, N, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( WORK( 1 ) ) )
+         LWKOPT = LWKOPT + N*( N + 1 )
+         LMIN = LWKOPT
+         WORK( 1 ) = REAL( LWKOPT )
+         IF( LWORK.LT.LMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -15
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'SGGHD4', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Initialize Q and Z if requested.
+*
+      IF( LSAME( COMPQ, 'I' ) ) THEN
+         CALL SLASET( 'F', N, N, 0.0E0, 1.0E0, Q, LDQ )
+      END IF
+      IF( LSAME( COMPZ, 'I' ) ) THEN
+         CALL SLASET( 'F', N, N, 0.0E0, 1.0E0, Z, LDZ )
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.LE.1 ) RETURN
+*
+      NORMA = SLANGE( 'F', N, N, A, LDA, WORK )
+      EPS = SLAMCH( 'E' )
+      TOL = EPS * NORMA
+      NITER = 0
+      K = ILO
+      IWORK = N*N + 1
+
+      AMAX = ZERO
+      DO J = 1, N
+         DO I = 1, N
+            AMAX = MAX( AMAX, ABS(A(I, J)) )
+         END DO
+      END DO
+      IF (AMAX.EQ.ZERO) THEN
+         AMAX = ONE
+      END IF
+      TOL = EPS * AMAX
+
+*
+* Outer reduction loop: iterate until K reaches IHI or NITER hits 50.
+*
+      DO WHILE( K.LT.IHI .AND. NITER.LT.50 )
+*
+* Inner deflation loop: advance K while subdiagonal entries are small.
+*
+         DO WHILE( K.LT.IHI )
+            COL_LEN = IHI - K - 1
+            
+            IF( COL_LEN.LE.0 ) THEN
+               K = K + 1
+               CYCLE
+            END IF
+            
+            NORM = 0.0E0
+            DO I = 1, COL_LEN
+               NORM = MAX( NORM, ABS( A( K + 1 + I, K ) ) )
+            END DO
+            
+            IF( NORM.GT.TOL ) THEN
+               EXIT
+            END IF
+
+*
+* Deflate strictly bounded values
+*
+            DO I = 1, COL_LEN
+               A( K + 1 + I, K ) = 0.0E0
+            END DO
+            K = K + 1
+         END DO
+
+         IF (K.GE.IHI) THEN
+            EXIT
+         END IF
+
+         NITER = NITER + 1
+         NCOLS = IHI - K + 1
+*
+* Copy A(K:IHI, K:IHI) into X (stored at WORK(1))
+*
+         CALL SLACPY( 'A', NCOLS, NCOLS, A( K, K ), LDA, WORK, NCOLS )
+*
+* STRSM to solve X * B = A
+*
+         CALL STRSM( 'R', 'U', 'N', 'N', NCOLS, NCOLS, ONE / AMAX,
+     $               B( K, K ), LDB, WORK, NCOLS )
+*
+* Hessenberg reduction of X
+*
+         CALL SGEHRD( NCOLS, 1, NCOLS, WORK, NCOLS, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Qc**T to A and B from the left
+*
+         CALL SORMHR( 'L', 'T', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), A( K, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         CALL SORMHR( 'L', 'T', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), B( K, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILQ ) THEN
+            CALL SORMHR( 'R', 'N', N, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                   WORK( IWORK ), Q( 1, K ), LDQ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+
+*
+* RQ factorization of B(K:IHI, K:IHI)
+*
+         CALL SGERQF( NCOLS, NCOLS, B( K, K ), LDB, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**T to A from the right (Updates rows 1:IHI)
+*
+         CALL SORMRQ( 'R', 'T', IHI, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), A( 1, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**T to B from the right (CRITICAL FIX: Updates rows 1:K-1)
+*
+         CALL SORMRQ( 'R', 'T', K-1, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), B( 1, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILZ ) THEN
+            CALL SORMRQ( 'R', 'T', N, NCOLS, NCOLS, B( K, K ), LDB,
+     $                   WORK( IWORK ), Z( 1, K ), LDZ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+*
+* Zero lower triangle of B globally
+*
+         CALL SLASET( 'L', N-1, N-1, 0.0E0, 0.0E0, B( 2, 1 ), LDB )
+
+*
+      END DO
+*
+* End of SGGHD4
+*
+      END SUBROUTINE SGGHD4

--- a/SRC/sggprp.f
+++ b/SRC/sggprp.f
@@ -1,0 +1,297 @@
+*> \brief \b SGGPRP
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> SGGPRP is a preprocessing routine for the generalized 
+*> eigenvalue problem. It prepares the matrices A and B by applying 
+*> an initial Rank-Revealing QR (RRQR) factorization on B, transposing
+*> and reversing arrays, and initializing orthogonal transformation 
+*> matrices Q and Z if requested.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WANTQ
+*> \verbatim
+*>          WANTQ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the orthogonal matrix Q.
+*>          = .FALSE.: Do not compute Q.
+*> \endverbatim
+*>
+*> \param[in] WANTZ
+*> \verbatim
+*>          WANTZ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the orthogonal matrix Z.
+*>          = .FALSE.: Do not compute Z.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A is overwritten by the preprocessed matrix.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is REAL array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B is overwritten by the preprocessed upper 
+*>          triangular matrix from the RRQR factorization.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is REAL array, dimension (LDQ, N)
+*>          If WANTQ = .TRUE., contains the initialized orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          If WANTQ = .TRUE., LDQ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is REAL array, dimension (LDZ, N)
+*>          If WANTZ = .TRUE., contains the initialized orthogonal matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          If WANTZ = .TRUE., LDZ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is REAL array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the norm of B, and 
+*>          WORK(2) returns the tolerance computed.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] JPVT
+*> \verbatim
+*>          JPVT is INTEGER array, dimension (N)
+*>          On exit, contains the pivot indices from SGEQP3.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim      
+      SUBROUTINE SGGPRP( WANTQ, WANTZ, N, A, LDA, B, LDB, Q, LDQ,
+     $                   Z, LDZ, WORK, LWORK, JPVT, INFO )
+*
+* -- LAPACK-style preprocessing routine --
+*
+* .. Scalar Arguments ..
+      LOGICAL            WANTQ, WANTZ
+      INTEGER            INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            JPVT( * )
+      REAL   A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IERR, J, LWKOPT, WORKNEEDED
+      REAL   NORMB, TOL
+* ..
+* .. Local Arrays ..
+      REAL   DUMMY( 1 )
+* ..
+* .. External Subroutines ..
+      EXTERNAL           SGEQP3, SLAREV, SLAPMR, SLATRN, SORGQR, SORMQR,
+     $                   XERBLA
+* ..
+* .. External Functions ..
+      REAL   SLAMCH, SLANGE
+      EXTERNAL           SLAMCH, SLANGE
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          REAL, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input arguments
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( WANTQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( WANTZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      END IF
+*
+* Compute workspace if no argument errors occurred
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 0
+         CALL SGEQP3( N, N, B, LDB, JPVT, DUMMY, DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DUMMY( 1 ) ) )
+*
+         CALL SORMQR( 'R', 'N', N, N, N, B, LDB, DUMMY, A, LDA,
+     $                DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DUMMY( 1 ) ) )
+*
+         CALL SORGQR( N, N, N, Z, LDZ, DUMMY, DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DUMMY( 1 ) ) )
+*
+* Total workspace must accommodate TAU (size N) plus the optimal
+* workspace sizes requested by the underlying routines.
+*
+         WORKNEEDED = N + LWKOPT
+*
+         IF( LWORK.LT.WORKNEEDED .AND. .NOT.LQUERY ) THEN
+            INFO = -13
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'SGGPRP', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         WORK( 1 ) = REAL( WORKNEEDED )
+         RETURN
+      END IF
+*
+* Compute norm of B and tolerance
+*
+      NORMB = SLANGE( 'F', N, N, B, LDB, WORK )
+      TOL = NORMB * SLAMCH( 'E' )
+*
+* B = B^T
+*
+      CALL SLATRN( N, B, LDB )
+*
+* B = B[:, ::-1]
+*
+      CALL SLAREV( 'C', N, N, B, LDB )
+*
+* RRQR(B)
+*
+      DO I = 1, N
+         JPVT( I ) = 0
+      END DO
+      CALL SGEQP3( N, N, B, LDB, JPVT, WORK, WORK( N + 1 ),
+     $             LWORK - N, IERR )
+*
+* A = A[::-1]
+*
+      CALL SLAREV( 'R', N, N, A, LDA )
+*
+* A = A[p]
+*
+      CALL SLAPMR( .TRUE., N, N, A, LDA, JPVT )
+*
+* A = A * Q
+*
+      CALL SORMQR( 'R', 'N', N, N, N, B, LDB, WORK, A, LDA,
+     $             WORK( N + 1 ), LWORK - N, IERR )
+*
+      IF( WANTQ ) THEN
+*
+* Initialize Q = J P J
+* (J is the column index, I is the row index)
+*
+         DO J = 1, N
+            DO I = 1, N
+               Q( I, J ) = 0.0E0
+            END DO
+         END DO
+         DO J = 1, N
+            I = N - JPVT( N - J + 1 ) + 1
+            Q( I, J ) = 1.0E0
+         END DO
+      END IF
+*
+      IF( WANTZ ) THEN
+*
+* Copy B into Z
+*
+         DO J = 1, N
+            DO I = 1, N
+               Z( I, J ) = B( I, J )
+            END DO
+         END DO
+         CALL SORGQR( N, N, N, Z, LDZ, WORK, WORK( N + 1 ),
+     $                LWORK - N, IERR )
+         CALL SLAREV( 'C', N, N, Z, LDZ )
+      END IF
+*
+* A = A[::-1][:, ::-1]
+*
+      CALL SLAREV( 'B', N, N, A, LDA )
+*
+* B = B.T[::-1][:, ::-1]
+* (Zero strictly lower triangle to preserve the R matrix from SGEQP3.
+* J is the column, I is the row.)
+*
+      DO J = 1, N - 1
+         DO I = J + 1, N
+            B( I, J ) = 0.0E0
+         END DO
+      END DO
+*
+      CALL SLATRN( N, B, LDB )
+      CALL SLAREV( 'B', N, N, B, LDB )
+*
+* Store norm and tolerance in the first two elements of WORK
+*
+      WORK( 1 ) = NORMB
+      WORK( 2 ) = TOL
+*
+      RETURN
+*
+* End of SGGPRP
+*
+      END

--- a/SRC/slarev.f
+++ b/SRC/slarev.f
@@ -1,0 +1,115 @@
+*> \brief \b SLAREV
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> SLAREV reverses the order of the rows and/or columns of a given
+*> M-by-N single precision matrix A.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WHICH
+*> \verbatim
+*>          WHICH is CHARACTER*1
+*>          Specifies whether to reverse rows, columns, or both:
+*>          = 'B': Reverse both rows and columns.
+*>          = 'R': Reverse rows only.
+*>          = 'C': Reverse columns only.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array, dimension (LDA, N)
+*>          On entry, the matrix A to be reversed.
+*>          On exit, the elements of A have been swapped according to WHICH.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.
+*> \endverbatim
+      SUBROUTINE SLAREV( WHICH, M, N, A, LDA )
+*     .. Scalar Arguments ..
+      CHARACTER          WHICH
+      INTEGER            M, N, LDA
+*     .. Array Arguments ..
+      REAL   A( LDA, * )
+*     .. Local Scalars ..
+      INTEGER            I, J, M2, N2
+      LOGICAL            ROWODD, COLODD
+      REAL   TMPA, TMPB, TMPC, TMPD
+*     .. Executable Statements ..
+
+      M2 = M / 2
+      N2 = N / 2
+      ROWODD = MOD(M, 2) .NE. 0
+      COLODD = MOD(N, 2) .NE. 0
+
+      IF ( WHICH .EQ. 'B' ) THEN
+         DO I = 1, N2
+            DO J = 1, M2
+               TMPA = A( J, I )
+               TMPB = A( J, N - I + 1 )
+               TMPC = A( M - J + 1, I )
+               TMPD = A( M - J + 1, N - I + 1 )
+               
+               A( J, I ) = TMPD
+               A( J, N - I + 1 ) = TMPC
+               A( M - J + 1, I ) = TMPB
+               A( M - J + 1, N - I + 1 ) = TMPA
+            END DO
+            IF ( ROWODD ) THEN
+               TMPA = A( M2 + 1, I )
+               A( M2 + 1, I ) = A( M2 + 1, N - I + 1 )
+               A( M2 + 1, N - I + 1 ) = TMPA
+            END IF
+         END DO
+         IF ( COLODD ) THEN
+            DO J = 1, M2
+               TMPA = A( J, N2 + 1 )
+               A( J, N2 + 1 ) = A( M - J + 1, N2 + 1 )
+               A( M - J + 1, N2 + 1 ) = TMPA
+            END DO
+         END IF
+
+      ELSE IF ( WHICH .EQ. 'R' ) THEN
+         DO I = 1, N
+            DO J = 1, M2
+               TMPA = A( J, I )
+               A( J, I ) = A( M - J + 1, I )
+               A( M - J + 1, I ) = TMPA
+            END DO
+         END DO
+
+      ELSE IF ( WHICH .EQ. 'C' ) THEN
+         DO I = 1, N2
+            DO J = 1, M
+               TMPA = A( J, I )
+               A( J, I ) = A( J, N - I + 1 )
+               A( J, N - I + 1 ) = TMPA
+            END DO
+         END DO
+      END IF
+
+      RETURN
+      END

--- a/SRC/slatrn.f
+++ b/SRC/slatrn.f
@@ -1,0 +1,125 @@
+*> \brief \b SLATRN
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> SLATRN performs an in-place transpose of an N-by-N single precision
+*> matrix A. It utilizes OpenMP parallelization and a blocked iteration 
+*> scheme to optimize cache usage during the transposition process.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array, dimension (LDA, N)
+*>          On entry, the N-by-N matrix to be transposed.
+*>          On exit, A is overwritten by its transpose.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+      SUBROUTINE SLATRN( N, A, LDA )
+
+#if defined(_OPENMP)
+      use omp_lib
+#endif
+*
+* -- LAPACK auxiliary routine --
+*
+* .. Scalar Arguments ..
+      INTEGER            LDA, N
+* ..
+* .. Array Arguments ..
+      REAL   A( LDA, * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      INTEGER            SIZE
+      PARAMETER          ( SIZE = 16 )
+* ..
+* .. Local Scalars ..
+      INTEGER            BLOCK, I, J, NUM_THREADS, TAIL_START
+      REAL   TEMP
+* ..
+* .. External Functions ..
+#if defined(_OPENMP)
+      INTEGER            OMP_GET_MAX_THREADS
+      EXTERNAL           OMP_GET_MAX_THREADS
+#endif
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          MIN
+* ..
+* .. Executable Statements ..
+*
+#if defined(_OPENMP)
+      IF( N.GE.256 ) THEN
+         NUM_THREADS = N / 64
+      ELSE
+         NUM_THREADS = 1
+      END IF
+      NUM_THREADS = MIN( NUM_THREADS, OMP_GET_MAX_THREADS() )
+#else
+      NUM_THREADS = 1
+#endif
+   
+!$OMP PARALLEL DO PRIVATE( BLOCK, I, J, TEMP )
+!$OMP+            NUM_THREADS( NUM_THREADS ) SCHEDULE( DYNAMIC, 1 )
+      DO BLOCK = 1, N - SIZE + 1, SIZE
+*
+* This pair takes care of the main diagonal block
+         DO I = BLOCK, BLOCK + SIZE - 1
+            DO J = I + 1, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = A( J, I )
+               A( J, I ) = TEMP
+            END DO
+         END DO
+*
+* Transpose sub-matrices not on the main diagonal
+         DO I = BLOCK + SIZE, N
+            DO J = BLOCK, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = A( J, I )
+               A( J, I ) = TEMP
+            END DO
+         END DO
+*
+      END DO
+!$OMP END PARALLEL DO
+*
+* Transpose remaining elements along the main diagonal
+* Note: TAIL_START is explicitly calculated because BLOCK is 
+* undefined outside the OpenMP parallel construct.
+      TAIL_START = ( N / SIZE ) * SIZE + 1
+      DO I = TAIL_START, N
+         DO J = I + 1, N
+            TEMP      = A( I, J )
+            A( I, J ) = A( J, I )
+            A( J, I ) = TEMP
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of SLATRN
+*
+      END

--- a/SRC/zggdef.f
+++ b/SRC/zggdef.f
@@ -1,0 +1,315 @@
+*> \brief \b ZGGDEF
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> ZGGDEF performs the deflation of infinite eigenvalues in the generalized
+*> eigenvalue problem.
+*> It applies QR and RQ factorizations to 
+*> sub-blocks of A and B to properly isolate and deflate these eigenvalues.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPVL
+*> \verbatim
+*>          COMPVL is LOGICAL
+*>          = .TRUE.:  Compute the left Schur vectors (VL).
+*>          = .FALSE.: Do not compute the left Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] COMPVR
+*> \verbatim
+*>          COMPVR is LOGICAL
+*>          = .TRUE.:  Compute the right Schur vectors (VR).
+*>          = .FALSE.: Do not compute the right Schur vectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.
+*>          N >= 0.
+*> \endverbatim
+*>
+*> \param[in] K
+*> \verbatim
+*>          K is INTEGER
+*>          The number of infinite eigenvalues to deflate (the block size).
+*>          0 <= K <= N.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension (LDA, N)
+*>          On entry, the matrix A to be deflated.
+*>          On exit, A has been updated by the unitary transformations.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX*16 array, dimension (LDB, N)
+*>          On entry, the matrix B to be deflated.
+*>          On exit, B has been updated by the unitary transformations.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VL
+*> \verbatim
+*>          VL is COMPLEX*16 array, dimension (LDVL, N)
+*>          If COMPVL = .TRUE., the left Schur vectors are accumulated in VL.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL.
+*>          If COMPVL = .TRUE., LDVL >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] VR
+*> \verbatim
+*>          VR is COMPLEX*16 array, dimension (LDVR, N)
+*>          If COMPVR = .TRUE., the right Schur vectors are accumulated in VR.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR.
+*>          If COMPVR = .TRUE., LDVR >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          LWORK >= max(1, 2*N).
+*>          If LWORK = -1, then a workspace query is assumed;
+*>          the routine
+*>          only calculates the optimal size of the WORK array.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE ZGGDEF( COMPVL, COMPVR, N, K, A, LDA, B, LDB, VL,
+     $                   LDVL, VR, LDVR, WORK, LWORK, INFO )
+*
+* -- LAPACK-style Code --
+*
+* .. Scalar Arguments ..
+      LOGICAL            COMPVL, COMPVR
+      INTEGER            INFO, K, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      COMPLEX*16         A( LDA, * ), B( LDB, * ), VL( LDVL, * ),
+     $                   VR( LDVR, * ), WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IINFO, J, LWKOPT
+* ..
+* .. External Subroutines ..
+      EXTERNAL           ZGEQRF, ZGERQF, ZUNMQR, ZUNMRQ, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          DBLE, DCMPLX, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input parameters.
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( K.LT.0 .OR. K.GT.N ) THEN
+         INFO = -4
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -6
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -8
+      ELSE IF( COMPVL .AND. LDVL.LT.MAX( 1, N ) ) THEN
+         INFO = -10
+      ELSE IF( COMPVR .AND. LDVR.LT.MAX( 1, N ) ) THEN
+         INFO = -12
+      ELSE IF( LWORK.LT.MAX( 1, 2*N ) .AND. .NOT.LQUERY ) THEN
+* Minimum workspace is N elements for TAU arrays + N elements for routines
+         INFO = -14
+      END IF
+*
+      IF( INFO.EQ.0 ) THEN
+*
+* Compute optimal workspace
+*
+         LWKOPT = MAX( 1, 2*N )
+         IF( K.GT.0 ) THEN
+            CALL ZGEQRF( N, K, A, LDA, WORK, WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( DBLE( WORK( 1 ) ) ) )
+*
+            IF( N.GT.K ) THEN
+               CALL ZUNMQR( 'L', 'C', N, N - K, K, A, LDA, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( DBLE( WORK( 1 ) ) ) )
+            END IF
+*
+            IF( COMPVL ) THEN
+               CALL ZUNMQR( 'R', 'N', N, N, K, A, LDA, WORK, VL,
+     $                      LDVL, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( DBLE( WORK( 1 ) ) ) )
+            END IF
+         END IF
+*
+         IF( N.GT.K ) THEN
+            CALL ZGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB, WORK,
+     $                   WORK, -1, IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( DBLE( WORK( 1 ) ) ) )
+*
+            IINFO = -1
+            CALL ZUNMRQ( 'R', 'C', N, N - K, N - K, 
+     $                   B( K + 1, K + 1 ),
+     $                   LDB, WORK, A( 1, K + 1 ), LDA, WORK, -1,
+     $                   IINFO )
+            LWKOPT = MAX( LWKOPT, N + INT( DBLE( WORK( 1 ) ) ) )
+*
+            IF( K.GT.0 ) THEN
+               CALL ZUNMRQ( 'R', 'C', K, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      B( 1, K + 1 ), LDB, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( DBLE( WORK( 1 ) ) ) )
+            END IF
+*
+            IF( COMPVR ) THEN
+               CALL ZUNMRQ( 'R', 'C', N, N - K, N - K,
+     $                      B( K + 1, K + 1 ), LDB, WORK,
+     $                      VR( 1, K + 1 ), LDVR, WORK, -1, IINFO )
+               LWKOPT = MAX( LWKOPT, N + INT( DBLE( WORK( 1 ) ) ) )
+            END IF
+         END IF
+*
+         WORK( 1 ) = DCMPLX( DBLE( LWKOPT ), 0.0D0 )
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'ZGGDEF', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+* QR portion
+* Factorize A(1:N, 1:K)
+* WORK(1:K) holds the TAU scalar factors for A
+*
+      IF( K.GT.0 ) THEN
+         CALL ZGEQRF( N, K, A, LDA, WORK( 1 ), WORK( N + 1 ),
+     $                LWORK - N, IINFO )
+*
+* Apply Q^H to A(1:N, K+1:N)
+*
+         IF( N.GT.K ) THEN
+            CALL ZUNMQR( 'L', 'C', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   A( 1, K + 1 ), LDA, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+*
+* Apply Q^H to B(1:N, K+1:N)
+*
+            CALL ZUNMQR( 'L', 'C', N, N - K, K, A, LDA, WORK( 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVL ) THEN
+* Accumulate Q in VL: VL = VL * Q
+            CALL ZUNMQR( 'R', 'N', N, N, K, A, LDA, WORK( 1 ), VL,
+     $                   LDVL, WORK( N + 1 ), LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* RQ portion
+* Factorize B(K+1:N, K+1:N)
+* WORK(K+1:N) holds the TAU scalar factors for B
+*
+      IF( N.GT.K ) THEN
+         CALL ZGERQF( N - K, N - K, B( K + 1, K + 1 ), LDB,
+     $                WORK( K + 1 ), WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^H to A(1:N, K+1:N) from the right: A = A * Q^H
+*
+         CALL ZUNMRQ( 'R', 'C', N, N - K, N - K, B( K + 1, K + 1 ),
+     $                LDB, WORK( K + 1 ), A( 1, K + 1 ), LDA,
+     $                WORK( N + 1 ), LWORK - N, IINFO )
+*
+* Apply Q^H to B(1:K, K+1:N) from the right: B = B * Q^H
+*
+         IF( K.GT.0 ) THEN
+            CALL ZUNMRQ( 'R', 'C', K, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   B( 1, K + 1 ), LDB, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+*
+         IF( COMPVR ) THEN
+* Accumulate Q^H in VR: VR(1:N, K+1:N) = VR(1:N, K+1:N) * Q^H
+            CALL ZUNMRQ( 'R', 'C', N, N - K, N - K,
+     $                   B( K + 1, K + 1 ), LDB, WORK( K + 1 ),
+     $                   VR( 1, K + 1 ), LDVR, WORK( N + 1 ),
+     $                   LWORK - N, IINFO )
+         END IF
+      END IF
+*
+* Zero out strictly lower triangular parts
+*
+      DO J = 1, K
+         DO I = J + 1, N
+            A( I, J ) = ( 0.0D0, 0.0D0 )
+         END DO
+      END DO
+*
+      DO J = K + 1, N
+         DO I = J + 1, N
+            B( I, J ) = ( 0.0D0, 0.0D0 )
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of ZGGDEF
+*
+      END

--- a/SRC/zggev4.f
+++ b/SRC/zggev4.f
@@ -1,0 +1,378 @@
+*> \brief \b ZGGEV4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> ZGGEV4 computes for a pair of N-by-N complex nonsymmetric matrices 
+*> (A,B) the generalized eigenvalues, and optionally, the left and/or 
+*> right generalized eigenvectors.
+*> 
+*> This routine performs the following steps:
+*> 1) Preprocessing (ZGGPRP) 
+*> 2) Deflation of infinite eigenvalues (ZGGDEF) 
+*> 3) Blocked Hessenberg-Triangular Reduction (ZGGHD4) 
+*> 4) QZ algorithm (ZLAQZ0) 
+*> 5) Eigenvector computation and normalization.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] JOBVL
+*> \verbatim
+*>          JOBVL is CHARACTER*1
+*>          = 'N':  do not compute the left generalized eigenvectors;
+*>          = 'V':  compute the left generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] JOBVR
+*> \verbatim
+*>          JOBVR is CHARACTER*1
+*>          = 'N':  do not compute the right generalized eigenvectors;
+*>          = 'V':  compute the right generalized eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A, B, VL, and VR.
+*>          N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX*16 array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B has been overwritten.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] ALPHA
+*> \verbatim
+*>          ALPHA is COMPLEX*16 array, dimension (N)
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is COMPLEX*16 array, dimension (N)
+*>          ALPHA(j)/BETA(j), j=1,...,N, will be the
+*>          generalized eigenvalues.
+*>          Deflated infinite eigenvalues will set BETA to zero.
+*> \endverbatim
+*>
+*> \param[out] VL
+*> \verbatim
+*>          VL is COMPLEX*16 array, dimension (LDVL, N)
+*>          If JOBVL = 'V', the left eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVL
+*> \verbatim
+*>          LDVL is INTEGER
+*>          The leading dimension of the array VL.
+*>          LDVL >= 1, and if JOBVL = 'V', LDVL >= N.
+*> \endverbatim
+*>
+*> \param[out] VR
+*> \verbatim
+*>          VR is COMPLEX*16 array, dimension (LDVR, N)
+*>          If JOBVR = 'V', the right eigenvectors are stored here.
+*> \endverbatim
+*>
+*> \param[in] LDVR
+*> \verbatim
+*>          LDVR is INTEGER
+*>          The leading dimension of the array VR.
+*>          LDVR >= 1, and if JOBVR = 'V', LDVR >= N.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the number of deflated 
+*>          infinite eigenvalues.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is DOUBLE PRECISION array, dimension (MAX(1, 8*N))
+*>          Workspace required for real magnitudes and operations.
+*> \endverbatim
+*>
+*> \param[out] IWORK
+*> \verbatim
+*>          IWORK is INTEGER array, dimension (N)
+*>          Pivot indices from preprocessing.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE ZGGEV4( JOBVL, JOBVR, N, A, LDA, B, LDB, ALPHA,
+     $                   BETA, VL, LDVL, VR, LDVR, WORK,
+     $                   LWORK, RWORK, IWORK, INFO )
+*
+* .. Scalar Arguments ..
+      CHARACTER          JOBVL, JOBVR
+      INTEGER            INFO, LDA, LDB, LDVL, LDVR, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            IWORK( * )
+      DOUBLE PRECISION   RWORK( * )
+      COMPLEX*16         A( LDA, * ), ALPHA( * ), B( LDB, * ),
+     $                   BETA( * ), VL( LDVL, * ), VR( LDVR, * ),
+     $                   WORK( * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      DOUBLE PRECISION   RZERO, RONE
+      PARAMETER          ( RZERO = 0.0D+0, RONE = 1.0D+0 )
+      COMPLEX*16         CZERO, CONE, X
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ), 
+     $                     CONE  = ( 1.0D+0, 0.0D+0 ) )
+* ..
+* .. Local Scalars ..
+      LOGICAL            COMPVL, COMPVR, LQUERY
+      CHARACTER          JOBQZ, JOBVEC
+*
+* IHI is added to support balancing: ZGGBAL sets ILO and IHI to
+* indicate the submatrix that was balanced. IHI is not needed by
+* the existing pipeline but is required by ZGGBAK.
+*
+      INTEGER            I, IN, J, K, NINFINITE, WORKNEEDED, ILO
+      DOUBLE PRECISION   RTMP, TOL
+* ..
+* .. Local Arrays ..
+      LOGICAL            LDUMMY( 1 )
+      COMPLEX*16         DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      EXTERNAL           LSAME
+* ..
+* .. External Subroutines ..
+*
+* ZGGBAL / ZGGBAK added for balancing (same as ZGGEV3).
+*
+      EXTERNAL           ZGEQRF, ZGERQF, ZGGBAL, ZGGBAK, ZGGDEF,
+     $                   ZGGHD4, ZGGPRP, ZLAQZ0, ZUNMQR, ZUNMRQ,
+     $                   ZTGEVC, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, DBLE, DCMPLX, INT, MAX, MIN
+* ..
+* .. Executable Statements ..
+*
+      ABS1(X) = ABS( DBLE( X ) ) + ABS( DIMAG( X ) )
+
+      COMPVL = LSAME( JOBVL, 'V' )
+      COMPVR = LSAME( JOBVR, 'V' )
+      IF( COMPVL .OR. COMPVR ) THEN
+         JOBQZ = 'S'
+      ELSE
+         JOBQZ = 'E'
+      END IF
+*
+* LAPACK style argument checks
+      INFO = 0
+      IF( .NOT.COMPVL .AND. .NOT.LSAME( JOBVL, 'N' ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.COMPVR .AND. .NOT.LSAME( JOBVR, 'N' ) ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDVL.LT.1 .OR. ( COMPVL .AND. LDVL.LT.N ) ) THEN
+         INFO = -11
+      ELSE IF( LDVR.LT.1 .OR. ( COMPVR .AND. LDVR.LT.N ) ) THEN
+         INFO = -13
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'ZGGEV4', -INFO )
+         RETURN
+       END IF
+*
+      IF( COMPVL .AND. COMPVR ) THEN
+         JOBVEC = 'B'
+      ELSE IF( COMPVL ) THEN
+         JOBVEC = 'L'
+      ELSE IF( COMPVR ) THEN
+         JOBVEC = 'R'
+      ELSE
+         JOBVEC = 'N'
+      END IF
+*
+* Workspace queries
+      LQUERY = ( LWORK.EQ.-1 )
+      WORKNEEDED = 0
+*
+      CALL ZGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, DUMMY, -1, RWORK, IWORK, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DBLE( DUMMY( 1 ) ) ) )
+      CALL ZGGHD4( JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB, VL, LDVL,
+     $             VR, LDVR, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DBLE( DUMMY( 1 ) ) ) )
+      CALL ZGEQRF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DBLE( DUMMY( 1 ) ) ) )
+      CALL ZUNMQR( 'L', 'C', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DBLE( DUMMY( 1 ) ) ) )
+      CALL ZGERQF( N, N, A, LDA, DUMMY, DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DBLE( DUMMY( 1 ) ) ) )
+      CALL ZUNMRQ( 'L', 'C', N, N, N, A, LDA, DUMMY, DUMMY, N,
+     $             DUMMY, -1, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DBLE( DUMMY( 1 ) ) ) )
+      CALL ZLAQZ0( JOBQZ, JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB,
+     $             ALPHA, BETA, VL, LDVL, VR, LDVR, DUMMY,
+     $             -1, RWORK, 0, INFO )
+      WORKNEEDED = MAX( WORKNEEDED, INT( DBLE( DUMMY( 1 ) ) ) )
+*
+* ZGGBAL does not use a workspace query; it always needs 6*N
+* elements. Ensure the workspace is large enough to accommodate it.
+*
+      WORKNEEDED = MAX( WORKNEEDED, 6*N )
+*
+      IF( LQUERY ) THEN
+         WORK( 1 ) = DCMPLX( DBLE( WORKNEEDED ), 0.0D+0 )
+         RETURN
+      END IF
+
+* ---------------------------------------------------------------
+*
+* Step 1: Preprocessing
+      CALL ZGGPRP( COMPVL, COMPVR, N, A, LDA, B, LDB, VL, LDVL, VR,
+     $             LDVR, WORK, LWORK, RWORK, IWORK, INFO )
+
+      TOL = RWORK( 2 )
+      NINFINITE = 0
+      DO K = 1, N
+         IF (TOL.LT.ABS(B(K, K))) THEN
+            EXIT
+         END IF
+         NINFINITE = NINFINITE + 1
+         DO I = 1, NINFINITE
+            B(I, K) = CZERO
+         END DO
+      END DO
+
+*
+* Step 2: Deflation of infinite eigenvalues
+      IF( NINFINITE.GT.0 ) THEN
+         CALL ZGGDEF( COMPVL, COMPVR, N, NINFINITE, A, LDA, B, LDB,
+     $                VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+      END IF
+
+      DO I = 1, NINFINITE
+         ALPHA(I) = A(I, I)
+         BETA(I) = CZERO
+      END DO
+
+*
+* Add small perturbation to B if needed
+      DO I = NINFINITE + 1, N
+         IF (ABS(B(I, I)).LE.TOL) THEN
+            B(I, I) = DCMPLX( TOL, RZERO )
+         END IF
+      END DO
+*
+* ---------------------------------------------------------------
+*
+* Step 3: Hessenberg-Triangular Reduction
+*
+      ILO = MIN( N, NINFINITE + 1 )
+      CALL ZGGHD4( JOBVL, JOBVR, N, ILO, N, A, LDA, B, LDB,
+     $             VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+
+*
+* ---------------------------------------------------------------
+*
+* Step 4: QZ
+* Use the balanced ILO (not the raw NINFINITE+1) so that ZLAQZ0
+* operates on exactly the same submatrix that ZGGHD4 reduced to
+* Hessenberg-triangular form. Rows NINFINITE+1..ILO-1 were
+* identified by ZGGBAL as already decoupled and were skipped by
+* ZGGHD4; passing NINFINITE+1 here would hand ZLAQZ0 a
+* non-Hessenberg leading block.
+      IF( NINFINITE.NE.N ) THEN
+         CALL ZLAQZ0( JOBQZ, JOBVL, JOBVR, N, ILO, N, A, LDA,
+     $                B, LDB, ALPHA, BETA, VL, LDVL, VR, LDVR,
+     $                WORK, LWORK, RWORK, 0, INFO )
+      END IF
+*
+* Step 5: Eigenvectors
+      IF( COMPVL .OR. COMPVR ) THEN
+         CALL ZTGEVC( JOBVEC, 'B', LDUMMY, N, A, LDA, B, LDB, VL, LDVL,
+     $                VR, LDVR, N, IN, WORK, RWORK, INFO )
+      END IF
+*
+* ---------------------------------------------------------------
+*
+* Normalise left eigenvectors
+      IF( COMPVL ) THEN
+         DO I = 1, N
+            RTMP = RZERO
+            DO J = 1, N
+               RTMP = MAX( RTMP, ABS1( VL( J, I ) ) )
+            END DO
+            RTMP = RONE / RTMP
+            DO J = 1, N
+               VL( J, I ) = VL( J, I ) * DCMPLX( RTMP, RZERO )
+            END DO
+         END DO
+      END IF
+*
+* Normalise right eigenvectors
+      IF( COMPVR ) THEN
+         DO I = 1, N
+            RTMP = RZERO
+            DO J = 1, N
+               RTMP = MAX( RTMP, ABS1( VR( J, I ) ) )
+            END DO
+            RTMP = RONE / RTMP
+            DO J = 1, N
+               VR( J, I ) = VR( J, I ) * DCMPLX( RTMP, RZERO )
+            END DO
+         END DO
+      END IF
+*
+      WORK( 1 ) = DCMPLX( DBLE( NINFINITE ), RZERO )
+      RETURN
+      END SUBROUTINE ZGGEV4

--- a/SRC/zgghd4.f
+++ b/SRC/zgghd4.f
@@ -1,0 +1,369 @@
+*> \brief \b ZGGHD4
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> ZGGHD4 reduces a pair of complex matrices (A,B) to generalized upper
+*> Hessenberg form using unitary transformations, where A is a
+*> Hessenberg matrix and B is upper triangular. This routine
+*> employs a blocked algorithm (Steel et al) to improve efficiency
+*> and scalability.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] COMPQ
+*> \verbatim
+*>          COMPQ is CHARACTER*1
+*>          = 'N': do not compute Q;
+*>          = 'I': Q is initialized to the unit matrix, and the
+*>                 unitary matrix Q is returned;
+*>          = 'V': Q must contain a unitary matrix Q1 on entry,
+*>                 and the product Q1*Q is returned.
+*> \endverbatim
+*>
+*> \param[in] COMPZ
+*> \verbatim
+*>          COMPZ is CHARACTER*1
+*>          = 'N': do not compute Z;
+*>          = 'I': Z is initialized to the unit matrix, and the
+*>                 unitary matrix Z is returned;
+*>          = 'V': Z must contain a unitary matrix Z1 on entry,
+*>                 and the product Z1*Z is returned.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in] ILO
+*> \param[in] IHI
+*> \verbatim
+*>          ILO and IHI are INTEGER
+*>          It is assumed that A is already upper triangular in rows
+*>          and columns 1:ILO-1 and IHI+1:N. ILO and IHI are normally
+*>          set by a previous call to ZGGBAL.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension (LDA, N)
+*>          On entry, the N-by-N general matrix to be reduced.
+*>          On exit, the upper triangle and the first subdiagonal of A
+*>          are overwritten with the upper Hessenberg matrix H.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX*16 array, dimension (LDB, N)
+*>          On entry, the N-by-N upper triangular matrix B.
+*>          On exit, the upper triangular matrix T = Q**H B Z.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] Q
+*> \verbatim
+*>          Q is COMPLEX*16 array, dimension (LDQ, N)
+*>          If COMPQ='N', then Q is not referenced.
+*>          If COMPQ='V', on entry Q must contain a unitary matrix.
+*>          If COMPQ='I', on exit Q contains the unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          LDQ >= N if COMPQ='V' or 'I'; LDQ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[in,out] Z
+*> \verbatim
+*>          Z is COMPLEX*16 array, dimension (LDZ, N)
+*>          If COMPZ='N', then Z is not referenced.
+*>          If COMPZ='V', on entry Z must contain a unitary matrix.
+*>          If COMPZ='I', on exit Z contains the unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          LDZ >= N if COMPZ='V' or 'I'; LDZ >= 1 otherwise.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim
+      SUBROUTINE ZGGHD4( COMPQ, COMPZ, N, ILO, IHI, A, LDA, B, LDB,
+     $                   Q, LDQ, Z, LDZ, WORK, LWORK, INFO )
+*
+* -- LAPACK-like routine --
+*
+* .. Scalar Arguments ..
+      CHARACTER          COMPQ, COMPZ
+      INTEGER            IHI, ILO, INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      COMPLEX*16         A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            ILQ, ILZ, LQUERY
+      INTEGER            I, J, IERR, IWORK, K, LWKOPT, NCOLS,
+     $                   NITER, COL_LEN, LMIN
+      DOUBLE PRECISION   EPS, NORM, NORMA, TOL, AMAX
+* ..
+* .. Local Arrays ..
+      DOUBLE PRECISION   RWORK( 1 )
+      COMPLEX*16         DUMMY( 1 )
+* ..
+* .. External Functions ..
+      LOGICAL            LSAME
+      DOUBLE PRECISION   DLAMCH, ZLANGE
+      EXTERNAL           LSAME, DLAMCH, ZLANGE
+* ..
+* .. External Subroutines ..
+      EXTERNAL           ZGEHRD, ZGERQF, ZLACPY, ZLASET, ZUNMHR,
+     $                   ZUNMRQ, ZTRSM, XERBLA
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          ABS, DBLE, DCMPLX, MAX, MIN
+* ..
+* .. Parameters ..
+      COMPLEX*16         CZERO, CONE
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ), 
+     $                     CONE  = ( 1.0D+0, 0.0D+0 ) )
+      DOUBLE PRECISION   RZERO, RONE
+      PARAMETER          ( RZERO = 0.0D+0, RONE = 1.0D+0 )
+* ..
+* .. Executable Statements ..
+*
+* Decode and test the input parameters.
+*
+      INFO = 0
+      ILQ = LSAME( COMPQ, 'V' ) .OR. LSAME( COMPQ, 'I' )
+      ILZ = LSAME( COMPZ, 'V' ) .OR. LSAME( COMPZ, 'I' )
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( .NOT.LSAME( COMPQ, 'N' ) .AND. .NOT.ILQ ) THEN
+         INFO = -1
+      ELSE IF( .NOT.LSAME( COMPZ, 'N' ) .AND. .NOT.ILZ ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( ILO.LT.1 .OR. ILO.GT.MAX( 1, N ) ) THEN
+         INFO = -4
+      ELSE IF( IHI.LT.MIN( ILO, N ) .OR. IHI.GT.N ) THEN
+         INFO = -5
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( ILQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      ELSE IF( ILZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -13
+      END IF
+*
+* Compute optimal workspace.
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 2*( N + 1 )
+         CALL ZGEHRD( N, 1, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DBLE( WORK( 1 ) ) ) )
+         CALL ZUNMHR( 'L', 'C', N, N, 1, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DBLE( WORK( 1 ) ) ) )
+         CALL ZGERQF( N, N, A, LDA, DUMMY, WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DBLE( WORK( 1 ) ) ) )
+         CALL ZUNMRQ( 'R', 'C', N, N, N, A, LDA, DUMMY, A, LDA,
+     $                WORK, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DBLE( WORK( 1 ) ) ) )
+         LWKOPT = LWKOPT + N*( N + 1 )
+         LMIN = LWKOPT
+         WORK( 1 ) = DCMPLX( DBLE( LWKOPT ), 0.0D+0 )
+         IF( LWORK.LT.LMIN .AND. .NOT.LQUERY ) THEN
+            INFO = -15
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'ZGGHD4', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         RETURN
+      END IF
+*
+* Initialize Q and Z if requested.
+*
+      IF( LSAME( COMPQ, 'I' ) ) THEN
+         CALL ZLASET( 'F', N, N, CZERO, CONE, Q, LDQ )
+      END IF
+      IF( LSAME( COMPZ, 'I' ) ) THEN
+         CALL ZLASET( 'F', N, N, CZERO, CONE, Z, LDZ )
+      END IF
+*
+* Quick return if possible
+*
+      IF( N.LE.1 ) RETURN
+*
+      NORMA = ZLANGE( 'F', N, N, A, LDA, RWORK )
+      EPS = DLAMCH( 'E' )
+      TOL = EPS * NORMA
+      NITER = 0
+      K = ILO
+      IWORK = N*N + 1
+
+      AMAX = RZERO
+      DO J = 1, N
+         DO I = 1, N
+            AMAX = MAX( AMAX, ABS(A(I, J)) )
+         END DO
+      END DO
+      IF (AMAX.EQ.RZERO) THEN
+         AMAX = RONE
+      END IF
+      TOL = EPS * AMAX
+
+*
+* Outer reduction loop: iterate until K reaches IHI or NITER hits 50.
+*
+      DO WHILE( K.LT.IHI .AND. NITER.LT.50 )
+*
+* Inner deflation loop: advance K while subdiagonal entries are small.
+*
+         DO WHILE( K.LT.IHI )
+            COL_LEN = IHI - K - 1
+            
+            IF( COL_LEN.LE.0 ) THEN
+               K = K + 1
+               CYCLE
+            END IF
+            
+            NORM = RZERO
+            DO I = 1, COL_LEN
+               NORM = MAX( NORM, ABS( A( K + 1 + I, K ) ) )
+            END DO
+            
+            IF( NORM.GT.TOL ) THEN
+               EXIT
+            END IF
+
+*
+* Deflate strictly bounded values
+*
+            DO I = 1, COL_LEN
+               A( K + 1 + I, K ) = CZERO
+            END DO
+            K = K + 1
+         END DO
+
+         IF (K.GE.IHI) THEN
+            EXIT
+         END IF
+
+         NITER = NITER + 1
+         NCOLS = IHI - K + 1
+*
+* Copy A(K:IHI, K:IHI) into X (stored at WORK(1))
+*
+         CALL ZLACPY( 'A', NCOLS, NCOLS, A( K, K ), LDA, WORK, NCOLS )
+*
+* ZTRSM to solve X * B = A
+*
+         CALL ZTRSM( 'R', 'U', 'N', 'N', NCOLS, NCOLS, 
+     $               DCMPLX( RONE / AMAX, RZERO ), B( K, K ), LDB, 
+     $               WORK, NCOLS )
+*
+* Hessenberg reduction of X
+*
+         CALL ZGEHRD( NCOLS, 1, NCOLS, WORK, NCOLS, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Qc**H to A and B from the left
+*
+         CALL ZUNMHR( 'L', 'C', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), A( K, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         CALL ZUNMHR( 'L', 'C', NCOLS, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                WORK( IWORK ), B( K, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILQ ) THEN
+            CALL ZUNMHR( 'R', 'N', N, NCOLS, 1, NCOLS, WORK, NCOLS,
+     $                   WORK( IWORK ), Q( 1, K ), LDQ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+
+*
+* RQ factorization of B(K:IHI, K:IHI)
+*
+         CALL ZGERQF( NCOLS, NCOLS, B( K, K ), LDB, WORK( IWORK ),
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**H to A from the right (Updates rows 1:IHI)
+*
+         CALL ZUNMRQ( 'R', 'C', IHI, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), A( 1, K ), LDA,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+*
+* Apply Zc**H to B from the right (CRITICAL FIX: Updates rows 1:K-1)
+*
+         CALL ZUNMRQ( 'R', 'C', K-1, NCOLS, NCOLS, B( K, K ), LDB,
+     $                WORK( IWORK ), B( 1, K ), LDB,
+     $                WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1, IERR )
+         IF( ILZ ) THEN
+            CALL ZUNMRQ( 'R', 'C', N, NCOLS, NCOLS, B( K, K ), LDB,
+     $                   WORK( IWORK ), Z( 1, K ), LDZ,
+     $                   WORK( IWORK+NCOLS ), LWORK-IWORK-NCOLS+1,
+     $                   IERR )
+         END IF
+*
+* Zero lower triangle of B globally
+*
+         CALL ZLASET( 'L', N-1, N-1, CZERO, CZERO, B( 2, 1 ), LDB )
+
+*
+      END DO
+*
+* End of ZGGHD4
+*
+      END SUBROUTINE ZGGHD4

--- a/SRC/zggprp.f
+++ b/SRC/zggprp.f
@@ -1,0 +1,308 @@
+*> \brief \b ZGGPRP
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> ZGGPRP is a preprocessing routine for the generalized 
+*> eigenvalue problem.
+*> It prepares the matrices A and B by applying 
+*> an initial Rank-Revealing QR (RRQR) factorization on B, transposing
+*> and reversing arrays, and initializing unitary transformation 
+*> matrices Q and Z if requested.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WANTQ
+*> \verbatim
+*>          WANTQ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the unitary matrix Q.
+*>          = .FALSE.: Do not compute Q.
+*> \endverbatim
+*>
+*> \param[in] WANTZ
+*> \verbatim
+*>          WANTZ is LOGICAL
+*>          = .TRUE.:  Initialize and compute the unitary matrix Z.
+*>          = .FALSE.: Do not compute Z.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrices A and B.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension (LDA, N)
+*>          On entry, the matrix A.
+*>          On exit, A is overwritten by the preprocessed matrix.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX*16 array, dimension (LDB, N)
+*>          On entry, the matrix B.
+*>          On exit, B is overwritten by the preprocessed upper 
+*>          triangular matrix from the RRQR factorization.
+*> \endverbatim
+*>
+*> \param[in] LDB
+*> \verbatim
+*>          LDB is INTEGER
+*>          The leading dimension of the array B.  LDB >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is COMPLEX*16 array, dimension (LDQ, N)
+*>          If WANTQ = .TRUE., contains the initialized unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of the array Q.
+*>          If WANTQ = .TRUE., LDQ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is COMPLEX*16 array, dimension (LDZ, N)
+*>          If WANTZ = .TRUE., contains the initialized unitary matrix.
+*> \endverbatim
+*>
+*> \param[in] LDZ
+*> \verbatim
+*>          LDZ is INTEGER
+*>          The leading dimension of the array Z.
+*>          If WANTZ = .TRUE., LDZ >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX*16 array, dimension (MAX(1,LWORK))
+*>          On exit, if INFO = 0, WORK(1) returns the optimal LWORK.
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The dimension of the array WORK.
+*>          If LWORK = -1, then a workspace query is assumed.
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is DOUBLE PRECISION array, dimension (MAX(1, 2*N))
+*>          On exit, if INFO = 0, RWORK(1) returns the norm of B, and 
+*>          RWORK(2) returns the tolerance computed.
+*> \endverbatim
+*>
+*> \param[out] JPVT
+*> \verbatim
+*>          JPVT is INTEGER array, dimension (N)
+*>          On exit, contains the pivot indices from ZGEQP3.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit.
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*> \endverbatim      
+      SUBROUTINE ZGGPRP( WANTQ, WANTZ, N, A, LDA, B, LDB, Q, LDQ,
+     $                   Z, LDZ, WORK, LWORK, RWORK, JPVT, INFO )
+*
+* -- LAPACK-style preprocessing routine --
+*
+* .. Scalar Arguments ..
+      LOGICAL            WANTQ, WANTZ
+      INTEGER            INFO, LDA, LDB, LDQ, LDZ, LWORK, N
+* ..
+* .. Array Arguments ..
+      INTEGER            JPVT( * )
+      DOUBLE PRECISION   RWORK( * )
+      COMPLEX*16         A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
+     $                   WORK( * ), Z( LDZ, * )
+* ..
+*
+* =====================================================================
+*
+* .. Local Scalars ..
+      LOGICAL            LQUERY
+      INTEGER            I, IERR, J, LWKOPT, WORKNEEDED
+      DOUBLE PRECISION   NORMB, TOL
+* ..
+* .. Local Arrays ..
+      COMPLEX*16         DUMMY( 1 )
+* ..
+* .. External Subroutines ..
+      EXTERNAL           ZGEQP3, ZLAREV, ZLAPMR, ZLATRN, ZUNGQR, ZUNMQR,
+     $                   XERBLA
+* ..
+* .. External Functions ..
+      DOUBLE PRECISION   DLAMCH, ZLANGE
+      EXTERNAL           DLAMCH, ZLANGE
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          DBLE, DCMPLX, INT, MAX
+* ..
+* .. Executable Statements ..
+*
+* Test the input arguments
+*
+      INFO = 0
+      LQUERY = ( LWORK.EQ.-1 )
+*
+      IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      ELSE IF( LDB.LT.MAX( 1, N ) ) THEN
+         INFO = -7
+      ELSE IF( WANTQ .AND. LDQ.LT.MAX( 1, N ) ) THEN
+         INFO = -9
+      ELSE IF( WANTZ .AND. LDZ.LT.MAX( 1, N ) ) THEN
+         INFO = -11
+      END IF
+*
+* Compute workspace if no argument errors occurred
+*
+      IF( INFO.EQ.0 ) THEN
+         LWKOPT = 0
+         CALL ZGEQP3( N, N, B, LDB, JPVT, DUMMY, DUMMY, -1, RWORK, 
+     $                IERR )
+         LWKOPT = MAX( LWKOPT, INT( DBLE( DUMMY( 1 ) ) ) )
+*
+         CALL ZUNMQR( 'R', 'N', N, N, N, B, LDB, DUMMY, A, LDA,
+     $                DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DBLE( DUMMY( 1 ) ) ) )
+*
+         CALL ZUNGQR( N, N, N, Z, LDZ, DUMMY, DUMMY, -1, IERR )
+         LWKOPT = MAX( LWKOPT, INT( DBLE( DUMMY( 1 ) ) ) )
+*
+* Total workspace must accommodate TAU (size N) plus the optimal
+* workspace sizes requested by the underlying routines.
+*
+         WORKNEEDED = N + LWKOPT
+*
+         IF( LWORK.LT.WORKNEEDED .AND. .NOT.LQUERY ) THEN
+            INFO = -13
+         END IF
+      END IF
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'ZGGPRP', -INFO )
+         RETURN
+      ELSE IF( LQUERY ) THEN
+         WORK( 1 ) = DCMPLX( DBLE( WORKNEEDED ), 0.0D0 )
+         RETURN
+      END IF
+*
+* Compute norm of B and tolerance
+*
+      NORMB = ZLANGE( 'F', N, N, B, LDB, RWORK )
+      TOL = NORMB * DLAMCH( 'E' )
+*
+* B = B^T
+*
+      CALL ZLATRN( N, B, LDB )
+*
+* B = B[:, ::-1]
+*
+      CALL ZLAREV( 'C', N, N, B, LDB )
+*
+* RRQR(B)
+*
+      DO I = 1, N
+         JPVT( I ) = 0
+      END DO
+      CALL ZGEQP3( N, N, B, LDB, JPVT, WORK, WORK( N + 1 ),
+     $             LWORK - N, RWORK, IERR )
+*
+* A = A[::-1]
+*
+      CALL ZLAREV( 'R', N, N, A, LDA )
+*
+* A = A[p]
+*
+      CALL ZLAPMR( .TRUE., N, N, A, LDA, JPVT )
+*
+* A = A * Q
+*
+      CALL ZUNMQR( 'R', 'N', N, N, N, B, LDB, WORK, A, LDA,
+     $             WORK( N + 1 ), LWORK - N, IERR )
+*
+      IF( WANTQ ) THEN
+*
+* Initialize Q = J P J
+* (J is the column index, I is the row index)
+*
+         DO J = 1, N
+            DO I = 1, N
+               Q( I, J ) = ( 0.0D0, 0.0D0 )
+            END DO
+         END DO
+         DO J = 1, N
+            I = N - JPVT( N - J + 1 ) + 1
+            Q( I, J ) = ( 1.0D0, 0.0D0 )
+         END DO
+      END IF
+*
+      IF( WANTZ ) THEN
+*
+* Copy B into Z
+*
+         DO J = 1, N
+            DO I = 1, N
+               Z( I, J ) = B( I, J )
+            END DO
+         END DO
+         CALL ZUNGQR( N, N, N, Z, LDZ, WORK, WORK( N + 1 ),
+     $                LWORK - N, IERR )
+         CALL ZLAREV( 'C', N, N, Z, LDZ )
+      END IF
+*
+* A = A[::-1][:, ::-1]
+*
+      CALL ZLAREV( 'B', N, N, A, LDA )
+*
+* B = B.T[::-1][:, ::-1]
+* (Zero strictly lower triangle to preserve the R matrix from ZGEQP3.
+* J is the column, I is the row.)
+*
+      DO J = 1, N - 1
+         DO I = J + 1, N
+            B( I, J ) = ( 0.0D0, 0.0D0 )
+         END DO
+      END DO
+*
+      CALL ZLATRN( N, B, LDB )
+      CALL ZLAREV( 'B', N, N, B, LDB )
+*
+* Store norm and tolerance in the first two elements of RWORK, 
+* and optimal LWORK in WORK(1)
+*
+      RWORK( 1 ) = NORMB
+      RWORK( 2 ) = TOL
+      WORK( 1 )  = DCMPLX( DBLE( WORKNEEDED ), 0.0D0 )
+*
+      RETURN
+*
+* End of ZGGPRP
+*
+      END

--- a/SRC/zlarev.f
+++ b/SRC/zlarev.f
@@ -1,0 +1,115 @@
+*> \brief \b ZLAREV
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> ZLAREV reverses the order of the rows and/or columns of a given
+*> M-by-N complex*16 matrix A.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] WHICH
+*> \verbatim
+*>          WHICH is CHARACTER*1
+*>          Specifies whether to reverse rows, columns, or both:
+*>          = 'B': Reverse both rows and columns.
+*>          = 'R': Reverse rows only.
+*>          = 'C': Reverse columns only.
+*> \endverbatim
+*>
+*> \param[in] M
+*> \verbatim
+*>          M is INTEGER
+*>          The number of rows of the matrix A.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The number of columns of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension (LDA, N)
+*>          On entry, the matrix A to be reversed.
+*>          On exit, the elements of A have been swapped according to WHICH.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.
+*> \endverbatim
+      SUBROUTINE ZLAREV( WHICH, M, N, A, LDA )
+* .. Scalar Arguments ..
+      CHARACTER          WHICH
+      INTEGER            M, N, LDA
+* .. Array Arguments ..
+      COMPLEX*16         A( LDA, * )
+* .. Local Scalars ..
+      INTEGER            I, J, M2, N2
+      LOGICAL            ROWODD, COLODD
+      COMPLEX*16         TMPA, TMPB, TMPC, TMPD
+* .. Executable Statements ..
+
+      M2 = M / 2
+      N2 = N / 2
+      ROWODD = MOD(M, 2) .NE. 0
+      COLODD = MOD(N, 2) .NE. 0
+
+      IF ( WHICH .EQ. 'B' ) THEN
+         DO I = 1, N2
+            DO J = 1, M2
+               TMPA = A( J, I )
+               TMPB = A( J, N - I + 1 )
+               TMPC = A( M - J + 1, I )
+               TMPD = A( M - J + 1, N - I + 1 )
+               
+               A( J, I ) = TMPD
+               A( J, N - I + 1 ) = TMPC
+               A( M - J + 1, I ) = TMPB
+               A( M - J + 1, N - I + 1 ) = TMPA
+            END DO
+            IF ( ROWODD ) THEN
+               TMPA = A( M2 + 1, I )
+               A( M2 + 1, I ) = A( M2 + 1, N - I + 1 )
+               A( M2 + 1, N - I + 1 ) = TMPA
+            END IF
+         END DO
+         IF ( COLODD ) THEN
+            DO J = 1, M2
+               TMPA = A( J, N2 + 1 )
+               A( J, N2 + 1 ) = A( M - J + 1, N2 + 1 )
+               A( M - J + 1, N2 + 1 ) = TMPA
+            END DO
+         END IF
+
+      ELSE IF ( WHICH .EQ. 'R' ) THEN
+         DO I = 1, N
+            DO J = 1, M2
+               TMPA = A( J, I )
+               A( J, I ) = A( M - J + 1, I )
+               A( M - J + 1, I ) = TMPA
+            END DO
+         END DO
+
+      ELSE IF ( WHICH .EQ. 'C' ) THEN
+         DO I = 1, N2
+            DO J = 1, M
+               TMPA = A( J, I )
+               A( J, I ) = A( J, N - I + 1 )
+               A( J, N - I + 1 ) = TMPA
+            END DO
+         END DO
+      END IF
+
+      RETURN
+      END

--- a/SRC/zlatrn.f
+++ b/SRC/zlatrn.f
@@ -1,0 +1,125 @@
+*> \brief \b ZLATRN
+*
+* =========== DOCUMENTATION ===========
+*
+*> \par Purpose:
+* =============
+*>
+*> \details \b Purpose:
+*> \verbatim
+*>
+*> ZLATRN performs an in-place conjugate transpose of an N-by-N complex*16
+*> matrix A. It utilizes OpenMP parallelization and a blocked iteration 
+*> scheme to optimize cache usage during the transposition process.
+*> \endverbatim
+*
+* Arguments:
+* ==========
+*
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrix A.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension (LDA, N)
+*>          On entry, the N-by-N matrix to be conjugate transposed.
+*>          On exit, A is overwritten by its conjugate transpose.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+      SUBROUTINE ZLATRN( N, A, LDA )
+
+#if defined(_OPENMP)
+      use omp_lib
+#endif
+*
+* -- LAPACK auxiliary routine --
+*
+* .. Scalar Arguments ..
+      INTEGER            LDA, N
+* ..
+* .. Array Arguments ..
+      COMPLEX*16         A( LDA, * )
+* ..
+*
+* =====================================================================
+*
+* .. Parameters ..
+      INTEGER            SIZE
+      PARAMETER          ( SIZE = 8 )
+* ..
+* .. Local Scalars ..
+      INTEGER            BLOCK, I, J, NUM_THREADS, TAIL_START
+      COMPLEX*16         TEMP
+* ..
+* .. External Functions ..
+#if defined(_OPENMP)
+      INTEGER            OMP_GET_MAX_THREADS
+      EXTERNAL           OMP_GET_MAX_THREADS
+#endif
+* ..
+* .. Intrinsic Functions ..
+      INTRINSIC          MIN, CONJG
+* ..
+* .. Executable Statements ..
+*
+#if defined(_OPENMP)
+      IF( N.GE.256 ) THEN
+         NUM_THREADS = N / 64
+      ELSE
+         NUM_THREADS = 1
+      END IF
+      NUM_THREADS = MIN( NUM_THREADS, OMP_GET_MAX_THREADS() )
+#else
+      NUM_THREADS = 1
+#endif
+   
+!$OMP PARALLEL DO PRIVATE( BLOCK, I, J, TEMP )
+!$OMP+            NUM_THREADS( NUM_THREADS ) SCHEDULE( DYNAMIC, 1 )
+      DO BLOCK = 1, N - SIZE + 1, SIZE
+*
+* This pair takes care of the main diagonal block
+         DO I = BLOCK, BLOCK + SIZE - 1
+            DO J = I + 0, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = CONJG(A( J, I ))
+               A( J, I ) = CONJG(TEMP)
+            END DO
+         END DO
+*
+* Transpose sub-matrices not on the main diagonal
+         DO I = BLOCK + SIZE, N
+            DO J = BLOCK, BLOCK + SIZE - 1
+               TEMP      = A( I, J )
+               A( I, J ) = CONJG(A( J, I ))
+               A( J, I ) = CONJG(TEMP)
+            END DO
+         END DO
+*
+      END DO
+!$OMP END PARALLEL DO
+*
+* Transpose remaining elements along the main diagonal
+* Note: TAIL_START is explicitly calculated because BLOCK is 
+* undefined outside the OpenMP parallel construct.
+      TAIL_START = ( N / SIZE ) * SIZE + 1
+      DO I = TAIL_START, N
+         DO J = I + 0, N
+            TEMP      = A( I, J )
+            A( I, J ) = CONJG(A( J, I ))
+            A( J, I ) = CONJG(TEMP)
+         END DO
+      END DO
+*
+      RETURN
+*
+* End of ZLATRN
+*
+      END

--- a/TESTING/EIG/CMakeLists.txt
+++ b/TESTING/EIG/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SEIGTST schkee.F
    schkbb.f schkbd.f schkbk.f schkbl.f schkec.f
    schkgg.f schkgk.f schkgl.f schkhs.f schksb.f schkst.f schkst2stg.f schksb2stg.f
    sckcsd.f sckglm.f sckgqr.f sckgsv.f scklse.f scsdts.f
-   sdrges.f sdrgev.f sdrges3.f sdrgev3.f sdrgsx.f sdrgvx.f
+   sdrges.f sdrgev.f sdrges3.f sdrgev3.f sdrgsx.f sdrgvx.f sdrgev4.f
    sdrvbd.f sdrves.f sdrvev.f sdrvsg.f sdrvsg2stg.f
    sdrvst.f sdrvst2stg.f sdrvsx.f sdrvvx.f
    serrbd.f serrec.f serred.f serrgg.f serrhs.f serrst.f
@@ -49,7 +49,7 @@ set(CEIGTST cchkee.F
    cchkbb.f cchkbd.f cchkbk.f cchkbl.f cchkec.f
    cchkgg.f cchkgk.f cchkgl.f cchkhb.f cchkhs.f cchkst.f cchkst2stg.f cchkhb2stg.f
    cckcsd.f cckglm.f cckgqr.f cckgsv.f ccklse.f ccsdts.f
-   cdrges.f cdrgev.f cdrges3.f cdrgev3.f cdrgsx.f cdrgvx.f
+   cdrges.f cdrgev.f cdrges3.f cdrgev3.f cdrgsx.f cdrgvx.f cdrgev4.f
    cdrvbd.f cdrves.f cdrvev.f cdrvsg.f cdrvsg2stg.f
    cdrvst.f cdrvst2stg.f cdrvsx.f cdrvvx.f
    cerrbd.f cerrec.f cerred.f cerrgg.f cerrhs.f cerrst.f
@@ -71,7 +71,7 @@ set(DEIGTST dchkee.F
    dchkbb.f dchkbd.f dchkbk.f dchkbl.f dchkec.f
    dchkgg.f dchkgk.f dchkgl.f dchkhs.f dchksb.f dchkst.f dchkst2stg.f dchksb2stg.f
    dckcsd.f dckglm.f dckgqr.f dckgsv.f dcklse.f dcsdts.f
-   ddrges.f ddrgev.f ddrges3.f ddrgev3.f ddrgsx.f ddrgvx.f
+   ddrges.f ddrgev.f ddrges3.f ddrgev3.f ddrgsx.f ddrgvx.f ddrgev4.f
    ddrvbd.f ddrves.f ddrvev.f ddrvsg.f ddrvsg2stg.f
    ddrvst.f ddrvst2stg.f ddrvsx.f ddrvvx.f
    derrbd.f derrec.f derred.f derrgg.f derrhs.f derrst.f
@@ -90,7 +90,7 @@ set(ZEIGTST zchkee.F
    zchkbb.f zchkbd.f zchkbk.f zchkbl.f zchkec.f
    zchkgg.f zchkgk.f zchkgl.f zchkhb.f zchkhs.f zchkst.f zchkst2stg.f zchkhb2stg.f
    zckcsd.f zckglm.f zckgqr.f zckgsv.f zcklse.f zcsdts.f
-   zdrges.f zdrgev.f zdrges3.f zdrgev3.f zdrgsx.f zdrgvx.f
+   zdrges.f zdrgev.f zdrges3.f zdrgev3.f zdrgsx.f zdrgvx.f zdrgev4.f
    zdrvbd.f zdrves.f zdrvev.f zdrvsg.f zdrvsg2stg.f
    zdrvst.f zdrvst2stg.f zdrvsx.f zdrvvx.f
    zerrbd.f zerrec.f zerred.f zerrgg.f zerrhs.f zerrst.f

--- a/TESTING/EIG/cchkee.F
+++ b/TESTING/EIG/cchkee.F
@@ -1108,7 +1108,7 @@
      $                   CDRGEV, CDRGSX, CDRGVX, CDRVBD, CDRVES, CDRVEV,
      $                   CDRVSG, CDRVST, CDRVSX, CDRVVX, CERRBD,
      $                   CERRED, CERRGG, CERRHS, CERRST, ILAVER, XLAENV,
-     $                   CDRGES3, CDRGEV3, 
+     $                   CDRGES3, CDRGEV3, CDRGEV4,
      $                   CCHKST2STG, CDRVST2STG, CCHKHB2STG
 *     ..
 *     .. Intrinsic Functions ..
@@ -2293,6 +2293,18 @@
      $                    RESULT, INFO )
             IF( INFO.NE.0 )
      $           WRITE( NOUT, FMT = 9980 )'CDRGEV3', INFO
+*
+* New Blocked version
+*
+            CALL XLAENV(16,2)
+            CALL CDRGEV4( NN, NVAL, MAXTYP, DOTYPE, ISEED, THRESH, NOUT,
+     $                    A( 1, 1 ), NMAX, A( 1, 2 ), A( 1, 3 ),
+     $                    A( 1, 4 ), A( 1, 7 ), NMAX, A( 1, 8 ),
+     $                    A( 1, 9 ), NMAX, DC( 1, 1 ), DC( 1, 2 ),
+     $                    DC( 1, 3 ), DC( 1, 4 ), WORK, LWORK, RWORK,
+     $                    IWORK, RESULT, INFO )
+            IF( INFO.NE.0 )
+     $           WRITE( NOUT, FMT = 9980 )'CDRGEV4', INFO
          END IF
          WRITE( NOUT, FMT = 9973 )
          GO TO 10

--- a/TESTING/EIG/cdrgev4.f
+++ b/TESTING/EIG/cdrgev4.f
@@ -1,0 +1,952 @@
+*> \brief \b CDRGEV4
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE CDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+*                          NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+*                          ALPHA, BETA, ALPHA1, BETA1, WORK, LWORK, RWORK,
+*                          IWORK, RESULT, INFO )
+*
+*       .. Scalar Arguments ..
+*       INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+*      $                   NTYPES
+*       REAL               THRESH
+*       ..
+*       .. Array Arguments ..
+*       LOGICAL            DOTYPE( * )
+*       INTEGER            ISEED( 4 ), NN( * )
+*       REAL               RESULT( * ), RWORK( * )
+*       COMPLEX            A( LDA, * ), ALPHA( * ), ALPHA1( * ),
+*      $                   B( LDA, * ), BETA( * ), BETA1( * ),
+*      $                   Q( LDQ, * ), QE( LDQE, * ), S( LDA, * ),
+*      $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> CDRGEV4 checks the nonsymmetric generalized eigenvalue problem driver
+*> routine CGGEV4.
+*>
+*> CGGEV4 computes for a pair of n-by-n nonsymmetric matrices (A,B) the
+*> generalized eigenvalues and, optionally, the left and right
+*> eigenvectors.
+*>
+*> A generalized eigenvalue for a pair of matrices (A,B) is a scalar w
+*> or a ratio  alpha/beta = w, such that A - w*B is singular.  It is
+*> usually represented as the pair (alpha,beta), as there is reasonable
+*> interpretation for beta=0, and even for both being zero.
+*>
+*> A right generalized eigenvector corresponding to a generalized
+*> eigenvalue  w  for a pair of matrices (A,B) is a vector r  such that
+*> (A - wB) * r = 0.  A left generalized eigenvector is a vector l such
+*> that l**H * (A - wB) = 0, where l**H is the conjugate-transpose of l.
+*>
+*> When CDRGEV4 is called, a number of matrix "sizes" ("n's") and a
+*> number of matrix "types" are specified.  For each size ("n")
+*> and each type of matrix, a pair of matrices (A, B) will be generated
+*> and used for testing.  For each matrix pair, the following tests
+*> will be performed and compared with the threshold THRESH.
+*>
+*> Results from CGGEV4:
+*>
+*> (1)  max over all left eigenvalue/-vector pairs (alpha/beta,l) of
+*>
+*>      | VL**H * (beta A - alpha B) |/( ulp max(|beta A|, |alpha B|) )
+*>
+*>      where VL**H is the conjugate-transpose of VL.
+*>
+*> (2)  | |VL(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VL(i) denotes the i-th column of VL.
+*>
+*> (3)  max over all left eigenvalue/-vector pairs (alpha/beta,r) of
+*>
+*>      | (beta A - alpha B) * VR | / ( ulp max(|beta A|, |alpha B|) )
+*>
+*> (4)  | |VR(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VR(i) denotes the i-th column of VR.
+*>
+*> (5)  W(full) = W(partial)
+*>      W(full) denotes the eigenvalues computed when both l and r
+*>      are also computed, and W(partial) denotes the eigenvalues
+*>      computed when only W, only W and r, or only W and l are
+*>      computed.
+*>
+*> (6)  VL(full) = VL(partial)
+*>      VL(full) denotes the left eigenvectors computed when both l
+*>      and r are computed, and VL(partial) denotes the result
+*>      when only l is computed.
+*>
+*> (7)  VR(full) = VR(partial)
+*>      VR(full) denotes the right eigenvectors computed when both l
+*>      and r are also computed, and VR(partial) denotes the result
+*>      when only l is computed.
+*>
+*>
+*> Test Matrices
+*> ---- --------
+*>
+*> The sizes of the test matrices are specified by an array
+*> NN(1:NSIZES); the value of each element NN(j) specifies one size.
+*> The "types" are specified by a logical array DOTYPE( 1:NTYPES ); if
+*> DOTYPE(j) is .TRUE., then matrix type "j" will be generated.
+*> Currently, the list of possible types is:
+*>
+*> (1)  ( 0, 0 )         (a pair of zero matrices)
+*>
+*> (2)  ( I, 0 )         (an identity and a zero matrix)
+*>
+*> (3)  ( 0, I )         (an identity and a zero matrix)
+*>
+*> (4)  ( I, I )         (a pair of identity matrices)
+*>
+*>         t   t
+*> (5)  ( J , J  )       (a pair of transposed Jordan blocks)
+*>
+*>                                     t                ( I   0  )
+*> (6)  ( X, Y )         where  X = ( J   0  )  and Y = (      t )
+*>                                  ( 0   I  )          ( 0   J  )
+*>                       and I is a k x k identity and J a (k+1)x(k+1)
+*>                       Jordan block; k=(N-1)/2
+*>
+*> (7)  ( D, I )         where D is diag( 0, 1,..., N-1 ) (a diagonal
+*>                       matrix with those diagonal entries.)
+*> (8)  ( I, D )
+*>
+*> (9)  ( big*D, small*I ) where "big" is near overflow and small=1/big
+*>
+*> (10) ( small*D, big*I )
+*>
+*> (11) ( big*I, small*D )
+*>
+*> (12) ( small*I, big*D )
+*>
+*> (13) ( big*D, big*I )
+*>
+*> (14) ( small*D, small*I )
+*>
+*> (15) ( D1, D2 )        where D1 is diag( 0, 0, 1, ..., N-3, 0 ) and
+*>                        D2 is diag( 0, N-3, N-4,..., 1, 0, 0 )
+*>           t   t
+*> (16) Q ( J , J ) Z     where Q and Z are random orthogonal matrices.
+*>
+*> (17) Q ( T1, T2 ) Z    where T1 and T2 are upper triangular matrices
+*>                        with random O(1) entries above the diagonal
+*>                        and diagonal entries diag(T1) =
+*>                        ( 0, 0, 1, ..., N-3, 0 ) and diag(T2) =
+*>                        ( 0, N-3, N-4,..., 1, 0, 0 )
+*>
+*> (18) Q ( T1, T2 ) Z    diag(T1) = ( 0, 0, 1, 1, s, ..., s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1,..., 1, 0 )
+*>                        s = machine precision.
+*>
+*> (19) Q ( T1, T2 ) Z    diag(T1)=( 0,0,1,1, 1-d, ..., 1-(N-5)*d=s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0 )
+*>
+*>                                                        N-5
+*> (20) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, 1, a, ..., a   =s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>
+*> (21) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, r1, r2, ..., r(N-4), 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>                        where r1,..., r(N-4) are random.
+*>
+*> (22) Q ( big*T1, small*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (23) Q ( small*T1, big*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (24) Q ( small*T1, small*T2 ) Z  diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (25) Q ( big*T1, big*T2 ) Z      diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (26) Q ( T1, T2 ) Z     where T1 and T2 are random upper-triangular
+*>                         matrices.
+*>
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] NSIZES
+*> \verbatim
+*>          NSIZES is INTEGER
+*>          The number of sizes of matrices to use.  If it is zero,
+*>          CDRGEV4 does nothing.  NSIZES >= 0.
+*> \endverbatim
+*>
+*> \param[in] NN
+*> \verbatim
+*>          NN is INTEGER array, dimension (NSIZES)
+*>          An array containing the sizes to be used for the matrices.
+*>          Zero values will be skipped.  NN >= 0.
+*> \endverbatim
+*>
+*> \param[in] NTYPES
+*> \verbatim
+*>          NTYPES is INTEGER
+*>          The number of elements in DOTYPE.   If it is zero, CDRGEV4
+*>          does nothing.  It must be at least zero.  If it is MAXTYP+1
+*>          and NSIZES is 1, then an additional type, MAXTYP+1 is
+*>          defined, which is to use whatever matrix is in A.  This
+*>          is only useful if DOTYPE(1:MAXTYP) is .FALSE. and
+*>          DOTYPE(MAXTYP+1) is .TRUE. .
+*> \endverbatim
+*>
+*> \param[in] DOTYPE
+*> \verbatim
+*>          DOTYPE is LOGICAL array, dimension (NTYPES)
+*>          If DOTYPE(j) is .TRUE., then for each size in NN a
+*>          matrix of that size and of type j will be generated.
+*>          If NTYPES is smaller than the maximum number of types
+*>          defined (PARAMETER MAXTYP), then types NTYPES+1 through
+*>          MAXTYP will not be generated. If NTYPES is larger
+*>          than MAXTYP, DOTYPE(MAXTYP+1) through DOTYPE(NTYPES)
+*>          will be ignored.
+*> \endverbatim
+*>
+*> \param[in,out] ISEED
+*> \verbatim
+*>          ISEED is INTEGER array, dimension (4)
+*>          On entry ISEED specifies the seed of the random number
+*>          generator. The array elements should be between 0 and 4095;
+*>          if not they will be reduced mod 4096. Also, ISEED(4) must
+*>          be odd.  The random number generator uses a linear
+*>          congruential sequence limited to small integers, and so
+*>          should produce machine independent random numbers. The
+*>          values of ISEED are changed on exit, and can be used in the
+*>          next call to CDRGEV4 to continue the same random number
+*>          sequence.
+*> \endverbatim
+*>
+*> \param[in] THRESH
+*> \verbatim
+*>          THRESH is REAL
+*>          A test will count as "failed" if the "error", computed as
+*>          described above, exceeds THRESH.  Note that the error is
+*>          scaled to be O(1), so THRESH should be a reasonably small
+*>          multiple of 1, e.g., 10 or 100.  In particular, it should
+*>          not depend on the precision (single vs. double) or the size
+*>          of the matrix.  It must be at least zero.
+*> \endverbatim
+*>
+*> \param[in] NOUNIT
+*> \verbatim
+*>          NOUNIT is INTEGER
+*>          The FORTRAN unit number for printing out error messages
+*>          (e.g., if a routine returns IERR not equal to 0.)
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX array, dimension(LDA, max(NN))
+*>          Used to hold the original A matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of A, B, S, and T.
+*>          It must be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX array, dimension(LDA, max(NN))
+*>          Used to hold the original B matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[out] S
+*> \verbatim
+*>          S is COMPLEX array, dimension (LDA, max(NN))
+*>          The Schur form matrix computed from A by CGGEV4.  On exit, S
+*>          contains the Schur form matrix corresponding to the matrix
+*>          in A.
+*> \endverbatim
+*>
+*> \param[out] T
+*> \verbatim
+*>          T is COMPLEX array, dimension (LDA, max(NN))
+*>          The upper triangular matrix computed from B by CGGEV4.
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is COMPLEX array, dimension (LDQ, max(NN))
+*>          The (left) eigenvectors matrix computed by CGGEV4.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of Q and Z. It must
+*>          be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is COMPLEX array, dimension( LDQ, max(NN) )
+*>          The (right) orthogonal matrix computed by CGGEV4.
+*> \endverbatim
+*>
+*> \param[out] QE
+*> \verbatim
+*>          QE is COMPLEX array, dimension( LDQ, max(NN) )
+*>          QE holds the computed right or left eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] LDQE
+*> \verbatim
+*>          LDQE is INTEGER
+*>          The leading dimension of QE. LDQE >= max(1,max(NN)).
+*> \endverbatim
+*>
+*> \param[out] ALPHA
+*> \verbatim
+*>          ALPHA is COMPLEX array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is COMPLEX array, dimension (max(NN))
+*>
+*>          The generalized eigenvalues of (A,B) computed by CGGEV4.
+*>          ( ALPHAR(k)+ALPHAI(k)*i ) / BETA(k) is the k-th
+*>          generalized eigenvalue of A and B.
+*> \endverbatim
+*>
+*> \param[out] ALPHA1
+*> \verbatim
+*>          ALPHA1 is COMPLEX array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA1
+*> \verbatim
+*>          BETA1 is COMPLEX array, dimension (max(NN))
+*>
+*>          Like ALPHAR, ALPHAI, BETA, these arrays contain the
+*>          eigenvalues of A and B, but those computed when CGGEV4 only
+*>          computes a partial eigendecomposition, i.e. not the
+*>          eigenvalues and left and right eigenvectors.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX array, dimension (LWORK)
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The number of entries in WORK.  LWORK >= N*(N+1)
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is REAL array, dimension (8*N)
+*>          Real workspace.
+*> \endverbatim
+*>
+*> \param[out] RESULT
+*> \verbatim
+*>          RESULT is REAL array, dimension (2)
+*>          The values computed by the tests described above.
+*>          The values are currently limited to 1/ulp, to avoid overflow.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  A routine returned an error code.  INFO is the
+*>                absolute value of the INFO value returned.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \ingroup complex_eig
+*
+*  =====================================================================
+      SUBROUTINE CDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+     $                    NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+     $                    ALPHA, BETA, ALPHA1, BETA1, WORK, LWORK,
+     $                    RWORK, IWORK, RESULT, INFO )
+      IMPLICIT NONE
+*
+*  -- LAPACK test routine --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*
+*     .. Scalar Arguments ..
+      INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+     $                   NTYPES
+      REAL               THRESH
+*     ..
+*     .. Array Arguments ..
+      LOGICAL            DOTYPE( * )
+      INTEGER            ISEED( 4 ), NN( * ), IWORK( * )
+      REAL               RESULT( * ), RWORK( * )
+      COMPLEX            A( LDA, * ), ALPHA( * ), ALPHA1( * ),
+     $                   B( LDA, * ), BETA( * ), BETA1( * ),
+     $                   Q( LDQ, * ), QE( LDQE, * ), S( LDA, * ),
+     $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
+      COMPLEX            CZERO, CONE
+      PARAMETER          ( CZERO = ( 0.0E+0, 0.0E+0 ),
+     $                   CONE = ( 1.0E+0, 0.0E+0 ) )
+      INTEGER            MAXTYP
+      PARAMETER          ( MAXTYP = 26 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            BADNN
+      INTEGER            I, IADD, IERR, IN, J, JC, JR, JSIZE, JTYPE,
+     $                   MAXWRK, MINWRK, MTYPES, N, N1, NB, NERRS,
+     $                   NMATS, NMAX, NTESTT
+      REAL               SAFMAX, SAFMIN, ULP, ULPINV
+      COMPLEX            CTEMP
+*     ..
+*     .. Local Arrays ..
+      LOGICAL            LASIGN( MAXTYP ), LBSIGN( MAXTYP )
+      INTEGER            IOLDSD( 4 ), KADD( 6 ), KAMAGN( MAXTYP ),
+     $                   KATYPE( MAXTYP ), KAZERO( MAXTYP ),
+     $                   KBMAGN( MAXTYP ), KBTYPE( MAXTYP ),
+     $                   KBZERO( MAXTYP ), KCLASS( MAXTYP ),
+     $                   KTRIAN( MAXTYP ), KZ1( 6 ), KZ2( 6 )
+      REAL               RMAGN( 0: 3 )
+*     ..
+*     .. External Functions ..
+      INTEGER            ILAENV
+      REAL               SLAMCH
+      COMPLEX            CLARND
+      EXTERNAL           ILAENV, SLAMCH, CLARND
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           ALASVM, CGET52, CGGEV4, CLACPY, CLARFG, CLASET,
+     $                   CLATM4, CUNM2R, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          ABS, CONJG, MAX, MIN, REAL, SIGN
+*     ..
+*     .. Data statements ..
+      DATA               KCLASS / 15*1, 10*2, 1*3 /
+      DATA               KZ1 / 0, 1, 2, 1, 3, 3 /
+      DATA               KZ2 / 0, 0, 1, 2, 1, 1 /
+      DATA               KADD / 0, 0, 0, 0, 3, 2 /
+      DATA               KATYPE / 0, 1, 0, 1, 2, 3, 4, 1, 4, 4, 1, 1, 4,
+     $                   4, 4, 2, 4, 5, 8, 7, 9, 4*4, 0 /
+      DATA               KBTYPE / 0, 0, 1, 1, 2, -3, 1, 4, 1, 1, 4, 4,
+     $                   1, 1, -4, 2, -4, 8*8, 0 /
+      DATA               KAZERO / 6*1, 2, 1, 2*2, 2*1, 2*2, 3, 1, 3,
+     $                   4*5, 4*3, 1 /
+      DATA               KBZERO / 6*1, 1, 2, 2*1, 2*2, 2*1, 4, 1, 4,
+     $                   4*6, 4*4, 1 /
+      DATA               KAMAGN / 8*1, 2, 3, 2, 3, 2, 3, 7*1, 2, 3, 3,
+     $                   2, 1 /
+      DATA               KBMAGN / 8*1, 3, 2, 3, 2, 2, 3, 7*1, 3, 2, 3,
+     $                   2, 1 /
+      DATA               KTRIAN / 16*0, 10*1 /
+      DATA               LASIGN / 6*.FALSE., .TRUE., .FALSE., 2*.TRUE.,
+     $                   2*.FALSE., 3*.TRUE., .FALSE., .TRUE.,
+     $                   3*.FALSE., 5*.TRUE., .FALSE. /
+      DATA               LBSIGN / 7*.FALSE., .TRUE., 2*.FALSE.,
+     $                   2*.TRUE., 2*.FALSE., .TRUE., .FALSE., .TRUE.,
+     $                   9*.FALSE. /
+*     ..
+*     .. Executable Statements ..
+*
+*     Check for errors
+*
+      INFO = 0
+*
+      BADNN = .FALSE.
+      NMAX = 1
+      DO 10 J = 1, NSIZES
+         NMAX = MAX( NMAX, NN( J ) )
+         IF( NN( J ).LT.0 )
+     $      BADNN = .TRUE.
+   10 CONTINUE
+*
+      IF( NSIZES.LT.0 ) THEN
+         INFO = -1
+      ELSE IF( BADNN ) THEN
+         INFO = -2
+      ELSE IF( NTYPES.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( THRESH.LT.ZERO ) THEN
+         INFO = -6
+      ELSE IF( LDA.LE.1 .OR. LDA.LT.NMAX ) THEN
+         INFO = -9
+      ELSE IF( LDQ.LE.1 .OR. LDQ.LT.NMAX ) THEN
+         INFO = -14
+      ELSE IF( LDQE.LE.1 .OR. LDQE.LT.NMAX ) THEN
+         INFO = -17
+      END IF
+*
+*     Compute workspace
+*      (Note: Comments in the code beginning "Workspace:" describe the
+*       minimal amount of workspace needed at that point in the code,
+*       as well as the preferred amount for good performance.
+*       NB refers to the optimal block size for the immediately
+*       following subroutine, as returned by ILAENV.
+*
+      MINWRK = 1
+      IF( INFO.EQ.0 .AND. LWORK.GE.1 ) THEN
+         MINWRK = NMAX*( NMAX+1 )
+         NB = MAX( 1, ILAENV( 1, 'CGEQRF', ' ', NMAX, NMAX, -1, -1 ),
+     $        ILAENV( 1, 'CUNMQR', 'LC', NMAX, NMAX, NMAX, -1 ),
+     $        ILAENV( 1, 'CUNGQR', ' ', NMAX, NMAX, NMAX, -1 ) )
+         MAXWRK = MAX( 2*NMAX, NMAX*( NB+1 ), NMAX*( NMAX+1 ) )
+         WORK( 1 ) = MAXWRK
+      END IF
+*
+      IF( LWORK.LT.MINWRK )
+     $   INFO = -23
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'CDRGEV4', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( NSIZES.EQ.0 .OR. NTYPES.EQ.0 )
+     $   RETURN
+*
+      ULP = SLAMCH( 'Precision' )
+      SAFMIN = SLAMCH( 'Safe minimum' )
+      SAFMIN = SAFMIN / ULP
+      SAFMAX = ONE / SAFMIN
+      ULPINV = ONE / ULP
+*
+*     The values RMAGN(2:3) depend on N, see below.
+*
+      RMAGN( 0 ) = ZERO
+      RMAGN( 1 ) = ONE
+*
+*     Loop over sizes, types
+*
+      NTESTT = 0
+      NERRS = 0
+      NMATS = 0
+*
+      DO 220 JSIZE = 1, NSIZES
+         N = NN( JSIZE )
+         N1 = MAX( 1, N )
+         RMAGN( 2 ) = SAFMAX*ULP / REAL( N1 )
+         RMAGN( 3 ) = SAFMIN*ULPINV*N1
+*
+         IF( NSIZES.NE.1 ) THEN
+            MTYPES = MIN( MAXTYP, NTYPES )
+         ELSE
+            MTYPES = MIN( MAXTYP+1, NTYPES )
+         END IF
+*
+         DO 210 JTYPE = 1, MTYPES
+            IF( .NOT.DOTYPE( JTYPE ) )
+     $         GO TO 210
+            NMATS = NMATS + 1
+*
+*           Save ISEED in case of an error.
+*
+            DO 20 J = 1, 4
+               IOLDSD( J ) = ISEED( J )
+   20       CONTINUE
+*
+*           Generate test matrices A and B
+*
+*           Description of control parameters:
+*
+*           KCLASS: =1 means w/o rotation, =2 means w/ rotation,
+*                   =3 means random.
+*           KATYPE: the "type" to be passed to CLATM4 for computing A.
+*           KAZERO: the pattern of zeros on the diagonal for A:
+*                   =1: ( xxx ), =2: (0, xxx ) =3: ( 0, 0, xxx, 0 ),
+*                   =4: ( 0, xxx, 0, 0 ), =5: ( 0, 0, 1, xxx, 0 ),
+*                   =6: ( 0, 1, 0, xxx, 0 ).  (xxx means a string of
+*                   non-zero entries.)
+*           KAMAGN: the magnitude of the matrix: =0: zero, =1: O(1),
+*                   =2: large, =3: small.
+*           LASIGN: .TRUE. if the diagonal elements of A are to be
+*                   multiplied by a random magnitude 1 number.
+*           KBTYPE, KBZERO, KBMAGN, LBSIGN: the same, but for B.
+*           KTRIAN: =0: don't fill in the upper triangle, =1: do.
+*           KZ1, KZ2, KADD: used to implement KAZERO and KBZERO.
+*           RMAGN: used to implement KAMAGN and KBMAGN.
+*
+            IF( MTYPES.GT.MAXTYP )
+     $         GO TO 100
+            IERR = 0
+            IF( KCLASS( JTYPE ).LT.3 ) THEN
+*
+*              Generate A (w/o rotation)
+*
+               IF( ABS( KATYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL CLASET( 'Full', N, N, CZERO, CZERO, A, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL CLATM4( KATYPE( JTYPE ), IN, KZ1( KAZERO( JTYPE ) ),
+     $                      KZ2( KAZERO( JTYPE ) ), LASIGN( JTYPE ),
+     $                      RMAGN( KAMAGN( JTYPE ) ), ULP,
+     $                      RMAGN( KTRIAN( JTYPE )*KAMAGN( JTYPE ) ), 2,
+     $                      ISEED, A, LDA )
+               IADD = KADD( KAZERO( JTYPE ) )
+               IF( IADD.GT.0 .AND. IADD.LE.N )
+     $            A( IADD, IADD ) = RMAGN( KAMAGN( JTYPE ) )
+*
+*              Generate B (w/o rotation)
+*
+               IF( ABS( KBTYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL CLASET( 'Full', N, N, CZERO, CZERO, B, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL CLATM4( KBTYPE( JTYPE ), IN, KZ1( KBZERO( JTYPE ) ),
+     $                      KZ2( KBZERO( JTYPE ) ), LBSIGN( JTYPE ),
+     $                      RMAGN( KBMAGN( JTYPE ) ), ONE,
+     $                      RMAGN( KTRIAN( JTYPE )*KBMAGN( JTYPE ) ), 2,
+     $                      ISEED, B, LDA )
+               IADD = KADD( KBZERO( JTYPE ) )
+               IF( IADD.NE.0 .AND. IADD.LE.N )
+     $            B( IADD, IADD ) = RMAGN( KBMAGN( JTYPE ) )
+*
+               IF( KCLASS( JTYPE ).EQ.2 .AND. N.GT.0 ) THEN
+*
+*                 Include rotations
+*
+*                 Generate Q, Z as Householder transformations times
+*                 a diagonal matrix.
+*
+                  DO 40 JC = 1, N - 1
+                     DO 30 JR = JC, N
+                        Q( JR, JC ) = CLARND( 3, ISEED )
+                        Z( JR, JC ) = CLARND( 3, ISEED )
+   30                CONTINUE
+                     CALL CLARFG( N+1-JC, Q( JC, JC ), Q( JC+1, JC ), 1,
+     $                            WORK( JC ) )
+                     WORK( 2*N+JC ) = SIGN( ONE, REAL( Q( JC, JC ) ) )
+                     Q( JC, JC ) = CONE
+                     CALL CLARFG( N+1-JC, Z( JC, JC ), Z( JC+1, JC ), 1,
+     $                            WORK( N+JC ) )
+                     WORK( 3*N+JC ) = SIGN( ONE, REAL( Z( JC, JC ) ) )
+                     Z( JC, JC ) = CONE
+   40             CONTINUE
+                  CTEMP = CLARND( 3, ISEED )
+                  Q( N, N ) = CONE
+                  WORK( N ) = CZERO
+                  WORK( 3*N ) = CTEMP / ABS( CTEMP )
+                  CTEMP = CLARND( 3, ISEED )
+                  Z( N, N ) = CONE
+                  WORK( 2*N ) = CZERO
+                  WORK( 4*N ) = CTEMP / ABS( CTEMP )
+*
+*                 Apply the diagonal matrices
+*
+                  DO 60 JC = 1, N
+                     DO 50 JR = 1, N
+                        A( JR, JC ) = WORK( 2*N+JR )*
+     $                                CONJG( WORK( 3*N+JC ) )*
+     $                                A( JR, JC )
+                        B( JR, JC ) = WORK( 2*N+JR )*
+     $                                CONJG( WORK( 3*N+JC ) )*
+     $                                B( JR, JC )
+   50                CONTINUE
+   60             CONTINUE
+                  CALL CUNM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, A,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL CUNM2R( 'R', 'C', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         A, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL CUNM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, B,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL CUNM2R( 'R', 'C', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         B, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+               END IF
+            ELSE
+*
+*              Random matrices
+*
+               DO 80 JC = 1, N
+                  DO 70 JR = 1, N
+                     A( JR, JC ) = RMAGN( KAMAGN( JTYPE ) )*
+     $                             CLARND( 4, ISEED )
+                     B( JR, JC ) = RMAGN( KBMAGN( JTYPE ) )*
+     $                             CLARND( 4, ISEED )
+   70             CONTINUE
+   80          CONTINUE
+            END IF
+*
+   90       CONTINUE
+*
+            IF( IERR.NE.0 ) THEN
+               WRITE( NOUNIT, FMT = 9999 )'Generator', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               RETURN
+            END IF
+*
+  100       CONTINUE
+*
+            DO 110 I = 1, 7
+               RESULT( I ) = -ONE
+  110       CONTINUE
+*
+*           Call XLAENV to set the parameters used in CLAQZ0
+*
+            CALL XLAENV( 12, 10 )
+            CALL XLAENV( 13, 12 )
+            CALL XLAENV( 14, 13 )
+            CALL XLAENV( 15, 2 )
+            CALL XLAENV( 17, 10 )
+*
+*           Call CGGEV4 to compute eigenvalues and eigenvectors.
+*
+            CALL CLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL CLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL CGGEV4( 'V', 'V', N, S, LDA, T, LDA, ALPHA, BETA, Q,
+     $                   LDQ, Z, LDQ, WORK, LWORK, RWORK,
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'CGGEV41', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+*           Do the tests (1) and (2)
+*
+            CALL CGET52( .TRUE., N, A, LDA, B, LDA, Q, LDQ, ALPHA, BETA,
+     $                   WORK, RWORK, RESULT( 1 ) )
+            IF( RESULT( 2 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Left', 'CGGEV41',
+     $            RESULT( 2 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do the tests (3) and (4)
+*
+            CALL CGET52( .FALSE., N, A, LDA, B, LDA, Z, LDQ, ALPHA,
+     $                   BETA, WORK, RWORK, RESULT( 3 ) )
+            IF( RESULT( 4 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Right', 'CGGEV41',
+     $            RESULT( 4 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do test (5)
+*
+            CALL CLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL CLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL CGGEV4( 'N', 'N', N, S, LDA, T, LDA, ALPHA1, BETA1, Q,
+     $                   LDQ, Z, LDQ, WORK, LWORK, RWORK,
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'CGGEV42', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 120 J = 1, N
+               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
+     $              BETA1( J ) ) RESULT( 5 ) = ULPINV
+  120       CONTINUE
+*
+*           Do the test (6): Compute eigenvalues and left eigenvectors,
+*           and test them
+*
+            CALL CLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL CLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL CGGEV4( 'V', 'N', N, S, LDA, T, LDA, ALPHA1, BETA1, QE,
+     $                   LDQE, Z, LDQ, WORK, LWORK, RWORK,
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'CGGEV43', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+
+*
+            DO 130 J = 1, N
+               IF( ALPHA( J ).NE.ALPHA1( J ) .OR.
+     $              BETA( J ).NE.BETA1( J ) ) THEN
+                  RESULT( 6 ) = ULPINV
+               ENDIF
+  130       CONTINUE
+*
+            DO 150 J = 1, N
+               DO 140 JC = 1, N
+                  IF( Q( J, JC ).NE.QE( J, JC ) ) THEN
+                     RESULT( 6 ) = ULPINV
+                  END IF
+  140          CONTINUE
+  150       CONTINUE
+*
+*           DO the test (7): Compute eigenvalues and right eigenvectors,
+*           and test them
+*
+            CALL CLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL CLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL CGGEV4( 'N', 'V', N, S, LDA, T, LDA, ALPHA1, BETA1, Q,
+     $                  LDQ, QE, LDQE, WORK, LWORK, RWORK,
+     $                  IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'CGGEV44', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 160 J = 1, N
+               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
+     $             BETA1( J ) )RESULT( 7 ) = ULPINV
+  160       CONTINUE
+*
+            DO 180 J = 1, N
+               DO 170 JC = 1, N
+                  IF( Z( J, JC ).NE.QE( J, JC ) )
+     $               RESULT( 7 ) = ULPINV
+  170          CONTINUE
+  180       CONTINUE
+*
+*           End of Loop -- Check for RESULT(j) > THRESH
+*
+  190       CONTINUE
+*
+            NTESTT = NTESTT + 7
+*
+*           Print out tests which fail.
+*
+            DO 200 JR = 1, 7
+               IF( RESULT( JR ).GE.THRESH ) THEN
+*
+*                 If this is the first test to fail,
+*                 print a header to the data file.
+*
+                  IF( NERRS.EQ.0 ) THEN
+                     WRITE( NOUNIT, FMT = 9997 )'CGV'
+*
+*                    Matrix types
+*
+                     WRITE( NOUNIT, FMT = 9996 )
+                     WRITE( NOUNIT, FMT = 9995 )
+                     WRITE( NOUNIT, FMT = 9994 )'Orthogonal'
+*
+*                    Tests performed
+*
+                     WRITE( NOUNIT, FMT = 9993 )
+*
+                  END IF
+                  NERRS = NERRS + 1
+                  IF( RESULT( JR ).LT.10000.0 ) THEN
+                     WRITE( NOUNIT, FMT = 9992 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  ELSE
+                     WRITE( NOUNIT, FMT = 9991 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  END IF
+               END IF
+  200       CONTINUE
+*
+  210    CONTINUE
+  220 CONTINUE
+*
+*     Summary
+*
+      CALL ALASVM( 'CGV3', NOUNIT, NERRS, NTESTT, 0 )
+*
+      WORK( 1 ) = MAXWRK
+*
+      RETURN
+*
+ 9999 FORMAT( ' CDRGEV4: ', A, ' returned INFO=', I6, '.', / 3X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+*
+ 9998 FORMAT( ' CDRGEV4: ', A, ' Eigenvectors from ', A,
+     $      ' incorrectly normalized.', / ' Bits of error=', 0P, G10.3,
+     $      ',', 3X, 'N=', I4, ', JTYPE=', I3, ', ISEED=(',
+     $       3( I4, ',' ), I5, ')' )
+*
+ 9997 FORMAT( / 1X, A3, ' -- Complex Generalized eigenvalue problem ',
+     $      'driver' )
+*
+ 9996 FORMAT( ' Matrix types (see CDRGEV4 for details): ' )
+*
+ 9995 FORMAT( ' Special Matrices:', 23X,
+     $      '(J''=transposed Jordan block)',
+     $      / '   1=(0,0)  2=(I,0)  3=(0,I)  4=(I,I)  5=(J'',J'')  ',
+     $      '6=(diag(J'',I), diag(I,J''))', / ' Diagonal Matrices:  ( ',
+     $      'D=diag(0,1,2,...) )', / '   7=(D,I)   9=(large*D, small*I',
+     $      ')  11=(large*I, small*D)  13=(large*D, large*I)', /
+     $      '   8=(I,D)  10=(small*D, large*I)  12=(small*I, large*D) ',
+     $      ' 14=(small*D, small*I)', / '  15=(D, reversed D)' )
+ 9994 FORMAT( ' Matrices Rotated by Random ', A, ' Matrices U, V:',
+     $      / '  16=Transposed Jordan Blocks             19=geometric ',
+     $      'alpha, beta=0,1', / '  17=arithm. alpha&beta             ',
+     $      '      20=arithmetic alpha, beta=0,1', / '  18=clustered ',
+     $      'alpha, beta=0,1            21=random alpha, beta=0,1',
+     $      / ' Large & Small Matrices:', / '  22=(large, small)   ',
+     $      '23=(small,large)    24=(small,small)    25=(large,large)',
+     $      / '  26=random O(1) matrices.' )
+*
+ 9993 FORMAT( / ' Tests performed:    ',
+     $      / ' 1 = max | ( b A - a B )''*l | / const.,',
+     $      / ' 2 = | |VR(i)| - 1 | / ulp,',
+     $      / ' 3 = max | ( b A - a B )*r | / const.',
+     $      / ' 4 = | |VL(i)| - 1 | / ulp,',
+     $      / ' 5 = 0 if W same no matter if r or l computed,',
+     $      / ' 6 = 0 if l same no matter if l computed,',
+     $      / ' 7 = 0 if r same no matter if r computed,', / 1X )
+ 9992 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 0P, F8.2 )
+ 9991 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 1P, E10.3 )
+*
+*     End of CDRGEV4
+*
+      END

--- a/TESTING/EIG/dchkee.F
+++ b/TESTING/EIG/dchkee.F
@@ -1111,7 +1111,7 @@
      $                   DDRGEV, DDRGSX, DDRGVX, DDRVBD, DDRVES, DDRVEV,
      $                   DDRVSG, DDRVST, DDRVSX, DDRVVX, DERRBD,
      $                   DERRED, DERRGG, DERRHS, DERRST, ILAVER, XLAENV,
-     $                   DDRGES3, DDRGEV3, 
+     $                   DDRGES3, DDRGEV3, DDRGEV4,
      $                   DCHKST2STG, DDRVST2STG, DCHKSB2STG, DDRVSG2STG
 *     ..
 *     .. Intrinsic Functions ..
@@ -2290,6 +2290,17 @@
      $                    WORK, LWORK, RESULT, INFO )
             IF( INFO.NE.0 )
      $         WRITE( NOUT, FMT = 9980 )'DDRGEV3', INFO
+*
+*     New Blocked version
+*
+            CALL DDRGEV4( NN, NVAL, MAXTYP, DOTYPE, ISEED, THRESH, NOUT,
+     $                    A( 1, 1 ), NMAX, A( 1, 2 ), A( 1, 3 ),
+     $                    A( 1, 4 ), A( 1, 7 ), NMAX, A( 1, 8 ),
+     $                    A( 1, 9 ), NMAX, D( 1, 1 ), D( 1, 2 ),
+     $                    D( 1, 3 ), D( 1, 4 ), D( 1, 5 ), D( 1, 6 ),
+     $                    WORK, LWORK, IWORK, RESULT, INFO )
+            IF( INFO.NE.0 )
+     $         WRITE( NOUT, FMT = 9980 )'DDRGEV4', INFO
          END IF
          WRITE( NOUT, FMT = 9973 )
          GO TO 10

--- a/TESTING/EIG/ddrgev4.f
+++ b/TESTING/EIG/ddrgev4.f
@@ -1,0 +1,981 @@
+*> \brief \b DDRGEV4
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE DDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+*                          NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+*                          ALPHAR, ALPHAI, BETA, ALPHR1, ALPHI1, BETA1,
+*                          WORK, LWORK, IWORK, RESULT, INFO )
+*
+*       .. Scalar Arguments ..
+*       INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+*      $                   NTYPES
+*       DOUBLE PRECISION   THRESH
+*       ..
+*       .. Array Arguments ..
+*       LOGICAL            DOTYPE( * )
+*       INTEGER            ISEED( 4 ), NN( * ), IWORK( * )
+*       DOUBLE PRECISION   A( LDA, * ), ALPHAI( * ), ALPHAR( * ),
+*      $                   ALPHI1( * ), ALPHR1( * ), B( LDA, * ),
+*      $                   BETA( * ), BETA1( * ), Q( LDQ, * ),
+*      $                   QE( LDQE, * ), RESULT( * ), S( LDA, * ),
+*      $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> DDRGEV4 checks the nonsymmetric generalized eigenvalue problem driver
+*> routine DGGEV4.
+*>
+*> DGGEV4 computes for a pair of n-by-n nonsymmetric matrices (A,B) the
+*> generalized eigenvalues and, optionally, the left and right
+*> eigenvectors.
+*>
+*> A generalized eigenvalue for a pair of matrices (A,B) is a scalar w
+*> or a ratio  alpha/beta = w, such that A - w*B is singular.  It is
+*> usually represented as the pair (alpha,beta), as there is reasonable
+*> interpretation for beta=0, and even for both being zero.
+*>
+*> A right generalized eigenvector corresponding to a generalized
+*> eigenvalue  w  for a pair of matrices (A,B) is a vector r  such that
+*> (A - wB) * r = 0.  A left generalized eigenvector is a vector l such
+*> that l**H * (A - wB) = 0, where l**H is the conjugate-transpose of l.
+*>
+*> When DDRGEV4 is called, a number of matrix "sizes" ("n's") and a
+*> number of matrix "types" are specified.  For each size ("n")
+*> and each type of matrix, a pair of matrices (A, B) will be generated
+*> and used for testing.  For each matrix pair, the following tests
+*> will be performed and compared with the threshold THRESH.
+*>
+*> Results from DGGEV4:
+*>
+*> (1)  max over all left eigenvalue/-vector pairs (alpha/beta,l) of
+*>
+*>      | VL**H * (beta A - alpha B) |/( ulp max(|beta A|, |alpha B|) )
+*>
+*>      where VL**H is the conjugate-transpose of VL.
+*>
+*> (2)  | |VL(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VL(i) denotes the i-th column of VL.
+*>
+*> (3)  max over all left eigenvalue/-vector pairs (alpha/beta,r) of
+*>
+*>      | (beta A - alpha B) * VR | / ( ulp max(|beta A|, |alpha B|) )
+*>
+*> (4)  | |VR(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VR(i) denotes the i-th column of VR.
+*>
+*> (5)  W(full) = W(partial)
+*>      W(full) denotes the eigenvalues computed when both l and r
+*>      are also computed, and W(partial) denotes the eigenvalues
+*>      computed when only W, only W and r, or only W and l are
+*>      computed.
+*>
+*> (6)  VL(full) = VL(partial)
+*>      VL(full) denotes the left eigenvectors computed when both l
+*>      and r are computed, and VL(partial) denotes the result
+*>      when only l is computed.
+*>
+*> (7)  VR(full) = VR(partial)
+*>      VR(full) denotes the right eigenvectors computed when both l
+*>      and r are also computed, and VR(partial) denotes the result
+*>      when only l is computed.
+*>
+*>
+*> Test Matrices
+*> ---- --------
+*>
+*> The sizes of the test matrices are specified by an array
+*> NN(1:NSIZES); the value of each element NN(j) specifies one size.
+*> The "types" are specified by a logical array DOTYPE( 1:NTYPES ); if
+*> DOTYPE(j) is .TRUE., then matrix type "j" will be generated.
+*> Currently, the list of possible types is:
+*>
+*> (1)  ( 0, 0 )         (a pair of zero matrices)
+*>
+*> (2)  ( I, 0 )         (an identity and a zero matrix)
+*>
+*> (3)  ( 0, I )         (an identity and a zero matrix)
+*>
+*> (4)  ( I, I )         (a pair of identity matrices)
+*>
+*>         t   t
+*> (5)  ( J , J  )       (a pair of transposed Jordan blocks)
+*>
+*>                                     t                ( I   0  )
+*> (6)  ( X, Y )         where  X = ( J   0  )  and Y = (      t )
+*>                                  ( 0   I  )          ( 0   J  )
+*>                       and I is a k x k identity and J a (k+1)x(k+1)
+*>                       Jordan block; k=(N-1)/2
+*>
+*> (7)  ( D, I )         where D is diag( 0, 1,..., N-1 ) (a diagonal
+*>                       matrix with those diagonal entries.)
+*> (8)  ( I, D )
+*>
+*> (9)  ( big*D, small*I ) where "big" is near overflow and small=1/big
+*>
+*> (10) ( small*D, big*I )
+*>
+*> (11) ( big*I, small*D )
+*>
+*> (12) ( small*I, big*D )
+*>
+*> (13) ( big*D, big*I )
+*>
+*> (14) ( small*D, small*I )
+*>
+*> (15) ( D1, D2 )        where D1 is diag( 0, 0, 1, ..., N-3, 0 ) and
+*>                        D2 is diag( 0, N-3, N-4,..., 1, 0, 0 )
+*>           t   t
+*> (16) Q ( J , J ) Z     where Q and Z are random orthogonal matrices.
+*>
+*> (17) Q ( T1, T2 ) Z    where T1 and T2 are upper triangular matrices
+*>                        with random O(1) entries above the diagonal
+*>                        and diagonal entries diag(T1) =
+*>                        ( 0, 0, 1, ..., N-3, 0 ) and diag(T2) =
+*>                        ( 0, N-3, N-4,..., 1, 0, 0 )
+*>
+*> (18) Q ( T1, T2 ) Z    diag(T1) = ( 0, 0, 1, 1, s, ..., s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1,..., 1, 0 )
+*>                        s = machine precision.
+*>
+*> (19) Q ( T1, T2 ) Z    diag(T1)=( 0,0,1,1, 1-d, ..., 1-(N-5)*d=s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0 )
+*>
+*>                                                        N-5
+*> (20) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, 1, a, ..., a   =s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>
+*> (21) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, r1, r2, ..., r(N-4), 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>                        where r1,..., r(N-4) are random.
+*>
+*> (22) Q ( big*T1, small*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (23) Q ( small*T1, big*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (24) Q ( small*T1, small*T2 ) Z  diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (25) Q ( big*T1, big*T2 ) Z      diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (26) Q ( T1, T2 ) Z     where T1 and T2 are random upper-triangular
+*>                         matrices.
+*>
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] NSIZES
+*> \verbatim
+*>          NSIZES is INTEGER
+*>          The number of sizes of matrices to use.  If it is zero,
+*>          DDRGEV4 does nothing.  NSIZES >= 0.
+*> \endverbatim
+*>
+*> \param[in] NN
+*> \verbatim
+*>          NN is INTEGER array, dimension (NSIZES)
+*>          An array containing the sizes to be used for the matrices.
+*>          Zero values will be skipped.  NN >= 0.
+*> \endverbatim
+*>
+*> \param[in] NTYPES
+*> \verbatim
+*>          NTYPES is INTEGER
+*>          The number of elements in DOTYPE.   If it is zero, DDRGEV4
+*>          does nothing.  It must be at least zero.  If it is MAXTYP+1
+*>          and NSIZES is 1, then an additional type, MAXTYP+1 is
+*>          defined, which is to use whatever matrix is in A.  This
+*>          is only useful if DOTYPE(1:MAXTYP) is .FALSE. and
+*>          DOTYPE(MAXTYP+1) is .TRUE. .
+*> \endverbatim
+*>
+*> \param[in] DOTYPE
+*> \verbatim
+*>          DOTYPE is LOGICAL array, dimension (NTYPES)
+*>          If DOTYPE(j) is .TRUE., then for each size in NN a
+*>          matrix of that size and of type j will be generated.
+*>          If NTYPES is smaller than the maximum number of types
+*>          defined (PARAMETER MAXTYP), then types NTYPES+1 through
+*>          MAXTYP will not be generated. If NTYPES is larger
+*>          than MAXTYP, DOTYPE(MAXTYP+1) through DOTYPE(NTYPES)
+*>          will be ignored.
+*> \endverbatim
+*>
+*> \param[in,out] ISEED
+*> \verbatim
+*>          ISEED is INTEGER array, dimension (4)
+*>          On entry ISEED specifies the seed of the random number
+*>          generator. The array elements should be between 0 and 4095;
+*>          if not they will be reduced mod 4096. Also, ISEED(4) must
+*>          be odd.  The random number generator uses a linear
+*>          congruential sequence limited to small integers, and so
+*>          should produce machine independent random numbers. The
+*>          values of ISEED are changed on exit, and can be used in the
+*>          next call to DDRGEV4 to continue the same random number
+*>          sequence.
+*> \endverbatim
+*>
+*> \param[in] THRESH
+*> \verbatim
+*>          THRESH is DOUBLE PRECISION
+*>          A test will count as "failed" if the "error", computed as
+*>          described above, exceeds THRESH.  Note that the error is
+*>          scaled to be O(1), so THRESH should be a reasonably small
+*>          multiple of 1, e.g., 10 or 100.  In particular, it should
+*>          not depend on the precision (single vs. double) or the size
+*>          of the matrix.  It must be at least zero.
+*> \endverbatim
+*>
+*> \param[in] NOUNIT
+*> \verbatim
+*>          NOUNIT is INTEGER
+*>          The FORTRAN unit number for printing out error messages
+*>          (e.g., if a routine returns IERR not equal to 0.)
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array,
+*>                                       dimension(LDA, max(NN))
+*>          Used to hold the original A matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of A, B, S, and T.
+*>          It must be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is DOUBLE PRECISION array,
+*>                                       dimension(LDA, max(NN))
+*>          Used to hold the original B matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[out] S
+*> \verbatim
+*>          S is DOUBLE PRECISION array,
+*>                                 dimension (LDA, max(NN))
+*>          The Schur form matrix computed from A by DGGEV4.  On exit, S
+*>          contains the Schur form matrix corresponding to the matrix
+*>          in A.
+*> \endverbatim
+*>
+*> \param[out] T
+*> \verbatim
+*>          T is DOUBLE PRECISION array,
+*>                                 dimension (LDA, max(NN))
+*>          The upper triangular matrix computed from B by DGGEV4.
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is DOUBLE PRECISION array,
+*>                                 dimension (LDQ, max(NN))
+*>          The (left) eigenvectors matrix computed by DGGEV4.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of Q and Z. It must
+*>          be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is DOUBLE PRECISION array, dimension( LDQ, max(NN) )
+*>          The (right) orthogonal matrix computed by DGGEV4.
+*> \endverbatim
+*>
+*> \param[out] QE
+*> \verbatim
+*>          QE is DOUBLE PRECISION array, dimension( LDQ, max(NN) )
+*>          QE holds the computed right or left eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] LDQE
+*> \verbatim
+*>          LDQE is INTEGER
+*>          The leading dimension of QE. LDQE >= max(1,max(NN)).
+*> \endverbatim
+*>
+*> \param[out] ALPHAR
+*> \verbatim
+*>          ALPHAR is DOUBLE PRECISION array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] ALPHAI
+*> \verbatim
+*>          ALPHAI is DOUBLE PRECISION array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is DOUBLE PRECISION array, dimension (max(NN))
+*>
+*>          The generalized eigenvalues of (A,B) computed by DGGEV4.
+*>          ( ALPHAR(k)+ALPHAI(k)*i ) / BETA(k) is the k-th
+*>          generalized eigenvalue of A and B.
+*> \endverbatim
+*>
+*> \param[out] ALPHR1
+*> \verbatim
+*>          ALPHR1 is DOUBLE PRECISION array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] ALPHI1
+*> \verbatim
+*>          ALPHI1 is DOUBLE PRECISION array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA1
+*> \verbatim
+*>          BETA1 is DOUBLE PRECISION array, dimension (max(NN))
+*>
+*>          Like ALPHAR, ALPHAI, BETA, these arrays contain the
+*>          eigenvalues of A and B, but those computed when DGGEV4 only
+*>          computes a partial eigendecomposition, i.e. not the
+*>          eigenvalues and left and right eigenvectors.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is DOUBLE PRECISION array, dimension (LWORK)
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The number of entries in WORK.  LWORK >= MAX( 8*N, N*(N+1) ).
+*> \endverbatim
+*>
+*> \param[out] RESULT
+*> \verbatim
+*>          RESULT is DOUBLE PRECISION array, dimension (2)
+*>          The values computed by the tests described above.
+*>          The values are currently limited to 1/ulp, to avoid overflow.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  A routine returned an error code.  INFO is the
+*>                absolute value of the INFO value returned.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \ingroup double_eig
+*
+*  =====================================================================
+      SUBROUTINE DDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+     $                   NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+     $                   ALPHAR, ALPHAI, BETA, ALPHR1, ALPHI1, BETA1,
+     $                   WORK, LWORK, IWORK, RESULT, INFO )
+      IMPLICIT NONE
+*
+*  -- LAPACK test routine --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*
+*     .. Scalar Arguments ..
+      INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+     $                   NTYPES
+      DOUBLE PRECISION   THRESH
+*     ..
+*     .. Array Arguments ..
+      LOGICAL            DOTYPE( * )
+      INTEGER            ISEED( 4 ), NN( * ), IWORK( * )
+      DOUBLE PRECISION   A( LDA, * ), ALPHAI( * ), ALPHAR( * ),
+     $                   ALPHI1( * ), ALPHR1( * ), B( LDA, * ),
+     $                   BETA( * ), BETA1( * ), Q( LDQ, * ),
+     $                   QE( LDQE, * ), RESULT( * ), S( LDA, * ),
+     $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
+      INTEGER            MAXTYP
+      PARAMETER          ( MAXTYP = 27 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            BADNN
+      INTEGER            I, IADD, IERR, IN, J, JC, JR, JSIZE, JTYPE,
+     $                   MAXWRK, MINWRK, MTYPES, N, N1, NERRS, NMATS,
+     $                   NMAX, NTESTT
+      DOUBLE PRECISION   SAFMAX, SAFMIN, ULP, ULPINV
+*     ..
+*     .. Local Arrays ..
+      INTEGER            IASIGN( MAXTYP ), IBSIGN( MAXTYP ),
+     $                   IOLDSD( 4 ), KADD( 6 ), KAMAGN( MAXTYP ),
+     $                   KATYPE( MAXTYP ), KAZERO( MAXTYP ),
+     $                   KBMAGN( MAXTYP ), KBTYPE( MAXTYP ),
+     $                   KBZERO( MAXTYP ), KCLASS( MAXTYP ),
+     $                   KTRIAN( MAXTYP ), KZ1( 6 ), KZ2( 6 )
+      DOUBLE PRECISION   RMAGN( 0: 3 )
+*     ..
+*     .. External Functions ..
+      INTEGER            ILAENV
+      DOUBLE PRECISION   DLAMCH, DLARND
+      EXTERNAL           ILAENV, DLAMCH, DLARND
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           ALASVM, DGET52, DGGEV4, DLACPY, DLARFG, DLASET,
+     $                   DLATM4, DORM2R, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          ABS, DBLE, MAX, MIN, SIGN
+*     ..
+*     .. Data statements ..
+      DATA               KCLASS / 15*1, 10*2, 1*3, 1*4 /
+      DATA               KZ1 / 0, 1, 2, 1, 3, 3 /
+      DATA               KZ2 / 0, 0, 1, 2, 1, 1 /
+      DATA               KADD / 0, 0, 0, 0, 3, 2 /
+      DATA               KATYPE / 0, 1, 0, 1, 2, 3, 4, 1, 4, 4, 1, 1, 4,
+     $                   4, 4, 2, 4, 5, 8, 7, 9, 4*4, 0, 0 /
+      DATA               KBTYPE / 0, 0, 1, 1, 2, -3, 1, 4, 1, 1, 4, 4,
+     $                   1, 1, -4, 2, -4, 8*8, 0, 0 /
+      DATA               KAZERO / 6*1, 2, 1, 2*2, 2*1, 2*2, 3, 1, 3,
+     $                   4*5, 4*3, 1, 1 /
+      DATA               KBZERO / 6*1, 1, 2, 2*1, 2*2, 2*1, 4, 1, 4,
+     $                   4*6, 4*4, 1, 1 /
+      DATA               KAMAGN / 8*1, 2, 3, 2, 3, 2, 3, 7*1, 2, 3, 3,
+     $                   2, 1, 3 /
+      DATA               KBMAGN / 8*1, 3, 2, 3, 2, 2, 3, 7*1, 3, 2, 3,
+     $                   2, 1, 3 /
+      DATA               KTRIAN / 16*0, 11*1 /
+      DATA               IASIGN / 6*0, 2, 0, 2*2, 2*0, 3*2, 0, 2, 3*0,
+     $                   5*2, 2*0 /
+      DATA               IBSIGN / 7*0, 2, 2*0, 2*2, 2*0, 2, 0, 2, 10*0 /
+*     ..
+*     .. Executable Statements ..
+*
+*     Check for errors
+*
+      INFO = 0
+*
+      BADNN = .FALSE.
+      NMAX = 1
+      DO 10 J = 1, NSIZES
+         NMAX = MAX( NMAX, NN( J ) )
+         IF( NN( J ).LT.0 )
+     $      BADNN = .TRUE.
+   10 CONTINUE
+*
+      IF( NSIZES.LT.0 ) THEN
+         INFO = -1
+      ELSE IF( BADNN ) THEN
+         INFO = -2
+      ELSE IF( NTYPES.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( THRESH.LT.ZERO ) THEN
+         INFO = -6
+      ELSE IF( LDA.LE.1 .OR. LDA.LT.NMAX ) THEN
+         INFO = -9
+      ELSE IF( LDQ.LE.1 .OR. LDQ.LT.NMAX ) THEN
+         INFO = -14
+      ELSE IF( LDQE.LE.1 .OR. LDQE.LT.NMAX ) THEN
+         INFO = -17
+      END IF
+*
+*     Compute workspace
+*      (Note: Comments in the code beginning "Workspace:" describe the
+*       minimal amount of workspace needed at that point in the code,
+*       as well as the preferred amount for good performance.
+*       NB refers to the optimal block size for the immediately
+*       following subroutine, as returned by ILAENV.
+*
+      MINWRK = 1
+      IF( INFO.EQ.0 .AND. LWORK.GE.1 ) THEN
+         MINWRK = MAX( 1, 8*NMAX, NMAX*( NMAX+1 ) )
+         MAXWRK = 7*NMAX + NMAX*ILAENV( 1, 'DGEQRF', ' ', NMAX, 1, NMAX,
+     $            0 )
+         MAXWRK = MAX( MAXWRK, NMAX*( NMAX+1 ) )
+         WORK( 1 ) = MAXWRK
+      END IF
+*
+      IF( LWORK.LT.MINWRK )
+     $   INFO = -25
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DDRGEV4', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( NSIZES.EQ.0 .OR. NTYPES.EQ.0 )
+     $   RETURN
+*
+      SAFMIN = DLAMCH( 'Safe minimum' )
+      ULP = DLAMCH( 'Epsilon' )*DLAMCH( 'Base' )
+      SAFMIN = SAFMIN / ULP
+      SAFMAX = ONE / SAFMIN
+      ULPINV = ONE / ULP
+*
+*     The values RMAGN(2:3) depend on N, see below.
+*
+      RMAGN( 0 ) = ZERO
+      RMAGN( 1 ) = ONE
+*
+*     Loop over sizes, types
+*
+      NTESTT = 0
+      NERRS = 0
+      NMATS = 0
+*
+      DO 220 JSIZE = 1, NSIZES
+         N = NN( JSIZE )
+         N1 = MAX( 1, N )
+         RMAGN( 2 ) = SAFMAX*ULP / DBLE( N1 )
+         RMAGN( 3 ) = SAFMIN*ULPINV*N1
+*
+         IF( NSIZES.NE.1 ) THEN
+            MTYPES = MIN( MAXTYP, NTYPES )
+         ELSE
+            MTYPES = MIN( MAXTYP+1, NTYPES )
+         END IF
+*
+         DO 210 JTYPE = 1, MTYPES
+            IF( .NOT.DOTYPE( JTYPE ) )
+     $         GO TO 210
+            NMATS = NMATS + 1
+*
+*           Save ISEED in case of an error.
+*
+            DO 20 J = 1, 4
+               IOLDSD( J ) = ISEED( J )
+   20       CONTINUE
+*
+*           Generate test matrices A and B
+*
+*           Description of control parameters:
+*
+*           KZLASS: =1 means w/o rotation, =2 means w/ rotation,
+*                   =3 means random, =4 means random generalized
+*                   upper Hessenberg.
+*           KATYPE: the "type" to be passed to DLATM4 for computing A.
+*           KAZERO: the pattern of zeros on the diagonal for A:
+*                   =1: ( xxx ), =2: (0, xxx ) =3: ( 0, 0, xxx, 0 ),
+*                   =4: ( 0, xxx, 0, 0 ), =5: ( 0, 0, 1, xxx, 0 ),
+*                   =6: ( 0, 1, 0, xxx, 0 ).  (xxx means a string of
+*                   non-zero entries.)
+*           KAMAGN: the magnitude of the matrix: =0: zero, =1: O(1),
+*                   =2: large, =3: small.
+*           IASIGN: 1 if the diagonal elements of A are to be
+*                   multiplied by a random magnitude 1 number, =2 if
+*                   randomly chosen diagonal blocks are to be rotated
+*                   to form 2x2 blocks.
+*           KBTYPE, KBZERO, KBMAGN, IBSIGN: the same, but for B.
+*           KTRIAN: =0: don't fill in the upper triangle, =1: do.
+*           KZ1, KZ2, KADD: used to implement KAZERO and KBZERO.
+*           RMAGN: used to implement KAMAGN and KBMAGN.
+*
+            IF( MTYPES.GT.MAXTYP )
+     $         GO TO 100
+            IERR = 0
+            IF( KCLASS( JTYPE ).LT.3 ) THEN
+*
+*              Generate A (w/o rotation)
+*
+               IF( ABS( KATYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL DLASET( 'Full', N, N, ZERO, ZERO, A, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL DLATM4( KATYPE( JTYPE ), IN, KZ1( KAZERO( JTYPE ) ),
+     $                      KZ2( KAZERO( JTYPE ) ), IASIGN( JTYPE ),
+     $                      RMAGN( KAMAGN( JTYPE ) ), ULP,
+     $                      RMAGN( KTRIAN( JTYPE )*KAMAGN( JTYPE ) ), 2,
+     $                      ISEED, A, LDA )
+               IADD = KADD( KAZERO( JTYPE ) )
+               IF( IADD.GT.0 .AND. IADD.LE.N )
+     $            A( IADD, IADD ) = ONE
+*
+*              Generate B (w/o rotation)
+*
+               IF( ABS( KBTYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL DLASET( 'Full', N, N, ZERO, ZERO, B, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL DLATM4( KBTYPE( JTYPE ), IN, KZ1( KBZERO( JTYPE ) ),
+     $                      KZ2( KBZERO( JTYPE ) ), IBSIGN( JTYPE ),
+     $                      RMAGN( KBMAGN( JTYPE ) ), ONE,
+     $                      RMAGN( KTRIAN( JTYPE )*KBMAGN( JTYPE ) ), 2,
+     $                      ISEED, B, LDA )
+               IADD = KADD( KBZERO( JTYPE ) )
+               IF( IADD.NE.0 .AND. IADD.LE.N )
+     $            B( IADD, IADD ) = ONE
+*
+               IF( KCLASS( JTYPE ).EQ.2 .AND. N.GT.0 ) THEN
+*
+*                 Include rotations
+*
+*                 Generate Q, Z as Householder transformations times
+*                 a diagonal matrix.
+*
+                  DO 40 JC = 1, N - 1
+                     DO 30 JR = JC, N
+                        Q( JR, JC ) = DLARND( 3, ISEED )
+                        Z( JR, JC ) = DLARND( 3, ISEED )
+   30                CONTINUE
+                     CALL DLARFG( N+1-JC, Q( JC, JC ), Q( JC+1, JC ), 1,
+     $                            WORK( JC ) )
+                     WORK( 2*N+JC ) = SIGN( ONE, Q( JC, JC ) )
+                     Q( JC, JC ) = ONE
+                     CALL DLARFG( N+1-JC, Z( JC, JC ), Z( JC+1, JC ), 1,
+     $                            WORK( N+JC ) )
+                     WORK( 3*N+JC ) = SIGN( ONE, Z( JC, JC ) )
+                     Z( JC, JC ) = ONE
+   40             CONTINUE
+                  Q( N, N ) = ONE
+                  WORK( N ) = ZERO
+                  WORK( 3*N ) = SIGN( ONE, DLARND( 2, ISEED ) )
+                  Z( N, N ) = ONE
+                  WORK( 2*N ) = ZERO
+                  WORK( 4*N ) = SIGN( ONE, DLARND( 2, ISEED ) )
+*
+*                 Apply the diagonal matrices
+*
+                  DO 60 JC = 1, N
+                     DO 50 JR = 1, N
+                        A( JR, JC ) = WORK( 2*N+JR )*WORK( 3*N+JC )*
+     $                                A( JR, JC )
+                        B( JR, JC ) = WORK( 2*N+JR )*WORK( 3*N+JC )*
+     $                                B( JR, JC )
+   50                CONTINUE
+   60             CONTINUE
+                  CALL DORM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, A,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL DORM2R( 'R', 'T', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         A, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL DORM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, B,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL DORM2R( 'R', 'T', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         B, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+               END IF
+            ELSE IF (KCLASS( JTYPE ).EQ.3) THEN
+*
+*              Random matrices
+*
+               DO 80 JC = 1, N
+                  DO 70 JR = 1, N
+                     A( JR, JC ) = RMAGN( KAMAGN( JTYPE ) )*
+     $                             DLARND( 2, ISEED )
+                     B( JR, JC ) = RMAGN( KBMAGN( JTYPE ) )*
+     $                             DLARND( 2, ISEED )
+   70             CONTINUE
+   80          CONTINUE
+            ELSE
+*
+*              Random upper Hessenberg pencil with singular B
+*
+               DO 81 JC = 1, N
+                  DO 71 JR = 1, min( JC + 1, N)
+                     A( JR, JC ) = RMAGN( KAMAGN( JTYPE ) )*
+     $                             DLARND( 2, ISEED )
+   71             CONTINUE
+                  DO 72 JR = JC + 2, N
+                     A( JR, JC ) = ZERO
+   72             CONTINUE
+   81          CONTINUE
+               DO 82 JC = 1, N
+                  DO 73 JR = 1, JC
+                     B( JR, JC ) = RMAGN( KAMAGN( JTYPE ) )*
+     $                             DLARND( 2, ISEED )
+   73             CONTINUE
+                  DO 74 JR = JC + 1, N
+                     B( JR, JC ) = ZERO
+   74             CONTINUE
+   82          CONTINUE
+               DO 83 JC = 1, N, 4
+                  B( JC, JC ) = ZERO
+   83          CONTINUE
+               
+            END IF
+*
+   90       CONTINUE
+*
+            IF( IERR.NE.0 ) THEN
+               WRITE( NOUNIT, FMT = 9999 )'Generator', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               RETURN
+            END IF
+*
+  100       CONTINUE
+*
+            DO 110 I = 1, 7
+               RESULT( I ) = -ONE
+  110       CONTINUE
+*
+*           Call XLAENV to set the parameters used in DLAQZ0
+*
+            CALL XLAENV( 12, 10 )
+            CALL XLAENV( 13, 12 )
+            CALL XLAENV( 14, 13 )
+            CALL XLAENV( 15, 2 )
+            CALL XLAENV( 17, 10 )
+*
+*           Call DGGEV4 to compute eigenvalues and eigenvectors.
+*
+            CALL DLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL DLACPY( ' ', N, N, B, LDA, T, LDA )
+
+            CALL DGGEV4( 'V', 'V', N, S, LDA, T, LDA, ALPHAR, ALPHAI,
+     $                  BETA, Q, LDQ, Z, LDQ, WORK, LWORK,
+     $                  IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'DGGEV41', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+
+*
+*           Do the tests (1) and (2)
+*
+            CALL DGET52( .TRUE., N, A, LDA, B, LDA, Q, LDQ, ALPHAR,
+     $                   ALPHAI, BETA, WORK, RESULT( 1 ) )
+            IF( RESULT( 2 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Left', 'DGGEV41',
+     $            RESULT( 2 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do the tests (3) and (4)
+*
+            CALL DGET52( .FALSE., N, A, LDA, B, LDA, Z, LDQ, ALPHAR,
+     $                   ALPHAI, BETA, WORK, RESULT( 3 ) )
+            IF( RESULT( 4 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Right', 'DGGEV41',
+     $            RESULT( 4 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do the test (5)
+*
+            CALL DLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL DLACPY( ' ', N, N, B, LDA, T, LDA )
+         
+
+            CALL DGGEV4( 'N', 'N', N, S, LDA, T, LDA, ALPHR1, ALPHI1,
+     $                  BETA1, Q, LDQ, Z, LDQ, WORK, LWORK,
+     $                  IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'DGGEV42', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 120 J = 1, N
+               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
+     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) ) THEN
+                  RESULT( 5 ) = ULPINV
+               END IF
+  120       CONTINUE
+*
+*           Do the test (6): Compute eigenvalues and left eigenvectors,
+*           and test them
+*
+            CALL DLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL DLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL DGGEV4( 'V', 'N', N, S, LDA, T, LDA, ALPHR1, ALPHI1,
+     $                  BETA1, QE, LDQE, Z, LDQ, WORK, LWORK,
+     $                  IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'DGGEV43', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 130 J = 1, N
+               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
+     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 6 )
+     $              = ULPINV
+  130       CONTINUE
+*
+            DO 150 J = 1, N
+               DO 140 JC = 1, N
+                  IF( Q( J, JC ).NE.QE( J, JC ) )
+     $               RESULT( 6 ) = ULPINV
+  140          CONTINUE
+  150       CONTINUE
+*
+*           DO the test (7): Compute eigenvalues and right eigenvectors,
+*           and test them
+*
+            CALL DLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL DLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL DGGEV4( 'N', 'V', N, S, LDA, T, LDA, ALPHR1, ALPHI1,
+     $                  BETA1, Q, LDQ, QE, LDQE, WORK, LWORK,
+     $                  IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'DGGEV44', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 160 J = 1, N
+               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
+     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 7 )
+     $              = ULPINV
+  160       CONTINUE
+*
+            DO 180 J = 1, N
+               DO 170 JC = 1, N
+                  IF( Z( J, JC ).NE.QE( J, JC ) )
+     $               RESULT( 7 ) = ULPINV
+  170          CONTINUE
+  180       CONTINUE
+*
+*           End of Loop -- Check for RESULT(j) > THRESH
+*
+  190       CONTINUE
+*
+            NTESTT = NTESTT + 7
+*
+*           Print out tests which fail.
+*
+            DO 200 JR = 1, 7
+               IF( RESULT( JR ).GE.THRESH ) THEN
+*
+*                 If this is the first test to fail,
+*                 print a header to the data file.
+*
+                  IF( NERRS.EQ.0 ) THEN
+                     WRITE( NOUNIT, FMT = 9997 )'DGV'
+*
+*                    Matrix types
+*
+                     WRITE( NOUNIT, FMT = 9996 )
+                     WRITE( NOUNIT, FMT = 9995 )
+                     WRITE( NOUNIT, FMT = 9994 )'Orthogonal'
+*
+*                    Tests performed
+*
+                     WRITE( NOUNIT, FMT = 9993 )
+*
+                  END IF
+                  NERRS = NERRS + 1
+                  IF( RESULT( JR ).LT.10000.0D0 ) THEN
+                     WRITE( NOUNIT, FMT = 9992 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  ELSE
+                     WRITE( NOUNIT, FMT = 9991 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  END IF
+               END IF
+  200       CONTINUE
+*
+  210    CONTINUE
+  220 CONTINUE
+*
+*     Summary
+*
+      CALL ALASVM( 'DGV', NOUNIT, NERRS, NTESTT, 0 )
+*
+      WORK( 1 ) = MAXWRK
+*
+      RETURN
+*
+ 9999 FORMAT( ' DDRGEV4: ', A, ' returned INFO=', I6, '.', / 3X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 4( I4, ',' ), I5, ')' )
+*
+ 9998 FORMAT( ' DDRGEV4: ', A, ' Eigenvectors from ', A,
+     $      ' incorrectly normalized.', / ' Bits of error=', 0P, G10.3,
+     $      ',', 3X, 'N=', I4, ', JTYPE=', I3, ', ISEED=(',
+     $       4( I4, ',' ), I5, ')' )
+*
+ 9997 FORMAT( / 1X, A3, ' -- Real Generalized eigenvalue problem driver'
+     $       )
+*
+ 9996 FORMAT( ' Matrix types (see DDRGEV4 for details): ' )
+*
+ 9995 FORMAT( ' Special Matrices:', 23X,
+     $      '(J''=transposed Jordan block)',
+     $      / '   1=(0,0)  2=(I,0)  3=(0,I)  4=(I,I)  5=(J'',J'')  ',
+     $      '6=(diag(J'',I), diag(I,J''))', / ' Diagonal Matrices:  ( ',
+     $      'D=diag(0,1,2,...) )', / '   7=(D,I)   9=(large*D, small*I',
+     $      ')  11=(large*I, small*D)  13=(large*D, large*I)', /
+     $      '   8=(I,D)  10=(small*D, large*I)  12=(small*I, large*D) ',
+     $      ' 14=(small*D, small*I)', / '  15=(D, reversed D)' )
+ 9994 FORMAT( ' Matrices Rotated by Random ', A, ' Matrices U, V:',
+     $      / '  16=Transposed Jordan Blocks             19=geometric ',
+     $      'alpha, beta=0,1', / '  17=arithm. alpha&beta             ',
+     $      '      20=arithmetic alpha, beta=0,1', / '  18=clustered ',
+     $      'alpha, beta=0,1            21=random alpha, beta=0,1',
+     $      / ' Large & Small Matrices:', / '  22=(large, small)   ',
+     $      '23=(small,large)    24=(small,small)    25=(large,large)',
+     $      / '  26=random O(1) matrices.' )
+*
+ 9993 FORMAT( / ' Tests performed:    ',
+     $      / ' 1 = max | ( b A - a B )''*l | / const.,',
+     $      / ' 2 = | |VR(i)| - 1 | / ulp,',
+     $      / ' 3 = max | ( b A - a B )*r | / const.',
+     $      / ' 4 = | |VL(i)| - 1 | / ulp,',
+     $      / ' 5 = 0 if W same no matter if r or l computed,',
+     $      / ' 6 = 0 if l same no matter if l computed,',
+     $      / ' 7 = 0 if r same no matter if r computed,', / 1X )
+ 9992 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 0P, F8.2 )
+ 9991 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 1P, D10.3 )
+*
+*     End of DDRGEV4
+*
+      END

--- a/TESTING/EIG/schkee.F
+++ b/TESTING/EIG/schkee.F
@@ -1111,7 +1111,7 @@
      $                   SDRGEV, SDRGSX, SDRGVX, SDRVBD, SDRVES, SDRVEV,
      $                   SDRVSG, SDRVST, SDRVSX, SDRVVX, SERRBD,
      $                   SERRED, SERRGG, SERRHS, SERRST, ILAVER, XLAENV,
-     $                   SDRGES3, SDRGEV3, 
+     $                   SDRGES3, SDRGEV3, SDRGEV4,
      $                   SCHKST2STG, SDRVST2STG, SCHKSB2STG, SDRVSG2STG
 *     ..
 *     .. Intrinsic Functions ..
@@ -2293,6 +2293,19 @@
      $                    WORK, LWORK, RESULT, INFO )
             IF( INFO.NE.0 )
      $         WRITE( NOUT, FMT = 9980 )'SDRGEV3', INFO
+
+*
+* New Blocked version
+*
+            CALL SDRGEV4( NN, NVAL, MAXTYP, DOTYPE, ISEED, THRESH, NOUT,
+     $                    A( 1, 1 ), NMAX, A( 1, 2 ), A( 1, 3 ),
+     $                    A( 1, 4 ), A( 1, 7 ), NMAX, A( 1, 8 ),
+     $                    A( 1, 9 ), NMAX, D( 1, 1 ), D( 1, 2 ),
+     $                    D( 1, 3 ), D( 1, 4 ), D( 1, 5 ), D( 1, 6 ),
+     $                    WORK, LWORK, IWORK, RESULT, INFO )
+            IF( INFO.NE.0 )
+     $         WRITE( NOUT, FMT = 9980 )'SDRGEV4', INFO
+
          END IF
          WRITE( NOUT, FMT = 9973 )
          GO TO 10

--- a/TESTING/EIG/sdrgev4.f
+++ b/TESTING/EIG/sdrgev4.f
@@ -1,0 +1,950 @@
+*> \brief \b SDRGEV4
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE SDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+*                           NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+*                           ALPHAR, ALPHAI, BETA, ALPHR1, ALPHI1, BETA1,
+*                           WORK, LWORK, IWORK, RESULT, INFO )
+*
+*       .. Scalar Arguments ..
+*       INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+*      $                   NTYPES
+*       REAL               THRESH
+*       ..
+*       .. Array Arguments ..
+*       LOGICAL            DOTYPE( * )
+*       INTEGER            ISEED( 4 ), NN( * )
+*       REAL               A( LDA, * ), ALPHAI( * ), ALPHI1( * ),
+*      $                   ALPHAR( * ), ALPHR1( * ), B( LDA, * ),
+*      $                   BETA( * ), BETA1( * ), Q( LDQ, * ),
+*      $                   QE( LDQE, * ), RESULT( * ), S( LDA, * ),
+*      $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> SDRGEV4 checks the nonsymmetric generalized eigenvalue problem driver
+*> routine SGGEV4.
+*>
+*> SGGEV4 computes for a pair of n-by-n nonsymmetric matrices (A,B) the
+*> generalized eigenvalues and, optionally, the left and right
+*> eigenvectors.
+*>
+*> A generalized eigenvalue for a pair of matrices (A,B) is a scalar w
+*> or a ratio  alpha/beta = w, such that A - w*B is singular.  It is
+*> usually represented as the pair (alpha,beta), as there is reasonable
+*> interpretation for beta=0, and even for both being zero.
+*>
+*> A right generalized eigenvector corresponding to a generalized
+*> eigenvalue  w  for a pair of matrices (A,B) is a vector r  such that
+*> (A - wB) * r = 0.  A left generalized eigenvector is a vector l such
+*> that l**H * (A - wB) = 0, where l**H is the conjugate-transpose of l.
+*>
+*> When SDRGEV4 is called, a number of matrix "sizes" ("n's") and a
+*> number of matrix "types" are specified.  For each size ("n")
+*> and each type of matrix, a pair of matrices (A, B) will be generated
+*> and used for testing.  For each matrix pair, the following tests
+*> will be performed and compared with the threshold THRESH.
+*>
+*> Results from SGGEV4:
+*>
+*> (1)  max over all left eigenvalue/-vector pairs (alpha/beta,l) of
+*>
+*>      | VL**H * (beta A - alpha B) |/( ulp max(|beta A|, |alpha B|) )
+*>
+*>      where VL**H is the conjugate-transpose of VL.
+*>
+*> (2)  | |VL(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VL(i) denotes the i-th column of VL.
+*>
+*> (3)  max over all left eigenvalue/-vector pairs (alpha/beta,r) of
+*>
+*>      | (beta A - alpha B) * VR | / ( ulp max(|beta A|, |alpha B|) )
+*>
+*> (4)  | |VR(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VR(i) denotes the i-th column of VR.
+*>
+*> (5)  W(full) = W(partial)
+*>      W(full) denotes the eigenvalues computed when both l and r
+*>      are also computed, and W(partial) denotes the eigenvalues
+*>      computed when only W, only W and r, or only W and l are
+*>      computed.
+*>
+*> (6)  VL(full) = VL(partial)
+*>      VL(full) denotes the left eigenvectors computed when both l
+*>      and r are computed, and VL(partial) denotes the result
+*>      when only l is computed.
+*>
+*> (7)  VR(full) = VR(partial)
+*>      VR(full) denotes the right eigenvectors computed when both l
+*>      and r are also computed, and VR(partial) denotes the result
+*>      when only l is computed.
+*>
+*>
+*> Test Matrices
+*> ---- --------
+*>
+*> The sizes of the test matrices are specified by an array
+*> NN(1:NSIZES); the value of each element NN(j) specifies one size.
+*> The "types" are specified by a logical array DOTYPE( 1:NTYPES ); if
+*> DOTYPE(j) is .TRUE., then matrix type "j" will be generated.
+*> Currently, the list of possible types is:
+*>
+*> (1)  ( 0, 0 )         (a pair of zero matrices)
+*>
+*> (2)  ( I, 0 )         (an identity and a zero matrix)
+*>
+*> (3)  ( 0, I )         (an identity and a zero matrix)
+*>
+*> (4)  ( I, I )         (a pair of identity matrices)
+*>
+*>         t   t
+*> (5)  ( J , J  )       (a pair of transposed Jordan blocks)
+*>
+*>                                     t                ( I   0  )
+*> (6)  ( X, Y )         where  X = ( J   0  )  and Y = (      t )
+*>                                  ( 0   I  )          ( 0   J  )
+*>                       and I is a k x k identity and J a (k+1)x(k+1)
+*>                       Jordan block; k=(N-1)/2
+*>
+*> (7)  ( D, I )         where D is diag( 0, 1,..., N-1 ) (a diagonal
+*>                       matrix with those diagonal entries.)
+*> (8)  ( I, D )
+*>
+*> (9)  ( big*D, small*I ) where "big" is near overflow and small=1/big
+*>
+*> (10) ( small*D, big*I )
+*>
+*> (11) ( big*I, small*D )
+*>
+*> (12) ( small*I, big*D )
+*>
+*> (13) ( big*D, big*I )
+*>
+*> (14) ( small*D, small*I )
+*>
+*> (15) ( D1, D2 )        where D1 is diag( 0, 0, 1, ..., N-3, 0 ) and
+*>                        D2 is diag( 0, N-3, N-4,..., 1, 0, 0 )
+*>           t   t
+*> (16) Q ( J , J ) Z     where Q and Z are random orthogonal matrices.
+*>
+*> (17) Q ( T1, T2 ) Z    where T1 and T2 are upper triangular matrices
+*>                        with random O(1) entries above the diagonal
+*>                        and diagonal entries diag(T1) =
+*>                        ( 0, 0, 1, ..., N-3, 0 ) and diag(T2) =
+*>                        ( 0, N-3, N-4,..., 1, 0, 0 )
+*>
+*> (18) Q ( T1, T2 ) Z    diag(T1) = ( 0, 0, 1, 1, s, ..., s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1,..., 1, 0 )
+*>                        s = machine precision.
+*>
+*> (19) Q ( T1, T2 ) Z    diag(T1)=( 0,0,1,1, 1-d, ..., 1-(N-5)*d=s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0 )
+*>
+*>                                                        N-5
+*> (20) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, 1, a, ..., a   =s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>
+*> (21) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, r1, r2, ..., r(N-4), 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>                        where r1,..., r(N-4) are random.
+*>
+*> (22) Q ( big*T1, small*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (23) Q ( small*T1, big*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (24) Q ( small*T1, small*T2 ) Z  diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (25) Q ( big*T1, big*T2 ) Z      diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (26) Q ( T1, T2 ) Z     where T1 and T2 are random upper-triangular
+*>                         matrices.
+*>
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] NSIZES
+*> \verbatim
+*>          NSIZES is INTEGER
+*>          The number of sizes of matrices to use.  If it is zero,
+*>          SDRGEV4 does nothing.  NSIZES >= 0.
+*> \endverbatim
+*>
+*> \param[in] NN
+*> \verbatim
+*>          NN is INTEGER array, dimension (NSIZES)
+*>          An array containing the sizes to be used for the matrices.
+*>          Zero values will be skipped.  NN >= 0.
+*> \endverbatim
+*>
+*> \param[in] NTYPES
+*> \verbatim
+*>          NTYPES is INTEGER
+*>          The number of elements in DOTYPE.   If it is zero, SDRGEV4
+*>          does nothing.  It must be at least zero.  If it is MAXTYP+1
+*>          and NSIZES is 1, then an additional type, MAXTYP+1 is
+*>          defined, which is to use whatever matrix is in A.  This
+*>          is only useful if DOTYPE(1:MAXTYP) is .FALSE. and
+*>          DOTYPE(MAXTYP+1) is .TRUE. .
+*> \endverbatim
+*>
+*> \param[in] DOTYPE
+*> \verbatim
+*>          DOTYPE is LOGICAL array, dimension (NTYPES)
+*>          If DOTYPE(j) is .TRUE., then for each size in NN a
+*>          matrix of that size and of type j will be generated.
+*>          If NTYPES is smaller than the maximum number of types
+*>          defined (PARAMETER MAXTYP), then types NTYPES+1 through
+*>          MAXTYP will not be generated. If NTYPES is larger
+*>          than MAXTYP, DOTYPE(MAXTYP+1) through DOTYPE(NTYPES)
+*>          will be ignored.
+*> \endverbatim
+*>
+*> \param[in,out] ISEED
+*> \verbatim
+*>          ISEED is INTEGER array, dimension (4)
+*>          On entry ISEED specifies the seed of the random number
+*>          generator. The array elements should be between 0 and 4095;
+*>          if not they will be reduced mod 4096. Also, ISEED(4) must
+*>          be odd.  The random number generator uses a linear
+*>          congruential sequence limited to small integers, and so
+*>          should produce machine independent random numbers. The
+*>          values of ISEED are changed on exit, and can be used in the
+*>          next call to SDRGEV4 to continue the same random number
+*>          sequence.
+*> \endverbatim
+*>
+*> \param[in] THRESH
+*> \verbatim
+*>          THRESH is REAL
+*>          A test will count as "failed" if the "error", computed as
+*>          described above, exceeds THRESH.  Note that the error is
+*>          scaled to be O(1), so THRESH should be a reasonably small
+*>          multiple of 1, e.g., 10 or 100.  In particular, it should
+*>          not depend on the precision (single vs. double) or the size
+*>          of the matrix.  It must be at least zero.
+*> \endverbatim
+*>
+*> \param[in] NOUNIT
+*> \verbatim
+*>          NOUNIT is INTEGER
+*>          The FORTRAN unit number for printing out error messages
+*>          (e.g., if a routine returns IERR not equal to 0.)
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is REAL array,
+*>                                       dimension(LDA, max(NN))
+*>          Used to hold the original A matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of A, B, S, and T.
+*>          It must be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is REAL array,
+*>                                       dimension(LDA, max(NN))
+*>          Used to hold the original B matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[out] S
+*> \verbatim
+*>          S is REAL array,
+*>                                 dimension (LDA, max(NN))
+*>          The Schur form matrix computed from A by SGGEV4.  On exit, S
+*>          contains the Schur form matrix corresponding to the matrix
+*>          in A.
+*> \endverbatim
+*>
+*> \param[out] T
+*> \verbatim
+*>          T is REAL array,
+*>                                 dimension (LDA, max(NN))
+*>          The upper triangular matrix computed from B by SGGEV4.
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is REAL array,
+*>                                 dimension (LDQ, max(NN))
+*>          The (left) eigenvectors matrix computed by SGGEV4.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of Q and Z. It must
+*>          be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is REAL array, dimension( LDQ, max(NN) )
+*>          The (right) orthogonal matrix computed by SGGEV4.
+*> \endverbatim
+*>
+*> \param[out] QE
+*> \verbatim
+*>          QE is REAL array, dimension( LDQ, max(NN) )
+*>          QE holds the computed right or left eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] LDQE
+*> \verbatim
+*>          LDQE is INTEGER
+*>          The leading dimension of QE. LDQE >= max(1,max(NN)).
+*> \endverbatim
+*>
+*> \param[out] ALPHAR
+*> \verbatim
+*>          ALPHAR is REAL array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] ALPHAI
+*> \verbatim
+*>          ALPHAI is REAL array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is REAL array, dimension (max(NN))
+*> \verbatim
+*>          The generalized eigenvalues of (A,B) computed by SGGEV4.
+*>          ( ALPHAR(k)+ALPHAI(k)*i ) / BETA(k) is the k-th
+*>          generalized eigenvalue of A and B.
+*> \endverbatim
+*>
+*> \param[out] ALPHR1
+*> \verbatim
+*>          ALPHR1 is REAL array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] ALPHI1
+*> \verbatim
+*>          ALPHI1 is REAL array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA1
+*> \verbatim
+*>          BETA1 is REAL array, dimension (max(NN))
+*>
+*>          Like ALPHAR, ALPHAI, BETA, these arrays contain the
+*>          eigenvalues of A and B, but those computed when SGGEV4 only
+*>          computes a partial eigendecomposition, i.e. not the
+*>          eigenvalues and left and right eigenvectors.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is REAL array, dimension (LWORK)
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The number of entries in WORK.  LWORK >= MAX( 8*N, N*(N+1) ).
+*> \endverbatim
+*>
+*> \param[out] RESULT
+*> \verbatim
+*>          RESULT is REAL array, dimension (2)
+*>          The values computed by the tests described above.
+*>          The values are currently limited to 1/ulp, to avoid overflow.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  A routine returned an error code.  INFO is the
+*>                absolute value of the INFO value returned.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \ingroup single_eig
+*
+*  =====================================================================
+      SUBROUTINE SDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+     $                    NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+     $                    ALPHAR, ALPHAI, BETA, ALPHR1, ALPHI1, BETA1,
+     $                    WORK, LWORK, IWORK, RESULT, INFO )
+      IMPLICIT NONE
+*
+*  -- LAPACK test routine --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*
+*     .. Scalar Arguments ..
+      INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+     $                   NTYPES
+      REAL               THRESH
+*     ..
+*     .. Array Arguments ..
+      LOGICAL            DOTYPE( * )
+      INTEGER            ISEED( 4 ), NN( * ), IWORK( * )
+      REAL               A( LDA, * ), ALPHAI( * ), ALPHI1( * ),
+     $                   ALPHAR( * ), ALPHR1( * ), B( LDA, * ),
+     $                   BETA( * ), BETA1( * ), Q( LDQ, * ),
+     $                   QE( LDQE, * ), RESULT( * ), S( LDA, * ),
+     $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
+      INTEGER            MAXTYP
+      PARAMETER          ( MAXTYP = 26 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            BADNN
+      INTEGER            I, IADD, IERR, IN, J, JC, JR, JSIZE, JTYPE,
+     $                   MAXWRK, MINWRK, MTYPES, N, N1, NERRS, NMATS,
+     $                   NMAX, NTESTT
+      REAL               SAFMAX, SAFMIN, ULP, ULPINV
+*     ..
+*     .. Local Arrays ..
+      INTEGER            IASIGN( MAXTYP ), IBSIGN( MAXTYP ),
+     $                   IOLDSD( 4 ), KADD( 6 ), KAMAGN( MAXTYP ),
+     $                   KATYPE( MAXTYP ), KAZERO( MAXTYP ),
+     $                   KBMAGN( MAXTYP ), KBTYPE( MAXTYP ),
+     $                   KBZERO( MAXTYP ), KCLASS( MAXTYP ),
+     $                   KTRIAN( MAXTYP ), KZ1( 6 ), KZ2( 6 )
+      REAL               RMAGN( 0: 3 )
+*     ..
+*     .. External Functions ..
+      INTEGER            ILAENV
+      REAL               SLAMCH, SLARND
+      EXTERNAL           ILAENV, SLAMCH, SLARND
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           ALASVM, SGET52, SGGEV4, SLACPY, SLARFG, SLASET,
+     $                   SLATM4, SORM2R, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          ABS, MAX, MIN, REAL, SIGN
+*     ..
+*     .. Data statements ..
+      DATA               KCLASS / 15*1, 10*2, 1*3 /
+      DATA               KZ1 / 0, 1, 2, 1, 3, 3 /
+      DATA               KZ2 / 0, 0, 1, 2, 1, 1 /
+      DATA               KADD / 0, 0, 0, 0, 3, 2 /
+      DATA               KATYPE / 0, 1, 0, 1, 2, 3, 4, 1, 4, 4, 1, 1, 4,
+     $                   4, 4, 2, 4, 5, 8, 7, 9, 4*4, 0 /
+      DATA               KBTYPE / 0, 0, 1, 1, 2, -3, 1, 4, 1, 1, 4, 4,
+     $                   1, 1, -4, 2, -4, 8*8, 0 /
+      DATA               KAZERO / 6*1, 2, 1, 2*2, 2*1, 2*2, 3, 1, 3,
+     $                   4*5, 4*3, 1 /
+      DATA               KBZERO / 6*1, 1, 2, 2*1, 2*2, 2*1, 4, 1, 4,
+     $                   4*6, 4*4, 1 /
+      DATA               KAMAGN / 8*1, 2, 3, 2, 3, 2, 3, 7*1, 2, 3, 3,
+     $                   2, 1 /
+      DATA               KBMAGN / 8*1, 3, 2, 3, 2, 2, 3, 7*1, 3, 2, 3,
+     $                   2, 1 /
+      DATA               KTRIAN / 16*0, 10*1 /
+      DATA               IASIGN / 6*0, 2, 0, 2*2, 2*0, 3*2, 0, 2, 3*0,
+     $                   5*2, 0 /
+      DATA               IBSIGN / 7*0, 2, 2*0, 2*2, 2*0, 2, 0, 2, 9*0 /
+*     ..
+*     .. Executable Statements ..
+*
+*     Check for errors
+*
+      INFO = 0
+*
+      BADNN = .FALSE.
+      NMAX = 1
+      DO 10 J = 1, NSIZES
+         NMAX = MAX( NMAX, NN( J ) )
+         IF( NN( J ).LT.0 )
+     $      BADNN = .TRUE.
+   10 CONTINUE
+*
+      IF( NSIZES.LT.0 ) THEN
+         INFO = -1
+      ELSE IF( BADNN ) THEN
+         INFO = -2
+      ELSE IF( NTYPES.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( THRESH.LT.ZERO ) THEN
+         INFO = -6
+      ELSE IF( LDA.LE.1 .OR. LDA.LT.NMAX ) THEN
+         INFO = -9
+      ELSE IF( LDQ.LE.1 .OR. LDQ.LT.NMAX ) THEN
+         INFO = -14
+      ELSE IF( LDQE.LE.1 .OR. LDQE.LT.NMAX ) THEN
+         INFO = -17
+      END IF
+*
+*     Compute workspace
+*      (Note: Comments in the code beginning "Workspace:" describe the
+*       minimal amount of workspace needed at that point in the code,
+*       as well as the preferred amount for good performance.
+*       NB refers to the optimal block size for the immediately
+*       following subroutine, as returned by ILAENV.
+*
+      MINWRK = 1
+      IF( INFO.EQ.0 .AND. LWORK.GE.1 ) THEN
+         MINWRK = MAX( 1, 8*NMAX, NMAX*( NMAX+1 ) )
+         MAXWRK = 7*NMAX + NMAX*ILAENV( 1, 'SGEQRF', ' ', NMAX, 1, NMAX,
+     $            0 )
+         MAXWRK = MAX( MAXWRK, NMAX*( NMAX+1 ) )
+         WORK( 1 ) = MAXWRK
+      END IF
+*
+      IF( LWORK.LT.MINWRK )
+     $   INFO = -25
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'SDRGEV4', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( NSIZES.EQ.0 .OR. NTYPES.EQ.0 )
+     $   RETURN
+*
+      SAFMIN = SLAMCH( 'Safe minimum' )
+      ULP = SLAMCH( 'Epsilon' )*SLAMCH( 'Base' )
+      SAFMIN = SAFMIN / ULP
+      SAFMAX = ONE / SAFMIN
+      ULPINV = ONE / ULP
+*
+*     The values RMAGN(2:3) depend on N, see below.
+*
+      RMAGN( 0 ) = ZERO
+      RMAGN( 1 ) = ONE
+*
+*     Loop over sizes, types
+*
+      NTESTT = 0
+      NERRS = 0
+      NMATS = 0
+*
+      DO 220 JSIZE = 1, NSIZES
+         N = NN( JSIZE )
+         N1 = MAX( 1, N )
+         RMAGN( 2 ) = SAFMAX*ULP / REAL( N1 )
+         RMAGN( 3 ) = SAFMIN*ULPINV*N1
+*
+         IF( NSIZES.NE.1 ) THEN
+            MTYPES = MIN( MAXTYP, NTYPES )
+         ELSE
+            MTYPES = MIN( MAXTYP+1, NTYPES )
+         END IF
+*
+         DO 210 JTYPE = 1, MTYPES
+            IF( .NOT.DOTYPE( JTYPE ) )
+     $         GO TO 210
+            NMATS = NMATS + 1
+*
+*           Save ISEED in case of an error.
+*
+            DO 20 J = 1, 4
+               IOLDSD( J ) = ISEED( J )
+   20       CONTINUE
+*
+*           Generate test matrices A and B
+*
+*           Description of control parameters:
+*
+*           KCLASS: =1 means w/o rotation, =2 means w/ rotation,
+*                   =3 means random.
+*           KATYPE: the "type" to be passed to SLATM4 for computing A.
+*           KAZERO: the pattern of zeros on the diagonal for A:
+*                   =1: ( xxx ), =2: (0, xxx ) =3: ( 0, 0, xxx, 0 ),
+*                   =4: ( 0, xxx, 0, 0 ), =5: ( 0, 0, 1, xxx, 0 ),
+*                   =6: ( 0, 1, 0, xxx, 0 ).  (xxx means a string of
+*                   non-zero entries.)
+*           KAMAGN: the magnitude of the matrix: =0: zero, =1: O(1),
+*                   =2: large, =3: small.
+*           IASIGN: 1 if the diagonal elements of A are to be
+*                   multiplied by a random magnitude 1 number, =2 if
+*                   randomly chosen diagonal blocks are to be rotated
+*                   to form 2x2 blocks.
+*           KBTYPE, KBZERO, KBMAGN, IBSIGN: the same, but for B.
+*           KTRIAN: =0: don't fill in the upper triangle, =1: do.
+*           KZ1, KZ2, KADD: used to implement KAZERO and KBZERO.
+*           RMAGN: used to implement KAMAGN and KBMAGN.
+*
+            IF( MTYPES.GT.MAXTYP )
+     $         GO TO 100
+            IERR = 0
+            IF( KCLASS( JTYPE ).LT.3 ) THEN
+*
+*              Generate A (w/o rotation)
+*
+               IF( ABS( KATYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL SLASET( 'Full', N, N, ZERO, ZERO, A, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL SLATM4( KATYPE( JTYPE ), IN, KZ1( KAZERO( JTYPE ) ),
+     $                      KZ2( KAZERO( JTYPE ) ), IASIGN( JTYPE ),
+     $                      RMAGN( KAMAGN( JTYPE ) ), ULP,
+     $                      RMAGN( KTRIAN( JTYPE )*KAMAGN( JTYPE ) ), 2,
+     $                      ISEED, A, LDA )
+               IADD = KADD( KAZERO( JTYPE ) )
+               IF( IADD.GT.0 .AND. IADD.LE.N )
+     $            A( IADD, IADD ) = ONE
+*
+*              Generate B (w/o rotation)
+*
+               IF( ABS( KBTYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL SLASET( 'Full', N, N, ZERO, ZERO, B, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL SLATM4( KBTYPE( JTYPE ), IN, KZ1( KBZERO( JTYPE ) ),
+     $                      KZ2( KBZERO( JTYPE ) ), IBSIGN( JTYPE ),
+     $                      RMAGN( KBMAGN( JTYPE ) ), ONE,
+     $                      RMAGN( KTRIAN( JTYPE )*KBMAGN( JTYPE ) ), 2,
+     $                      ISEED, B, LDA )
+               IADD = KADD( KBZERO( JTYPE ) )
+               IF( IADD.NE.0 .AND. IADD.LE.N )
+     $            B( IADD, IADD ) = ONE
+*
+               IF( KCLASS( JTYPE ).EQ.2 .AND. N.GT.0 ) THEN
+*
+*                 Include rotations
+*
+*                 Generate Q, Z as Householder transformations times
+*                 a diagonal matrix.
+*
+                  DO 40 JC = 1, N - 1
+                     DO 30 JR = JC, N
+                        Q( JR, JC ) = SLARND( 3, ISEED )
+                        Z( JR, JC ) = SLARND( 3, ISEED )
+   30                CONTINUE
+                     CALL SLARFG( N+1-JC, Q( JC, JC ), Q( JC+1, JC ), 1,
+     $                            WORK( JC ) )
+                     WORK( 2*N+JC ) = SIGN( ONE, Q( JC, JC ) )
+                     Q( JC, JC ) = ONE
+                     CALL SLARFG( N+1-JC, Z( JC, JC ), Z( JC+1, JC ), 1,
+     $                            WORK( N+JC ) )
+                     WORK( 3*N+JC ) = SIGN( ONE, Z( JC, JC ) )
+                     Z( JC, JC ) = ONE
+   40             CONTINUE
+                  Q( N, N ) = ONE
+                  WORK( N ) = ZERO
+                  WORK( 3*N ) = SIGN( ONE, SLARND( 2, ISEED ) )
+                  Z( N, N ) = ONE
+                  WORK( 2*N ) = ZERO
+                  WORK( 4*N ) = SIGN( ONE, SLARND( 2, ISEED ) )
+*
+*                 Apply the diagonal matrices
+*
+                  DO 60 JC = 1, N
+                     DO 50 JR = 1, N
+                        A( JR, JC ) = WORK( 2*N+JR )*WORK( 3*N+JC )*
+     $                                A( JR, JC )
+                        B( JR, JC ) = WORK( 2*N+JR )*WORK( 3*N+JC )*
+     $                                B( JR, JC )
+   50                CONTINUE
+   60             CONTINUE
+                  CALL SORM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, A,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL SORM2R( 'R', 'T', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         A, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL SORM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, B,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL SORM2R( 'R', 'T', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         B, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+               END IF
+            ELSE
+*
+*              Random matrices
+*
+               DO 80 JC = 1, N
+                  DO 70 JR = 1, N
+                     A( JR, JC ) = RMAGN( KAMAGN( JTYPE ) )*
+     $                             SLARND( 2, ISEED )
+                     B( JR, JC ) = RMAGN( KBMAGN( JTYPE ) )*
+     $                             SLARND( 2, ISEED )
+   70             CONTINUE
+   80          CONTINUE
+            END IF
+*
+   90       CONTINUE
+*
+            IF( IERR.NE.0 ) THEN
+               WRITE( NOUNIT, FMT = 9999 )'Generator', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               RETURN
+            END IF
+*
+  100       CONTINUE
+*
+            DO 110 I = 1, 7
+               RESULT( I ) = -ONE
+  110       CONTINUE
+*
+*           Call XLAENV to set the parameters used in SLAQZ0
+*
+            CALL XLAENV( 12, 10 )
+            CALL XLAENV( 13, 12 )
+            CALL XLAENV( 14, 13 )
+            CALL XLAENV( 15, 2 )
+            CALL XLAENV( 17, 10 )
+*
+*           Call SGGEV4 to compute eigenvalues and eigenvectors.
+*
+            CALL SLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL SLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL SGGEV4( 'V', 'V', N, S, LDA, T, LDA, ALPHAR, ALPHAI,
+     $                   BETA, Q, LDQ, Z, LDQ, WORK, LWORK,
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'SGGEV41', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+*           Do the tests (1) and (2)
+*
+            CALL SGET52( .TRUE., N, A, LDA, B, LDA, Q, LDQ, ALPHAR,
+     $                   ALPHAI, BETA, WORK, RESULT( 1 ) )
+            IF( RESULT( 2 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Left', 'SGGEV41',
+     $            RESULT( 2 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do the tests (3) and (4)
+*
+            CALL SGET52( .FALSE., N, A, LDA, B, LDA, Z, LDQ, ALPHAR,
+     $                   ALPHAI, BETA, WORK, RESULT( 3 ) )
+            IF( RESULT( 4 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Right', 'SGGEV41',
+     $            RESULT( 4 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do the test (5)
+*
+            CALL SLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL SLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL SGGEV4( 'N', 'N', N, S, LDA, T, LDA, ALPHR1, ALPHI1,
+     $                   BETA1, Q, LDQ, Z, LDQ, WORK, LWORK, 
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'SGGEV42', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 120 J = 1, N
+               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR.
+     $             BETA( J ).NE. BETA1( J ) ) THEN
+                  RESULT( 5 ) = ULPINV
+               END IF
+  120       CONTINUE
+*
+*           Do the test (6): Compute eigenvalues and left eigenvectors,
+*           and test them
+*
+            CALL SLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL SLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL SGGEV4( 'V', 'N', N, S, LDA, T, LDA, ALPHR1, ALPHI1,
+     $                   BETA1, QE, LDQE, Z, LDQ, WORK, LWORK,
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'SGGEV43', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 130 J = 1, N
+               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
+     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )
+     $             RESULT( 6 ) = ULPINV
+  130       CONTINUE
+*
+            DO 150 J = 1, N
+               DO 140 JC = 1, N
+                  IF( Q( J, JC ).NE.QE( J, JC ) )
+     $               RESULT( 6 ) = ULPINV
+  140          CONTINUE
+  150       CONTINUE
+*
+*           DO the test (7): Compute eigenvalues and right eigenvectors,
+*           and test them
+*
+            CALL SLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL SLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL SGGEV4( 'N', 'V', N, S, LDA, T, LDA, ALPHR1, ALPHI1,
+     $                   BETA1, Q, LDQ, QE, LDQE, WORK, LWORK,
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'SGGEV44', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 160 J = 1, N
+               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
+     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )
+     $             RESULT( 7 ) = ULPINV
+  160       CONTINUE
+*
+            DO 180 J = 1, N
+               DO 170 JC = 1, N
+                  IF( Z( J, JC ).NE.QE( J, JC ) )
+     $               RESULT( 7 ) = ULPINV
+  170          CONTINUE
+  180       CONTINUE
+*
+*           End of Loop -- Check for RESULT(j) > THRESH
+*
+  190       CONTINUE
+*
+            NTESTT = NTESTT + 7
+*
+*           Print out tests which fail.
+*
+            DO 200 JR = 1, 7
+               IF( RESULT( JR ).GE.THRESH ) THEN
+*
+*                 If this is the first test to fail,
+*                 print a header to the data file.
+*
+                  IF( NERRS.EQ.0 ) THEN
+                     WRITE( NOUNIT, FMT = 9997 )'SGV'
+*
+*                    Matrix types
+*
+                     WRITE( NOUNIT, FMT = 9996 )
+                     WRITE( NOUNIT, FMT = 9995 )
+                     WRITE( NOUNIT, FMT = 9994 )'Orthogonal'
+*
+*                    Tests performed
+*
+                     WRITE( NOUNIT, FMT = 9993 )
+*
+                  END IF
+                  NERRS = NERRS + 1
+                  IF( RESULT( JR ).LT.10000.0 ) THEN
+                     WRITE( NOUNIT, FMT = 9992 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  ELSE
+                     WRITE( NOUNIT, FMT = 9991 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  END IF
+               END IF
+  200       CONTINUE
+*
+  210    CONTINUE
+  220 CONTINUE
+*
+*     Summary
+*
+      CALL ALASVM( 'SGV', NOUNIT, NERRS, NTESTT, 0 )
+*
+      WORK( 1 ) = MAXWRK
+*
+      RETURN
+*
+ 9999 FORMAT( ' SDRGEV4: ', A, ' returned INFO=', I6, '.', / 3X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 4( I4, ',' ), I5, ')' )
+*
+ 9998 FORMAT( ' SDRGEV4: ', A, ' Eigenvectors from ', A,
+     $      ' incorrectly normalized.', / ' Bits of error=', 0P, G10.3,
+     $      ',', 3X, 'N=', I4, ', JTYPE=', I3, ', ISEED=(',
+     $       4( I4, ',' ), I5, ')' )
+*
+ 9997 FORMAT( / 1X, A3, ' -- Real Generalized eigenvalue problem driver'
+     $       )
+*
+ 9996 FORMAT( ' Matrix types (see SDRGEV4 for details): ' )
+*
+ 9995 FORMAT( ' Special Matrices:', 23X,
+     $      '(J''=transposed Jordan block)',
+     $      / '   1=(0,0)  2=(I,0)  3=(0,I)  4=(I,I)  5=(J'',J'')  ',
+     $      '6=(diag(J'',I), diag(I,J''))', / ' Diagonal Matrices:  ( ',
+     $      'D=diag(0,1,2,...) )', / '   7=(D,I)   9=(large*D, small*I',
+     $      ')  11=(large*I, small*D)  13=(large*D, large*I)', /
+     $      '   8=(I,D)  10=(small*D, large*I)  12=(small*I, large*D) ',
+     $      ' 14=(small*D, small*I)', / '  15=(D, reversed D)' )
+ 9994 FORMAT( ' Matrices Rotated by Random ', A, ' Matrices U, V:',
+     $      / '  16=Transposed Jordan Blocks             19=geometric ',
+     $      'alpha, beta=0,1', / '  17=arithm. alpha&beta             ',
+     $      '      20=arithmetic alpha, beta=0,1', / '  18=clustered ',
+     $      'alpha, beta=0,1            21=random alpha, beta=0,1',
+     $      / ' Large & Small Matrices:', / '  22=(large, small)   ',
+     $      '23=(small,large)    24=(small,small)    25=(large,large)',
+     $      / '  26=random O(1) matrices.' )
+*
+ 9993 FORMAT( / ' Tests performed:    ',
+     $      / ' 1 = max | ( b A - a B )''*l | / const.,',
+     $      / ' 2 = | |VR(i)| - 1 | / ulp,',
+     $      / ' 3 = max | ( b A - a B )*r | / const.',
+     $      / ' 4 = | |VL(i)| - 1 | / ulp,',
+     $      / ' 5 = 0 if W same no matter if r or l computed,',
+     $      / ' 6 = 0 if l same no matter if l computed,',
+     $      / ' 7 = 0 if r same no matter if r computed,', / 1X )
+ 9992 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 0P, F8.2 )
+ 9991 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 1P, E10.3 )
+*
+*     End of SDRGEV4
+*
+      END

--- a/TESTING/EIG/zchkee.F
+++ b/TESTING/EIG/zchkee.F
@@ -1108,7 +1108,7 @@
      $                   ZDRGES, ZDRGEV, ZDRGSX, ZDRGVX, ZDRVBD, ZDRVES,
      $                   ZDRVEV, ZDRVSG, ZDRVST, ZDRVSX, ZDRVVX,
      $                   ZERRBD, ZERRED, ZERRGG, ZERRHS, ZERRST, ILAVER,
-     $                   ZDRGES3, ZDRGEV3, 
+     $                   ZDRGES3, ZDRGEV3, ZDRGEV4,
      $                   ZCHKST2STG, ZDRVST2STG, ZCHKHB2STG
 *     ..
 *     .. Intrinsic Functions ..
@@ -2291,6 +2291,18 @@
      $                    RESULT, INFO )
             IF( INFO.NE.0 )
      $         WRITE( NOUT, FMT = 9980 )'ZDRGEV3', INFO
+*
+* New Blocked version
+*
+            CALL XLAENV(16,2)
+            CALL ZDRGEV4( NN, NVAL, MAXTYP, DOTYPE, ISEED, THRESH, NOUT,
+     $                    A( 1, 1 ), NMAX, A( 1, 2 ), A( 1, 3 ),
+     $                    A( 1, 4 ), A( 1, 7 ), NMAX, A( 1, 8 ),
+     $                    A( 1, 9 ), NMAX, DC( 1, 1 ), DC( 1, 2 ),
+     $                    DC( 1, 3 ), DC( 1, 4 ), WORK, LWORK, RWORK,
+     $                    IWORK, RESULT, INFO )
+            IF( INFO.NE.0 )
+     $         WRITE( NOUT, FMT = 9980 )'ZDRGEV4', INFO     
          END IF
          WRITE( NOUT, FMT = 9973 )
          GO TO 10

--- a/TESTING/EIG/zdrgev4.f
+++ b/TESTING/EIG/zdrgev4.f
@@ -1,0 +1,945 @@
+*> \brief \b ZDRGEV4
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE ZDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+*                           NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+*                           ALPHA, BETA, ALPHA1, BETA1, WORK, LWORK, RWORK,
+*                           IWORK, RESULT, INFO )
+*
+*       .. Scalar Arguments ..
+*       INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+*      $                   NTYPES
+*       DOUBLE PRECISION   THRESH
+*       ..
+*       .. Array Arguments ..
+*       LOGICAL            DOTYPE( * )
+*       INTEGER            ISEED( 4 ), NN( * )
+*       DOUBLE PRECISION   RESULT( * ), RWORK( * )
+*       COMPLEX*16         A( LDA, * ), ALPHA( * ), ALPHA1( * ),
+*      $                   B( LDA, * ), BETA( * ), BETA1( * ),
+*      $                   Q( LDQ, * ), QE( LDQE, * ), S( LDA, * ),
+*      $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> ZDRGEV4 checks the nonsymmetric generalized eigenvalue problem driver
+*> routine ZGGEV4.
+*>
+*> ZGGEV4 computes for a pair of n-by-n nonsymmetric matrices (A,B) the
+*> generalized eigenvalues and, optionally, the left and right
+*> eigenvectors.
+*>
+*> A generalized eigenvalue for a pair of matrices (A,B) is a scalar w
+*> or a ratio  alpha/beta = w, such that A - w*B is singular.  It is
+*> usually represented as the pair (alpha,beta), as there is reasonable
+*> interpretation for beta=0, and even for both being zero.
+*>
+*> A right generalized eigenvector corresponding to a generalized
+*> eigenvalue  w  for a pair of matrices (A,B) is a vector r  such that
+*> (A - wB) * r = 0.  A left generalized eigenvector is a vector l such
+*> that l**H * (A - wB) = 0, where l**H is the conjugate-transpose of l.
+*>
+*> When ZDRGEV4 is called, a number of matrix "sizes" ("n's") and a
+*> number of matrix "types" are specified.  For each size ("n")
+*> and each type of matrix, a pair of matrices (A, B) will be generated
+*> and used for testing.  For each matrix pair, the following tests
+*> will be performed and compared with the threshold THRESH.
+*>
+*> Results from ZGGEV4:
+*>
+*> (1)  max over all left eigenvalue/-vector pairs (alpha/beta,l) of
+*>
+*>      | VL**H * (beta A - alpha B) |/( ulp max(|beta A|, |alpha B|) )
+*>
+*>      where VL**H is the conjugate-transpose of VL.
+*>
+*> (2)  | |VL(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VL(i) denotes the i-th column of VL.
+*>
+*> (3)  max over all left eigenvalue/-vector pairs (alpha/beta,r) of
+*>
+*>      | (beta A - alpha B) * VR | / ( ulp max(|beta A|, |alpha B|) )
+*>
+*> (4)  | |VR(i)| - 1 | / ulp and whether largest component real
+*>
+*>      VR(i) denotes the i-th column of VR.
+*>
+*> (5)  W(full) = W(partial)
+*>      W(full) denotes the eigenvalues computed when both l and r
+*>      are also computed, and W(partial) denotes the eigenvalues
+*>      computed when only W, only W and r, or only W and l are
+*>      computed.
+*>
+*> (6)  VL(full) = VL(partial)
+*>      VL(full) denotes the left eigenvectors computed when both l
+*>      and r are computed, and VL(partial) denotes the result
+*>      when only l is computed.
+*>
+*> (7)  VR(full) = VR(partial)
+*>      VR(full) denotes the right eigenvectors computed when both l
+*>      and r are also computed, and VR(partial) denotes the result
+*>      when only l is computed.
+*>
+*>
+*> Test Matrices
+*> ---- --------
+*>
+*> The sizes of the test matrices are specified by an array
+*> NN(1:NSIZES); the value of each element NN(j) specifies one size.
+*> The "types" are specified by a logical array DOTYPE( 1:NTYPES ); if
+*> DOTYPE(j) is .TRUE., then matrix type "j" will be generated.
+*> Currently, the list of possible types is:
+*>
+*> (1)  ( 0, 0 )         (a pair of zero matrices)
+*>
+*> (2)  ( I, 0 )         (an identity and a zero matrix)
+*>
+*> (3)  ( 0, I )         (an identity and a zero matrix)
+*>
+*> (4)  ( I, I )         (a pair of identity matrices)
+*>
+*>         t   t
+*> (5)  ( J , J  )       (a pair of transposed Jordan blocks)
+*>
+*>                                     t                ( I   0  )
+*> (6)  ( X, Y )         where  X = ( J   0  )  and Y = (      t )
+*>                                  ( 0   I  )          ( 0   J  )
+*>                       and I is a k x k identity and J a (k+1)x(k+1)
+*>                       Jordan block; k=(N-1)/2
+*>
+*> (7)  ( D, I )         where D is diag( 0, 1,..., N-1 ) (a diagonal
+*>                       matrix with those diagonal entries.)
+*> (8)  ( I, D )
+*>
+*> (9)  ( big*D, small*I ) where "big" is near overflow and small=1/big
+*>
+*> (10) ( small*D, big*I )
+*>
+*> (11) ( big*I, small*D )
+*>
+*> (12) ( small*I, big*D )
+*>
+*> (13) ( big*D, big*I )
+*>
+*> (14) ( small*D, small*I )
+*>
+*> (15) ( D1, D2 )        where D1 is diag( 0, 0, 1, ..., N-3, 0 ) and
+*>                        D2 is diag( 0, N-3, N-4,..., 1, 0, 0 )
+*>           t   t
+*> (16) Q ( J , J ) Z     where Q and Z are random orthogonal matrices.
+*>
+*> (17) Q ( T1, T2 ) Z    where T1 and T2 are upper triangular matrices
+*>                        with random O(1) entries above the diagonal
+*>                        and diagonal entries diag(T1) =
+*>                        ( 0, 0, 1, ..., N-3, 0 ) and diag(T2) =
+*>                        ( 0, N-3, N-4,..., 1, 0, 0 )
+*>
+*> (18) Q ( T1, T2 ) Z    diag(T1) = ( 0, 0, 1, 1, s, ..., s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1,..., 1, 0 )
+*>                        s = machine precision.
+*>
+*> (19) Q ( T1, T2 ) Z    diag(T1)=( 0,0,1,1, 1-d, ..., 1-(N-5)*d=s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0 )
+*>
+*>                                                        N-5
+*> (20) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, 1, a, ..., a   =s, 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>
+*> (21) Q ( T1, T2 ) Z    diag(T1)=( 0, 0, 1, r1, r2, ..., r(N-4), 0 )
+*>                        diag(T2) = ( 0, 1, 0, 1, ..., 1, 0, 0 )
+*>                        where r1,..., r(N-4) are random.
+*>
+*> (22) Q ( big*T1, small*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (23) Q ( small*T1, big*T2 ) Z    diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (24) Q ( small*T1, small*T2 ) Z  diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (25) Q ( big*T1, big*T2 ) Z      diag(T1) = ( 0, 0, 1, ..., N-3, 0 )
+*>                                  diag(T2) = ( 0, 1, ..., 1, 0, 0 )
+*>
+*> (26) Q ( T1, T2 ) Z     where T1 and T2 are random upper-triangular
+*>                         matrices.
+*>
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] NSIZES
+*> \verbatim
+*>          NSIZES is INTEGER
+*>          The number of sizes of matrices to use.  If it is zero,
+*>          ZDRGEV4 does nothing.  NSIZES >= 0.
+*> \endverbatim
+*>
+*> \param[in] NN
+*> \verbatim
+*>          NN is INTEGER array, dimension (NSIZES)
+*>          An array containing the sizes to be used for the matrices.
+*>          Zero values will be skipped.  NN >= 0.
+*> \endverbatim
+*>
+*> \param[in] NTYPES
+*> \verbatim
+*>          NTYPES is INTEGER
+*>          The number of elements in DOTYPE.   If it is zero, ZDRGEV4
+*>          does nothing.  It must be at least zero.  If it is MAXTYP+1
+*>          and NSIZES is 1, then an additional type, MAXTYP+1 is
+*>          defined, which is to use whatever matrix is in A.  This
+*>          is only useful if DOTYPE(1:MAXTYP) is .FALSE. and
+*>          DOTYPE(MAXTYP+1) is .TRUE. .
+*> \endverbatim
+*>
+*> \param[in] DOTYPE
+*> \verbatim
+*>          DOTYPE is LOGICAL array, dimension (NTYPES)
+*>          If DOTYPE(j) is .TRUE., then for each size in NN a
+*>          matrix of that size and of type j will be generated.
+*>          If NTYPES is smaller than the maximum number of types
+*>          defined (PARAMETER MAXTYP), then types NTYPES+1 through
+*>          MAXTYP will not be generated. If NTYPES is larger
+*>          than MAXTYP, DOTYPE(MAXTYP+1) through DOTYPE(NTYPES)
+*>          will be ignored.
+*> \endverbatim
+*>
+*> \param[in,out] ISEED
+*> \verbatim
+*>          ISEED is INTEGER array, dimension (4)
+*>          On entry ISEED specifies the seed of the random number
+*>          generator. The array elements should be between 0 and 4095;
+*>          if not they will be reduced mod 4096. Also, ISEED(4) must
+*>          be odd.  The random number generator uses a linear
+*>          congruential sequence limited to small integers, and so
+*>          should produce machine independent random numbers. The
+*>          values of ISEED are changed on exit, and can be used in the
+*>          next call to ZDRGES to continue the same random number
+*>          sequence.
+*> \endverbatim
+*>
+*> \param[in] THRESH
+*> \verbatim
+*>          THRESH is DOUBLE PRECISION
+*>          A test will count as "failed" if the "error", computed as
+*>          described above, exceeds THRESH.  Note that the error is
+*>          scaled to be O(1), so THRESH should be a reasonably small
+*>          multiple of 1, e.g., 10 or 100.  In particular, it should
+*>          not depend on the precision (single vs. double) or the size
+*>          of the matrix.  It must be at least zero.
+*> \endverbatim
+*>
+*> \param[in] NOUNIT
+*> \verbatim
+*>          NOUNIT is INTEGER
+*>          The FORTRAN unit number for printing out error messages
+*>          (e.g., if a routine returns IERR not equal to 0.)
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is COMPLEX*16 array, dimension(LDA, max(NN))
+*>          Used to hold the original A matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of A, B, S, and T.
+*>          It must be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[in,out] B
+*> \verbatim
+*>          B is COMPLEX*16 array, dimension(LDA, max(NN))
+*>          Used to hold the original B matrix.  Used as input only
+*>          if NTYPES=MAXTYP+1, DOTYPE(1:MAXTYP)=.FALSE., and
+*>          DOTYPE(MAXTYP+1)=.TRUE.
+*> \endverbatim
+*>
+*> \param[out] S
+*> \verbatim
+*>          S is COMPLEX*16 array, dimension (LDA, max(NN))
+*>          The Schur form matrix computed from A by ZGGEV4.  On exit, S
+*>          contains the Schur form matrix corresponding to the matrix
+*>          in A.
+*> \endverbatim
+*>
+*> \param[out] T
+*> \verbatim
+*>          T is COMPLEX*16 array, dimension (LDA, max(NN))
+*>          The upper triangular matrix computed from B by ZGGEV4.
+*> \endverbatim
+*>
+*> \param[out] Q
+*> \verbatim
+*>          Q is COMPLEX*16 array, dimension (LDQ, max(NN))
+*>          The (left) eigenvectors matrix computed by ZGGEV4.
+*> \endverbatim
+*>
+*> \param[in] LDQ
+*> \verbatim
+*>          LDQ is INTEGER
+*>          The leading dimension of Q and Z. It must
+*>          be at least 1 and at least max( NN ).
+*> \endverbatim
+*>
+*> \param[out] Z
+*> \verbatim
+*>          Z is COMPLEX*16 array, dimension( LDQ, max(NN) )
+*>          The (right) orthogonal matrix computed by ZGGEV4.
+*> \endverbatim
+*>
+*> \param[out] QE
+*> \verbatim
+*>          QE is COMPLEX*16 array, dimension( LDQ, max(NN) )
+*>          QE holds the computed right or left eigenvectors.
+*> \endverbatim
+*>
+*> \param[in] LDQE
+*> \verbatim
+*>          LDQE is INTEGER
+*>          The leading dimension of QE. LDQE >= max(1,max(NN)).
+*> \endverbatim
+*>
+*> \param[out] ALPHA
+*> \verbatim
+*>          ALPHA is COMPLEX*16 array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA
+*> \verbatim
+*>          BETA is COMPLEX*16 array, dimension (max(NN))
+*>
+*>          The generalized eigenvalues of (A,B) computed by ZGGEV4.
+*>          ( ALPHAR(k)+ALPHAI(k)*i ) / BETA(k) is the k-th
+*>          generalized eigenvalue of A and B.
+*> \endverbatim
+*>
+*> \param[out] ALPHA1
+*> \verbatim
+*>          ALPHA1 is COMPLEX*16 array, dimension (max(NN))
+*> \endverbatim
+*>
+*> \param[out] BETA1
+*> \verbatim
+*>          BETA1 is COMPLEX*16 array, dimension (max(NN))
+*>
+*>          Like ALPHAR, ALPHAI, BETA, these arrays contain the
+*>          eigenvalues of A and B, but those computed when ZGGEV4 only
+*>          computes a partial eigendecomposition, i.e. not the
+*>          eigenvalues and left and right eigenvectors.
+*> \endverbatim
+*>
+*> \param[out] WORK
+*> \verbatim
+*>          WORK is COMPLEX*16 array, dimension (LWORK)
+*> \endverbatim
+*>
+*> \param[in] LWORK
+*> \verbatim
+*>          LWORK is INTEGER
+*>          The number of entries in WORK.  LWORK >= N*(N+1)
+*> \endverbatim
+*>
+*> \param[out] RWORK
+*> \verbatim
+*>          RWORK is DOUBLE PRECISION array, dimension (8*N)
+*>          Real workspace.
+*> \endverbatim
+*>
+*> \param[out] RESULT
+*> \verbatim
+*>          RESULT is DOUBLE PRECISION array, dimension (2)
+*>          The values computed by the tests described above.
+*>          The values are currently limited to 1/ulp, to avoid overflow.
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value.
+*>          > 0:  A routine returned an error code.  INFO is the
+*>                absolute value of the INFO value returned.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \ingroup complex16_eig
+*
+*  =====================================================================
+      SUBROUTINE ZDRGEV4( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
+     $                    NOUNIT, A, LDA, B, S, T, Q, LDQ, Z, QE, LDQE,
+     $                    ALPHA, BETA, ALPHA1, BETA1, WORK, LWORK,
+     $                    RWORK, IWORK, RESULT, INFO )
+      IMPLICIT NONE
+*
+*  -- LAPACK test routine --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*
+*     .. Scalar Arguments ..
+      INTEGER            INFO, LDA, LDQ, LDQE, LWORK, NOUNIT, NSIZES,
+     $                   NTYPES
+      DOUBLE PRECISION   THRESH
+*     ..
+*     .. Array Arguments ..
+      LOGICAL            DOTYPE( * )
+      INTEGER            ISEED( 4 ), NN( * ), IWORK( * )
+      DOUBLE PRECISION   RESULT( * ), RWORK( * )
+      COMPLEX*16         A( LDA, * ), ALPHA( * ), ALPHA1( * ),
+     $                   B( LDA, * ), BETA( * ), BETA1( * ),
+     $                   Q( LDQ, * ), QE( LDQE, * ), S( LDA, * ),
+     $                   T( LDA, * ), WORK( * ), Z( LDQ, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
+      COMPLEX*16         CZERO, CONE
+      PARAMETER          ( CZERO = ( 0.0D+0, 0.0D+0 ),
+     $                   CONE = ( 1.0D+0, 0.0D+0 ) )
+      INTEGER            MAXTYP
+      PARAMETER          ( MAXTYP = 26 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            BADNN
+      INTEGER            I, IADD, IERR, IN, J, JC, JR, JSIZE, JTYPE,
+     $                   MAXWRK, MINWRK, MTYPES, N, N1, NB, NERRS,
+     $                   NMATS, NMAX, NTESTT
+      DOUBLE PRECISION   SAFMAX, SAFMIN, ULP, ULPINV
+      COMPLEX*16         CTEMP
+*     ..
+*     .. Local Arrays ..
+      LOGICAL            LASIGN( MAXTYP ), LBSIGN( MAXTYP )
+      INTEGER            IOLDSD( 4 ), KADD( 6 ), KAMAGN( MAXTYP ),
+     $                   KATYPE( MAXTYP ), KAZERO( MAXTYP ),
+     $                   KBMAGN( MAXTYP ), KBTYPE( MAXTYP ),
+     $                   KBZERO( MAXTYP ), KCLASS( MAXTYP ),
+     $                   KTRIAN( MAXTYP ), KZ1( 6 ), KZ2( 6 )
+      DOUBLE PRECISION   RMAGN( 0: 3 )
+*     ..
+*     .. External Functions ..
+      INTEGER            ILAENV
+      DOUBLE PRECISION   DLAMCH
+      COMPLEX*16         ZLARND
+      EXTERNAL           ILAENV, DLAMCH, ZLARND
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           ALASVM, XERBLA, ZGET52, ZGGEV4, ZLACPY, ZLARFG,
+     $                   ZLASET, ZLATM4, ZUNM2R
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          ABS, DBLE, DCONJG, MAX, MIN, SIGN
+*     ..
+*     .. Data statements ..
+      DATA               KCLASS / 15*1, 10*2, 1*3 /
+      DATA               KZ1 / 0, 1, 2, 1, 3, 3 /
+      DATA               KZ2 / 0, 0, 1, 2, 1, 1 /
+      DATA               KADD / 0, 0, 0, 0, 3, 2 /
+      DATA               KATYPE / 0, 1, 0, 1, 2, 3, 4, 1, 4, 4, 1, 1, 4,
+     $                   4, 4, 2, 4, 5, 8, 7, 9, 4*4, 0 /
+      DATA               KBTYPE / 0, 0, 1, 1, 2, -3, 1, 4, 1, 1, 4, 4,
+     $                   1, 1, -4, 2, -4, 8*8, 0 /
+      DATA               KAZERO / 6*1, 2, 1, 2*2, 2*1, 2*2, 3, 1, 3,
+     $                   4*5, 4*3, 1 /
+      DATA               KBZERO / 6*1, 1, 2, 2*1, 2*2, 2*1, 4, 1, 4,
+     $                   4*6, 4*4, 1 /
+      DATA               KAMAGN / 8*1, 2, 3, 2, 3, 2, 3, 7*1, 2, 3, 3,
+     $                   2, 1 /
+      DATA               KBMAGN / 8*1, 3, 2, 3, 2, 2, 3, 7*1, 3, 2, 3,
+     $                   2, 1 /
+      DATA               KTRIAN / 16*0, 10*1 /
+      DATA               LASIGN / 6*.FALSE., .TRUE., .FALSE., 2*.TRUE.,
+     $                   2*.FALSE., 3*.TRUE., .FALSE., .TRUE.,
+     $                   3*.FALSE., 5*.TRUE., .FALSE. /
+      DATA               LBSIGN / 7*.FALSE., .TRUE., 2*.FALSE.,
+     $                   2*.TRUE., 2*.FALSE., .TRUE., .FALSE., .TRUE.,
+     $                   9*.FALSE. /
+*     ..
+*     .. Executable Statements ..
+*
+*     Check for errors
+*
+      INFO = 0
+*
+      BADNN = .FALSE.
+      NMAX = 1
+      DO 10 J = 1, NSIZES
+         NMAX = MAX( NMAX, NN( J ) )
+         IF( NN( J ).LT.0 )
+     $      BADNN = .TRUE.
+   10 CONTINUE
+*
+      IF( NSIZES.LT.0 ) THEN
+         INFO = -1
+      ELSE IF( BADNN ) THEN
+         INFO = -2
+      ELSE IF( NTYPES.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( THRESH.LT.ZERO ) THEN
+         INFO = -6
+      ELSE IF( LDA.LE.1 .OR. LDA.LT.NMAX ) THEN
+         INFO = -9
+      ELSE IF( LDQ.LE.1 .OR. LDQ.LT.NMAX ) THEN
+         INFO = -14
+      ELSE IF( LDQE.LE.1 .OR. LDQE.LT.NMAX ) THEN
+         INFO = -17
+      END IF
+*
+*     Compute workspace
+*      (Note: Comments in the code beginning "Workspace:" describe the
+*       minimal amount of workspace needed at that point in the code,
+*       as well as the preferred amount for good performance.
+*       NB refers to the optimal block size for the immediately
+*       following subroutine, as returned by ILAENV.
+*
+      MINWRK = 1
+      IF( INFO.EQ.0 .AND. LWORK.GE.1 ) THEN
+         MINWRK = NMAX*( NMAX+1 )
+         NB = MAX( 1, ILAENV( 1, 'ZGEQRF', ' ', NMAX, NMAX, -1, -1 ),
+     $        ILAENV( 1, 'ZUNMQR', 'LC', NMAX, NMAX, NMAX, -1 ),
+     $        ILAENV( 1, 'ZUNGQR', ' ', NMAX, NMAX, NMAX, -1 ) )
+         MAXWRK = MAX( 2*NMAX, NMAX*( NB+1 ), NMAX*( NMAX+1 ) )
+         WORK( 1 ) = MAXWRK
+      END IF
+*
+      IF( LWORK.LT.MINWRK )
+     $   INFO = -23
+*
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'ZDRGEV4', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( NSIZES.EQ.0 .OR. NTYPES.EQ.0 )
+     $   RETURN
+*
+      ULP = DLAMCH( 'Precision' )
+      SAFMIN = DLAMCH( 'Safe minimum' )
+      SAFMIN = SAFMIN / ULP
+      SAFMAX = ONE / SAFMIN
+      ULPINV = ONE / ULP
+*
+*     The values RMAGN(2:3) depend on N, see below.
+*
+      RMAGN( 0 ) = ZERO
+      RMAGN( 1 ) = ONE
+*
+*     Loop over sizes, types
+*
+      NTESTT = 0
+      NERRS = 0
+      NMATS = 0
+*
+      DO 220 JSIZE = 1, NSIZES
+         N = NN( JSIZE )
+         N1 = MAX( 1, N )
+         RMAGN( 2 ) = SAFMAX*ULP / DBLE( N1 )
+         RMAGN( 3 ) = SAFMIN*ULPINV*N1
+*
+         IF( NSIZES.NE.1 ) THEN
+            MTYPES = MIN( MAXTYP, NTYPES )
+         ELSE
+            MTYPES = MIN( MAXTYP+1, NTYPES )
+         END IF
+*
+         DO 210 JTYPE = 1, MTYPES
+            IF( .NOT.DOTYPE( JTYPE ) )
+     $         GO TO 210
+            NMATS = NMATS + 1
+*
+*           Save ISEED in case of an error.
+*
+            DO 20 J = 1, 4
+               IOLDSD( J ) = ISEED( J )
+   20       CONTINUE
+*
+*           Generate test matrices A and B
+*
+*           Description of control parameters:
+*
+*           KZLASS: =1 means w/o rotation, =2 means w/ rotation,
+*                   =3 means random.
+*           KATYPE: the "type" to be passed to ZLATM4 for computing A.
+*           KAZERO: the pattern of zeros on the diagonal for A:
+*                   =1: ( xxx ), =2: (0, xxx ) =3: ( 0, 0, xxx, 0 ),
+*                   =4: ( 0, xxx, 0, 0 ), =5: ( 0, 0, 1, xxx, 0 ),
+*                   =6: ( 0, 1, 0, xxx, 0 ).  (xxx means a string of
+*                   non-zero entries.)
+*           KAMAGN: the magnitude of the matrix: =0: zero, =1: O(1),
+*                   =2: large, =3: small.
+*           LASIGN: .TRUE. if the diagonal elements of A are to be
+*                   multiplied by a random magnitude 1 number.
+*           KBTYPE, KBZERO, KBMAGN, LBSIGN: the same, but for B.
+*           KTRIAN: =0: don't fill in the upper triangle, =1: do.
+*           KZ1, KZ2, KADD: used to implement KAZERO and KBZERO.
+*           RMAGN: used to implement KAMAGN and KBMAGN.
+*
+            IF( MTYPES.GT.MAXTYP )
+     $         GO TO 100
+            IERR = 0
+            IF( KCLASS( JTYPE ).LT.3 ) THEN
+*
+*              Generate A (w/o rotation)
+*
+               IF( ABS( KATYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL ZLASET( 'Full', N, N, CZERO, CZERO, A, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL ZLATM4( KATYPE( JTYPE ), IN, KZ1( KAZERO( JTYPE ) ),
+     $                      KZ2( KAZERO( JTYPE ) ), LASIGN( JTYPE ),
+     $                      RMAGN( KAMAGN( JTYPE ) ), ULP,
+     $                      RMAGN( KTRIAN( JTYPE )*KAMAGN( JTYPE ) ), 2,
+     $                      ISEED, A, LDA )
+               IADD = KADD( KAZERO( JTYPE ) )
+               IF( IADD.GT.0 .AND. IADD.LE.N )
+     $            A( IADD, IADD ) = RMAGN( KAMAGN( JTYPE ) )
+*
+*              Generate B (w/o rotation)
+*
+               IF( ABS( KBTYPE( JTYPE ) ).EQ.3 ) THEN
+                  IN = 2*( ( N-1 ) / 2 ) + 1
+                  IF( IN.NE.N )
+     $               CALL ZLASET( 'Full', N, N, CZERO, CZERO, B, LDA )
+               ELSE
+                  IN = N
+               END IF
+               CALL ZLATM4( KBTYPE( JTYPE ), IN, KZ1( KBZERO( JTYPE ) ),
+     $                      KZ2( KBZERO( JTYPE ) ), LBSIGN( JTYPE ),
+     $                      RMAGN( KBMAGN( JTYPE ) ), ONE,
+     $                      RMAGN( KTRIAN( JTYPE )*KBMAGN( JTYPE ) ), 2,
+     $                      ISEED, B, LDA )
+               IADD = KADD( KBZERO( JTYPE ) )
+               IF( IADD.NE.0 .AND. IADD.LE.N )
+     $            B( IADD, IADD ) = RMAGN( KBMAGN( JTYPE ) )
+*
+               IF( KCLASS( JTYPE ).EQ.2 .AND. N.GT.0 ) THEN
+*
+*                 Include rotations
+*
+*                 Generate Q, Z as Householder transformations times
+*                 a diagonal matrix.
+*
+                  DO 40 JC = 1, N - 1
+                     DO 30 JR = JC, N
+                        Q( JR, JC ) = ZLARND( 3, ISEED )
+                        Z( JR, JC ) = ZLARND( 3, ISEED )
+   30                CONTINUE
+                     CALL ZLARFG( N+1-JC, Q( JC, JC ), Q( JC+1, JC ), 1,
+     $                            WORK( JC ) )
+                     WORK( 2*N+JC ) = SIGN( ONE, DBLE( Q( JC, JC ) ) )
+                     Q( JC, JC ) = CONE
+                     CALL ZLARFG( N+1-JC, Z( JC, JC ), Z( JC+1, JC ), 1,
+     $                            WORK( N+JC ) )
+                     WORK( 3*N+JC ) = SIGN( ONE, DBLE( Z( JC, JC ) ) )
+                     Z( JC, JC ) = CONE
+   40             CONTINUE
+                  CTEMP = ZLARND( 3, ISEED )
+                  Q( N, N ) = CONE
+                  WORK( N ) = CZERO
+                  WORK( 3*N ) = CTEMP / ABS( CTEMP )
+                  CTEMP = ZLARND( 3, ISEED )
+                  Z( N, N ) = CONE
+                  WORK( 2*N ) = CZERO
+                  WORK( 4*N ) = CTEMP / ABS( CTEMP )
+*
+*                 Apply the diagonal matrices
+*
+                  DO 60 JC = 1, N
+                     DO 50 JR = 1, N
+                        A( JR, JC ) = WORK( 2*N+JR )*
+     $                                DCONJG( WORK( 3*N+JC ) )*
+     $                                A( JR, JC )
+                        B( JR, JC ) = WORK( 2*N+JR )*
+     $                                DCONJG( WORK( 3*N+JC ) )*
+     $                                B( JR, JC )
+   50                CONTINUE
+   60             CONTINUE
+                  CALL ZUNM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, A,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL ZUNM2R( 'R', 'C', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         A, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL ZUNM2R( 'L', 'N', N, N, N-1, Q, LDQ, WORK, B,
+     $                         LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+                  CALL ZUNM2R( 'R', 'C', N, N, N-1, Z, LDQ, WORK( N+1 ),
+     $                         B, LDA, WORK( 2*N+1 ), IERR )
+                  IF( IERR.NE.0 )
+     $               GO TO 90
+               END IF
+            ELSE
+*
+*              Random matrices
+*
+               DO 80 JC = 1, N
+                  DO 70 JR = 1, N
+                     A( JR, JC ) = RMAGN( KAMAGN( JTYPE ) )*
+     $                             ZLARND( 4, ISEED )
+                     B( JR, JC ) = RMAGN( KBMAGN( JTYPE ) )*
+     $                             ZLARND( 4, ISEED )
+   70             CONTINUE
+   80          CONTINUE
+            END IF
+*
+   90       CONTINUE
+*
+            IF( IERR.NE.0 ) THEN
+               WRITE( NOUNIT, FMT = 9999 )'Generator', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               RETURN
+            END IF
+*
+  100       CONTINUE
+*
+            DO 110 I = 1, 7
+               RESULT( I ) = -ONE
+  110       CONTINUE
+*
+*           Call XLAENV to set the parameters used in ZLAQZ0
+*
+            CALL XLAENV( 12, 10 )
+            CALL XLAENV( 13, 12 )
+            CALL XLAENV( 14, 13 )
+            CALL XLAENV( 15, 2 )
+            CALL XLAENV( 17, 10 )
+*
+*           Call ZGGEV4 to compute eigenvalues and eigenvectors.
+*
+            CALL ZLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL ZLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL ZGGEV4( 'V', 'V', N, S, LDA, T, LDA, ALPHA, BETA, Q,
+     $                   LDQ, Z, LDQ, WORK, LWORK, RWORK, IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'ZGGEV41', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+*           Do the tests (1) and (2)
+*
+            CALL ZGET52( .TRUE., N, A, LDA, B, LDA, Q, LDQ, ALPHA, BETA,
+     $                   WORK, RWORK, RESULT( 1 ) )
+            IF( RESULT( 2 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Left', 'ZGGEV41',
+     $            RESULT( 2 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do the tests (3) and (4)
+*
+            CALL ZGET52( .FALSE., N, A, LDA, B, LDA, Z, LDQ, ALPHA,
+     $                   BETA, WORK, RWORK, RESULT( 3 ) )
+            IF( RESULT( 4 ).GT.THRESH ) THEN
+               WRITE( NOUNIT, FMT = 9998 )'Right', 'ZGGEV41',
+     $            RESULT( 4 ), N, JTYPE, IOLDSD
+            END IF
+*
+*           Do test (5)
+*
+            CALL ZLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL ZLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL ZGGEV4( 'N', 'N', N, S, LDA, T, LDA, ALPHA1, BETA1, Q,
+     $                   LDQ, Z, LDQ, WORK, LWORK, RWORK, IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'ZGGEV42', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 120 J = 1, N
+               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
+     $             BETA1( J ) )RESULT( 5 ) = ULPINV
+  120       CONTINUE
+*
+*           Do test (6): Compute eigenvalues and left eigenvectors,
+*           and test them
+*
+            CALL ZLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL ZLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL ZGGEV4( 'V', 'N', N, S, LDA, T, LDA, ALPHA1, BETA1, QE,
+     $                   LDQE, Z, LDQ, WORK, LWORK, RWORK, IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'ZGGEV43', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 130 J = 1, N
+               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
+     $             BETA1( J ) )RESULT( 6 ) = ULPINV
+  130       CONTINUE
+*
+            DO 150 J = 1, N
+               DO 140 JC = 1, N
+                  IF( Q( J, JC ).NE.QE( J, JC ) )
+     $               RESULT( 6 ) = ULPINV
+  140          CONTINUE
+  150       CONTINUE
+*
+*           Do test (7): Compute eigenvalues and right eigenvectors,
+*           and test them
+*
+            CALL ZLACPY( ' ', N, N, A, LDA, S, LDA )
+            CALL ZLACPY( ' ', N, N, B, LDA, T, LDA )
+            CALL ZGGEV4( 'N', 'V', N, S, LDA, T, LDA, ALPHA1, BETA1, Q,
+     $                   LDQ, QE, LDQE, WORK, LWORK, RWORK,
+     $                   IWORK, IERR )
+            IF( IERR.NE.0 .AND. IERR.NE.N+1 ) THEN
+               RESULT( 1 ) = ULPINV
+               WRITE( NOUNIT, FMT = 9999 )'ZGGEV44', IERR, N, JTYPE,
+     $            IOLDSD
+               INFO = ABS( IERR )
+               GO TO 190
+            END IF
+*
+            DO 160 J = 1, N
+               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
+     $             BETA1( J ) )RESULT( 7 ) = ULPINV
+  160       CONTINUE
+*
+            DO 180 J = 1, N
+               DO 170 JC = 1, N
+                  IF( Z( J, JC ).NE.QE( J, JC ) )
+     $               RESULT( 7 ) = ULPINV
+  170          CONTINUE
+  180       CONTINUE
+*
+*           End of Loop -- Check for RESULT(j) > THRESH
+*
+  190       CONTINUE
+*
+            NTESTT = NTESTT + 7
+*
+*           Print out tests which fail.
+*
+            DO 200 JR = 1, 7
+               IF( RESULT( JR ).GE.THRESH ) THEN
+*
+*                 If this is the first test to fail,
+*                 print a header to the data file.
+*
+                  IF( NERRS.EQ.0 ) THEN
+                     WRITE( NOUNIT, FMT = 9997 )'ZGV'
+*
+*                    Matrix types
+*
+                     WRITE( NOUNIT, FMT = 9996 )
+                     WRITE( NOUNIT, FMT = 9995 )
+                     WRITE( NOUNIT, FMT = 9994 )'Orthogonal'
+*
+*                    Tests performed
+*
+                     WRITE( NOUNIT, FMT = 9993 )
+*
+                  END IF
+                  NERRS = NERRS + 1
+                  IF( RESULT( JR ).LT.10000.0D0 ) THEN
+                     WRITE( NOUNIT, FMT = 9992 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  ELSE
+                     WRITE( NOUNIT, FMT = 9991 )N, JTYPE, IOLDSD, JR,
+     $                  RESULT( JR )
+                  END IF
+               END IF
+  200       CONTINUE
+*
+  210    CONTINUE
+  220 CONTINUE
+*
+*     Summary
+*
+      CALL ALASVM( 'ZGV3', NOUNIT, NERRS, NTESTT, 0 )
+*
+      WORK( 1 ) = MAXWRK
+*
+      RETURN
+*
+ 9999 FORMAT( ' ZDRGEV4: ', A, ' returned INFO=', I6, '.', / 3X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+*
+ 9998 FORMAT( ' ZDRGEV4: ', A, ' Eigenvectors from ', A,
+     $      ' incorrectly normalized.', / ' Bits of error=', 0P, G10.3,
+     $      ',', 3X, 'N=', I4, ', JTYPE=', I3, ', ISEED=(',
+     $       3( I4, ',' ), I5, ')' )
+*
+ 9997 FORMAT( / 1X, A3, ' -- Complex Generalized eigenvalue problem ',
+     $      'driver' )
+*
+ 9996 FORMAT( ' Matrix types (see ZDRGEV4 for details): ' )
+*
+ 9995 FORMAT( ' Special Matrices:', 23X,
+     $      '(J''=transposed Jordan block)',
+     $      / '   1=(0,0)  2=(I,0)  3=(0,I)  4=(I,I)  5=(J'',J'')  ',
+     $      '6=(diag(J'',I), diag(I,J''))', / ' Diagonal Matrices:  ( ',
+     $      'D=diag(0,1,2,...) )', / '   7=(D,I)   9=(large*D, small*I',
+     $      ')  11=(large*I, small*D)  13=(large*D, large*I)', /
+     $      '   8=(I,D)  10=(small*D, large*I)  12=(small*I, large*D) ',
+     $      ' 14=(small*D, small*I)', / '  15=(D, reversed D)' )
+ 9994 FORMAT( ' Matrices Rotated by Random ', A, ' Matrices U, V:',
+     $      / '  16=Transposed Jordan Blocks             19=geometric ',
+     $      'alpha, beta=0,1', / '  17=arithm. alpha&beta             ',
+     $      '      20=arithmetic alpha, beta=0,1', / '  18=clustered ',
+     $      'alpha, beta=0,1            21=random alpha, beta=0,1',
+     $      / ' Large & Small Matrices:', / '  22=(large, small)   ',
+     $      '23=(small,large)    24=(small,small)    25=(large,large)',
+     $      / '  26=random O(1) matrices.' )
+*
+ 9993 FORMAT( / ' Tests performed:    ',
+     $      / ' 1 = max | ( b A - a B )''*l | / const.,',
+     $      / ' 2 = | |VR(i)| - 1 | / ulp,',
+     $      / ' 3 = max | ( b A - a B )*r | / const.',
+     $      / ' 4 = | |VL(i)| - 1 | / ulp,',
+     $      / ' 5 = 0 if W same no matter if r or l computed,',
+     $      / ' 6 = 0 if l same no matter if l computed,',
+     $      / ' 7 = 0 if r same no matter if r computed,', / 1X )
+ 9992 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 0P, F8.2 )
+ 9991 FORMAT( ' Matrix order=', I5, ', type=', I2, ', seed=',
+     $      4( I4, ',' ), ' result ', I2, ' is', 1P, D10.3 )
+*
+*     End of ZDRGEV4
+*
+      END


### PR DESCRIPTION
Currently, the algorithms used for the generalized eigenvalue algorithm have a few bottlenecks
 1. The hessenberg-triangular reduction step does not scale very well and givens rotations must be accumulated which adds a lot of redundant work
 2. the QZ algorithm can experience drastic slowdowns in the presence of infinite eigenvalues

The first issue can be addressed using a different HT reduction approach from [Steel et al](https://journals.uwyo.edu/index.php/ela/article/view/6483). The second issue can solved by identifying and deflating all of the infinite eigenvalues before the HT step.

These two bottlenecks are addressed in the xGGEV4 routines in this fork leading to 3-5x speedups when computing eigenvalues compared to xGGEV3.