### PR TITLE
Optimize looping over the lower triangular in fat matrix cases of LACPY/LANTR/LASCL

### DIFF
--- a/SRC/clacpy.f
+++ b/SRC/clacpy.f
@@ -134,7 +134,7 @@
    20    CONTINUE
 *
       ELSE IF( LSAME( UPLO, 'L' ) ) THEN
-         DO 40 J = 1, N
+         DO 40 J = 1, MIN( M, N )
             DO 30 I = J, M
                B( I, J ) = A( I, J )
    30       CONTINUE

--- a/SRC/clantr.f
+++ b/SRC/clantr.f
@@ -193,7 +193,7 @@
    10             CONTINUE
    20          CONTINUE
             ELSE
-               DO 40 J = 1, N
+               DO 40 J = 1, MIN( M, N )
                   DO 30 I = J + 1, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -212,7 +212,7 @@
    50             CONTINUE
    60          CONTINUE
             ELSE
-               DO 80 J = 1, N
+               DO 80 J = 1, MIN( M, N )
                   DO 70 I = J, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -243,7 +243,7 @@
                IF( VALUE .LT. SUM .OR. SISNAN( SUM ) ) VALUE = SUM
   110       CONTINUE
          ELSE
-            DO 140 J = 1, N
+            DO 140 J = 1, MIN( M, N )
                IF( UDIAG ) THEN
                   SUM = ONE
                   DO 120 I = J + 1, M
@@ -290,7 +290,7 @@
                DO 220 I = N + 1, M
                   WORK( I ) = ZERO
   220          CONTINUE
-               DO 240 J = 1, N
+               DO 240 J = 1, MIN( M, N )
                   DO 230 I = J + 1, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   230             CONTINUE
@@ -299,7 +299,7 @@
                DO 250 I = 1, M
                   WORK( I ) = ZERO
   250          CONTINUE
-               DO 270 J = 1, N
+               DO 270 J = 1, MIN( M, N )
                   DO 260 I = J, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   260             CONTINUE
@@ -336,14 +336,14 @@
             IF( LSAME( DIAG, 'U' ) ) THEN
                SCALE = ONE
                SUM = REAL( MIN( M, N ) )
-               DO 310 J = 1, N
+               DO 310 J = 1, MIN( M, N )
                   CALL CLASSQ( M-J, A( MIN( M, J+1 ), J ), 1, SCALE,
      $                         SUM )
   310          CONTINUE
             ELSE
                SCALE = ZERO
                SUM = ONE
-               DO 320 J = 1, N
+               DO 320 J = 1, MIN( M, N )
                   CALL CLASSQ( M-J+1, A( J, J ), 1, SCALE, SUM )
   320          CONTINUE
             END IF

--- a/SRC/clascl.f
+++ b/SRC/clascl.f
@@ -291,7 +291,7 @@
 *
 *        Lower triangular matrix
 *
-         DO 50 J = 1, N
+         DO 50 J = 1, MIN( M, N )
             DO 40 I = J, M
                A( I, J ) = A( I, J )*MUL
    40       CONTINUE

--- a/SRC/dlacpy.f
+++ b/SRC/dlacpy.f
@@ -133,7 +133,7 @@
    10       CONTINUE
    20    CONTINUE
       ELSE IF( LSAME( UPLO, 'L' ) ) THEN
-         DO 40 J = 1, N
+         DO 40 J = 1, MIN( M, N )
             DO 30 I = J, M
                B( I, J ) = A( I, J )
    30       CONTINUE

--- a/SRC/dlantr.f
+++ b/SRC/dlantr.f
@@ -191,7 +191,7 @@
    10             CONTINUE
    20          CONTINUE
             ELSE
-               DO 40 J = 1, N
+               DO 40 J = 1, MIN( M, N )
                   DO 30 I = J + 1, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -210,7 +210,7 @@
    50             CONTINUE
    60          CONTINUE
             ELSE
-               DO 80 J = 1, N
+               DO 80 J = 1, MIN( M, N )
                   DO 70 I = J, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -241,7 +241,7 @@
                IF( VALUE .LT. SUM .OR. DISNAN( SUM ) ) VALUE = SUM
   110       CONTINUE
          ELSE
