### PR TITLE
Remove unused intrinsic MAX

### DIFF
--- a/SRC/dlansf.f
+++ b/SRC/dlansf.f
@@ -237,7 +237,7 @@
       EXTERNAL           DLASSQ
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, MAX, SQRT
+      INTRINSIC          ABS, SQRT
 *     ..
 *     .. Executable Statements ..
 *

--- a/SRC/zlanht.f
+++ b/SRC/zlanht.f
@@ -129,7 +129,7 @@
       EXTERNAL           DLASSQ, ZLASSQ
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, MAX, SQRT
+      INTRINSIC          ABS, SQRT
 *     ..
 *     .. Executable Statements ..
 *


### PR DESCRIPTION
Contrary to their single precision counterparts,
DLANSF and ZLANHT declare MAX intrinsic which is not used.