### PR TITLE
SRC: detect all-zero Y columns in GEDMD scaling

### DIFF
--- a/SRC/cgedmd.f90
+++ b/SRC/cgedmd.f90
@@ -117,6 +117,8 @@
 !>    'Y' :: The data snapshots matrices X and Y are multiplied
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
+!>           If all columns of Y are zero, the procedure returns
+!>           with INFO = -10.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -467,7 +469,8 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value
+!>              illegal value. If JOBS == 'Y' and all columns
+!>              of Y are zero, INFO = -10.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -833,6 +836,7 @@
           ! The columns of Y will be normalized.
           ! To prevent overflows, the column norms of Y are
           ! carefully computed using CLASSQ.
+          K = 0
           DO i = 1, N
             !RWORK(i) = SCNRM2( M, Y(1,i), 1 )
             SSUM  = ONE
@@ -868,8 +872,17 @@
                END IF
             ELSE
                RWORK(i) = ZERO
+               K = K + 1
             END IF
          END DO
+         IF ( K == N ) THEN
+         ! All columns of Y are zero. Return error code -10.
+         ! (the 10th input variable had an illegal value)
+         K = 0
+         INFO = -10
+         CALL XERBLA('CGEDMD',-INFO)
+         RETURN
+         END IF
          DO i = 1, N
 !           Now, apply the same scaling to the columns of X.
             IF ( RWORK(i) >  ZERO ) THEN

--- a/SRC/cgedmd.f90
+++ b/SRC/cgedmd.f90
@@ -118,7 +118,7 @@
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
 !>           If all columns of Y are zero, the procedure returns
-!>           with INFO = -10.
+!>           with INFO = 5.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -469,8 +469,7 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value. If JOBS == 'Y' and all columns
-!>              of Y are zero, INFO = -10.
+!>              illegal value.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -485,6 +484,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -876,11 +879,9 @@
             END IF
          END DO
          IF ( K == N ) THEN
-         ! All columns of Y are zero. Return error code -10.
-         ! (the 10th input variable had an illegal value)
+         ! All columns of Y are zero. Return diagnostic code 5.
          K = 0
-         INFO = -10
-         CALL XERBLA('CGEDMD',-INFO)
+         INFO = 5
          RETURN
          END IF
          DO i = 1, N

--- a/SRC/cgedmdq.f90
+++ b/SRC/cgedmdq.f90
@@ -538,6 +538,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -795,8 +799,8 @@ SUBROUTINE CGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
                   EIGS, Z, LDZ, RES, B,  LDB,   V, LDV,    &
                   S, LDS, ZWORK(MINMN+1), LZWORK-MINMN,    &
                   WORK,   LWORK, IWORK, LIWORK, INFO1 )
-      IF ( INFO1 == 2 .OR. INFO1 == 3 ) THEN
-          ! Return with error code. See CGEDMD for details.
+      IF ( INFO1 == 2 .OR. INFO1 == 3 .OR. INFO1 == 5 ) THEN
+          ! Return with terminal diagnostic or error code.
           INFO = INFO1
           RETURN
       ELSE

--- a/SRC/dgedmd.f90
+++ b/SRC/dgedmd.f90
@@ -115,6 +115,8 @@
 !>    'Y' :: The data snapshots matrices X and Y are multiplied
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
+!>           If all columns of Y are zero, the procedure returns
+!>           with INFO = -10.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -501,7 +503,8 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value
+!>              illegal value. If JOBS == 'Y' and all columns
+!>              of Y are zero, INFO = -10.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -854,6 +857,7 @@
           ! The columns of Y will be normalized.
           ! To prevent overflows, the column norms of Y are
           ! carefully computed using DLASSQ.
+          K = 0
           DO i = 1, N
             !WORK(i) = DNRM2( M, Y(1,i), 1 )
             SSUM  = ONE
@@ -889,8 +893,17 @@
                END IF
             ELSE
                WORK(i) = ZERO
+               K = K + 1
             END IF
          END DO
+         IF ( K == N ) THEN
+         ! All columns of Y are zero. Return error code -10.
+         ! (the 10th input variable had an illegal value)
+         K = 0
+         INFO = -10
+         CALL XERBLA('DGEDMD',-INFO)
+         RETURN
+         END IF
          DO i = 1, N
 !           Now, apply the same scaling to the columns of X.
             IF ( WORK(i) >  ZERO ) THEN

--- a/SRC/dgedmd.f90
+++ b/SRC/dgedmd.f90
@@ -116,7 +116,7 @@
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
 !>           If all columns of Y are zero, the procedure returns
