### PR TITLE
avoid large intermediates in complex LARTG

### DIFF
--- a/SRC/cbbcsd.f
+++ b/SRC/cbbcsd.f
@@ -351,9 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      REAL               HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      REAL               HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0E0, MEIGHTH = -0.125E0,
-     $                     ONE = 1.0E0, TEN = 10.0E0, ZERO = 0.0E0 )
+     $                     ZERO = 0.0E0, ONE = 1.0E0, TEN = 10.0E0 )
       COMPLEX            NEGONECOMPLEX
       PARAMETER          ( NEGONECOMPLEX = (-1.0E0,0.0E0) )
       REAL               PIOVER2
@@ -576,7 +576,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1092,4 +1092,3 @@
 *     End of CBBCSD
 *
       END
-

--- a/SRC/clartg.f90
+++ b/SRC/clartg.f90
@@ -204,7 +204,7 @@ subroutine CLARTG( f, g, c, s, r )
             rtmax = rtmax * 2
             if( f2 > rtmin .and. h2 < rtmax ) then
                ! safmin <= sqrt( f2*h2 ) <= safmax
-               s = conjg( g ) * ( f / sqrt( f2*h2 ) )
+               s = ( f / sqrt( f2 ) ) * ( conjg( g ) / sqrt( h2 ) )
             else
                s = conjg( g ) * ( r / h2 )
             end if
@@ -224,7 +224,7 @@ subroutine CLARTG( f, g, c, s, r )
                !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = f * ( h2 / d )
             end if
-            s = conjg( g ) * ( f / d )
+            s = ( f / sqrt( f2 ) ) * ( conjg( g ) / sqrt( h2 ) )
          end if
       else
 !
@@ -260,7 +260,7 @@ subroutine CLARTG( f, g, c, s, r )
             rtmax = rtmax * 2
             if( f2 > rtmin .and. h2 < rtmax ) then
                ! safmin <= sqrt( f2*h2 ) <= safmax
-               s = conjg( gs ) * ( fs / sqrt( f2*h2 ) )
+               s = ( fs / sqrt( f2 ) ) * ( conjg( gs ) / sqrt( h2 ) )
             else
                s = conjg( gs ) * ( r / h2 )
             end if
@@ -280,7 +280,7 @@ subroutine CLARTG( f, g, c, s, r )
                !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = fs * ( h2 / d )
             end if
-            s = conjg( gs ) * ( fs / d )
+            s = ( fs / sqrt( f2 ) ) * ( conjg( gs ) / sqrt( h2 ) )
          end if
          ! Rescale c and r
          c = c * w

--- a/SRC/dbbcsd.f
+++ b/SRC/dbbcsd.f
@@ -351,9 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      DOUBLE PRECISION   HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0D0, MEIGHTH = -0.125D0,
-     $                     ONE = 1.0D0, TEN = 10.0D0, ZERO = 0.0D0 )
+     $                     ZERO = 0.0D0, ONE = 1.0D0, TEN = 10.0D0 )
       DOUBLE PRECISION   NEGONE
       PARAMETER          ( NEGONE = -1.0D0 )
       DOUBLE PRECISION   PIOVER2
@@ -576,7 +576,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1086,4 +1086,3 @@
 *     End of DBBCSD
 *
       END
-

--- a/SRC/sbbcsd.f
+++ b/SRC/sbbcsd.f
@@ -351,9 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      REAL               HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      REAL               HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0E0, MEIGHTH = -0.125E0,
-     $                     ONE = 1.0E0, TEN = 10.0E0, ZERO = 0.0E0 )
+     $                     ZERO = 0.0E0, ONE = 1.0E0, TEN = 10.0E0 )
       REAL               NEGONE
       PARAMETER          ( NEGONE = -1.0E0 )
       REAL               PIOVER2
@@ -576,7 +576,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1086,4 +1086,3 @@
 *     End of SBBCSD
 *
       END
-

--- a/SRC/zbbcsd.f
+++ b/SRC/zbbcsd.f
@@ -351,9 +351,9 @@
 *     .. Parameters ..
       INTEGER            MAXITR
       PARAMETER          ( MAXITR = 6 )
