### PR TITLE
Fix INFO=-N in argument-validation

### DIFF
--- a/SRC/cggsvd3.f
+++ b/SRC/cggsvd3.f
@@ -421,7 +421,7 @@
       ELSE IF( LDQ.LT.1 .OR. ( WANTQ .AND. LDQ.LT.N ) ) THEN
          INFO = -20
       ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
-         INFO = -24
+         INFO = -22
       END IF
 *
 *     Compute workspace

--- a/SRC/claqz0.f
+++ b/SRC/claqz0.f
@@ -447,7 +447,7 @@
          WORK( 1 ) = REAL( LWORKREQ )
          RETURN
       ELSE IF ( LWORK .LT. LWORKREQ ) THEN
-         INFO = -19
+         INFO = -18
       END IF
       IF( INFO.NE.0 ) THEN
          CALL XERBLA( 'CLAQZ0', INFO )

--- a/SRC/claqz2.f
+++ b/SRC/claqz2.f
@@ -285,7 +285,7 @@
          WORK( 1 ) = CMPLX( LWORKREQ )
          RETURN
       ELSE IF ( LWORK .LT. LWORKREQ ) THEN
-         INFO = -26
+         INFO = -25
       END IF
 
       IF( INFO.NE.0 ) THEN

--- a/SRC/cunbdb4.f
+++ b/SRC/cunbdb4.f
@@ -280,7 +280,7 @@
          LWORKMIN = LWORKOPT
          WORK(1) = SROUNDUP_LWORK(LWORKOPT)
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
-           INFO = -14
+           INFO = -15
          END IF
       END IF
       IF( INFO .NE. 0 ) THEN

--- a/SRC/cuncsd.f
+++ b/SRC/cuncsd.f
@@ -512,10 +512,10 @@
 *
          IF( LWORK .LT. LWORKMIN
      $       .AND. .NOT. ( LQUERY .OR. LRQUERY ) ) THEN
-            INFO = -22
+            INFO = -28
          ELSE IF( LRWORK .LT. LRWORKMIN
      $            .AND. .NOT. ( LQUERY .OR. LRQUERY ) ) THEN
-            INFO = -24
+            INFO = -30
          ELSE
             LORGQRWORK = LWORK - IORGQR + 1
             LORGLQWORK = LWORK - IORGLQ + 1

--- a/SRC/dggsvd3.f
+++ b/SRC/dggsvd3.f
@@ -416,7 +416,7 @@
       ELSE IF( LDQ.LT.1 .OR. ( WANTQ .AND. LDQ.LT.N ) ) THEN
          INFO = -20
       ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
-         INFO = -24
+         INFO = -22
       END IF
 *
 *     Compute workspace

--- a/SRC/dorbdb4.f
+++ b/SRC/dorbdb4.f
@@ -278,7 +278,7 @@
          LWORKMIN = LWORKOPT
          WORK(1) = LWORKOPT
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
-           INFO = -14
+           INFO = -15
          END IF
       END IF
       IF( INFO .NE. 0 ) THEN

--- a/SRC/dorcsd.f
+++ b/SRC/dorcsd.f
@@ -475,7 +475,7 @@
          WORK(1) = MAX(LWORKOPT,LWORKMIN)
 *
          IF( LWORK .LT. LWORKMIN .AND. .NOT. LQUERY ) THEN
-            INFO = -22
+            INFO = -28
          ELSE
             LORGQRWORK = LWORK - IORGQR + 1
             LORGLQWORK = LWORK - IORGLQ + 1

--- a/SRC/sggsvd3.f
+++ b/SRC/sggsvd3.f
@@ -417,7 +417,7 @@
       ELSE IF( LDQ.LT.1 .OR. ( WANTQ .AND. LDQ.LT.N ) ) THEN
          INFO = -20
       ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
-         INFO = -24
+         INFO = -22
       END IF
 *
 *     Compute workspace

