### PR TITLE
TESTING/LIN: use LSAME for UPLO checks in latsp and latsy

### DIFF
--- a/SRC/cgttrs.f
+++ b/SRC/cgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CGTTS2, XERBLA
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2
@@ -193,7 +194,7 @@
 *
       IF( NOTRAN ) THEN
          ITRANS = 0
-      ELSE IF( TRANS.EQ.'T' .OR. TRANS.EQ.'t' ) THEN
+      ELSE IF( LSAME( TRANS, 'T' ) ) THEN
          ITRANS = 1
       ELSE
          ITRANS = 2

--- a/SRC/clalsd.f
+++ b/SRC/clalsd.f
@@ -212,7 +212,8 @@
 *     .. External Functions ..
       INTEGER            ISAMAX
       REAL               SLAMCH, SLANST
-      EXTERNAL           ISAMAX, SLAMCH, SLANST
+      LOGICAL            LSAME
+      EXTERNAL           ISAMAX, SLAMCH, SLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CCOPY, CLACPY, CLALSA, CLASCL, CLASET,
@@ -271,7 +272,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL SLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R

--- a/SRC/cpttrs.f
+++ b/SRC/cpttrs.f
@@ -139,7 +139,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CPTTS2, XERBLA
@@ -152,8 +153,8 @@
 *     Test the input arguments.
 *
       INFO = 0
