### PR TITLE
SRC: use LSAME for UPLO checks in lalsd

### DIFF
--- a/SRC/clalsd.f
+++ b/SRC/clalsd.f
@@ -212,7 +212,8 @@
 *     .. External Functions ..
       INTEGER            ISAMAX
       REAL               SLAMCH, SLANST
-      EXTERNAL           ISAMAX, SLAMCH, SLANST
+      LOGICAL            LSAME
+      EXTERNAL           ISAMAX, SLAMCH, SLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CCOPY, CLACPY, CLALSA, CLASCL, CLASET,
@@ -271,7 +272,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL SLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R

--- a/SRC/dlalsd.f
+++ b/SRC/dlalsd.f
@@ -200,7 +200,8 @@
 *     .. External Functions ..
       INTEGER            IDAMAX
       DOUBLE PRECISION   DLAMCH, DLANST
-      EXTERNAL           IDAMAX, DLAMCH, DLANST
+      LOGICAL            LSAME
+      EXTERNAL           IDAMAX, DLAMCH, DLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DCOPY, DGEMM, DLACPY, DLALSA, DLARTG,
@@ -258,7 +259,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL DLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R

--- a/SRC/slalsd.f
+++ b/SRC/slalsd.f
@@ -200,7 +200,8 @@
 *     .. External Functions ..
       INTEGER            ISAMAX
       REAL               SLAMCH, SLANST
-      EXTERNAL           ISAMAX, SLAMCH, SLANST
+      LOGICAL            LSAME
+      EXTERNAL           ISAMAX, SLAMCH, SLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SCOPY, SGEMM, SLACPY, SLALSA, SLARTG,
@@ -258,7 +259,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL SLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R

--- a/SRC/zlalsd.f
+++ b/SRC/zlalsd.f
@@ -213,7 +213,8 @@
 *     .. External Functions ..
       INTEGER            IDAMAX
       DOUBLE PRECISION   DLAMCH, DLANST
-      EXTERNAL           IDAMAX, DLAMCH, DLANST
+      LOGICAL            LSAME
+      EXTERNAL           IDAMAX, DLAMCH, DLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DGEMM, DLARTG, DLASCL, DLASDA, DLASDQ,
@@ -272,7 +273,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL DLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R


### PR DESCRIPTION
This PR replaces direct `UPLO` character comparisons in the `LALSD` routines with `LSAME`.

  Files updated:
  ```text
  SRC/slalsd.f
  SRC/dlalsd.f
  SRC/clalsd.f
  SRC/zlalsd.f
```
  Summary:

  - Replace UPLO.EQ.'L' with LSAME( UPLO, 'L' ).
  - Add LSAME as a logical external function.

  Validation:

  - Ran git diff --check for the staged changes before commit.
  - Confirmed full build and full TESTING pass.