### PR TITLE
Fixes for LAPACK test crashes -ffpe-trap

### DIFF
--- a/SRC/cgedmd.f90
+++ b/SRC/cgedmd.f90
@@ -540,7 +540,7 @@
 !     Local scalars
 !     ~~~~~~~~~~~~~
       REAL(KIND=WP) :: OFL,   ROOTSC, SCALE,  SMALL,   &
-                       SSUM,  XSCL1,  XSCL2
+                       SSUM,  XSCL1,  XSCL2, TBIG
       INTEGER       ::  i,  j, IMINWR,  INFO1, INFO2,   &
                         LWRKEV, LWRSDD, LWRSVD, LWRSVJ, &
                        LWRSVQ, MLWORK, MWRKEV, MWRSDD, &
@@ -771,7 +771,9 @@
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of X(:,i) overflows. First, X(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||X(:,i)||_2.
@@ -845,7 +847,9 @@
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of Y(:,i) overflows. First, Y(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||Y(:,i)||_2.

--- a/SRC/cgejsv.f
+++ b/SRC/cgejsv.f
@@ -591,7 +591,7 @@
       COMPLEX CTEMP
       REAL    AAPP,   AAQQ,   AATMAX, AATMIN, BIG,    BIG1,   COND_OK,
      $        CONDR1, CONDR2, ENTRA,  ENTRAT, EPSLN,  MAXPRJ, SCALEM,
-     $        SCONDA, SFMIN,  SMALL,  TEMP1,  USCAL1, USCAL2, XSC
+     $        SCONDA, SFMIN,  SMALL,  TEMP1,  USCAL1, USCAL2, XSC, TBIG
       INTEGER IERR,   N1,     NR,     NUMRANK,        p, q,   WARNING
       LOGICAL ALMORT, DEFR,   ERREST, GOSCAL,  JRACC,  KILL,   LQUERY,
      $        LSVEC,  L2ABER, L2KILL, L2PERT,  L2RANK, L2TRAN, NOSCAL,
@@ -1000,7 +1000,9 @@
             RETURN
          END IF
          AAQQ = SQRT(AAQQ)
-         IF ( ( AAPP .LT. (BIG / AAQQ) ) .AND. NOSCAL  ) THEN
+         TBIG = BIG
+         IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+         IF ( ( AAPP .LT. TBIG ) .AND. NOSCAL  ) THEN
             SVA(p)  = AAPP * AAQQ
          ELSE
             NOSCAL  = .FALSE.
@@ -1074,7 +1076,10 @@
          IF ( RSVEC ) THEN
              V(1,1) = CONE
          END IF
-         IF ( SVA(1) .LT. (BIG*SCALEM) ) THEN
+         TBIG = BIG
+         IF ( SCALEM .EQ. ZERO ) SCALEM = ONE
+         IF ( SCALEM .LT. ONE) TBIG = BIG*SCALEM
+         IF ( SVA(1) .LT. TBIG ) THEN
             SVA(1)  = SVA(1) / SCALEM
             SCALEM  = ONE
          END IF

--- a/SRC/cgesvdx.f
+++ b/SRC/cgesvdx.f
@@ -846,13 +846,14 @@
 *
 *     Undo scaling if necessary
 *
-      IF( ISCL.EQ.1 ) THEN
-         IF( ANRM.GT.BIGNUM )
-     $      CALL SLASCL( 'G', 0, 0, BIGNUM, ANRM, MINMN, 1,
+      IF( ISCL.EQ.1 .AND. NS.GT.0 ) THEN
+        IF( ANRM.GT.BIGNUM ) THEN
+            CALL SLASCL( 'G', 0, 0, BIGNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
-         IF( ANRM.LT.SMLNUM )
-     $      CALL SLASCL( 'G', 0, 0, SMLNUM, ANRM, MINMN, 1,
+        ELSE IF( ANRM.LT.SMLNUM ) THEN
+            CALL SLASCL( 'G', 0, 0, SMLNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
+        ENDIF
       END IF
 *
 *     Return optimal workspace in WORK(1)

--- a/SRC/cgesvj.f
+++ b/SRC/cgesvj.f
@@ -378,7 +378,7 @@
 *     .. Local Scalars ..
       COMPLEX    AAPQ, OMPQ
       REAL       AAPP, AAPP0, AAPQ1, AAQQ, APOAQ, AQOAP, BIG,
-     $           BIGTHETA, CS, CTOL, EPSLN, MXAAPQ,
+     $           BIGTHETA, CS, CTOL, EPSLN, MXAAPQ, TBIG,
      $           MXSINJ, ROOTBIG, ROOTEPS, ROOTSFMIN, ROOTTOL,
      $           SKL, SFMIN, SMALL, SN, T, TEMP1, THETA, THSIGN, TOL
       INTEGER    BLSKIP, EMPTSW, i, ibr, IERR, igl, IJBLSK, ir1,
@@ -457,8 +457,6 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $          ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( RWORK( 1 ).LT.ONE ) ) THEN
-         INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13
       ELSE IF( LRWORK.LT.LRWMIN .AND. ( .NOT.LQUERY ) ) THEN
@@ -490,7 +488,12 @@
 *
       IF( UCTOL ) THEN
 *        ... user controlled
-         CTOL = RWORK( 1 )
+         IF( RWORK( 1 ).LE.ONE )  THEN
+            INFO = -12
+            RETURN
+         ELSE
+            CTOL = RWORK( 1 )
+         ENDIF
       ELSE
 *        ... default
          IF( LSVEC .OR. RSVEC .OR. APPLV ) THEN
@@ -557,7 +560,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT. TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -582,7 +587,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -607,7 +614,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -1419,9 +1428,10 @@
 *
       IF( LSVEC .OR. UCTOL ) THEN
          DO 1998 p = 1, N4
-*           CALL CSSCAL( M, ONE / SVA( p ), A( 1, p ), 1 )
-            CALL CLASCL( 'G',0,0, SVA(p), ONE, M, 1, A(1,p), M,
-     $                   IERR )
+            TEMP1 = ONE
+            IF( SVA(p).GT.ZERO ) TEMP1 = SVA(p)
+*           CALL CSSCAL( M, ONE/SVA(p), A( 1, p ), 1 )
+            CALL CLASCL( 'G',0,0, TEMP1, ONE, M, 1, A(1,p), M, IERR )
  1998    CONTINUE
       END IF
 *
@@ -1435,9 +1445,14 @@
       END IF
 *
 *     Undo scaling, if necessary (and possible).
-      IF( ( ( SKL.GT.ONE ) .AND. ( SVA( 1 ).LT.( BIG / SKL ) ) )
-     $    .OR. ( ( SKL.LT.ONE ) .AND. ( SVA( MAX( N2, 1 ) ) .GT.
-     $    ( SFMIN / SKL ) ) ) ) THEN
+      NOSCALE = .FALSE.
+      IF ( SKL.GT.ONE ) THEN
+          IF( SVA( 1 ).LT.( BIG / SKL ) ) NOSCALE = .TRUE.
+      ELSE IF( SKL.LT.ONE ) THEN
+          IF ( SVA( MAX( N2, 1 ) ) .GT.
+     $      ( SFMIN / SKL ) )  NOSCALE = .TRUE.
+      ENDIF
+      IF( NOSCALE ) THEN
          DO 2400 p = 1, N
             SVA( P ) = SKL*SVA( P )
  2400    CONTINUE

--- a/SRC/dgedmd.f90
+++ b/SRC/dgedmd.f90
@@ -571,7 +571,7 @@
 !     Local scalars
 !     ~~~~~~~~~~~~~
       REAL(KIND=WP) :: OFL,    ROOTSC, SCALE,  SMALL,  &
-                       SSUM,   XSCL1,  XSCL2
+                       SSUM,   XSCL1,  XSCL2, TBIG
       INTEGER       :: i,   j, IMINWR,  INFO1, INFO2,  &
                        LWRKEV, LWRSDD, LWRSVD,         &
                        LWRSVQ, MLWORK, MWRKEV, MWRSDD, &
@@ -792,7 +792,9 @@
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of X(:,i) overflows. First, X(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||X(:,i)||_2.
@@ -866,7 +868,9 @@
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of Y(:,i) overflows. First, Y(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||Y(:,i)||_2.

--- a/SRC/dgejsv.f
+++ b/SRC/dgejsv.f
@@ -496,7 +496,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION AAPP, AAQQ, AATMAX, AATMIN, BIG, BIG1, COND_OK,
      $        CONDR1, CONDR2, ENTRA,  ENTRAT, EPSLN,  MAXPRJ, SCALEM,
-     $        SCONDA, SFMIN,  SMALL,  TEMP1,  USCAL1, USCAL2, XSC
+     $        SCONDA, SFMIN,  SMALL,  TEMP1,  USCAL1, USCAL2, XSC, TBIG
       INTEGER IERR,   N1,     NR,     NUMRANK,        p, q,   WARNING
       LOGICAL ALMORT, DEFR,   ERREST, GOSCAL, JRACC,  KILL,   LSVEC,
      $        L2ABER, L2KILL, L2PERT, L2RANK, L2TRAN,
@@ -628,7 +628,9 @@
             RETURN
          END IF
          AAQQ = DSQRT(AAQQ)
-         IF ( ( AAPP .LT. (BIG / AAQQ) ) .AND. NOSCAL  ) THEN
+         TBIG = BIG
+         IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+         IF ( ( AAPP .LT. TBIG ) .AND. NOSCAL  ) THEN
             SVA(p)  = AAPP * AAQQ
          ELSE
             NOSCAL  = .FALSE.
@@ -701,7 +703,10 @@
          IF ( RSVEC ) THEN
              V(1,1) = ONE
          END IF
-         IF ( SVA(1) .LT. (BIG*SCALEM) ) THEN
+         TBIG = BIG
+         IF ( SCALEM .EQ. ZERO ) SCALEM = ONE
+         IF ( SCALEM .LT. ONE) TBIG = BIG*SCALEM
+         IF ( SVA(1) .LT. TBIG ) THEN
             SVA(1)  = SVA(1) / SCALEM
             SCALEM  = ONE
          END IF

--- a/SRC/dgesvdx.f
+++ b/SRC/dgesvdx.f
@@ -825,13 +825,14 @@
 *
 *     Undo scaling if necessary
 *
-      IF( ISCL.EQ.1 ) THEN
-         IF( ANRM.GT.BIGNUM )
-     $      CALL DLASCL( 'G', 0, 0, BIGNUM, ANRM, MINMN, 1,
+      IF( ISCL.EQ.1 .AND. NS.GT.0 ) THEN
+        IF( ANRM.GT.BIGNUM ) THEN
+            CALL DLASCL( 'G', 0, 0, BIGNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
-         IF( ANRM.LT.SMLNUM )
-     $      CALL DLASCL( 'G', 0, 0, SMLNUM, ANRM, MINMN, 1,
+        ELSE IF( ANRM.LT.SMLNUM ) THEN
+            CALL DLASCL( 'G', 0, 0, SMLNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
+        ENDIF
       END IF
 *
 *     Return optimal workspace in WORK(1)

--- a/SRC/dgesvj.f
+++ b/SRC/dgesvj.f
@@ -365,7 +365,7 @@
      $                   BIGTHETA, CS, CTOL, EPSLN, LARGE, MXAAPQ,
      $                   MXSINJ, ROOTBIG, ROOTEPS, ROOTSFMIN, ROOTTOL,
      $                   SKL, SFMIN, SMALL, SN, T, TEMP1, THETA,
-     $                   THSIGN, TOL
+     $                   THSIGN, TOL, TBIG
       INTEGER            BLSKIP, EMPTSW, i, ibr, IERR, igl, IJBLSK, ir1,
      $                   ISWROT, jbc, jgl, KBL, LKAHEAD, MVL, N2, N34,
      $                   N4, NBL, NOTROT, p, PSKIPPED, q, ROWSKIP,
@@ -441,8 +441,6 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $         ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( WORK( 1 ).LT.ONE ) ) THEN
-         INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13
       ELSE
@@ -471,7 +469,12 @@
 *
       IF( UCTOL ) THEN
 *        ... user controlled
-         CTOL = WORK( 1 )
+         IF( WORK( 1 ).LE.ONE )  THEN
+            INFO = -12
+            RETURN
+         ELSE
+            CTOL = WORK( 1 )
+         ENDIF
       ELSE
 *        ... default
          IF( LSVEC .OR. RSVEC .OR. APPLV ) THEN
@@ -538,7 +541,9 @@
                RETURN
             END IF
             AAQQ = DSQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT. TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -563,7 +568,9 @@
                RETURN
             END IF
             AAQQ = DSQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -588,7 +595,9 @@
                RETURN
             END IF
             AAQQ = DSQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -1601,7 +1610,9 @@
 *
       IF( LSVEC .OR. UCTOL ) THEN
          DO 1998 p = 1, N2
-            CALL DSCAL( M, WORK( p ) / SVA( p ), A( 1, p ), 1 )
+            TEMP1 = ONE
+            IF( SVA(p).GT.ZERO ) TEMP1 = ONE/SVA(p)
+            CALL DSCAL( M, WORK( p )*TEMP1, A( 1, p ), 1 )
  1998    CONTINUE
       END IF
 *
@@ -1621,9 +1632,14 @@
       END IF
 *
 *     Undo scaling, if necessary (and possible).
-      IF( ( ( SKL.GT.ONE ) .AND. ( SVA( 1 ).LT.( BIG / SKL) ) )
-     $    .OR. ( ( SKL.LT.ONE ) .AND. ( SVA( MAX( N2, 1 ) ) .GT.
-     $    ( SFMIN / SKL) ) ) ) THEN
+      NOSCALE = .FALSE.
+      IF ( SKL.GT.ONE ) THEN
+          IF( SVA( 1 ).LT.( BIG / SKL ) ) NOSCALE = .TRUE.
+      ELSE IF( SKL.LT.ONE ) THEN
+          IF ( SVA( MAX( N2, 1 ) ) .GT.
+     $      ( SFMIN / SKL ) )  NOSCALE = .TRUE.
+      ENDIF
+      IF( NOSCALE ) THEN
          DO 2400 p = 1, N
             SVA( P ) = SKL*SVA( P )
  2400    CONTINUE

--- a/SRC/sgedmd.f90
+++ b/SRC/sgedmd.f90
@@ -571,7 +571,7 @@
 !     Local scalars
 !     ~~~~~~~~~~~~~
       REAL(KIND=WP) :: OFL,   ROOTSC, SCALE,  SMALL,   &
-                       SSUM,  XSCL1,  XSCL2
+                       SSUM,  XSCL1,  XSCL2, TBIG
       INTEGER       ::  i,  j, IMINWR,  INFO1, INFO2,  &
                        LWRKEV, LWRSDD, LWRSVD, &
                        LWRSVQ, MLWORK, MWRKEV, MWRSDD, &
@@ -792,7 +792,9 @@
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of X(:,i) overflows. First, X(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||X(:,i)||_2.
@@ -866,7 +868,9 @@
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of Y(:,i) overflows. First, Y(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||Y(:,i)||_2.

--- a/SRC/sgejsv.f
+++ b/SRC/sgejsv.f
@@ -496,7 +496,7 @@
 *     .. Local Scalars ..
       REAL    AAPP,   AAQQ,   AATMAX, AATMIN, BIG,    BIG1,   COND_OK,
      $        CONDR1, CONDR2, ENTRA,  ENTRAT, EPSLN,  MAXPRJ, SCALEM,
-     $        SCONDA, SFMIN,  SMALL,  TEMP1,  USCAL1, USCAL2, XSC
+     $        SCONDA, SFMIN,  SMALL,  TEMP1,  USCAL1, USCAL2, XSC, TBIG
       INTEGER IERR,   N1,     NR,     NUMRANK,        p, q,   WARNING
       LOGICAL ALMORT, DEFR,   ERREST, GOSCAL, JRACC,  KILL,   LSVEC,
      $        L2ABER, L2KILL, L2PERT, L2RANK, L2TRAN,
@@ -628,7 +628,9 @@
             RETURN
          END IF
          AAQQ = SQRT(AAQQ)
-         IF ( ( AAPP .LT. (BIG / AAQQ) ) .AND. NOSCAL  ) THEN
+         TBIG = BIG
+         IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+         IF ( ( AAPP .LT. TBIG ) .AND. NOSCAL  ) THEN
             SVA(p)  = AAPP * AAQQ
          ELSE
             NOSCAL  = .FALSE.
@@ -701,7 +703,10 @@
          IF ( RSVEC ) THEN
              V(1,1) = ONE
          END IF
-         IF ( SVA(1) .LT. (BIG*SCALEM) ) THEN
+         TBIG = BIG
+         IF ( SCALEM .EQ. ZERO ) SCALEM = ONE
+         IF ( SCALEM .LT. ONE) TBIG = BIG*SCALEM
+         IF ( SVA(1) .LT. TBIG ) THEN
             SVA(1)  = SVA(1) / SCALEM
             SCALEM  = ONE
          END IF

--- a/SRC/sgesvdx.f
+++ b/SRC/sgesvdx.f
@@ -826,13 +826,14 @@
 *
 *     Undo scaling if necessary
 *
-      IF( ISCL.EQ.1 ) THEN
-         IF( ANRM.GT.BIGNUM )
-     $      CALL SLASCL( 'G', 0, 0, BIGNUM, ANRM, MINMN, 1,
+      IF( ISCL.EQ.1 .AND. NS.GT.0 ) THEN
+        IF( ANRM.GT.BIGNUM ) THEN
+            CALL SLASCL( 'G', 0, 0, BIGNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
-         IF( ANRM.LT.SMLNUM )
-     $      CALL SLASCL( 'G', 0, 0, SMLNUM, ANRM, MINMN, 1,
+        ELSE IF( ANRM.LT.SMLNUM ) THEN
+            CALL SLASCL( 'G', 0, 0, SMLNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
+        ENDIF
       END IF
 *
 *     Return optimal workspace in WORK(1)

--- a/SRC/sgesvj.f
+++ b/SRC/sgesvj.f
@@ -351,7 +351,7 @@
      $                   BIGTHETA, CS, CTOL, EPSLN, LARGE, MXAAPQ,
      $                   MXSINJ, ROOTBIG, ROOTEPS, ROOTSFMIN, ROOTTOL,
      $                   SKL, SFMIN, SMALL, SN, T, TEMP1, THETA,
-     $                   THSIGN, TOL
+     $                   THSIGN, TOL, TBIG
       INTEGER            BLSKIP, EMPTSW, i, ibr, IERR, igl, IJBLSK, ir1,
      $                   ISWROT, jbc, jgl, KBL, LKAHEAD, MVL, N2, N34,
      $                   N4, NBL, NOTROT, p, PSKIPPED, q, ROWSKIP,
@@ -427,8 +427,6 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $         ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( WORK( 1 ).LT.ONE ) ) THEN
-         INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13
       ELSE
@@ -457,7 +455,12 @@
 *
       IF( UCTOL ) THEN
 *        ... user controlled
-         CTOL = WORK( 1 )
+         IF( WORK( 1 ).LE.ONE )  THEN
+            INFO = -12
+            RETURN
+         ELSE
+            CTOL = WORK( 1 )
+         ENDIF
       ELSE
 *        ... default
          IF( LSVEC .OR. RSVEC .OR. APPLV ) THEN
@@ -524,7 +527,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT. TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -549,7 +554,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -574,7 +581,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -1587,7 +1596,9 @@
 *
       IF( LSVEC .OR. UCTOL ) THEN
          DO 1998 p = 1, N2
-            CALL SSCAL( M, WORK( p ) / SVA( p ), A( 1, p ), 1 )
+            TEMP1 = ONE
+            IF( SVA(p).GT.ZERO ) TEMP1 = ONE/SVA(p)
+            CALL SSCAL( M, WORK( p )*TEMP1, A( 1, p ), 1 )
  1998    CONTINUE
       END IF
 *
@@ -1607,9 +1618,14 @@
       END IF
 *
 *     Undo scaling, if necessary (and possible).
-      IF( ( ( SKL.GT.ONE ) .AND. ( SVA( 1 ).LT.( BIG / SKL ) ) )
-     $    .OR. ( ( SKL.LT.ONE ) .AND. ( SVA( MAX( N2, 1 ) ) .GT.
-     $    ( SFMIN / SKL ) ) ) ) THEN
+      NOSCALE = .FALSE.
+      IF ( SKL.GT.ONE ) THEN
+          IF( SVA( 1 ).LT.( BIG / SKL ) ) NOSCALE = .TRUE.
+      ELSE IF( SKL.LT.ONE ) THEN
+          IF ( SVA( MAX( N2, 1 ) ) .GT.
+     $      ( SFMIN / SKL ) )  NOSCALE = .TRUE.
+      ENDIF
+      IF( NOSCALE ) THEN
          DO 2400 p = 1, N
             SVA( P ) = SKL*SVA( P )
  2400    CONTINUE

--- a/SRC/zgedmd.f90
+++ b/SRC/zgedmd.f90
@@ -540,7 +540,7 @@
 !     Local scalars
 !     ~~~~~~~~~~~~~
       REAL(KIND=WP) :: OFL,   ROOTSC, SCALE,  SMALL,    &
-                       SSUM,  XSCL1,  XSCL2
+                       SSUM,  XSCL1,  XSCL2, TBIG
       INTEGER       ::  i,  j,  IMINWR,  INFO1, INFO2,  &
                         LWRKEV, LWRSDD, LWRSVD, LWRSVJ, &
                         LWRSVQ, MLWORK, MWRKEV, MWRSDD, &
@@ -771,7 +771,9 @@
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of X(:,i) overflows. First, X(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||X(:,i)||_2.
@@ -845,7 +847,9 @@
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
-               IF ( SCALE .GE. (OFL / ROOTSC) ) THEN
+               TBIG = OFL
+               IF ( ROOTSC .GT. ONE ) TBIG = OFL / ROOTSC
+               IF ( SCALE .GE. TBIG ) THEN
 !                 Norm of Y(:,i) overflows. First, Y(:,i)
 !                 is scaled by
 !                 ( ONE / ROOTSC ) / SCALE = 1/||Y(:,i)||_2.

--- a/SRC/zgejsv.f
+++ b/SRC/zgejsv.f
@@ -594,7 +594,7 @@
       DOUBLE PRECISION AAPP,    AAQQ,   AATMAX, AATMIN, BIG,    BIG1,
      $                 COND_OK, CONDR1, CONDR2, ENTRA,  ENTRAT, EPSLN,
      $                 MAXPRJ,  SCALEM, SCONDA, SFMIN,  SMALL,  TEMP1,
-     $                 USCAL1,  USCAL2, XSC
+     $                 USCAL1,  USCAL2, XSC, TBIG
       INTEGER IERR,   N1,     NR,     NUMRANK,        p, q,   WARNING
       LOGICAL ALMORT, DEFR,   ERREST, GOSCAL,  JRACC,  KILL,   LQUERY,
      $        LSVEC,  L2ABER, L2KILL, L2PERT,  L2RANK, L2TRAN, NOSCAL,
@@ -1003,7 +1003,9 @@
             RETURN
          END IF
          AAQQ = SQRT(AAQQ)
-         IF ( ( AAPP .LT. (BIG / AAQQ) ) .AND. NOSCAL  ) THEN
+         TBIG = BIG
+         IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+         IF ( ( AAPP .LT. TBIG ) .AND. NOSCAL  ) THEN
             SVA(p)  = AAPP * AAQQ
          ELSE
             NOSCAL  = .FALSE.
@@ -1077,7 +1079,10 @@
          IF ( RSVEC ) THEN
              V(1,1) = CONE
          END IF
-         IF ( SVA(1) .LT. (BIG*SCALEM) ) THEN
+         TBIG = BIG
+         IF ( SCALEM .EQ. ZERO ) SCALEM = ONE
+         IF ( SCALEM .LT. ONE) TBIG = BIG*SCALEM
+         IF ( SVA(1) .LT. TBIG ) THEN
             SVA(1)  = SVA(1) / SCALEM
             SCALEM  = ONE
          END IF

--- a/SRC/zgesvdx.f
+++ b/SRC/zgesvdx.f
@@ -844,13 +844,14 @@
 *
 *     Undo scaling if necessary
 *
-      IF( ISCL.EQ.1 ) THEN
-         IF( ANRM.GT.BIGNUM )
-     $      CALL DLASCL( 'G', 0, 0, BIGNUM, ANRM, MINMN, 1,
+      IF( ISCL.EQ.1 .AND. NS.GT.0 ) THEN
+        IF( ANRM.GT.BIGNUM ) THEN
+            CALL DLASCL( 'G', 0, 0, BIGNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
-         IF( ANRM.LT.SMLNUM )
-     $      CALL DLASCL( 'G', 0, 0, SMLNUM, ANRM, MINMN, 1,
+        ELSE IF( ANRM.LT.SMLNUM ) THEN
+            CALL DLASCL( 'G', 0, 0, SMLNUM, ANRM, NS, 1,
      $                   S, MINMN, INFO )
+        ENDIF
       END IF
 *
 *     Return optimal workspace in WORK(1)

--- a/SRC/zgesvj.f
+++ b/SRC/zgesvj.f
@@ -381,7 +381,7 @@
      $                   BIGTHETA, CS, CTOL, EPSLN, MXAAPQ,
      $                   MXSINJ, ROOTBIG, ROOTEPS, ROOTSFMIN, ROOTTOL,
      $                   SKL, SFMIN, SMALL, SN, T, TEMP1, THETA, THSIGN,
-     $                   TOL
+     $                   TOL, TBIG
       INTEGER            BLSKIP, EMPTSW, i, ibr, IERR, igl, IJBLSK, ir1,
      $                   ISWROT, jbc, jgl, KBL, LKAHEAD, MVL, N2, N34,
      $                   N4, NBL, NOTROT, p, PSKIPPED, q, ROWSKIP,
@@ -458,8 +458,6 @@
       ELSE IF( ( RSVEC .AND. ( LDV.LT.N ) ) .OR.
      $          ( APPLV .AND. ( LDV.LT.MV ) ) ) THEN
          INFO = -11
-      ELSE IF( UCTOL .AND. ( RWORK( 1 ).LT.ONE ) ) THEN
-         INFO = -12
       ELSE IF( LWORK.LT.LWMIN .AND. ( .NOT.LQUERY ) ) THEN
          INFO = -13
       ELSE IF( LRWORK.LT.LRWMIN .AND. ( .NOT.LQUERY ) ) THEN
@@ -491,7 +489,12 @@
 *
       IF( UCTOL ) THEN
 *        ... user controlled
-         CTOL = RWORK( 1 )
+         IF( RWORK( 1 ).LE.ONE )  THEN
+            INFO = -12
+            RETURN
+         ELSE
+            CTOL = RWORK( 1 )
+         ENDIF
       ELSE
 *        ... default
          IF( LSVEC .OR. RSVEC .OR. APPLV ) THEN
@@ -558,7 +561,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT. TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -583,7 +588,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -608,7 +615,9 @@
                RETURN
             END IF
             AAQQ = SQRT( AAQQ )
-            IF( ( AAPP.LT.( BIG / AAQQ ) ) .AND. NOSCALE ) THEN
+            TBIG = BIG
+            IF( AAQQ.GT.ONE ) TBIG = BIG / AAQQ
+            IF( ( AAPP.LT.TBIG ) .AND. NOSCALE ) THEN
                SVA( p ) = AAPP*AAQQ
             ELSE
                NOSCALE = .FALSE.
@@ -1422,9 +1431,10 @@
 *
       IF( LSVEC .OR. UCTOL ) THEN
          DO 1998 p = 1, N4
+            TEMP1 = ONE
+            IF( SVA(p).GT.ZERO ) TEMP1 = SVA(p)
 *            CALL ZDSCAL( M, ONE / SVA( p ), A( 1, p ), 1 )
-            CALL ZLASCL( 'G',0,0, SVA(p), ONE, M, 1, A(1,p), M,
-     $                   IERR )
+            CALL ZLASCL( 'G',0,0, TEMP1, ONE, M, 1, A(1,p), M, IERR )
  1998    CONTINUE
       END IF
 *
@@ -1438,9 +1448,14 @@
       END IF
 *
 *     Undo scaling, if necessary (and possible).
-      IF( ( ( SKL.GT.ONE ) .AND. ( SVA( 1 ).LT.( BIG / SKL ) ) )
-     $    .OR. ( ( SKL.LT.ONE ) .AND. ( SVA( MAX( N2, 1 ) ) .GT.
-     $    ( SFMIN / SKL ) ) ) ) THEN
+      NOSCALE = .FALSE.
+      IF ( SKL.GT.ONE ) THEN
+          IF( SVA( 1 ).LT.( BIG / SKL ) ) NOSCALE = .TRUE.
+      ELSE IF( SKL.LT.ONE ) THEN
+          IF ( SVA( MAX( N2, 1 ) ) .GT.
+     $      ( SFMIN / SKL ) )  NOSCALE = .TRUE.
+      ENDIF
+      IF( NOSCALE ) THEN
          DO 2400 p = 1, N
             SVA( p ) = SKL*SVA( p )
  2400    CONTINUE


### PR DESCRIPTION
The pull request contains a part of fixes for LAPACK test crashes if the test are compiled  Gfortran compiler flag  -ffpe-trap=invalid,overflow,zero. See the issue https://github.com/Reference-LAPACK/lapack/issues/1282

The following files have been changed
        modified:   SRC/cgedmd.f90
        modified:   SRC/cgejsv.f
        modified:   SRC/cgesvdx.f
        modified:   SRC/cgesvj.f
        modified:   SRC/dgedmd.f90
        modified:   SRC/dgesvdx.f
        modified:   SRC/dgesvj.f
        modified:   SRC/sgedmd.f90
        modified:   SRC/sgesvdx.f
        modified:   SRC/sgesvj.f
        modified:   SRC/zgedmd.f90
        modified:   SRC/zgesvdx.f
        modified:   SRC/zgesvj.f
        modified:   SRC/dgejsv.f
        modified:   SRC/sgejsv.f
        modified:   SRC/zgejsv.f


 The documentation update is not needed.
- [x ] If the PR solves a specific issue, it is set to be closed on merge.