### PR TITLE
dorcsd2by1/uncsd2by1: avoid OOB access with zero rows

### DIFF
--- a/SRC/cuncsd2by1.f
+++ b/SRC/cuncsd2by1.f
@@ -294,6 +294,7 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CBBCSD, CCOPY, CLACPY, CLAPMR, CLAPMT,
+     $                   CLASET,
      $                   CUNBDB1,
      $                   CUNBDB2, CUNBDB3, CUNBDB4, CUNGLQ, CUNGQR,
      $                   XERBLA
@@ -533,6 +534,36 @@
       END IF
       LORGQR = LWORK-IORGQR+1
       LORGLQ = LWORK-IORGLQ+1
+*
+      IF( R .EQ. 0 ) THEN
+*
+*        R = 0: C and S are empty. Handle the trivial CSD directly.
+*
+         IF( Q .EQ. 0 ) THEN
+            IF( WANTU1 .AND. P .GT. 0 )
+     $         CALL CLASET( 'A', P, P, ZERO, ONE, U1, LDU1 )
+            IF( WANTU2 .AND. M-P .GT. 0 )
+     $         CALL CLASET( 'A', M-P, M-P, ZERO, ONE, U2, LDU2 )
+            RETURN
+         END IF
+*
+         IF( P .EQ. 0 .AND. M .EQ. Q ) THEN
+            IF( WANTU2 )
+     $         CALL CLACPY( 'A', M-P, Q, X21, LDX21, U2, LDU2 )
+            IF( WANTV1T )
+     $         CALL CLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+         IF( P .EQ. M .AND. M .EQ. Q ) THEN
+            IF( WANTU1 )
+     $         CALL CLACPY( 'A', P, Q, X11, LDX11, U1, LDU1 )
+            IF( WANTV1T )
+     $         CALL CLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+      END IF
 *
 *     Handle four cases separately: R = Q, R = P, R = M-P, and R = M-Q,
 *     in which R = MIN(P,M-P,Q,M-Q)

--- a/SRC/dorcsd2by1.f
+++ b/SRC/dorcsd2by1.f
@@ -267,6 +267,7 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DBBCSD, DCOPY, DLACPY, DLAPMR, DLAPMT,
+     $                   DLASET,
      $                   DORBDB1,
      $                   DORBDB2, DORBDB3, DORBDB4, DORGLQ, DORGQR,
      $                   XERBLA
@@ -488,6 +489,36 @@
       END IF
       LORGQR = LWORK-IORGQR+1
       LORGLQ = LWORK-IORGLQ+1
+*
+      IF( R .EQ. 0 ) THEN
+*
+*        R = 0: C and S are empty. Handle the trivial CSD directly.
+*
+         IF( Q .EQ. 0 ) THEN
+            IF( WANTU1 .AND. P .GT. 0 )
+     $         CALL DLASET( 'A', P, P, ZERO, ONE, U1, LDU1 )
+            IF( WANTU2 .AND. M-P .GT. 0 )
+     $         CALL DLASET( 'A', M-P, M-P, ZERO, ONE, U2, LDU2 )
+            RETURN
+         END IF
+*
+         IF( P .EQ. 0 .AND. M .EQ. Q ) THEN
+            IF( WANTU2 )
+     $         CALL DLACPY( 'A', M-P, Q, X21, LDX21, U2, LDU2 )
+            IF( WANTV1T )
+     $         CALL DLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+         IF( P .EQ. M .AND. M .EQ. Q ) THEN
+            IF( WANTU1 )
+     $         CALL DLACPY( 'A', P, Q, X11, LDX11, U1, LDU1 )
+            IF( WANTV1T )
+     $         CALL DLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+      END IF
 *
 *     Handle four cases separately: R = Q, R = P, R = M-P, and R = M-Q,
 *     in which R = MIN(P,M-P,Q,M-Q)

--- a/SRC/sorcsd2by1.f
+++ b/SRC/sorcsd2by1.f
@@ -267,6 +267,7 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SBBCSD, SCOPY, SLACPY, SLAPMR, SLAPMT,
+     $                   SLASET,
      $                   SORBDB1,
      $                   SORBDB2, SORBDB3, SORBDB4, SORGLQ, SORGQR,
      $                   XERBLA
@@ -488,6 +489,36 @@
       END IF
       LORGQR = LWORK-IORGQR+1
       LORGLQ = LWORK-IORGLQ+1