-            DO 140 J = 1, N
+            DO 140 J = 1, MIN( M, N )
                IF( UDIAG ) THEN
                   SUM = ONE
                   DO 120 I = J + 1, M
@@ -288,7 +288,7 @@
                DO 220 I = N + 1, M
                   WORK( I ) = ZERO
   220          CONTINUE
-               DO 240 J = 1, N
+               DO 240 J = 1, MIN (M, N )
                   DO 230 I = J + 1, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   230             CONTINUE
@@ -297,7 +297,7 @@
                DO 250 I = 1, M
                   WORK( I ) = ZERO
   250          CONTINUE
-               DO 270 J = 1, N
+               DO 270 J = 1, MIN( M, N )
                   DO 260 I = J, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   260             CONTINUE
@@ -334,14 +334,14 @@
             IF( LSAME( DIAG, 'U' ) ) THEN
                SCALE = ONE
                SUM = MIN( M, N )
-               DO 310 J = 1, N
+               DO 310 J = 1, MIN( M, N )
                   CALL DLASSQ( M-J, A( MIN( M, J+1 ), J ), 1, SCALE,
      $                         SUM )
   310          CONTINUE
             ELSE
                SCALE = ZERO
                SUM = ONE
-               DO 320 J = 1, N
+               DO 320 J = 1, MIN( M, N )
                   CALL DLASSQ( M-J+1, A( J, J ), 1, SCALE, SUM )
   320          CONTINUE
             END IF

--- a/SRC/dlascl.f
+++ b/SRC/dlascl.f
@@ -291,7 +291,7 @@
 *
 *        Lower triangular matrix
 *
-         DO 50 J = 1, N
+         DO 50 J = 1, MIN( M, N )
             DO 40 I = J, M
                A( I, J ) = A( I, J )*MUL
    40       CONTINUE

--- a/SRC/slacpy.f
+++ b/SRC/slacpy.f
@@ -133,7 +133,7 @@
    10       CONTINUE
    20    CONTINUE
       ELSE IF( LSAME( UPLO, 'L' ) ) THEN
-         DO 40 J = 1, N
+         DO 40 J = 1, MIN( M, N )
             DO 30 I = J, M
                B( I, J ) = A( I, J )
    30       CONTINUE

--- a/SRC/slantr.f
+++ b/SRC/slantr.f
@@ -191,7 +191,7 @@
    10             CONTINUE
    20          CONTINUE
             ELSE
-               DO 40 J = 1, N
+               DO 40 J = 1, MIN( M, N )
                   DO 30 I = J + 1, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -210,7 +210,7 @@
    50             CONTINUE
    60          CONTINUE
             ELSE
-               DO 80 J = 1, N
+               DO 80 J = 1, MIN( M, N )
                   DO 70 I = J, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -241,7 +241,7 @@
                IF( VALUE .LT. SUM .OR. SISNAN( SUM ) ) VALUE = SUM
   110       CONTINUE
          ELSE
-            DO 140 J = 1, N
+            DO 140 J = 1, MIN( M, N )
                IF( UDIAG ) THEN
                   SUM = ONE
                   DO 120 I = J + 1, M
@@ -288,7 +288,7 @@
                DO 220 I = N + 1, M
                   WORK( I ) = ZERO
   220          CONTINUE
-               DO 240 J = 1, N
+               DO 240 J = 1, MIN( M, N )
                   DO 230 I = J + 1, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   230             CONTINUE
@@ -297,7 +297,7 @@
                DO 250 I = 1, M
                   WORK( I ) = ZERO
   250          CONTINUE
-               DO 270 J = 1, N
+               DO 270 J = 1, MIN( M, N )
                   DO 260 I = J, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   260             CONTINUE
@@ -334,14 +334,14 @@
             IF( LSAME( DIAG, 'U' ) ) THEN
                SCALE = ONE
                SUM = REAL( MIN( M, N ) )