-!>           with INFO = -10.
+!>           with INFO = 5.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -503,8 +503,7 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value. If JOBS == 'Y' and all columns
-!>              of Y are zero, INFO = -10.
+!>              illegal value.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -519,6 +518,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -897,11 +900,9 @@
             END IF
          END DO
          IF ( K == N ) THEN
-         ! All columns of Y are zero. Return error code -10.
-         ! (the 10th input variable had an illegal value)
+         ! All columns of Y are zero. Return diagnostic code 5.
          K = 0
-         INFO = -10
-         CALL XERBLA('DGEDMD',-INFO)
+         INFO = 5
          RETURN
          END IF
          DO i = 1, N

--- a/SRC/dgedmdq.f90
+++ b/SRC/dgedmdq.f90
@@ -557,6 +557,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -807,8 +811,8 @@ SUBROUTINE DGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
                    REIG, IMEIG, Z, LDZ, RES, B, LDB, V,     &
                    LDV, S, LDS, WORK(MINMN+1), LWORK-MINMN, &
                    IWORK, LIWORK, INFO1 )
-      IF ( INFO1 == 2 .OR. INFO1 == 3 ) THEN
-          ! Return with error code. See DGEDMD for details.
+      IF ( INFO1 == 2 .OR. INFO1 == 3 .OR. INFO1 == 5 ) THEN
+          ! Return with terminal diagnostic or error code.
           INFO = INFO1
           RETURN
       ELSE

--- a/SRC/sgedmd.f90
+++ b/SRC/sgedmd.f90
@@ -117,7 +117,7 @@
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
 !>           If all columns of Y are zero, the procedure returns
-!>           with INFO = -10.
+!>           with INFO = 5.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -503,8 +503,7 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value. If JOBS == 'Y' and all columns
-!>              of Y are zero, INFO = -10.
+!>              illegal value.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -519,6 +518,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -897,11 +900,9 @@
             END IF
          END DO
          IF ( K == N ) THEN
-         ! All columns of Y are zero. Return error code -10.
-         ! (the 10th input variable had an illegal value)
+         ! All columns of Y are zero. Return diagnostic code 5.
          K = 0
-         INFO = -10
-         CALL XERBLA('SGEDMD',-INFO)
+         INFO = 5
          RETURN
          END IF
          DO i = 1, N

--- a/SRC/sgedmd.f90
+++ b/SRC/sgedmd.f90
@@ -116,6 +116,8 @@
 !>    'Y' :: The data snapshots matrices X and Y are multiplied
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
+!>           If all columns of Y are zero, the procedure returns
+!>           with INFO = -10.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -501,7 +503,8 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value
+!>              illegal value. If JOBS == 'Y' and all columns
+!>              of Y are zero, INFO = -10.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -854,6 +857,7 @@
           ! The columns of Y will be normalized.
           ! To prevent overflows, the column norms of Y are
           ! carefully computed using SLASSQ.
+          K = 0
           DO i = 1, N
             !WORK(i) = DNRM2( M, Y(1,i), 1 )
             SSUM  = ONE
@@ -889,8 +893,17 @@
                END IF
             ELSE
                WORK(i) = ZERO
+               K = K + 1
             END IF
          END DO
+         IF ( K == N ) THEN
+         ! All columns of Y are zero. Return error code -10.
+         ! (the 10th input variable had an illegal value)
+         K = 0
+         INFO = -10
+         CALL XERBLA('SGEDMD',-INFO)
+         RETURN
+         END IF
          DO i = 1, N
 !           Now, apply the same scaling to the columns of X.
             IF ( WORK(i) >  ZERO ) THEN

--- a/SRC/sgedmdq.f90
+++ b/SRC/sgedmdq.f90
@@ -557,6 +557,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -806,8 +810,8 @@ SUBROUTINE SGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
                    REIG, IMEIG, Z, LDZ, RES, B, LDB, V,     &
                    LDV, S, LDS, WORK(MINMN+1), LWORK-MINMN, IWORK,  &
                    LIWORK, INFO1 )
-      IF ( INFO1 == 2 .OR. INFO1 == 3 ) THEN
-          ! Return with error code.
+      IF ( INFO1 == 2 .OR. INFO1 == 3 .OR. INFO1 == 5 ) THEN
+          ! Return with terminal diagnostic or error code.
           INFO = INFO1
           RETURN
       ELSE

--- a/SRC/zgedmd.f90
+++ b/SRC/zgedmd.f90
@@ -118,7 +118,7 @@
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
 !>           If all columns of Y are zero, the procedure returns
-!>           with INFO = -10.
+!>           with INFO = 5.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -469,8 +469,7 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value. If JOBS == 'Y' and all columns
-!>              of Y are zero, INFO = -10.
+!>              illegal value.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -485,6 +484,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -876,11 +879,9 @@
             END IF
          END DO
          IF ( K == N ) THEN
