### PR TITLE
Fix workspace size argument in DGEJSV inner DGESVJ call

### DIFF
--- a/SRC/dgejsv.f
+++ b/SRC/dgejsv.f
@@ -1170,7 +1170,7 @@
      $                   LDV )
 *
             CALL DGESVJ( 'Lower', 'U','N', NR, NR, V,LDV, SVA, NR, U,
-     $                  LDU, WORK(N+1), LWORK, INFO )
+     $                  LDU, WORK(N+1), LWORK-N, INFO )
             SCALEM  = WORK(N+1)
             NUMRANK = IDNINT(WORK(N+2))
             IF ( NR .LT. N ) THEN


### PR DESCRIPTION
In the RSVEC && !LSVEC && !ALMORT branch of DGEJSV, the inner DGESVJ call passes WORK(N+1) as the workspace base (offset by N) but the full LWORK as the workspace size. DGESVJ may then write up to N entries past the end of WORK(LWORK). The float sibling SGEJSV correctly passes LWORK-N at the same call site.

https://github.com/Reference-LAPACK/lapack/blob/fd5303c002f47fc3d8c83ae64ec6dd15eade10b9/SRC/sgejsv.f#L1170-L1176