### PR TITLE
Improve getenv usage

### DIFF
--- a/BLAS/SRC/CMakeLists.txt
+++ b/BLAS/SRC/CMakeLists.txt
@@ -129,7 +129,7 @@ if(BUILD_INDEX64_EXT_API)
   set_target_properties(${BLASLIB}_64_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
   #Add _64 suffix to all Fortran functions via macros
   foreach(F IN LISTS SOURCES_64_F)
-    if(CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
+    if(CMAKE_Fortran_COMPILER_ID STREQUAL "NAG" OR CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
       set_source_files_properties(${F} PROPERTIES COMPILE_FLAGS "-fpp")
     else()
       set_source_files_properties(${F} PROPERTIES COMPILE_FLAGS "-cpp")

--- a/LAPACKE/src/lapacke_nancheck.c
+++ b/LAPACKE/src/lapacke_nancheck.c
@@ -33,6 +33,7 @@
 #include "lapacke_utils.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 static int nancheck_flag = -1;
 
@@ -42,11 +43,11 @@ void LAPACKE_set_nancheck( int flag )
 }
 
 typedef struct {
-  int found;
-  char *value;
-} _lapacke_env_var;
+    int found;
+    char *value;
+} lapacke_env_var;
 
-static inline const _lapacke_env_var LAPACKE_getenv(const char *var_name)
+static inline lapacke_env_var LAPACKE_getenv(const char *var_name)
 {
     size_t var_length = 0;
 
@@ -54,12 +55,12 @@ static inline const _lapacke_env_var LAPACKE_getenv(const char *var_name)
 #if defined(_WIN32)
     errno_t result = getenv_s( &var_length, NULL, 0, var_name );
     if ( result != 0 || var_length == 0 ) {
-        return (_lapacke_env_var){ 0, NULL };
+        return (lapacke_env_var){ 0, NULL };
     }
 #else
     const char *env = getenv( var_name );
     if ( env == NULL ) {
-        return (_lapacke_env_var){ 0, NULL };
+        return (lapacke_env_var){ 0, NULL };
     }
     var_length = strlen( env ) + 1;
 #endif
@@ -67,7 +68,7 @@ static inline const _lapacke_env_var LAPACKE_getenv(const char *var_name)
     /* Allocate memory for the environment variable value */
     char *value = (char *)LAPACKE_malloc( var_length );
     if ( value == NULL ) {
-        return (_lapacke_env_var){ 0, NULL };
+        return (lapacke_env_var){ 0, NULL };
     }
 
     /* Get the value of the environment variable */
@@ -75,16 +76,16 @@ static inline const _lapacke_env_var LAPACKE_getenv(const char *var_name)
     result = getenv_s( &var_length, value, var_length, var_name );
     if ( result != 0 ) {
         LAPACKE_free( value );
-        return (_lapacke_env_var){ 0, NULL };
+        return (lapacke_env_var){ 0, NULL };
     }
 #else
     memcpy( value, env, var_length );
 #endif
 
-    return (_lapacke_env_var){ 1, value };
+    return (lapacke_env_var){ 1, value };
 }
 
-static inline void LAPACKE_freenv(_lapacke_env_var *var)
+static inline void LAPACKE_freenv(lapacke_env_var *var)
 {
     if ( var->found && var->value != NULL ) {
         LAPACKE_free( var->value );
@@ -100,7 +101,7 @@ int LAPACKE_get_nancheck( )
     }
 
     /* Check environment variable, once and only once */
-    _lapacke_env_var lapacke_nancheck = LAPACKE_getenv( "LAPACKE_NANCHECK" );
+    lapacke_env_var lapacke_nancheck = LAPACKE_getenv( "LAPACKE_NANCHECK" );
     if ( !lapacke_nancheck.found ) {
         /* By default, NaN checking is enabled */
         nancheck_flag = 1;

--- a/LAPACKE/src/lapacke_nancheck.c
+++ b/LAPACKE/src/lapacke_nancheck.c
@@ -32,6 +32,8 @@
 
 #include "lapacke_utils.h"
 
+#include <stdlib.h>
+
 static int nancheck_flag = -1;
 
 void LAPACKE_set_nancheck( int flag )
@@ -39,21 +41,73 @@ void LAPACKE_set_nancheck( int flag )
     nancheck_flag = ( flag ) ? 1 : 0;
 }
 
+typedef struct {
+  int found;
+  char *value;
+} _lapacke_env_var;
+
+static inline const _lapacke_env_var LAPACKE_getenv(const char *var_name)
+{
+    size_t var_length = 0;
+
+    /* Get the length of the environment variable value */
+#if defined(_WIN32)
+    errno_t result = getenv_s( &var_length, NULL, 0, var_name );
+    if ( result != 0 || var_length == 0 ) {
+        return (_lapacke_env_var){ 0, NULL };
+    }
+#else
+    const char *env = getenv( var_name );
+    if ( env == NULL ) {
+        return (_lapacke_env_var){ 0, NULL };
+    }
+    var_length = strlen( env ) + 1;
+#endif
+
+    /* Allocate memory for the environment variable value */
+    char *value = (char *)LAPACKE_malloc( var_length );
+    if ( value == NULL ) {
+        return (_lapacke_env_var){ 0, NULL };
+    }
+
+    /* Get the value of the environment variable */
+#if defined(_WIN32)
+    result = getenv_s( &var_length, value, var_length, var_name );
+    if ( result != 0 ) {
+        LAPACKE_free( value );
+        return (_lapacke_env_var){ 0, NULL };
+    }
+#else
+    memcpy( value, env, var_length );
+#endif
+
+    return (_lapacke_env_var){ 1, value };
+}
+
+static inline void LAPACKE_freenv(_lapacke_env_var *var)
+{
+    if ( var->found && var->value != NULL ) {
+        LAPACKE_free( var->value );
+    }
+    var->found = 0;
+    var->value = NULL;
+}
+
 int LAPACKE_get_nancheck( )
 {
-    char* env;
     if ( nancheck_flag != -1 ) {
         return nancheck_flag;
     }
 
     /* Check environment variable, once and only once */
-    env = getenv( "LAPACKE_NANCHECK" );
-    if ( !env ) {
+    _lapacke_env_var lapacke_nancheck = LAPACKE_getenv( "LAPACKE_NANCHECK" );
+    if ( !lapacke_nancheck.found ) {
         /* By default, NaN checking is enabled */
         nancheck_flag = 1;
     } else {
-        nancheck_flag = atoi( env ) ? 1 : 0;
+        nancheck_flag = atoi( lapacke_nancheck.value ) ? 1 : 0;
     }
 
+    LAPACKE_freenv( &lapacke_nancheck );
     return nancheck_flag;
 }


### PR DESCRIPTION
**Description**

On Windows, using getenv is deprecated in favor of getenv_s. With this PR, we first query the length of the variable and then use our own buffer to store the value. Additionally, the use of getenv is now safer on Unix as well by copying the env value into the aforementioned buffer that we allocated ourselves.

Additional change: Fixed the preprocessor flag for BUILD_INDEX64_EXT_API builds when using Intel compilers.