### PR TITLE
Fix JOBA argument in SGEJSV inner SGESVJ call (LSVEC && RSVEC branch)

### DIFF
--- a/SRC/sgejsv.f
+++ b/SRC/sgejsv.f
@@ -1706,7 +1706,7 @@
             CALL SLASET('U', NR-1, NR-1, ZERO, ZERO, U(1,2), LDU )
          END IF
 
-         CALL SGESVJ( 'L', 'U', 'V', NR, NR, U, LDU, SVA,
+         CALL SGESVJ( 'G', 'U', 'V', NR, NR, U, LDU, SVA,
      $        N, V, LDV, WORK(2*N+N*NR+1), LWORK-2*N-N*NR, INFO )
          SCALEM  = WORK(2*N+N*NR+1)
          NUMRANK = NINT(WORK(2*N+N*NR+2))


### PR DESCRIPTION
In the LSVEC && RSVEC branch of SGEJSV, the IF arm fills the strict upper triangle of U with U(p,q) = -SIGN(TEMP1, U(q,p)) while the ELSE arm zeros it via SLASET('U', ...). Both arms then call SGESVJ on U with JOBA='L', which tells SGESVJ that U is lower triangular and the strict upper is zero. After the IF arm that is not true: SGESVJ silently drops the upper-triangular data the IF arm just deposited, biasing the SVD result. JOBA='G' (general) is correct for both arms; DGEJSV already uses 'G' at the matching call site.