### PR TITLE
SRC: use LSAME for TRANS checks in gttrs

### DIFF
--- a/SRC/cgttrs.f
+++ b/SRC/cgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CGTTS2, XERBLA
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2
@@ -193,7 +194,7 @@
 *
       IF( NOTRAN ) THEN
          ITRANS = 0
-      ELSE IF( TRANS.EQ.'T' .OR. TRANS.EQ.'t' ) THEN
+      ELSE IF( LSAME( TRANS, 'T' ) ) THEN
          ITRANS = 1
       ELSE
          ITRANS = 2

--- a/SRC/dgttrs.f
+++ b/SRC/dgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DGTTS2, XERBLA
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/SRC/sgttrs.f
+++ b/SRC/sgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SGTTS2, XERBLA
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/SRC/zgttrs.f
+++ b/SRC/zgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZGTTS2
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2
@@ -193,7 +194,7 @@
 *
       IF( NOTRAN ) THEN
          ITRANS = 0
-      ELSE IF( TRANS.EQ.'T' .OR. TRANS.EQ.'t' ) THEN
+      ELSE IF( LSAME( TRANS, 'T' ) ) THEN
          ITRANS = 1
       ELSE
          ITRANS = 2


### PR DESCRIPTION
  This PR replaces direct case-sensitive `TRANS` character comparisons in the `GTTRS` routines with `LSAME`.

  Files updated:
  ```text
  SRC/sgttrs.f
  SRC/dgttrs.f
  SRC/cgttrs.f
  SRC/zgttrs.f
```
  Summary:

  - Replace direct N/n, T/t, and C/c TRANS checks with LSAME.
  - Use LSAME( TRANS, 'T' ) for the complex ITRANS branch.
  - Add LSAME as a logical external function.

  Validation:

  - Compiled sgttrs.f, dgttrs.f, cgttrs.f, and zgttrs.f with gfortran -O2 -c.
  - Ran git diff --check for the staged changes before commit.
