### PR TITLE
dlasd2/slasd2: Increase deflation tolerance to match dlasd7/slasd7

### DIFF
--- a/SRC/dlasd2.f
+++ b/SRC/dlasd2.f
@@ -397,7 +397,7 @@
 *
       EPS = DLAMCH( 'Epsilon' )
       TOL = MAX( ABS( ALPHA ), ABS( BETA ) )
-      TOL = EIGHT*EPS*MAX( ABS( D( N ) ), TOL )
+      TOL = EIGHT*EIGHT*EPS*MAX( ABS( D( N ) ), TOL )
 *
 *     There are 2 kinds of deflation -- first a value in the z-vector
 *     is small, second two (or more) singular values are very close

--- a/SRC/slasd2.f
+++ b/SRC/slasd2.f
@@ -397,7 +397,7 @@
 *
       EPS = SLAMCH( 'Epsilon' )
       TOL = MAX( ABS( ALPHA ), ABS( BETA ) )
-      TOL = EIGHT*EPS*MAX( ABS( D( N ) ), TOL )
+      TOL = EIGHT*EIGHT*EPS*MAX( ABS( D( N ) ), TOL )
 *
 *     There are 2 kinds of deflation -- first a value in the z-vector
 *     is small, second two (or more) singular values are very close


### PR DESCRIPTION
Fix DBDSDC/SBDSDC returning non-orthogonal U/V for bidiagonal matrices with many nearly-equal singular values (e.g., all singular values ≈ 1).

The divide-and-conquer bidiagonal SVD has two code paths:
- Full vector path (DLASD2/SLASD2): deflation tolerance = 8 * EPS
- Compact path  (DLASD7/SLASD7): deflation tolerance = 64 * EPS

With the weaker tolerance (8*EPS), singular values differing by only ~10*EPS (e.g., ~2e-15 for double precision) escape deflation.  The subsequent Z computation in DLASD3 then suffers catastrophic cancellation from denominators (σ_i - σ_j) that are tiny, polluting the singular vectors and causing loss of orthogonality.

Raise DLASD2 and SLASD2 to 64*EPS, matching DLASD7 and SLASD7, so more close singular values are deflated and the singular-vector computation remains stable.

Closes #255