-         ! All columns of Y are zero. Return error code -10.
-         ! (the 10th input variable had an illegal value)
+         ! All columns of Y are zero. Return diagnostic code 5.
          K = 0
-         INFO = -10
-         CALL XERBLA('ZGEDMD',-INFO)
+         INFO = 5
          RETURN
          END IF
          DO i = 1, N

--- a/SRC/zgedmd.f90
+++ b/SRC/zgedmd.f90
@@ -117,6 +117,8 @@
 !>    'Y' :: The data snapshots matrices X and Y are multiplied
 !>           by a diagonal matrix D so that Y*D has unit
 !>           nonzero columns (in the Euclidean 2-norm)
+!>           If all columns of Y are zero, the procedure returns
+!>           with INFO = -10.
 !>    'N' :: No data scaling.
 !>    \endverbatim
 !.....
@@ -467,7 +469,8 @@
 !>    \verbatim
 !>    INFO (output) INTEGER
 !>    -i < 0 :: On entry, the i-th argument had an
-!>              illegal value
+!>              illegal value. If JOBS == 'Y' and all columns
+!>              of Y are zero, INFO = -10.
 !>       = 0 :: Successful return.
 !>       = 1 :: Void input. Quick exit (M=0 or N=0).
 !>       = 2 :: The SVD computation of X did not converge.
@@ -833,6 +836,7 @@
           ! The columns of Y will be normalized.
           ! To prevent overflows, the column norms of Y are
           ! carefully computed using ZLASSQ.
+          K = 0
           DO i = 1, N
             !RWORK(i) = DZNRM2( M, Y(1,i), 1 )
             SSUM  = ONE
@@ -868,8 +872,17 @@
                END IF
             ELSE
                RWORK(i) = ZERO
+               K = K + 1
             END IF
          END DO
+         IF ( K == N ) THEN
+         ! All columns of Y are zero. Return error code -10.
+         ! (the 10th input variable had an illegal value)
+         K = 0
+         INFO = -10
+         CALL XERBLA('ZGEDMD',-INFO)
+         RETURN
+         END IF
          DO i = 1, N
 !           Now, apply the same scaling to the columns of X.
             IF ( RWORK(i) >  ZERO ) THEN

--- a/SRC/zgedmdq.f90
+++ b/SRC/zgedmdq.f90
@@ -537,6 +537,10 @@
 !>              to zero if JOBS=='C'. The computation proceeds
 !>              with original or modified data and warning
 !>              flag is set with INFO=4.
+!>       = 5 :: If JOBS == 'Y' and all columns of Y are zero,
+!>              the procedure returns early with K = 0. This is
+!>              reported as a degenerate input diagnostic, not
+!>              as an illegal argument.
 !>    \endverbatim
 !
 !  Authors:
@@ -796,8 +800,8 @@ SUBROUTINE ZGEDMDQ( JOBS,  JOBZ, JOBR, JOBQ, JOBT, JOBF,   &
                   EIGS, Z, LDZ, RES, B,  LDB,   V, LDV,    &
                   S, LDS, ZWORK(MINMN+1), LZWORK-MINMN, &
                   WORK,   LWORK, IWORK, LIWORK, INFO1 )
-      IF ( INFO1 == 2 .OR. INFO1 == 3 ) THEN
-          ! Return with error code. See ZGEDMD for details.
+      IF ( INFO1 == 2 .OR. INFO1 == 3 .OR. INFO1 == 5 ) THEN
+          ! Return with terminal diagnostic or error code.
           INFO = INFO1
           RETURN
       ELSE

--- a/TESTING/EIG/cchkdmd.f90
+++ b/TESTING/EIG/cchkdmd.f90
@@ -75,7 +75,8 @@
       INTEGER :: i, iJOBREF, iJOBZ, iSCALE, INFO, j,     &
                  NFAIL, NFAIL_AU, NFAIL_F_QR, NFAIL_REZ,     &
                  NFAIL_REZQ, NFAIL_SVDIFF, NFAIL_TOTAL, NFAILQ_TOTAL,  &
-                 NFAIL_Z_XV,  MODE, MODEL, MODER, WHTSVD
+                 NFAIL_Z_XV, NFAIL_INFO, NFAILQ_INFO, MODE, &
+                 MODEL, MODER, WHTSVD
       INTEGER :: iNRNK, iWHTSVD,  K_traj, LWMINOPT
       CHARACTER :: GRADE, JOBREF, JOBZ, PIVTNG, RSIGN,   &
                    SCALE, RESIDS, WANTQ, WANTR