--- a/SRC/sorbdb4.f
+++ b/SRC/sorbdb4.f
@@ -279,7 +279,7 @@
          LWORKMIN = LWORKOPT
          WORK(1) = REAL( LWORKOPT )
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
-           INFO = -14
+           INFO = -15
          END IF
       END IF
       IF( INFO .NE. 0 ) THEN

--- a/SRC/sorcsd.f
+++ b/SRC/sorcsd.f
@@ -480,7 +480,7 @@
          WORK(1) = REAL( MAX(LWORKOPT,LWORKMIN) )
 *
          IF( LWORK .LT. LWORKMIN .AND. .NOT. LQUERY ) THEN
-            INFO = -22
+            INFO = -28
          ELSE
             LORGQRWORK = LWORK - IORGQR + 1
             LORGLQWORK = LWORK - IORGLQ + 1

--- a/SRC/zggsvd3.f
+++ b/SRC/zggsvd3.f
@@ -420,7 +420,7 @@
       ELSE IF( LDQ.LT.1 .OR. ( WANTQ .AND. LDQ.LT.N ) ) THEN
          INFO = -20
       ELSE IF( LWORK.LT.1 .AND. .NOT.LQUERY ) THEN
-         INFO = -24
+         INFO = -22
       END IF
 *
 *     Compute workspace

--- a/SRC/zlaqz0.f
+++ b/SRC/zlaqz0.f
@@ -448,7 +448,7 @@
          WORK( 1 ) = DBLE( LWORKREQ )
          RETURN
       ELSE IF ( LWORK .LT. LWORKREQ ) THEN
-         INFO = -19
+         INFO = -18
       END IF
       IF( INFO.NE.0 ) THEN
          CALL XERBLA( 'ZLAQZ0', INFO )

--- a/SRC/zlaqz2.f
+++ b/SRC/zlaqz2.f
@@ -285,7 +285,7 @@
          WORK( 1 ) = LWORKREQ
          RETURN
       ELSE IF ( LWORK .LT. LWORKREQ ) THEN
-         INFO = -26
+         INFO = -25
       END IF
 
       IF( INFO.NE.0 ) THEN

--- a/SRC/zunbdb4.f
+++ b/SRC/zunbdb4.f
@@ -280,7 +280,7 @@
          LWORKMIN = LWORKOPT
          WORK(1) = LWORKOPT
          IF( LWORK .LT. LWORKMIN .AND. .NOT.LQUERY ) THEN
-           INFO = -14
+           INFO = -15
          END IF
       END IF
       IF( INFO .NE. 0 ) THEN

--- a/SRC/zuncsd.f
+++ b/SRC/zuncsd.f
@@ -510,10 +510,10 @@
 *
          IF( LWORK .LT. LWORKMIN
      $       .AND. .NOT. ( LQUERY .OR. LRQUERY ) ) THEN
-            INFO = -22
+            INFO = -28
          ELSE IF( LRWORK .LT. LRWORKMIN
      $            .AND. .NOT. ( LQUERY .OR. LRQUERY ) ) THEN
-            INFO = -24
+            INFO = -30
          ELSE
             LORGQRWORK = LWORK - IORGQR + 1
             LORGLQWORK = LWORK - IORGLQ + 1


### PR DESCRIPTION
INFO=-N value reported to XERBLA on a too-small workspace (or LRWORK) does not match the actual signature position of the argument being tested.

Sites:
- ?ORBDB4 / ?UNBDB4: LWORK test reported -14 (WORK), should be -15.
- ?GGSVD3: LWORK.LT.1 test reported -24 (the INFO arg in S/D; IWORK in C/Z), should be -22 (LWORK).
- ?ORCSD / ?UNCSD: LWORK test reported -22 (LDU2), should be -28 (LWORK). Z/C also report LRWORK as -24 (LDV1T), should be -30.
- C/ZLAQZ0: LWORK test reported -19 (RWORK), should be -18. (S/DLAQZ0 use ALPHAR+ALPHAI instead of ALPHA, so LWORK is at position 19 there and -19 is already correct.)
- C/ZLAQZ2: LWORK test reported -26 (RWORK), should be -25.