### PR TITLE
Fixes for Intel compilers on Windows

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -13,9 +13,16 @@ endif()
 
 set(LAPACK_INSTALL_EXPORT_NAME ${CBLASLIB}-targets)
 
-include(CheckCSourceCompiles)
-check_c_source_compiles("int __attribute__((weak)) main() {};"
-                        HAS_ATTRIBUTE_WEAK_SUPPORT)
+if(WIN32)
+  # MSVC does not support __attribute__((weak)) and the Intel compiler supports
+  # it but produces linker errors when used in CBLAS, so we disable it for all
+  # Windows builds.
+  set(HAS_ATTRIBUTE_WEAK_SUPPORT FALSE)
+else()
+  include(CheckCSourceCompiles)
+  check_c_source_compiles("int __attribute__((weak)) main() {};"
+                          HAS_ATTRIBUTE_WEAK_SUPPORT)
+endif()
 
 include_directories(include ${LAPACK_BINARY_DIR}/include)
 add_subdirectory(src)

--- a/LAPACKE/include/lapack.h
+++ b/LAPACKE/include/lapack.h
@@ -47,7 +47,8 @@
 #else
 #include <complex>
 #endif
-#if _MSC_VER
+
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
 #define lapack_complex_float    _Fcomplex
 #else
 #define lapack_complex_float    float _Complex
@@ -69,7 +70,8 @@
 #else
 #include <complex>
 #endif
-#if _MSC_VER
+
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
 #define lapack_complex_double   _Dcomplex
 #else
 #define lapack_complex_double   double _Complex

--- a/LAPACKE/include/lapacke_config.h
+++ b/LAPACKE/include/lapacke_config.h
@@ -99,7 +99,7 @@ typedef struct { double real, imag; } _lapack_complex_double;
 #define lapack_complex_double_real(z)       ((z).real())
 #define lapack_complex_double_imag(z)       ((z).imag())
 
-#elif _MSC_VER
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
 
 #include <complex.h>
 #define lapack_complex_float    _Fcomplex

--- a/LAPACKE/utils/lapacke_make_complex_double.c
+++ b/LAPACKE/utils/lapacke_make_complex_double.c
@@ -43,7 +43,7 @@ lapack_complex_double lapack_make_complex_double( double re, double im ) {
     z = re + im * I;
 #elif defined(LAPACK_COMPLEX_CPP)
     z = std::complex<double>(re,im);
-#elif _MSC_VER
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
     z = _Cbuild(re, im);
 #else /* C99 is default */
     z = re + im*I;

--- a/LAPACKE/utils/lapacke_make_complex_float.c
+++ b/LAPACKE/utils/lapacke_make_complex_float.c
@@ -43,7 +43,7 @@ lapack_complex_float lapack_make_complex_float( float re, float im ) {
     z = re + im * I;
 #elif defined(LAPACK_COMPLEX_CPP)
     z = std::complex<float>(re,im);
-#elif _MSC_VER
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
     z = _FCbuild(re, im);
 #else /* C99 is default */
     z = re + im*I;


### PR DESCRIPTION
**Description**

Fixes two issues for Intel compilers on Windows:
- The MSVC complex types (`_Fcomplex`, `_Dcomplex`) were selected for Intel compilers as well. Use standard `_Complex` types instead.
- Disable weak symbol support on Windows because weak symbols in CBLAS causes linker errors:

```
libcblas.lib(cblas_sgemm.c.obj) : fatal error LNK1227: conflicting weak extern definition for 'cblas_xerbla'.  New default '.weak.cblas_xerbla.default.cblas_sgemm' conflicts with old default '.weak.cblas_xerbla.default.XERBLA' in c_xerbla.c.obj
ninja: build stopped: subcommand failed.
```