-               DO 310 J = 1, N
+               DO 310 J = 1, MIN ( M, N )
                   CALL SLASSQ( M-J, A( MIN( M, J+1 ), J ), 1, SCALE,
      $                         SUM )
   310          CONTINUE
             ELSE
                SCALE = ZERO
                SUM = ONE
-               DO 320 J = 1, N
+               DO 320 J = 1, MIN( M, N )
                   CALL SLASSQ( M-J+1, A( J, J ), 1, SCALE, SUM )
   320          CONTINUE
             END IF

--- a/SRC/slascl.f
+++ b/SRC/slascl.f
@@ -291,7 +291,7 @@
 *
 *        Lower triangular matrix
 *
-         DO 50 J = 1, N
+         DO 50 J = 1, MIN( M, N )
             DO 40 I = J, M
                A( I, J ) = A( I, J )*MUL
    40       CONTINUE

--- a/SRC/zlacpy.f
+++ b/SRC/zlacpy.f
@@ -134,7 +134,7 @@
    20    CONTINUE
 *
       ELSE IF( LSAME( UPLO, 'L' ) ) THEN
-         DO 40 J = 1, N
+         DO 40 J = 1, MIN( M, N )
             DO 30 I = J, M
                B( I, J ) = A( I, J )
    30       CONTINUE

--- a/SRC/zlantr.f
+++ b/SRC/zlantr.f
@@ -193,7 +193,7 @@
    10             CONTINUE
    20          CONTINUE
             ELSE
-               DO 40 J = 1, N
+               DO 40 J = 1, MIN( M, N )
                   DO 30 I = J + 1, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -212,7 +212,7 @@
    50             CONTINUE
    60          CONTINUE
             ELSE
-               DO 80 J = 1, N
+               DO 80 J = 1, MIN( M, N )
                   DO 70 I = J, M
                      SUM = ABS( A( I, J ) )
                      IF( VALUE .LT. SUM .OR.
@@ -243,7 +243,7 @@
                IF( VALUE .LT. SUM .OR. DISNAN( SUM ) ) VALUE = SUM
   110       CONTINUE
          ELSE
-            DO 140 J = 1, N
+            DO 140 J = 1, MIN( M, N )
                IF( UDIAG ) THEN
                   SUM = ONE
                   DO 120 I = J + 1, M
@@ -290,7 +290,7 @@
                DO 220 I = N + 1, M
                   WORK( I ) = ZERO
   220          CONTINUE
-               DO 240 J = 1, N
+               DO 240 J = 1, MIN( M, N )
                   DO 230 I = J + 1, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   230             CONTINUE
@@ -299,7 +299,7 @@
                DO 250 I = 1, M
                   WORK( I ) = ZERO
   250          CONTINUE
-               DO 270 J = 1, N
+               DO 270 J = 1, MIN( M, N )
                   DO 260 I = J, M
                      WORK( I ) = WORK( I ) + ABS( A( I, J ) )
   260             CONTINUE
@@ -336,14 +336,14 @@
             IF( LSAME( DIAG, 'U' ) ) THEN
                SCALE = ONE
                SUM = MIN( M, N )
-               DO 310 J = 1, N
+               DO 310 J = 1, MIN( M, N )
                   CALL ZLASSQ( M-J, A( MIN( M, J+1 ), J ), 1, SCALE,
      $                         SUM )
   310          CONTINUE
             ELSE
                SCALE = ZERO
                SUM = ONE
-               DO 320 J = 1, N
+               DO 320 J = 1, MIN( M, N )
                   CALL ZLASSQ( M-J+1, A( J, J ), 1, SCALE, SUM )
   320          CONTINUE
             END IF

--- a/SRC/zlascl.f
+++ b/SRC/zlascl.f
@@ -291,7 +291,7 @@
 *
 *        Lower triangular matrix
 *
-         DO 50 J = 1, N
+         DO 50 J = 1, MIN( M, N )
             DO 40 I = J, M
                A( I, J ) = A( I, J )*MUL
    40       CONTINUE


### PR DESCRIPTION
**Description**
fixes #1183 as suggested there 
**Checklist**

- [ ] The documentation has been updated.
- [x] If the PR solves a specific issue, it is set to be closed on merge.