### PR TITLE
slaruv/dlaruv: fix seed advancement on rejected uniform deviate

### DIFF
--- a/SRC/dlaruv.f
+++ b/SRC/dlaruv.f
@@ -425,10 +425,10 @@
 *           the statistically correct thing to do in this situation is
 *           simply to iterate again.
 *           N.B. the case X( I ) = 0.0 should not be possible.
-            I1 = I1 + 2
-            I2 = I2 + 2
-            I3 = I3 + 2
-            I4 = I4 + 2
+            I1 = IT1
+            I2 = IT2
+            I3 = IT3
+            I4 = IT4
             GOTO 20
          END IF
 *

--- a/SRC/slaruv.f
+++ b/SRC/slaruv.f
@@ -426,10 +426,10 @@
 *           the statistically correct thing to do in this situation is
 *           simply to iterate again.
 *           N.B. the case X( I ) = 0.0 should not be possible.
-            I1 = I1 + 2
-            I2 = I2 + 2
-            I3 = I3 + 2
-            I4 = I4 + 2
+            I1 = IT1
+            I2 = IT2
+            I3 = IT3
+            I4 = IT4
             GOTO 20
          END IF
 *


### PR DESCRIPTION
When the computed random value rounds to exactly 1.0 (once every ~2^24 single-precision calls), both SLARAN and SLARUV reject it and recompute — but they advanced the seed differently:

  SLARAN:   ISEED(1:4) = IT1..IT4   (correct — carry forward the
                                       multiplier-transformed state)
  SLARUV:   I1 = I1 + 2              (wrong — ad-hoc skip in seed
                                       space)

SLARUV's +2 produces a different subsequent random sequence than SLARAN would for the same initial seed.  Fix by using the same seed advancement in both: set I1..I4 = IT1..IT4, matching SLARAN.

Applies to DLARUV as well.

Closes #1108