-      UPPER = ( UPLO.EQ.'U' .OR. UPLO.EQ.'u' )
-      IF( .NOT.UPPER .AND. .NOT.( UPLO.EQ.'L' .OR. UPLO.EQ.'l' ) ) THEN
+      UPPER = LSAME( UPLO, 'U' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/SRC/dgttrs.f
+++ b/SRC/dgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DGTTS2, XERBLA
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/SRC/dlalsd.f
+++ b/SRC/dlalsd.f
@@ -200,7 +200,8 @@
 *     .. External Functions ..
       INTEGER            IDAMAX
       DOUBLE PRECISION   DLAMCH, DLANST
-      EXTERNAL           IDAMAX, DLAMCH, DLANST
+      LOGICAL            LSAME
+      EXTERNAL           IDAMAX, DLAMCH, DLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DCOPY, DGEMM, DLACPY, DLALSA, DLARTG,
@@ -258,7 +259,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL DLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R

--- a/SRC/sgttrs.f
+++ b/SRC/sgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SGTTS2, XERBLA
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/SRC/slalsd.f
+++ b/SRC/slalsd.f
@@ -200,7 +200,8 @@
 *     .. External Functions ..
       INTEGER            ISAMAX
       REAL               SLAMCH, SLANST
-      EXTERNAL           ISAMAX, SLAMCH, SLANST
+      LOGICAL            LSAME
+      EXTERNAL           ISAMAX, SLAMCH, SLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SCOPY, SGEMM, SLACPY, SLALSA, SLARTG,
@@ -258,7 +259,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL SLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R

--- a/SRC/zgttrs.f
+++ b/SRC/zgttrs.f
@@ -157,7 +157,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZGTTS2
@@ -168,9 +169,9 @@
 *     .. Executable Statements ..
 *
       INFO = 0
-      NOTRAN = ( TRANS.EQ.'N' .OR. TRANS.EQ.'n' )
-      IF( .NOT.NOTRAN .AND. .NOT.( TRANS.EQ.'T' .OR. TRANS.EQ.
-     $    't' ) .AND. .NOT.( TRANS.EQ.'C' .OR. TRANS.EQ.'c' ) ) THEN
+      NOTRAN = LSAME( TRANS, 'N' )
+      IF( .NOT.NOTRAN .AND. .NOT.LSAME( TRANS, 'T' ) .AND.
+     $    .NOT.LSAME( TRANS, 'C' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2
@@ -193,7 +194,7 @@
 *
       IF( NOTRAN ) THEN
          ITRANS = 0
-      ELSE IF( TRANS.EQ.'T' .OR. TRANS.EQ.'t' ) THEN
+      ELSE IF( LSAME( TRANS, 'T' ) ) THEN
          ITRANS = 1
       ELSE
          ITRANS = 2

--- a/SRC/zlalsd.f
+++ b/SRC/zlalsd.f
@@ -213,7 +213,8 @@
 *     .. External Functions ..
       INTEGER            IDAMAX
       DOUBLE PRECISION   DLAMCH, DLANST
-      EXTERNAL           IDAMAX, DLAMCH, DLANST
+      LOGICAL            LSAME
+      EXTERNAL           IDAMAX, DLAMCH, DLANST, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DGEMM, DLARTG, DLASCL, DLASDA, DLASDQ,
@@ -272,7 +273,7 @@
 *
 *     Rotate the matrix if it is lower bidiagonal.
 *
-      IF( UPLO.EQ.'L' ) THEN
+      IF( LSAME( UPLO, 'L' ) ) THEN
          DO 10 I = 1, N - 1
             CALL DLARTG( D( I ), E( I ), CS, SN, R )
             D( I ) = R

--- a/SRC/zpttrs.f
+++ b/SRC/zpttrs.f
@@ -139,7 +139,8 @@
 *     ..
 *     .. External Functions ..
       INTEGER            ILAENV
-      EXTERNAL           ILAENV
+      LOGICAL            LSAME
+      EXTERNAL           ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZPTTS2
@@ -152,8 +153,8 @@
 *     Test the input arguments.
 *
       INFO = 0
-      UPPER = ( UPLO.EQ.'U' .OR. UPLO.EQ.'u' )
-      IF( .NOT.UPPER .AND. .NOT.( UPLO.EQ.'L' .OR. UPLO.EQ.'l' ) ) THEN
+      UPPER = LSAME( UPLO, 'U' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN
          INFO = -2

--- a/TESTING/EIG/cerrec.f
+++ b/TESTING/EIG/cerrec.f
@@ -69,8 +69,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX*( NMAX+2 ) )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/cerred.f
+++ b/TESTING/EIG/cerred.f
@@ -83,8 +83,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = 5*NMAX )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/cerrgg.f
+++ b/TESTING/EIG/cerrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -129,8 +129,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0E0
-      TOLB = 1.0E0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/derrec.f
+++ b/TESTING/EIG/derrec.f
@@ -68,8 +68,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/derred.f
+++ b/TESTING/EIG/derred.f
@@ -82,8 +82,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/derrgg.f
+++ b/TESTING/EIG/derrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -128,8 +128,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0D0
-      TOLB = 1.0D0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/serrec.f
+++ b/TESTING/EIG/serrec.f
@@ -68,8 +68,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      REAL               ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/serred.f
+++ b/TESTING/EIG/serred.f
@@ -82,8 +82,8 @@
 *
 *     .. Parameters ..
       INTEGER            NMAX
-      REAL               ONE, ZERO
-      PARAMETER          ( NMAX = 4, ONE = 1.0E0, ZERO = 0.0E0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( NMAX = 4, ZERO = 0.0E0, ONE = 1.0E0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/serrgg.f
+++ b/TESTING/EIG/serrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      REAL               ONE, ZERO
-      PARAMETER          ( ONE = 1.0E+0, ZERO = 0.0E+0 )
+      REAL               ZERO, ONE
+      PARAMETER          ( ZERO = 0.0E+0, ONE = 1.0E+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -128,8 +128,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0E0
-      TOLB = 1.0E0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/zerrec.f
+++ b/TESTING/EIG/zerrec.f
@@ -69,8 +69,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = NMAX*( NMAX+2 ) )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       INTEGER            I, IFST, ILST, INFO, J, M, NT

--- a/TESTING/EIG/zerred.f
+++ b/TESTING/EIG/zerred.f
@@ -83,8 +83,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 4, LW = 5*NMAX )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D0, ZERO = 0.0D0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D0, ONE = 1.0D0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2

--- a/TESTING/EIG/zerrgg.f
+++ b/TESTING/EIG/zerrgg.f
@@ -70,8 +70,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = 6*NMAX )
-      DOUBLE PRECISION   ONE, ZERO
-      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+      DOUBLE PRECISION   ZERO, ONE
+      PARAMETER          ( ZERO = 0.0D+0, ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -129,8 +129,8 @@
          B( I, I ) = ONE
    30 CONTINUE
       OK = .TRUE.
-      TOLA = 1.0D0
-      TOLB = 1.0D0
+      TOLA = ONE
+      TOLB = ONE
       IFST = 1
       ILST = 1
       NT = 0

--- a/TESTING/EIG/zerrhs.f
+++ b/TESTING/EIG/zerrhs.f
@@ -68,6 +68,8 @@
 *     .. Parameters ..
       INTEGER            NMAX, LW
       PARAMETER          ( NMAX = 3, LW = NMAX*NMAX )
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
 *     ..
 *     .. Local Scalars ..
       CHARACTER*2        C2
@@ -111,7 +113,7 @@
 *
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
-            A( I, J ) = 1.D0 / DBLE( I+J )
+            A( I, J ) = ONE / DBLE( I+J )
    10    CONTINUE
          SEL( J ) = .TRUE.
    20 CONTINUE

--- a/TESTING/LIN/clatsp.f
+++ b/TESTING/LIN/clatsp.f
@@ -109,7 +109,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX            CLARND
-      EXTERNAL           CLARND
+      LOGICAL            LSAME
+      EXTERNAL           CLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -130,7 +131,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
          N5 = N / 5
          N5 = N - 5*N5 + 1
 *

--- a/TESTING/LIN/clatsy.f
+++ b/TESTING/LIN/clatsy.f
@@ -114,7 +114,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX            CLARND
-      EXTERNAL           CLARND
+      LOGICAL            LSAME
+      EXTERNAL           CLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -129,7 +130,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
 *
 *        Fill the upper triangle of the matrix with zeros.
 *

--- a/TESTING/LIN/zlatsp.f
+++ b/TESTING/LIN/zlatsp.f
@@ -109,7 +109,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX*16         ZLARND
-      EXTERNAL           ZLARND
+      LOGICAL            LSAME
+      EXTERNAL           ZLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -130,7 +131,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
          N5 = N / 5
          N5 = N - 5*N5 + 1
 *

--- a/TESTING/LIN/zlatsy.f
+++ b/TESTING/LIN/zlatsy.f
@@ -114,7 +114,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX*16         ZLARND
-      EXTERNAL           ZLARND
+      LOGICAL            LSAME
+      EXTERNAL           ZLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -129,7 +130,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
 *
 *        Fill the upper triangle of the matrix with zeros.
 *


### PR DESCRIPTION
This PR replaces direct `UPLO` character comparisons in the `LATSP` and `LATSY` test helpers with `LSAME`.

  Files updated:
  ```text
  TESTING/LIN/clatsp.f
  TESTING/LIN/zlatsp.f
  TESTING/LIN/clatsy.f
  TESTING/LIN/zlatsy.f
```
  Summary:

  - Replace UPLO.EQ.'U' with LSAME( UPLO, 'U' ).
  - Add LSAME as a logical external function.