### PR TITLE
cleanup: normalize ZERO/ONE constant order in TESTING/EIG error-exit tests

### DIFF
--- a/TESTING/EIG/cerrec.f
+++ b/TESTING/EIG/cerrec.f
@@ -69,8 +69,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX*( NMAX+2 ) )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/cerred.f
+++ b/TESTING/EIG/cerred.f
@@ -83,8 +83,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = 5*NMAX )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/derrec.f
+++ b/TESTING/EIG/derrec.f
@@ -68,8 +68,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/derred.f
+++ b/TESTING/EIG/derred.f
@@ -82,8 +82,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/serrec.f
+++ b/TESTING/EIG/serrec.f
@@ -68,8 +68,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      REAL               ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/serred.f
+++ b/TESTING/EIG/serred.f
@@ -82,8 +82,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      REAL               ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/zerrec.f
+++ b/TESTING/EIG/zerrec.f
@@ -69,8 +69,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX*( NMAX+2 ) )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/zerred.f
+++ b/TESTING/EIG/zerred.f
@@ -83,8 +83,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = 5*NMAX )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2


### PR DESCRIPTION
This PR normalizes the declaration and PARAMETER definition order
of the named constants ZERO and ONE across TESTING/EIG error-exit
test routines:

- {s,d,c,z}errec
- {s,d,c,z}erred

Specifically, the order is unified to:
    ZERO, ONE

This matches the prevailing style used in other parts of LAPACK
and improves consistency for automated translation and maintenance
(e.g., fable-based workflows in MPLAPACK).

No functional changes are intended. This is a pure cleanup.