### PR TITLE
gelsy: fix ILAENV workspace query routines for TZRZF/UNMRZ

### DIFF
--- a/SRC/cgelsy.f
+++ b/SRC/cgelsy.f
@@ -266,9 +266,9 @@
 *
       INFO = 0
       NB1 = ILAENV( 1, 'CGEQRF', ' ', M, N, -1, -1 )
-      NB2 = ILAENV( 1, 'CGERQF', ' ', M, N, -1, -1 )
+      NB2 = ILAENV( 1, 'CTZRZF', ' ', M, N, -1, -1 )
       NB3 = ILAENV( 1, 'CUNMQR', ' ', M, N, NRHS, -1 )
-      NB4 = ILAENV( 1, 'CUNMRQ', ' ', M, N, NRHS, -1 )
+      NB4 = ILAENV( 1, 'CUNMRZ', ' ', M, N, NRHS, -1 )
       NB = MAX( NB1, NB2, NB3, NB4 )
       LWKOPT = MAX( 1, MN+2*N+NB*(N+1), 2*MN+NB*NRHS )
       WORK( 1 ) = CMPLX( LWKOPT )

--- a/SRC/dgelsy.f
+++ b/SRC/dgelsy.f
@@ -275,9 +275,9 @@
             LWKOPT = 1
          ELSE
             NB1 = ILAENV( 1, 'DGEQRF', ' ', M, N, -1, -1 )
-            NB2 = ILAENV( 1, 'DGERQF', ' ', M, N, -1, -1 )
+            NB2 = ILAENV( 1, 'DTZRZF', ' ', M, N, -1, -1 )
             NB3 = ILAENV( 1, 'DORMQR', ' ', M, N, NRHS, -1 )
-            NB4 = ILAENV( 1, 'DORMRQ', ' ', M, N, NRHS, -1 )
+            NB4 = ILAENV( 1, 'DORMRZ', ' ', M, N, NRHS, -1 )
             NB = MAX( NB1, NB2, NB3, NB4 )
             LWKMIN = MN + MAX( 2*MN, N + 1, MN + NRHS )
             LWKOPT = MAX( LWKMIN,

--- a/SRC/sgelsy.f
+++ b/SRC/sgelsy.f
@@ -276,9 +276,9 @@
             LWKOPT = 1
          ELSE
             NB1 = ILAENV( 1, 'SGEQRF', ' ', M, N, -1, -1 )
-            NB2 = ILAENV( 1, 'SGERQF', ' ', M, N, -1, -1 )
+            NB2 = ILAENV( 1, 'STZRZF', ' ', M, N, -1, -1 )
             NB3 = ILAENV( 1, 'SORMQR', ' ', M, N, NRHS, -1 )
-            NB4 = ILAENV( 1, 'SORMRQ', ' ', M, N, NRHS, -1 )
+            NB4 = ILAENV( 1, 'SORMRZ', ' ', M, N, NRHS, -1 )
             NB = MAX( NB1, NB2, NB3, NB4 )
             LWKMIN = MN + MAX( 2*MN, N + 1, MN + NRHS )
             LWKOPT = MAX( LWKMIN,

--- a/SRC/zgelsy.f
+++ b/SRC/zgelsy.f
@@ -266,9 +266,9 @@
 *
       INFO = 0
       NB1 = ILAENV( 1, 'ZGEQRF', ' ', M, N, -1, -1 )
-      NB2 = ILAENV( 1, 'ZGERQF', ' ', M, N, -1, -1 )
+      NB2 = ILAENV( 1, 'ZTZRZF', ' ', M, N, -1, -1 )
       NB3 = ILAENV( 1, 'ZUNMQR', ' ', M, N, NRHS, -1 )
-      NB4 = ILAENV( 1, 'ZUNMRQ', ' ', M, N, NRHS, -1 )
+      NB4 = ILAENV( 1, 'ZUNMRZ', ' ', M, N, NRHS, -1 )
       NB = MAX( NB1, NB2, NB3, NB4 )
       LWKOPT = MAX( 1, MN+2*N+NB*( N+1 ), 2*MN+NB*NRHS )
       WORK( 1 ) = DCMPLX( LWKOPT )


### PR DESCRIPTION
The workspace NB queries in all four ?gelsy variants used ?GERQF and ?UNMRQ, but the routines actually called at runtime are ?TZRZF and ?UNMRZ (real) / ?UNMRZ (complex).

While ?GERQF and ?TZRZF are related (both produce an RQ-like factorization), their block sizes may differ in ILAENV's tuned values.  If the user relied on LWKOPT from the query to allocate exactly the right workspace, the actual ?TZRZF/?UNMRZ calls could underflow or overflow the work array.

Fix the ILAENV calls to match the routines actually invoked:
  ?GERQF -> ?TZRZF
  ?UNMRQ -> ?UNMRZ

Closes #676