@@ -123,6 +124,8 @@
       NFAIL_Z_XV = 0
       NFAIL_F_QR = 0
       NFAIL_AU   = 0
+      NFAIL_INFO = 0
+      NFAILQ_INFO = 0
       NFAIL_SVDIFF = 0
       NFAIL_TOTAL  = 0
       NFAILQ_TOTAL = 0
@@ -272,6 +275,63 @@
 
       DEALLOCATE( CEIGSA )
 !........................................................................
+
+      IF ( K_traj == 1 .AND. MODE == 1 ) THEN
+      X(1:M,1:N) = X0(1:M,1:N)
+      Y(1:M,1:N) = CZERO
+      CALL CGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, X, LDX, Y, &
+                LDY, -1, TOL, K, CEIGS, Z, LDZ, RES,       &
+                AU, LDAU, W, LDW, S, LDS, CDUMMY, -1,      &
+                WDUMMY, -1, IDUMMY, -1, INFO )
+      LCWORK = INT(CDUMMY(1))
+      ALLOCATE(CWORK(LCWORK))
+      LIWORK = IDUMMY(1)
+      ALLOCATE(IWORK(LIWORK))
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE(WORK(LWORK))
+      K = -1
+      CALL CGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, X, LDX, Y, &
+                   LDY, -1, TOL, K, CEIGS, Z, LDZ, RES,    &
+                   AU, LDAU, W, LDW, S, LDS, CWORK,        &
+                   LCWORK, WORK, LWORK, IWORK, LIWORK,     &
+                   INFO )
+      IF ( INFO /= 5 .OR. K /= 0 ) THEN
+          WRITE(*,*) 'CGEDMD all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, K
+          NFAIL_INFO = NFAIL_INFO + 1
+      END IF
+      DEALLOCATE(WORK)
+      DEALLOCATE(IWORK)
+      DEALLOCATE(CWORK)
+
+      F(1:M,1:N+1) = CZERO
+      F(1:M,1) = X0(1:M,1)
+      CALL CGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,   &
+                    M, N+1, F, LDF, X, LDX, Y, LDY, -1,   &
+                    TOL, KQ, CEIGS, Z, LDZ, RES, AU,      &
+                    LDAU, W, LDW, S, LDS, CDUMMY, -1,     &
+                    WDUMMY, -1, IDUMMY, -1, INFO )
+      LCWORK = INT(CDUMMY(1))
+      ALLOCATE(CWORK(LCWORK))
+      LIWORK = IDUMMY(1)
+      ALLOCATE(IWORK(LIWORK))
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE(WORK(LWORK))
+      KQ = -1
+      CALL CGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,   &
+                    M, N+1, F, LDF, X, LDX, Y, LDY, -1,   &
+                    TOL, KQ, CEIGS, Z, LDZ, RES, AU,      &
+                    LDAU, W, LDW, S, LDS, CWORK, LCWORK,  &
+                    WORK, LWORK, IWORK, LIWORK, INFO )
+      IF ( INFO /= 5 .OR. KQ /= 0 ) THEN
+          WRITE(*,*) 'CGEDMDQ all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, KQ
+          NFAILQ_INFO = NFAILQ_INFO + 1
+      END IF
+      DEALLOCATE(WORK)
+      DEALLOCATE(IWORK)
+      DEALLOCATE(CWORK)
+      END IF
 
       DO iJOBZ = 1, 4
 
@@ -666,6 +726,14 @@
         WRITE(*,*) 'It should be up to O(M*N) times EPS, EPS = ', EPS
         NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_REZ
       END IF
+
+      IF ( NFAIL_INFO == 0 ) THEN
+        WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+        WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                   NFAIL_INFO, ' time(s)'
+        NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_INFO
+      END IF
       IF ( NFAIL_TOTAL == 0 ) THEN
         WRITE(*,*) '>>>> CGEDMD :: ALL TESTS PASSED.'
       ELSE
@@ -706,6 +774,14 @@
         WRITE(*,*) 'Max residual computing test adjusted error measure was ', TMP_REZQ
         WRITE(*,*) 'It should be up to O(M*N) times EPS, EPS = ', EPS
         NFAILQ_TOTAL = NFAILQ_TOTAL + NFAIL_REZQ
+      END IF
+
+      IF ( NFAILQ_INFO == 0 ) THEN
+        WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+        WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                   NFAILQ_INFO, ' time(s)'
+        NFAILQ_TOTAL = NFAILQ_TOTAL + NFAILQ_INFO
       END IF
 
       IF ( NFAILQ_TOTAL == 0 ) THEN

