### PR TITLE
Update the ancient flang version used in Appveyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,15 +19,16 @@ environment:
 install:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 #  - conda config --set auto_update_conda false
-  - conda install -c conda-forge --yes --quiet flang=11.0.1 jom
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+  - conda install -c conda-forge --yes --quiet flang flang-rt_win-64 cmake ninja
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   - set "LIB=%CONDA_INSTALL_LOCN%\Library\lib;%LIB%"
   - set "CPATH=%CONDA_INSTALL_LOCN%\Library\include;%CPATH%"
 
 before_build:
   - ps: if (-Not (Test-Path .\build)) { mkdir build }
   - cd build
-  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+  - cmake -G "Ninja" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
+#  - cmake -G "NMake Makefiles JOM" -DCMAKE_Fortran_COMPILER=flang -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
 
 build_script:
   - cmake --build .


### PR DESCRIPTION
**Description**
CI is still using flang-11.0.1 from 2022 - back then it was necessary to tell conda to install exactly this version, an anything newer appeared to cause a circular dependency problem with updates to conda itself. 
This appears to be creating problems for some recent commits like #1173 now, causing CI failures not reproducible with
more modern toolchains.

Unfortunately, the updated LLVM requires updates to both CMake and Visual Studio (where CI was still using VS2015 on an image providing 2017 as the latest and greatest). I've also had to switch the build tool from JOM to NINJA to make CMake's
compiler checks work with this version.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.