### PR TITLE
SRC: use LSAME for NORM checks in condition routines

### DIFF
--- a/SRC/cgbcon.f
+++ b/SRC/cgbcon.f
@@ -201,7 +201,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/cgecon.f
+++ b/SRC/cgecon.f
@@ -184,7 +184,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/cgtcon.f
+++ b/SRC/cgtcon.f
@@ -181,7 +181,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/ctbcon.f
+++ b/SRC/ctbcon.f
@@ -195,7 +195,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/ctpcon.f
+++ b/SRC/ctpcon.f
@@ -181,7 +181,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/ctrcon.f
+++ b/SRC/ctrcon.f
@@ -188,7 +188,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/dgbcon.f
+++ b/SRC/dgbcon.f
@@ -191,7 +191,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/dgecon.f
+++ b/SRC/dgecon.f
@@ -177,7 +177,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/dgtcon.f
+++ b/SRC/dgtcon.f
@@ -183,7 +183,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/dtbcon.f
+++ b/SRC/dtbcon.f
@@ -188,7 +188,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/dtpcon.f
+++ b/SRC/dtpcon.f
@@ -174,7 +174,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/dtrcon.f
+++ b/SRC/dtrcon.f
@@ -181,7 +181,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/sgbcon.f
+++ b/SRC/sgbcon.f
@@ -190,7 +190,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/sgecon.f
+++ b/SRC/sgecon.f
@@ -177,7 +177,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/sgtcon.f
+++ b/SRC/sgtcon.f
@@ -183,7 +183,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/stbcon.f
+++ b/SRC/stbcon.f
@@ -188,7 +188,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/stpcon.f
+++ b/SRC/stpcon.f
@@ -174,7 +174,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/strcon.f
+++ b/SRC/strcon.f
@@ -181,7 +181,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/zgbcon.f
+++ b/SRC/zgbcon.f
@@ -201,7 +201,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/zgecon.f
+++ b/SRC/zgecon.f
@@ -184,7 +184,7 @@
 *     Test the input parameters.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/zgtcon.f
+++ b/SRC/zgtcon.f
@@ -181,7 +181,7 @@
 *     Test the input arguments.
 *
       INFO = 0
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN
          INFO = -1
       ELSE IF( N.LT.0 ) THEN

--- a/SRC/ztbcon.f
+++ b/SRC/ztbcon.f
@@ -195,7 +195,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/ztpcon.f
+++ b/SRC/ztpcon.f
@@ -181,7 +181,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/SRC/ztrcon.f
+++ b/SRC/ztrcon.f
@@ -188,7 +188,7 @@
 *
       INFO = 0
       UPPER = LSAME( UPLO, 'U' )
-      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )
+      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )
       NOUNIT = LSAME( DIAG, 'N' )
 *
       IF( .NOT.ONENRM .AND. .NOT.LSAME( NORM, 'I' ) ) THEN

--- a/TESTING/LIN/clatsp.f
+++ b/TESTING/LIN/clatsp.f
@@ -109,7 +109,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX            CLARND
-      EXTERNAL           CLARND
+      LOGICAL            LSAME
+      EXTERNAL           CLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -130,7 +131,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
          N5 = N / 5
          N5 = N - 5*N5 + 1
 *

--- a/TESTING/LIN/clatsy.f
+++ b/TESTING/LIN/clatsy.f
@@ -114,7 +114,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX            CLARND
-      EXTERNAL           CLARND
+      LOGICAL            LSAME
+      EXTERNAL           CLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -129,7 +130,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
 *
 *        Fill the upper triangle of the matrix with zeros.
 *

--- a/TESTING/LIN/zlatsp.f
+++ b/TESTING/LIN/zlatsp.f
@@ -109,7 +109,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX*16         ZLARND
-      EXTERNAL           ZLARND
+      LOGICAL            LSAME
+      EXTERNAL           ZLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -130,7 +131,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
          N5 = N / 5
          N5 = N - 5*N5 + 1
 *

--- a/TESTING/LIN/zlatsy.f
+++ b/TESTING/LIN/zlatsy.f
@@ -114,7 +114,8 @@
 *     ..
 *     .. External Functions ..
       COMPLEX*16         ZLARND
-      EXTERNAL           ZLARND
+      LOGICAL            LSAME
+      EXTERNAL           ZLARND, LSAME
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, SQRT
@@ -129,7 +130,7 @@
 *
 *     UPLO = 'U':  Upper triangular storage
 *
-      IF( UPLO.EQ.'U' ) THEN
+      IF( LSAME( UPLO, 'U' ) ) THEN
 *
 *        Fill the upper triangle of the matrix with zeros.
 *


### PR DESCRIPTION
This PR updates the condition estimation routines to use LSAME for checking
  the one-norm NORM option.

  The affected routines already use LSAME to accept the equivalent 'O' option:

      ONENRM = NORM.EQ.'1' .OR. LSAME( NORM, 'O' )

  This PR makes the handling consistent by replacing the direct character
  comparison with LSAME:

      ONENRM = LSAME( NORM, '1' ) .OR. LSAME( NORM, 'O' )

  This is a cleanup-only change. It does not change the accepted NORM options
  or the numerical behavior of the routines.