### PR TITLE
Fix stale externals and documentation typo

### DIFF
--- a/SRC/dlaqp2.f
+++ b/SRC/dlaqp2.f
@@ -168,7 +168,7 @@
       DOUBLE PRECISION   TEMP, TEMP2, TOL3Z
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           DLARF, DLARFG, DSWAP
+      EXTERNAL           DLARF1F, DLARFG, DSWAP
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX, MIN, SQRT

--- a/SRC/sgelqt.f
+++ b/SRC/sgelqt.f
@@ -144,7 +144,7 @@
       INTEGER    I, IB, IINFO, K
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL   SGEQRT2, SGEQRT3, SGELQT3, SLARFB, XERBLA
+      EXTERNAL   SGELQT3, SLARFB, XERBLA
 *     ..
 *     .. Executable Statements ..
 *

--- a/SRC/sgges.f
+++ b/SRC/sgges.f
@@ -327,7 +327,7 @@
 *     .. External Subroutines ..
       EXTERNAL           SGEQRF, SGGBAK, SGGBAL, SGGHRD, SHGEQZ,
      $                   SLACPY,
-     $                   SLASCL, SLASET, SORGQR, SORMQR, STGSEN
+     $                   SLASCL, SLASET, SORGQR, SORMQR, STGSEN, XERBLA
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME

--- a/SRC/slaqr2.f
+++ b/SRC/slaqr2.f
@@ -311,7 +311,7 @@
 *     .. External Subroutines ..
       EXTERNAL           SCOPY, SGEHRD, SGEMM, SLACPY,
      $                   SLAHQR,
-     $                   SLANV2, SLARF1L, SLARFG, SLASET, SORMHR,
+     $                   SLANV2, SLARF1F, SLARFG, SLASET, SORMHR,
      $                   STREXC
 *     ..
 *     .. Intrinsic Functions ..

--- a/SRC/zhetrf_aa.f
+++ b/SRC/zhetrf_aa.f
@@ -163,7 +163,7 @@
       EXTERNAL     LSAME, ILAENV
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL     ZLAHEF_AA, ZGEMM, ZGEMV, ZCOPY, ZSCAL, ZSWAP,
+      EXTERNAL     ZLAHEF_AA, ZGEMM, ZCOPY, ZSCAL, ZSWAP,
      $                   XERBLA
 *     ..
 *     .. Intrinsic Functions ..

--- a/SRC/zlahef_aa.f
+++ b/SRC/zlahef_aa.f
@@ -170,7 +170,7 @@
       EXTERNAL     LSAME, ILAENV, IZAMAX
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL     ZGEMM, ZGEMV, ZAXPY, ZLACGV, ZCOPY, ZSCAL,
+      EXTERNAL     ZGEMV, ZAXPY, ZLACGV, ZCOPY, ZSCAL,
      $             ZSWAP, ZLASET, XERBLA
 *     ..
 *     .. Intrinsic Functions ..

--- a/SRC/zrscl.f
+++ b/SRC/zrscl.f
@@ -1,16 +1,16 @@
-*> \brief \b ZDRSCL multiplies a vector by the reciprocal of a real scalar.
+*> \brief \b ZRSCL multiplies a vector by the reciprocal of a complex scalar.
 *
 *  =========== DOCUMENTATION ===========
 *
 * Online html documentation available at
 *            http://www.netlib.org/lapack/explore-html/
 *
-*> Download ZDRSCL + dependencies
-*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/zdrscl.f">
+*> Download ZRSCL + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/zrscl.f">
 *> [TGZ]</a>
-*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/zdrscl.f">
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/zrscl.f">
 *> [ZIP]</a>
-*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/zdrscl.f">
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/zrscl.f">
 *> [TXT]</a>
 *
 *  Definition:


### PR DESCRIPTION
Cleans up stale and missing EXTERNAL declarations across several routines and fixes a documentation typo in zrscl.f.

Changes:
* Fix stale/missing EXTERNAL declarations:
  * dlaqp2.f: Replaced stale DLARF with DLARF1F
  * sgelqt.f: Dropped stale SGEQRT2 and SGEQRT3
  * sgges.f: Added missing XERBLA declaration
  * slaqr2.f: Replaced stale SLARF1L with SLARF1F
  * zhetrf_aa.f: Dropped stale ZGEMV
  * zlahef_aa.f: Dropped stale ZGEMM
* Fix zrscl.f doc header