### PR TITLE
Fixed wrong external symbol declarations

### DIFF
--- a/SRC/clarf1f.f
+++ b/SRC/clarf1f.f
@@ -150,7 +150,7 @@
       INTEGER            I, LASTV, LASTC
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           CAXPY, CGEMV, CGER, CSCAL
+      EXTERNAL           CAXPY, CGEMV, CGERC, CSCAL
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          CONJG

--- a/SRC/zupmtr.f
+++ b/SRC/zupmtr.f
@@ -176,7 +176,7 @@
       EXTERNAL           LSAME
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           XERBLA, ZLARF1, ZLARF1F
+      EXTERNAL           XERBLA, ZLARF1L, ZLARF1F
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          DCONJG, MAX


### PR DESCRIPTION
**Description**

This fixes two wrong external symbol declarations:
- `CGER` -> `CGERC`
- `ZLARF1` -> `ZLARF1L`

This was flagged by the Intel Classic compiler (no other compiler/linker complained ...).