### PR TITLE
Gate SGGEV3 workspace query on ILV, not ILVL

### DIFF
--- a/SRC/sggev3.f
+++ b/SRC/sggev3.f
@@ -330,18 +330,22 @@
          CALL SORMQR( 'L', 'T', N, N, N, B, LDB, WORK, A, LDA, WORK,
      $                -1, IERR )
          LWKOPT = MAX( LWKOPT, 3*N+INT( WORK( 1 ) ) )
-         CALL SGGHD3( JOBVL, JOBVR, N, 1, N, A, LDA,
-     $                B, LDB, VL, LDVL,
-     $                VR, LDVR, WORK, -1, IERR )
-         LWKOPT = MAX( LWKOPT, 3*N+INT( WORK( 1 ) ) )
          IF( ILVL ) THEN
             CALL SORGQR( N, N, N, VL, LDVL, WORK, WORK, -1, IERR )
+            LWKOPT = MAX( LWKOPT, 3*N+INT( WORK( 1 ) ) )
+         END IF
+         IF( ILV ) THEN
+            CALL SGGHD3( JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB, VL,
+     $                   LDVL, VR, LDVR, WORK, -1, IERR )
             LWKOPT = MAX( LWKOPT, 3*N+INT( WORK( 1 ) ) )
             CALL SLAQZ0( 'S', JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB,
      $                   ALPHAR, ALPHAI, BETA, VL, LDVL, VR, LDVR,
      $                   WORK, -1, 0, IERR )
             LWKOPT = MAX( LWKOPT, 2*N+INT( WORK( 1 ) ) )
          ELSE
+            CALL SGGHD3( 'N', 'N', N, 1, N, A, LDA, B, LDB, VL, LDVL,
+     $                   VR, LDVR, WORK, -1, IERR )
+            LWKOPT = MAX( LWKOPT, 3*N+INT( WORK( 1 ) ) )
             CALL SLAQZ0( 'E', JOBVL, JOBVR, N, 1, N, A, LDA, B, LDB,
      $                   ALPHAR, ALPHAI, BETA, VL, LDVL, VR, LDVR,
      $                   WORK, -1, 0, IERR )


### PR DESCRIPTION
The actual SLAQZ0 call uses 'S' when ILV is true and 'E' otherwise, but the query gated that choice on ILVL, undersizing LWORK for JOBVL='N', JOBVR='V'. Mirror DGGEV3: gate SLAQZ0 and SGGHD3 on ILV, SORGQR on ILVL.

https://github.com/Reference-LAPACK/lapack/blob/5da5348aa00b65b10550ca4aeb83384d533589dd/SRC/dggev3.f#L329-L351

## Reproducer
 
```fortran
  ! Workspace query -- JOBVL='N', JOBVR='V' (right eigenvectors only).
  ! Pre-patch: SGGEV3 gates the SLAQZ0 query on ILVL, so it queries with
  ! 'E' (eigenvalues-only) -- but the actual run gates on ILV and calls
  ! SLAQZ0('S',...), which needs more workspace.
  CALL SGGEV3('N', 'V', N, A, N, B, N, ALPHAR, ALPHAI, BETA, &
              VL, 1, VR, N, WQ, -1, INFO)
  IF (INFO /= 0) THEN
     PRINT *, 'query failed, INFO =', INFO
     STOP 1
  END IF
  LWORK = INT(WQ(1))
  PRINT *, 'query returned LWORK =', LWORK
  ALLOCATE(WORK(LWORK))

  ! Actual call. Pre-patch: under-sized WORK -> INFO=-17 from inner
  ! SLAQZ0 guard, or silent OOB write. Post-patch: INFO=0.
  CALL SGGEV3('N', 'V', N, A, N, B, N, ALPHAR, ALPHAI, BETA, &
              VL, 1, VR, N, WORK, LWORK, INFO)
  PRINT *, 'compute INFO =', INFO