### PR TITLE
Reject NB=0 in DLASWLQ argument validation

### DIFF
--- a/SRC/dlaswlq.f
+++ b/SRC/dlaswlq.f
@@ -218,7 +218,7 @@
         INFO = -2
       ELSE IF( MB.LT.1 .OR. ( MB.GT.M .AND. M.GT.0 ) ) THEN
         INFO = -3
-      ELSE IF( NB.LT.0 ) THEN
+      ELSE IF( NB.LE.0 ) THEN
         INFO = -4
       ELSE IF( LDA.LT.MAX( 1, M ) ) THEN
         INFO = -6


### PR DESCRIPTION
DLASWLQ tested NB.LT.0 instead of NB.LE.0, accepting NB=0 silently and falling into the divide-by-(NB-M) path on line 255 (KK = MOD((N-M),(NB-M))) when M=0. The single/complex/double-complex siblings all use NB.LE.0.

https://github.com/Reference-LAPACK/lapack/blob/5da5348aa00b65b10550ca4aeb83384d533589dd/SRC/slaswlq.f#L219-L225