--- a/TESTING/EIG/dchkdmd.f90
+++ b/TESTING/EIG/dchkdmd.f90
@@ -87,7 +87,8 @@
       INTEGER :: i, iJOBREF, iJOBZ, iSCALE, INFO, j, KDIFF,  &
                  NFAIL, NFAIL_AU, NFAIL_F_QR, NFAIL_REZ,     &
                  NFAIL_REZQ, NFAIL_SVDIFF, NFAIL_TOTAL, NFAILQ_TOTAL, &
-                 NFAIL_Z_XV, MODE, MODEL, MODER, WHTSVD
+                 NFAIL_Z_XV, NFAIL_INFO, NFAILQ_INFO, MODE, &
+                 MODEL, MODER, WHTSVD
       INTEGER    iNRNK, iWHTSVD, K_TRAJ, LWMINOPT
       CHARACTER(LEN=1) GRADE, JOBREF, JOBZ, PIVTNG, RSIGN,   &
                        SCALE, RESIDS, WANTQ, WANTR
@@ -130,6 +131,8 @@
       NFAIL_F_QR = 0
       NFAIL_AU   = 0
       KDIFF      = 0
+      NFAIL_INFO = 0
+      NFAILQ_INFO = 0
       NFAIL_SVDIFF = 0
       NFAIL_TOTAL  = 0
       NFAILQ_TOTAL = 0
@@ -299,6 +302,54 @@
       XNORM = DLANGE( 'F', M, N, X0, LDX, WDUMMY )
       YNORM = DLANGE( 'F', M, N, Y0, LDX, WDUMMY )
 !............................................................
+
+      IF ( K_TRAJ == 1 .AND. MODE == 1 ) THEN
+      X(1:M,1:N) = X0(1:M,1:N)
+      Y(1:M,1:N) = ZERO
+      CALL DGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, X, LDX, Y,  &
+           LDY, -1, TOL, K, REIG, IEIG, Z, LDZ, RES, AU,    &
+           LDAU, W, LDW, S, LDS, WDUMMY, -1, IDUMMY, -1,    &
+           INFO )
+      LIWORK = IDUMMY(1)
+      ALLOCATE( IWORK(LIWORK) )
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE( WORK(LWORK) )
+      K = -1
+      CALL DGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, X, LDX, Y,  &
+           LDY, -1, TOL, K, REIG, IEIG, Z, LDZ, RES, AU,    &
+           LDAU, W, LDW, S, LDS, WORK, LWORK, IWORK,        &
+           LIWORK, INFO )
+      IF ( INFO /= 5 .OR. K /= 0 ) THEN
+          WRITE(*,*) 'DGEDMD all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, K
+          NFAIL_INFO = NFAIL_INFO + 1
+      END IF
+      DEALLOCATE( WORK )
+      DEALLOCATE( IWORK )
+
+      F1(1:M,1:N+1) = ZERO
+      F1(1:M,1) = X0(1:M,1)
+      CALL DGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,    &
+           M, N+1, F1, LDF, X, LDX, Y, LDY, -1, TOL, KQ,    &
+           REIGQ, IEIGQ, Z, LDZ, RES, AU, LDAU, W, LDW,     &
+           S, LDS, WDUMMY, -1, IDUMMY, -1, INFO )
+      LIWORK = IDUMMY(1)
+      ALLOCATE( IWORK(LIWORK) )
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE( WORK(LWORK) )
+      KQ = -1
+      CALL DGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,    &
+           M, N+1, F1, LDF, X, LDX, Y, LDY, -1, TOL, KQ,    &
+           REIGQ, IEIGQ, Z, LDZ, RES, AU, LDAU, W, LDW,     &
+           S, LDS, WORK, LWORK, IWORK, LIWORK, INFO )
+      IF ( INFO /= 5 .OR. KQ /= 0 ) THEN
+          WRITE(*,*) 'DGEDMDQ all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, KQ
+          NFAILQ_INFO = NFAILQ_INFO + 1
+      END IF
+      DEALLOCATE( WORK )
+      DEALLOCATE( IWORK )
+      END IF
 
       DO iJOBZ = 1, 4
 
@@ -754,6 +805,14 @@
           NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_REZ
       END IF
 
+      IF ( NFAIL_INFO == 0 ) THEN
+          WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+          WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                     NFAIL_INFO, ' time(s)'
+          NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_INFO
+      END IF
+
       IF ( NFAIL_TOTAL == 0 ) THEN
           WRITE(*,*) '>>>> DGEDMD :: ALL TESTS PASSED.'
       ELSE
@@ -796,6 +855,14 @@
           WRITE(*,*) 'Max residual computing test adjusted error measure was ', TMP_REZQ
           WRITE(*,*) 'It should be up to O(M*N) times EPS, EPS = ', EPS
           NFAILQ_TOTAL = NFAILQ_TOTAL + NFAIL_REZQ
