### PR TITLE
SRC: use LSAME for UPLO checks in pttrs

### DIFF
--- a/SRC/cpttrs.f
+++ b/SRC/cpttrs.f
@@ -139,7 +139,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CPTTS2, XERBLA
@@ -152,8 +153,8 @@
 *     Test the input arguments.
 *
       INFO = 0
-      UPPER = ( UPLO.EQ.'U' .OR. UPLO.EQ.'u' )
-      IF( .NOT.UPPER .AND. .NOT.( UPLO.EQ.'L' .OR. UPLO.EQ.'l' ) ) THEN
+      UPPER = LSAME( UPLO, 'U' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/SRC/zpttrs.f
+++ b/SRC/zpttrs.f
@@ -139,7 +139,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZPTTS2
@@ -152,8 +153,8 @@
 *     Test the input arguments.
 *
       INFO = 0
-      UPPER = ( UPLO.EQ.'U' .OR. UPLO.EQ.'u' )
-      IF( .NOT.UPPER .AND. .NOT.( UPLO.EQ.'L' .OR. UPLO.EQ.'l' ) ) THEN
+      UPPER = LSAME( UPLO, 'U' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/TESTING/EIG/cerrec.f
+++ b/TESTING/EIG/cerrec.f
@@ -69,8 +69,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX*( NMAX+2 ) )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/cerred.f
+++ b/TESTING/EIG/cerred.f
@@ -83,8 +83,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = 5*NMAX )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/cerrgg.f
+++ b/TESTING/EIG/cerrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -129,8 +129,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0E0
-      TOLB = 1.0E0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/derrec.f
+++ b/TESTING/EIG/derrec.f
@@ -68,8 +68,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/derred.f
+++ b/TESTING/EIG/derred.f
@@ -82,8 +82,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/derrgg.f
+++ b/TESTING/EIG/derrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -128,8 +128,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0D0
-      TOLB = 1.0D0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/serrec.f
+++ b/TESTING/EIG/serrec.f
@@ -68,8 +68,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      REAL               ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/serred.f
+++ b/TESTING/EIG/serred.f
@@ -82,8 +82,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      REAL               ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/serrgg.f
+++ b/TESTING/EIG/serrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -128,8 +128,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0E0
-      TOLB = 1.0E0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/zerrec.f
+++ b/TESTING/EIG/zerrec.f
@@ -69,8 +69,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX*( NMAX+2 ) )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/zerred.f
+++ b/TESTING/EIG/zerred.f
@@ -83,8 +83,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = 5*NMAX )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/zerrgg.f
+++ b/TESTING/EIG/zerrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -129,8 +129,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0D0
-      TOLB = 1.0D0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/zerrhs.f
+++ b/TESTING/EIG/zerrhs.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = NMAX*NMAX )
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -111,7 +113,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
          SEL( J ) = .TRUE.
    20 CONTINUE


### PR DESCRIPTION
This PR replaces direct case-sensitive `UPLO` character comparisons in the complex `PTTRS` routines with `LSAME`.

  Files updated:
  ```text
  SRC/cpttrs.f
  SRC/zpttrs.f
```
  Summary:

  - Replace UPLO.EQ.'U' .OR. UPLO.EQ.'u' with LSAME( UPLO, 'U' ).
  - Replace the corresponding lower-triangular check with LSAME( UPLO, 'L' ).
  - Add LSAME as a logical external function.

  Validation:

  - Compiled cpttrs.f and zpttrs.f with gfortran -O2 -c.
  - Ran git diff --check for the staged changes before commit.