### PR TITLE
in .github/workflows/cmake.yml, removed redundant '--config ${{env.BUILD_TYPE}}' from 'cmake --build build'

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,7 +48,7 @@ jobs:
 
   test-install-release:
     # Use GNU compilers
-  
+
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -66,9 +66,9 @@ jobs:
         fflags: [
           "-Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all",
           "-Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all -fopenmp" ]
-    
+
     steps:
-    
+
     - name: Checkout LAPACK
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
@@ -90,7 +90,8 @@ jobs:
         -D CMAKE_EXE_LINKER_FLAGS="-Wl,--stack=2097152"
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using
+      # a single-configuration generator such as make or Ninja.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B build -G Ninja
@@ -103,9 +104,9 @@ jobs:
         -D BUILD_SHARED_LIBS:BOOL=ON
 
     - name: Build
-      # Execute tests defined by the CMake configuration.  
+      # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: cmake --build build --config ${{env.BUILD_TYPE}}
+      run: cmake --build build
 
     - name: Test with OpenMP
       working-directory: ${{github.workspace}}/build
@@ -118,15 +119,20 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}} --schedule-random -j2 --output-on-failure --timeout 100
 
     - name: Install
+      # Since we use a single configuration generator, Ninja, there is no need to provide
+      # the '--config ${{env.BUILD_TYPE}}' option for the build step in the 'cmake --build' command.
       run: cmake --build build --target install -j2
 
   coverage:
-    runs-on: ubuntu-latest 
+
+    runs-on: ubuntu-latest
+
     env:
       BUILD_TYPE: Coverage
       FFLAGS: "-fopenmp"
-    steps:     
-    
+
+    steps:
+
     - name: Checkout LAPACK
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
@@ -134,7 +140,8 @@ jobs:
       uses: seanmiddleditch/gha-setup-ninja@16b940825621068d98711680b6c3ff92201f8fc0 # v3
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using
+      # a single-configuration generator such as make or Ninja.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B build -G Ninja
@@ -147,17 +154,27 @@ jobs:
         -D BUILD_SHARED_LIBS:BOOL=ON
 
     - name: Install
+      # Since we use a single configuration generator, Ninja, there is no need to provide
+      # the '--config ${{env.BUILD_TYPE}}' option for the build step in the 'cmake --build' command.
       run: cmake --build build --target install -j2
 
     - name: Coverage
+      # Since we use a single configuration generator, Ninja, there is no need to provide
+      # the '--config ${{env.BUILD_TYPE}}' option for the build step in the 'cmake --build' command.
       run: |
         echo "Coverage"
         cmake --build build --target coverage
         bash <(curl -s https://codecov.io/bash) -X gcov
 
   test-install-cblas-lapacke-without-fortran-compiler:
+
     runs-on: ubuntu-latest
+
+    env:
+      BUILD_TYPE: Release
+
     steps:
+
     - name: Checkout LAPACK
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
@@ -171,9 +188,12 @@ jobs:
         sudo apt purge gfortran
 
     - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using
+      # a single-configuration generator such as make or Ninja.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B build -G Ninja
-        -D CMAKE_BUILD_TYPE=Release
+        -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -D CMAKE_INSTALL_PREFIX=${{github.workspace}}/lapack_install
         -D CBLAS:BOOL=ON
         -D LAPACKE:BOOL=ON
@@ -184,10 +204,14 @@ jobs:
         -D BUILD_SHARED_LIBS:BOOL=ON
 
     - name: Install
+      # Since we use a single configuration generator, Ninja, there is no need to provide
+      # the '--config ${{env.BUILD_TYPE}}' option for the build step in the 'cmake --build' command.
       run: cmake --build build --target install -j2
 
   memory-check:
+
     runs-on: ubuntu-latest
+
     env:
       BUILD_TYPE: Debug
 
@@ -198,13 +222,16 @@ jobs:
 
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@16b940825621068d98711680b6c3ff92201f8fc0 # v3
-    
+
     - name: Install APT packages
       run: |
         sudo apt update
         sudo apt install -y cmake valgrind gfortran
 
     - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using
+      # a single-configuration generator such as make or Ninja.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B build -G Ninja
         -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
@@ -216,7 +243,9 @@ jobs:
         -D LAPACK_TESTING_USE_PYTHON:BOOL=OFF
 
     - name: Build
-      run: cmake --build build --config ${{env.BUILD_TYPE}}
+      # Since we use a single configuration generator, Ninja, there is no need to provide
+      # the '--config ${{env.BUILD_TYPE}}' option for the build step in the 'cmake --build' command.
+      run: cmake --build build
 
     - name: Test
       working-directory: ${{github.workspace}}/build


### PR DESCRIPTION



**Description**
1) removed redundant `--config ${{env.BUILD_TYPE}}` from `cmake --build build -config ${{env.BUILD_TYPE}}` for a single configuration generator Ninja.
2) wrote comments before each `cmake --build build` about `--config ${{env.BUILD_TYPE}}` redundancy. 
3) in `test-install-cblas-lapacke-without-fortran-compiler` job, added an `env` field `BUILD_TYPE: Release` to make it consistent with other jobs in the script.
4) Removed whitespace at the end of each line.

**Checklist**

- [ ] The documentation has been updated.
- [ ] If the PR solves a specific issue, it is set to be closed on merge.