### PR TITLE
Appveyor CI: Don't clamp flang to the ancient version 11 anymore

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang jom cmake python-gil ninja
+  - conda install -c conda-forge --yes --quiet flang jom cmake python ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,8 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 15.0\VC\vcvarsall.bat" amd64
+  - dir "C:\Program Files (x86)"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 15.1\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang=11.0.1 jom
+  - conda install -c conda-forge --yes --quiet flang jom
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,6 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
-  - where python3.exe
   - dir "C:\Program Files (x86)\Microsoft Visual Studio"
   - call "C:\Program Files (x86)\Microsoft Visual Studio\15.5\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang jom cmake python3
+  - conda install -c conda-forge --yes --quiet flang jom cmake python
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,8 +20,8 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
-  - dir "C:\Program Files (x86)\Microsoft Visual Studio\2017"
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\VC\vcvarsall.bat" amd64
+  - dir "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,8 +20,8 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
-  - dir "C:\Program Files (x86)\Microsoft Visual Studio"
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\15.5\VC\vcvarsall.bat" amd64
+  - dir "C:\Program Files (x86)\Microsoft Visual Studio\2017"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,8 +20,9 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
-  - dir "C:\Program Files (x86)"
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\VC\vcvarsall.bat" amd64
+  - where python3.exe
+  - dir "C:\Program Files (x86)\Microsoft Visual Studio"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\15.5\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 15.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 ninja
+  - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 cmake ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
   - dir "C:\Program Files (x86)"
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 15.1\VC\vcvarsall.bat" amd64
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang jom
+  - conda install -c conda-forge --yes --quiet flang jom cmake python3
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang jom cmake python ninja
+  - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
+  - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
@@ -27,8 +27,8 @@ install:
 before_build:
   - ps: if (-Not (Test-Path .\build)) { mkdir build }
   - cd build
-#  - cmake -G "Ninja" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
-  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+  - cmake -G "Ninja" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+#  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
 
 build_script:
   - cmake --build .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang jom cmake python
+  - conda install -c conda-forge --yes --quiet flang jom cmake python-gil ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
@@ -27,7 +27,8 @@ install:
 before_build:
   - ps: if (-Not (Test-Path .\build)) { mkdir build }
   - cd build
-  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+  - cmake -G "Ninja" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+#  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
 
 build_script:
   - cmake --build .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,6 @@ install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
   - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 jom cmake python ninja
-  - dir "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC"
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
@@ -28,8 +27,8 @@ install:
 before_build:
   - ps: if (-Not (Test-Path .\build)) { mkdir build }
   - cd build
-  - cmake -G "Ninja" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
-#  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+#  - cmake -G "Ninja" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
 
 build_script:
   - cmake --build .


### PR DESCRIPTION
**Description**
Hopefully this old kludge is no longer necessary...
**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.