### PR TITLE
Fix complex NRM2 tests for matching infinite results

### DIFF
--- a/BLAS/TESTING/cblat1.f
+++ b/BLAS/TESTING/cblat1.f
@@ -1033,6 +1033,8 @@
                ELSE
                   TRAT = ZERO
                END IF
+            ELSE IF (SNRM == ZNRM) THEN
+               TRAT = ZERO
             ELSE IF (ZNRM == ZERO) THEN
                TRAT = SNRM / ULP
             ELSE

--- a/BLAS/TESTING/zblat1.f
+++ b/BLAS/TESTING/zblat1.f
@@ -1033,6 +1033,8 @@
                ELSE
                   TRAT = ZERO
                END IF
+            ELSE IF (SNRM == ZNRM) THEN
+               TRAT = ZERO
             ELSE IF (ZNRM == ZERO) THEN
                TRAT = SNRM / ULP
             ELSE


### PR DESCRIPTION
**Description**

The extended complex NRM2 tests can compare an expected +Inf norm with a computed +Inf norm. The relative-error path then evaluates Inf - Inf, producing NaN and reporting a spurious failure.

Treat exactly equal results as zero test ratio before computing the relative difference. This matches the existing SNRM2 and DNRM2 test logic.

Fixes #1047.

**Checklist**

- [X] The documentation has been updated.
- [X] If the PR solves a specific issue, it is set to be closed on merge.