+*
+      IF( R .EQ. 0 ) THEN
+*
+*        R = 0: C and S are empty. Handle the trivial CSD directly.
+*
+         IF( Q .EQ. 0 ) THEN
+            IF( WANTU1 .AND. P .GT. 0 )
+     $         CALL SLASET( 'A', P, P, ZERO, ONE, U1, LDU1 )
+            IF( WANTU2 .AND. M-P .GT. 0 )
+     $         CALL SLASET( 'A', M-P, M-P, ZERO, ONE, U2, LDU2 )
+            RETURN
+         END IF
+*
+         IF( P .EQ. 0 .AND. M .EQ. Q ) THEN
+            IF( WANTU2 )
+     $         CALL SLACPY( 'A', M-P, Q, X21, LDX21, U2, LDU2 )
+            IF( WANTV1T )
+     $         CALL SLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+         IF( P .EQ. M .AND. M .EQ. Q ) THEN
+            IF( WANTU1 )
+     $         CALL SLACPY( 'A', P, Q, X11, LDX11, U1, LDU1 )
+            IF( WANTV1T )
+     $         CALL SLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+      END IF
 *
 *     Handle four cases separately: R = Q, R = P, R = M-P, and R = M-Q,
 *     in which R = MIN(P,M-P,Q,M-Q)

--- a/SRC/zuncsd2by1.f
+++ b/SRC/zuncsd2by1.f
@@ -293,6 +293,7 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           ZBBCSD, ZCOPY, ZLACPY, ZLAPMR, ZLAPMT,
+     $                   ZLASET,
      $                   ZUNBDB1,
      $                   ZUNBDB2, ZUNBDB3, ZUNBDB4, ZUNGLQ, ZUNGQR,
      $                   XERBLA
@@ -531,6 +532,36 @@
       END IF
       LORGQR = LWORK-IORGQR+1
       LORGLQ = LWORK-IORGLQ+1
+*
+      IF( R .EQ. 0 ) THEN
+*
+*        R = 0: C and S are empty. Handle the trivial CSD directly.
+*
+         IF( Q .EQ. 0 ) THEN
+            IF( WANTU1 .AND. P .GT. 0 )
+     $         CALL ZLASET( 'A', P, P, ZERO, ONE, U1, LDU1 )
+            IF( WANTU2 .AND. M-P .GT. 0 )
+     $         CALL ZLASET( 'A', M-P, M-P, ZERO, ONE, U2, LDU2 )
+            RETURN
+         END IF
+*
+         IF( P .EQ. 0 .AND. M .EQ. Q ) THEN
+            IF( WANTU2 )
+     $         CALL ZLACPY( 'A', M-P, Q, X21, LDX21, U2, LDU2 )
+            IF( WANTV1T )
+     $         CALL ZLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+         IF( P .EQ. M .AND. M .EQ. Q ) THEN
+            IF( WANTU1 )
+     $         CALL ZLACPY( 'A', P, Q, X11, LDX11, U1, LDU1 )
+            IF( WANTV1T )
+     $         CALL ZLASET( 'A', Q, Q, ZERO, ONE, V1T, LDV1T )
+            RETURN
+         END IF
+*
+      END IF
 *
 *     Handle four cases separately: R = Q, R = P, R = M-P, and R = M-Q,
 *     in which R = MIN(P,M-P,Q,M-Q)


### PR DESCRIPTION
When P=0 and M=Q (U2 is M-by-M, X21 is M-by-M and orthogonal), or P=M and M=Q (U1 is M-by-M, X11 is M-by-M and orthogonal), or Q=0, the minimal dimension R = MIN(P, M-P, Q, M-Q) is zero, so C and S are empty.  In these degenerate cases the preceding code entered the R == P or R == M-P branch and called the bidiagonalization subroutines (SORBDB2/SORBDB3) which then accessed elements X21(I,I+1) or X11(I,I+1) out of bounds in the second DO loop (I = P+1, Q or I = M-P+1, Q).

Fix: handle R = 0 directly in the four driver routines before the case-dependent bidiagonalization path.  The three trivial CSD cases are:

  Q = 0:     set U1 = I, U2 = I, return.
  P = 0, M = Q:  copy X21 to U2, set V1T = I, return.
  P = M, M = Q:  copy X11 to U1, set V1T = I, return.

All other R=0 configurations are non-standard and still fall through to the existing path (which may fail).

Fixes #549