+      END IF
+
+      IF ( NFAILQ_INFO == 0 ) THEN
+          WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+          WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                     NFAILQ_INFO, ' time(s)'
+          NFAILQ_TOTAL = NFAILQ_TOTAL + NFAILQ_INFO
       END IF
 
       IF ( NFAILQ_TOTAL == 0 ) THEN

--- a/TESTING/EIG/schkdmd.f90
+++ b/TESTING/EIG/schkdmd.f90
@@ -87,7 +87,8 @@
       INTEGER :: i, iJOBREF, iJOBZ, iSCALE, INFO, KDIFF,     &
                  NFAIL, NFAIL_AU, NFAIL_F_QR, NFAIL_REZ,     &
                  NFAIL_REZQ, NFAIL_SVDIFF, NFAIL_TOTAL, NFAILQ_TOTAL, &
-                 NFAIL_Z_XV, MODE, MODEL, MODER, WHTSVD
+                 NFAIL_Z_XV, NFAIL_INFO, NFAILQ_INFO, MODE, &
+                 MODEL, MODER, WHTSVD
       INTEGER    iNRNK, iWHTSVD, K_TRAJ, LWMINOPT
       CHARACTER(LEN=1) GRADE, JOBREF, JOBZ, PIVTNG, RSIGN,   &
                        SCALE, RESIDS, WANTQ, WANTR
@@ -130,6 +131,8 @@
       NFAIL_F_QR = 0
       NFAIL_AU   = 0
       KDIFF      = 0
+      NFAIL_INFO = 0
+      NFAILQ_INFO = 0
       NFAIL_SVDIFF = 0
       NFAIL_TOTAL  = 0
       NFAILQ_TOTAL = 0
@@ -300,6 +303,54 @@
       XNORM = SLANGE( 'F', M, N, X0, LDX, WDUMMY )
       YNORM = SLANGE( 'F', M, N, Y0, LDX, WDUMMY )
 !............................................................
+
+      IF ( K_TRAJ == 1 .AND. MODE == 1 ) THEN
+      X(1:M,1:N) = X0(1:M,1:N)
+      Y(1:M,1:N) = ZERO
+      CALL SGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, X, LDX, Y,  &
+           LDY, -1, TOL, K, REIG, IEIG, Z, LDZ, RES, AU,    &
+           LDAU, W, LDW, S, LDS, WDUMMY, -1, IDUMMY, -1,    &
+           INFO )
+      LIWORK = IDUMMY(1)
+      ALLOCATE( IWORK(LIWORK) )
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE( WORK(LWORK) )
+      K = -1
+      CALL SGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, X, LDX, Y,  &
+           LDY, -1, TOL, K, REIG, IEIG, Z, LDZ, RES, AU,    &
+           LDAU, W, LDW, S, LDS, WORK, LWORK, IWORK,        &
+           LIWORK, INFO )
+      IF ( INFO /= 5 .OR. K /= 0 ) THEN
+          WRITE(*,*) 'SGEDMD all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, K
+          NFAIL_INFO = NFAIL_INFO + 1
+      END IF
+      DEALLOCATE( WORK )
+      DEALLOCATE( IWORK )
+
+      F1(1:M,1:N+1) = ZERO
+      F1(1:M,1) = X0(1:M,1)
+      CALL SGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,    &
+           M, N+1, F1, LDF, X, LDX, Y, LDY, -1, TOL, KQ,    &
+           REIGQ, IEIGQ, Z, LDZ, RES, AU, LDAU, W, LDW,     &
+           S, LDS, WDUMMY, -1, IDUMMY, -1, INFO )
+      LIWORK = IDUMMY(1)
+      ALLOCATE( IWORK(LIWORK) )
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE( WORK(LWORK) )
+      KQ = -1
+      CALL SGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,    &
+           M, N+1, F1, LDF, X, LDX, Y, LDY, -1, TOL, KQ,    &
+           REIGQ, IEIGQ, Z, LDZ, RES, AU, LDAU, W, LDW,     &
+           S, LDS, WORK, LWORK, IWORK, LIWORK, INFO )
+      IF ( INFO /= 5 .OR. KQ /= 0 ) THEN
+          WRITE(*,*) 'SGEDMDQ all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, KQ
+          NFAILQ_INFO = NFAILQ_INFO + 1
+      END IF
+      DEALLOCATE( WORK )
+      DEALLOCATE( IWORK )
+      END IF
 
       DO iJOBZ = 1, 4
 
@@ -733,6 +784,14 @@
           NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_REZ
       END IF
 
