### PR TITLE
Adjust line reflow in complex (GER/POR/SYR)FSX for ILP64 build

### DIFF
--- a/SRC/cgbrfsx.f
+++ b/SRC/cgbrfsx.f
@@ -498,7 +498,8 @@
       EXTERNAL           LSAME, ILATRANS, ILAPREC
       EXTERNAL           SLAMCH, CLANGB, CLA_GBRCOND_X,
      $                   CLA_GBRCOND_C
-      REAL               SLAMCH, CLANGB, CLA_GBRCOND_X, CLA_GBRCOND_C
+      REAL               SLAMCH, CLANGB, CLA_GBRCOND_X,
+     $                   CLA_GBRCOND_C
       LOGICAL            LSAME
       INTEGER            ILATRANS, ILAPREC
 *     ..

--- a/SRC/cgerfsx.f
+++ b/SRC/cgerfsx.f
@@ -475,7 +475,8 @@
       EXTERNAL           LSAME, ILATRANS, ILAPREC
       EXTERNAL           SLAMCH, CLANGE, CLA_GERCOND_X,
      $                   CLA_GERCOND_C
-      REAL               SLAMCH, CLANGE, CLA_GERCOND_X, CLA_GERCOND_C
+      REAL               SLAMCH, CLANGE, CLA_GERCOND_X,
+     $                   CLA_GERCOND_C
       LOGICAL            LSAME
       INTEGER            ILATRANS, ILAPREC
 *     ..

--- a/SRC/cherfsx.f
+++ b/SRC/cherfsx.f
@@ -461,7 +461,8 @@
       EXTERNAL           LSAME, ILAPREC
       EXTERNAL           SLAMCH, CLANHE, CLA_HERCOND_X,
      $                   CLA_HERCOND_C
-      REAL               SLAMCH, CLANHE, CLA_HERCOND_X, CLA_HERCOND_C
+      REAL               SLAMCH, CLANHE, CLA_HERCOND_X,
+     $                   CLA_HERCOND_C
       LOGICAL            LSAME
       INTEGER            ILAPREC
 *     ..

--- a/SRC/cporfsx.f
+++ b/SRC/cporfsx.f
@@ -453,7 +453,8 @@
       EXTERNAL           LSAME, ILAPREC
       EXTERNAL           SLAMCH, CLANHE, CLA_PORCOND_X,
      $                   CLA_PORCOND_C
-      REAL               SLAMCH, CLANHE, CLA_PORCOND_X, CLA_PORCOND_C
+      REAL               SLAMCH, CLANHE, CLA_PORCOND_X,
+     $                   CLA_PORCOND_C
       LOGICAL            LSAME
       INTEGER            ILAPREC
 *     ..

--- a/SRC/csyrfsx.f
+++ b/SRC/csyrfsx.f
@@ -463,7 +463,8 @@
       EXTERNAL           LSAME, ILAPREC
       EXTERNAL           SLAMCH, CLANSY, CLA_SYRCOND_X,
      $                   CLA_SYRCOND_C
-      REAL               SLAMCH, CLANSY, CLA_SYRCOND_X, CLA_SYRCOND_C
+      REAL               SLAMCH, CLANSY, CLA_SYRCOND_X,
+     $                   CLA_SYRCOND_C
       LOGICAL            LSAME
       INTEGER            ILAPREC
 *     ..

--- a/SRC/zgbrfsx.f
+++ b/SRC/zgbrfsx.f
@@ -498,7 +498,8 @@
       EXTERNAL           LSAME, ILAPREC
       EXTERNAL           DLAMCH, ZLANGB, ZLA_GBRCOND_X,
      $                   ZLA_GBRCOND_C
-      DOUBLE PRECISION   DLAMCH, ZLANGB, ZLA_GBRCOND_X, ZLA_GBRCOND_C
+      DOUBLE PRECISION   DLAMCH, ZLANGB, ZLA_GBRCOND_X,
+     $                   ZLA_GBRCOND_C
       LOGICAL            LSAME
       INTEGER            ILATRANS, ILAPREC
 *     ..

--- a/SRC/zgerfsx.f
+++ b/SRC/zgerfsx.f
@@ -475,7 +475,8 @@
       EXTERNAL           LSAME, ILATRANS, ILAPREC
       EXTERNAL           DLAMCH, ZLANGE, ZLA_GERCOND_X,
      $                   ZLA_GERCOND_C
-      DOUBLE PRECISION   DLAMCH, ZLANGE, ZLA_GERCOND_X, ZLA_GERCOND_C
+      DOUBLE PRECISION   DLAMCH, ZLANGE, ZLA_GERCOND_X,
+     $                   ZLA_GERCOND_C
       LOGICAL            LSAME
       INTEGER            ILATRANS, ILAPREC
 *     ..

--- a/SRC/zherfsx.f
+++ b/SRC/zherfsx.f
@@ -461,7 +461,8 @@
       EXTERNAL           LSAME, ILAPREC
       EXTERNAL           DLAMCH, ZLANHE, ZLA_HERCOND_X,
      $                   ZLA_HERCOND_C
-      DOUBLE PRECISION   DLAMCH, ZLANHE, ZLA_HERCOND_X, ZLA_HERCOND_C
+      DOUBLE PRECISION   DLAMCH, ZLANHE, ZLA_HERCOND_X,
+     $                   ZLA_HERCOND_C
       LOGICAL            LSAME
       INTEGER            ILAPREC
 *     ..

--- a/SRC/zporfsx.f
+++ b/SRC/zporfsx.f
@@ -453,7 +453,8 @@
       EXTERNAL           LSAME, ILAPREC
       EXTERNAL           DLAMCH, ZLANHE, ZLA_PORCOND_X,
      $                   ZLA_PORCOND_C
-      DOUBLE PRECISION   DLAMCH, ZLANHE, ZLA_PORCOND_X, ZLA_PORCOND_C
+      DOUBLE PRECISION   DLAMCH, ZLANHE, ZLA_PORCOND_X,
+     $                   ZLA_PORCOND_C
       LOGICAL            LSAME
       INTEGER            ILAPREC
 *     ..

--- a/SRC/zsyrfsx.f
+++ b/SRC/zsyrfsx.f
@@ -463,7 +463,8 @@
       EXTERNAL           LSAME, ILAPREC
       EXTERNAL           DLAMCH, ZLANSY, ZLA_SYRCOND_X,
      $                   ZLA_SYRCOND_C
-      DOUBLE PRECISION   DLAMCH, ZLANSY, ZLA_SYRCOND_X, ZLA_SYRCOND_C
+      DOUBLE PRECISION   DLAMCH, ZLANSY, ZLA_SYRCOND_X,
+     $                   ZLA_SYRCOND_C
       LOGICAL            LSAME
       INTEGER            ILAPREC
 *     ..


### PR DESCRIPTION
**Description**
Another line length issue caused by the ILP64 symbol name rewriting and uncovered by the recent addition of IMPLICIT NONE - but visible only  with USE_XBLAS=ON, which none of the CI jobs has.
Noticed while trying to reproduce #1223 - fixes #1223 although the detailed origin of the problem changed between the 3.12.1 release and now
