### PR TITLE
bdsqr: Fix INFO return when NCVT=NRU=NCC=0

### DIFF
--- a/SRC/cbdsqr.f
+++ b/SRC/cbdsqr.f
@@ -330,9 +330,10 @@
       IF( .NOT.ROTATE ) THEN
          CALL SLASQ1( N, D, E, RWORK, INFO )
 *
-*     If INFO equals 2, dqds didn't finish, try to finish
+*     If the dqds algorithm failed, try to finish with
+*     the standard QR algorithm
 *
-         IF( INFO .NE. 2 ) RETURN
+         IF( INFO .EQ. 0 ) RETURN
          INFO = 0
       END IF
 *

--- a/SRC/dbdsqr.f
+++ b/SRC/dbdsqr.f
@@ -181,7 +181,7 @@
 *>                     iterations (in inner while loop)
 *>                = 3, termination criterion of outer while loop not met
 *>                     (program created more than N unreduced blocks)
-*>             else NCVT = NRU = NCC = 0,
+*>             else,
 *>                   the algorithm did not converge; D and E contain the
 *>                   elements of a bidiagonal matrix which is orthogonally
 *>                   similar to the input matrix B;  if INFO = i, i
@@ -338,9 +338,10 @@
       IF( .NOT.ROTATE ) THEN
          CALL DLASQ1( N, D, E, WORK, INFO )
 *
-*     If INFO equals 2, dqds didn't finish, try to finish
+*     If the dqds algorithm failed, try to finish with
+*     the standard QR algorithm
 *
-         IF( INFO .NE. 2 ) RETURN
+         IF( INFO .EQ. 0 ) RETURN
          INFO = 0
       END IF
 *

--- a/SRC/sbdsqr.f
+++ b/SRC/sbdsqr.f
@@ -181,7 +181,7 @@
 *>                     iterations (in inner while loop)
 *>                = 3, termination criterion of outer while loop not met
 *>                     (program created more than N unreduced blocks)
-*>             else NCVT = NRU = NCC = 0,
+*>             else,
 *>                   the algorithm did not converge; D and E contain the
 *>                   elements of a bidiagonal matrix which is orthogonally
 *>                   similar to the input matrix B;  if INFO = i, i
@@ -337,9 +337,10 @@
       IF( .NOT.ROTATE ) THEN
          CALL SLASQ1( N, D, E, WORK, INFO )
 *
-*     If INFO equals 2, dqds didn't finish, try to finish
+*     If the dqds algorithm failed, try to finish with
+*     the standard QR algorithm
 *
-         IF( INFO .NE. 2 ) RETURN
+         IF( INFO .EQ. 0 ) RETURN
          INFO = 0
       END IF
 *

--- a/SRC/zbdsqr.f
+++ b/SRC/zbdsqr.f
@@ -330,9 +330,10 @@
       IF( .NOT.ROTATE ) THEN
          CALL DLASQ1( N, D, E, RWORK, INFO )
 *
-*     If INFO equals 2, dqds didn't finish, try to finish
+*     If the dqds algorithm failed, try to finish with
+*     the standard QR algorithm
 *
-         IF( INFO .NE. 2 ) RETURN
+         IF( INFO .EQ. 0 ) RETURN
          INFO = 0
       END IF
 *


### PR DESCRIPTION
Problem: When NCVT = NRU = NCC = 0 (no singular vectors requested), BDSQR calls the dqds algorithm. If dqds failed with INFO = 1 or 3, the routine returned immediately with that error, even though the standard QR algorithm could still compute the singular values. Only INFO = 2 triggered the fallback.

Change `IF( INFO .NE. 2 ) RETURN` to `IF( INFO .EQ. 0 ) RETURN` after the dqds call, so the standard QR fallback runs on any dqds failure (INFO=1,2,3) and not only INFO=2.

Closes #242