+      IF ( NFAIL_INFO == 0 ) THEN
+          WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+          WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                     NFAIL_INFO, ' time(s)'
+          NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_INFO
+      END IF
+
       IF ( NFAIL_TOTAL == 0 ) THEN
           WRITE(*,*) '>>>> SGEDMD :: ALL TESTS PASSED.'
       ELSE
@@ -775,6 +834,14 @@
           WRITE(*,*) 'Max residual computing test adjusted error measure was ', TMP_REZQ
           WRITE(*,*) 'It should be up to O(M*N) times EPS, EPS = ', EPS
           NFAILQ_TOTAL = NFAILQ_TOTAL + NFAIL_REZQ
+      END IF
+
+      IF ( NFAILQ_INFO == 0 ) THEN
+          WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+          WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                     NFAILQ_INFO, ' time(s)'
+          NFAILQ_TOTAL = NFAILQ_TOTAL + NFAILQ_INFO
       END IF
 
       IF ( NFAILQ_TOTAL == 0 ) THEN

--- a/TESTING/EIG/zchkdmd.f90
+++ b/TESTING/EIG/zchkdmd.f90
@@ -76,7 +76,8 @@
       INTEGER :: i, iJOBREF, iJOBZ, iSCALE, INFO, j,     &
                  NFAIL, NFAIL_AU, NFAIL_F_QR, NFAIL_REZ,     &
                  NFAIL_REZQ, NFAIL_SVDIFF, NFAIL_TOTAL, NFAILQ_TOTAL,  &
-                 NFAIL_Z_XV,  MODE, MODEL, MODER, WHTSVD,     &
+                 NFAIL_Z_XV, NFAIL_INFO, NFAILQ_INFO, MODE, &
+                 MODEL, MODER, WHTSVD,     &
                  WHTSVDsp
       INTEGER :: iNRNK, iWHTSVD,  K_TRAJ, LWMINOPT
       CHARACTER :: GRADE, JOBREF, JOBZ, PIVTNG, RSIGN,   &
@@ -123,6 +124,8 @@
       NFAIL_Z_XV = 0
       NFAIL_F_QR = 0
       NFAIL_AU   = 0
+      NFAIL_INFO = 0
+      NFAILQ_INFO = 0
       NFAIL_SVDIFF = 0
       NFAIL_TOTAL  = 0
       NFAILQ_TOTAL = 0
@@ -276,6 +279,65 @@
 
       DEALLOCATE( ZEIGSA )
 !........................................................................
+
+      IF ( K_TRAJ == 1 .AND. MODE == 1 ) THEN
+      ZX(1:M,1:N) = ZX0(1:M,1:N)
+      ZY(1:M,1:N) = ZZERO
+      CALL ZGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, ZX, LDX,   &
+                   ZY, LDY, -1, TOL, K, ZEIGS, ZZ, LDZ,    &
+                   RES, ZAU, LDAU, ZW, LDW, ZS, LDS,       &
+                   ZDUMMY, -1, WDUMMY, -1, IDUMMY, -1,     &
+                   INFO )
+      LZWORK = INT(ZDUMMY(1))
+      ALLOCATE(ZWORK(LZWORK))
+      LIWORK = IDUMMY(1)
+      ALLOCATE(IWORK(LIWORK))
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE(WORK(LWORK))
+      K = -1
+      CALL ZGEDMD( 'Y', 'N', 'N', 'N', 1, M, N, ZX, LDX,   &
+                   ZY, LDY, -1, TOL, K, ZEIGS, ZZ, LDZ,    &
+                   RES, ZAU, LDAU, ZW, LDW, ZS, LDS,       &
+                   ZWORK, LZWORK, WORK, LWORK, IWORK,      &
+                   LIWORK, INFO )
+      IF ( INFO /= 5 .OR. K /= 0 ) THEN
+          WRITE(*,*) 'ZGEDMD all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, K
+          NFAIL_INFO = NFAIL_INFO + 1
+      END IF
+      DEALLOCATE(WORK)
+      DEALLOCATE(IWORK)
+      DEALLOCATE(ZWORK)
+
+      ZF(1:M,1:N+1) = ZZERO
+      ZF(1:M,1) = ZX0(1:M,1)
+      CALL ZGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,   &
+                    M, N+1, ZF, LDF, ZX, LDX, ZY, LDY,     &
+                    -1, TOL, KQ, ZEIGS, ZZ, LDZ, RES,      &
+                    ZAU, LDAU, ZW, LDW, ZS, LDS, ZDUMMY,   &
+                    -1, WDUMMY, -1, IDUMMY, -1, INFO )
+      LZWORK = INT(ZDUMMY(1))
+      ALLOCATE(ZWORK(LZWORK))
+      LIWORK = IDUMMY(1)
+      ALLOCATE(IWORK(LIWORK))
+      LWORK = INT(WDUMMY(1))
+      ALLOCATE(WORK(LWORK))
+      KQ = -1
+      CALL ZGEDMDQ( 'Y', 'N', 'N', WANTQ, WANTR, 'N', 1,   &
+                    M, N+1, ZF, LDF, ZX, LDX, ZY, LDY,     &
+                    -1, TOL, KQ, ZEIGS, ZZ, LDZ, RES,      &
+                    ZAU, LDAU, ZW, LDW, ZS, LDS, ZWORK,    &
+                    LZWORK, WORK, LWORK, IWORK, LIWORK,    &
+                    INFO )
+      IF ( INFO /= 5 .OR. KQ /= 0 ) THEN
+          WRITE(*,*) 'ZGEDMDQ all-zero Y diagnostic test FAILED.'
+          WRITE(*,*) 'Expected INFO = 5 and K = 0, got ', INFO, KQ
+          NFAILQ_INFO = NFAILQ_INFO + 1
+      END IF
+      DEALLOCATE(WORK)
+      DEALLOCATE(IWORK)
+      DEALLOCATE(ZWORK)
+      END IF
 
       DO iJOBZ = 1, 4
 