-      DOUBLE PRECISION   HUNDRED, MEIGHTH, ONE, TEN, ZERO
+      DOUBLE PRECISION   HUNDRED, MEIGHTH, ZERO, ONE, TEN
       PARAMETER          ( HUNDRED = 100.0D0, MEIGHTH = -0.125D0,
-     $                     ONE = 1.0D0, TEN = 10.0D0, ZERO = 0.0D0 )
+     $                     ZERO = 0.0D0, ONE = 1.0D0, TEN = 10.0D0 )
       COMPLEX*16         NEGONECOMPLEX
       PARAMETER          ( NEGONECOMPLEX = (-1.0D0,0.0D0) )
       DOUBLE PRECISION   PIOVER2
@@ -575,7 +575,7 @@
                END IF
             ELSE
                NU = SIGMA21
-               MU = SQRT( 1.0 - NU**2 )
+               MU = SQRT( ONE - NU**2 )
                IF( NU .LT. THRESH ) THEN
                   MU = ONE
                   NU = ZERO
@@ -1091,4 +1091,3 @@
 *     End of ZBBCSD
 *
       END
-

--- a/SRC/zlartg.f90
+++ b/SRC/zlartg.f90
@@ -204,7 +204,7 @@ subroutine ZLARTG( f, g, c, s, r )
             rtmax = rtmax * 2
             if( f2 > rtmin .and. h2 < rtmax ) then
                ! safmin <= sqrt( f2*h2 ) <= safmax
-               s = conjg( g ) * ( f / sqrt( f2*h2 ) )
+               s = ( f / sqrt( f2 ) ) * ( conjg( g ) / sqrt( h2 ) )
             else
                s = conjg( g ) * ( r / h2 )
             end if
@@ -224,7 +224,7 @@ subroutine ZLARTG( f, g, c, s, r )
                !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = f * ( h2 / d )
             end if
-            s = conjg( g ) * ( f / d )
+            s = ( f / sqrt( f2 ) ) * ( conjg( g ) / sqrt( h2 ) )
          end if
       else
 !
@@ -260,7 +260,7 @@ subroutine ZLARTG( f, g, c, s, r )
             rtmax = rtmax * 2
             if( f2 > rtmin .and. h2 < rtmax ) then
                ! safmin <= sqrt( f2*h2 ) <= safmax
-               s = conjg( gs ) * ( fs / sqrt( f2*h2 ) )
+               s = ( fs / sqrt( f2 ) ) * ( conjg( gs ) / sqrt( h2 ) )
             else
                s = conjg( gs ) * ( r / h2 )
             end if
@@ -280,7 +280,7 @@ subroutine ZLARTG( f, g, c, s, r )
                !  sqrt(safmin) <= f2 * sqrt(safmax) <= h2 / sqrt(f2 * h2) <= h2 * (safmin / f2) <= h2 <= safmax
                r = fs * ( h2 / d )
             end if
-            s = conjg( gs ) * ( fs / d )
+            s = ( fs / sqrt( f2 ) ) * ( conjg( gs ) / sqrt( h2 ) )
          end if
          ! Rescale c and r
          c = c * w


### PR DESCRIPTION
  This PR rewrites the complex sine computation in `CLARTG` and `ZLARTG`
  to avoid forming unnecessarily large intermediate values.

  The existing implementation uses expressions of the following form:

      s = conjg(g) * ( f / sqrt(f2*h2) )

  and similarly in the scaled branch:

      s = conjg(gs) * ( fs / sqrt(f2*h2) )

  The existing scaling and branch conditions already keep `f2*h2` in a
  safe range. Therefore, this is not primarily an overflow or underflow
  fix for the product `f2*h2` itself.

  However, even when `sqrt(f2*h2)` is safely representable, the division

      f / sqrt(f2*h2)

  can still create a large intermediate value before it is multiplied by
  `conjg(g)`. This is mathematically equivalent to multiplying normalized
  factors instead:

      ( f / sqrt(f2) ) * ( conjg(g) / sqrt(h2) )

  This PR applies that rewrite in both the unscaled and scaled branches of
  `CLARTG` and `ZLARTG`.

  The goal is to keep intermediate values closer to unit scale while
  preserving the same mathematical result.

  Updated files:

  - `SRC/clartg.f90`
  - `SRC/zlartg.f90`