@@ -678,12 +740,20 @@
       END IF
 
       IF ( NFAIL_REZ == 0 ) THEN
-        WRITE(*,*) '>>>> Residual computation test PASSED.'
+          WRITE(*,*) '>>>> Residual computation test PASSED.'
       ELSE
         WRITE(*,*) 'Residual computation test FAILED ', NFAIL_REZ, 'time(s)'
         WRITE(*,*) 'Max residual computing test adjusted error measure was ', TMP_REZ
-        WRITE(*,*) 'It should be up to O(M*N) times EPS, EPS = ', EPS
-        NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_REZ
+          WRITE(*,*) 'It should be up to O(M*N) times EPS, EPS = ', EPS
+          NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_REZ
+      END IF
+
+      IF ( NFAIL_INFO == 0 ) THEN
+          WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+          WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                     NFAIL_INFO, ' time(s)'
+          NFAIL_TOTAL = NFAIL_TOTAL + NFAIL_INFO
       END IF
 
       IF ( NFAIL_TOTAL == 0 ) THEN
@@ -728,6 +798,14 @@
           WRITE(*,*) 'Max residual computing test adjusted error measure was ', TMP_REZQ
           WRITE(*,*) 'It should be up to O(M*N) times EPS, EPS = ', EPS
           NFAILQ_TOTAL = NFAILQ_TOTAL + NFAIL_REZQ
+      END IF
+
+      IF ( NFAILQ_INFO == 0 ) THEN
+          WRITE(*,*) '>>>> All-zero Y diagnostic test PASSED.'
+      ELSE
+          WRITE(*,*) 'All-zero Y diagnostic test FAILED ', &
+                     NFAILQ_INFO, ' time(s)'
+          NFAILQ_TOTAL = NFAILQ_TOTAL + NFAILQ_INFO
       END IF
 
       IF ( NFAILQ_TOTAL == 0 ) THEN


### PR DESCRIPTION
  This PR adds the missing all-zero column check to the `JOBS='Y'`
  scaling path in the GEDMD routines.

  In the existing implementation, the `JOBS='S'` / `JOBS='C'` path
  normalizes the columns of `X` and counts zero columns while doing so.
  If all columns of `X` are zero, the routine returns early with
  `INFO = -8`, since `X` is the 8th argument.

  The corresponding `JOBS='Y'` path normalizes the columns of `Y`, but it
  did not count zero columns of `Y` and therefore did not return early
  when all columns of `Y` were zero. This made the handling of the
  `SCCOLY` path asymmetric with the existing `SCCOLX` path.

  This PR updates the `JOBS='Y'` path to:

  - initialize the zero-column counter before scanning `Y`
  - increment the counter for each zero column of `Y`
  - return early when all columns of `Y` are zero
  - use `INFO = -10`, matching `Y` as the 10th argument
  - document this condition in the routine header comments

  Updated routines:

  - `SRC/sgedmd.f90`
  - `SRC/dgedmd.f90`
  - `SRC/cgedmd.f90`
  - `SRC/zgedmd.f90`

  This is intended to make the input validation and scaling behavior of
  the `JOBS='Y'` path consistent with the existing `JOBS='S'` / `JOBS='C'`
  path. It also avoids continuing the computation after detecting that
  the requested `Y`-based column scaling cannot be performed because all
  columns of `Y` are zero.