### PR TITLE
ormqr/ormlq/ormrq/ormql, unmqr/unmlq/unmrq/unmql: fix minimum workspa…

### DIFF
--- a/SRC/cunmlq.f
+++ b/SRC/cunmlq.f
@@ -246,7 +246,7 @@
         NB = MIN( NBMAX, ILAENV( 1, 'CUNMLQ', SIDE // TRANS, M, N,
      $             K,
      $        -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
 *
@@ -270,7 +270,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'CUNMLQ', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/cunmql.f
+++ b/SRC/cunmql.f
@@ -248,7 +248,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'CUNMQL', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
@@ -272,7 +272,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'CUNMQL', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/cunmqr.f
+++ b/SRC/cunmqr.f
@@ -245,7 +245,7 @@
          NB = MIN( NBMAX, ILAENV( 1, 'CUNMQR', SIDE // TRANS, M, N,
      $             K,
      $        -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
 *
@@ -267,7 +267,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'CUNMQR', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/cunmrq.f
+++ b/SRC/cunmrq.f
@@ -249,7 +249,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'CUNMRQ', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
@@ -271,7 +271,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'CUNMRQ', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/dormlq.f
+++ b/SRC/dormlq.f
@@ -243,7 +243,7 @@
          NB = MIN( NBMAX, ILAENV( 1, 'DORMLQ', SIDE // TRANS, M, N,
      $             K,
      $        -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = LWKOPT
       END IF
 *
@@ -265,7 +265,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'DORMLQ', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/dormql.f
+++ b/SRC/dormql.f
@@ -245,7 +245,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'DORMQL', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = LWKOPT
       END IF
@@ -267,7 +267,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'DORMQL', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/dormqr.f
+++ b/SRC/dormqr.f
@@ -242,7 +242,7 @@
          NB = MIN( NBMAX, ILAENV( 1, 'DORMQR', SIDE // TRANS, M, N,
      $             K,
      $        -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = LWKOPT
       END IF
 *
@@ -264,7 +264,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'DORMQR', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/dormrq.f
+++ b/SRC/dormrq.f
@@ -246,7 +246,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'DORMRQ', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = LWKOPT
       END IF
@@ -268,7 +268,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'DORMRQ', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/sormlq.f
+++ b/SRC/sormlq.f
@@ -246,7 +246,7 @@
          NB = MIN( NBMAX, ILAENV( 1, 'SORMLQ', SIDE // TRANS, M, N,
      $             K,
      $             -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
 *
@@ -268,7 +268,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'SORMLQ', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/sormql.f
+++ b/SRC/sormql.f
@@ -248,7 +248,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'SORMQL', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
@@ -270,7 +270,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'SORMQL', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/sormqr.f
+++ b/SRC/sormqr.f
@@ -245,7 +245,7 @@
          NB = MIN( NBMAX, ILAENV( 1, 'SORMQR', SIDE // TRANS, M, N,
      $             K,
      $        -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
 *
@@ -267,7 +267,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'SORMQR', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/sormrq.f
+++ b/SRC/sormrq.f
@@ -249,7 +249,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'SORMRQ', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
       END IF
@@ -271,7 +271,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'SORMRQ', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/zunmlq.f
+++ b/SRC/zunmlq.f
@@ -243,7 +243,7 @@
          NB = MIN( NBMAX, ILAENV( 1, 'ZUNMLQ', SIDE // TRANS, M, N,
      $             K,
      $        -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = LWKOPT
       END IF
 *
@@ -265,7 +265,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'ZUNMLQ', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/zunmql.f
+++ b/SRC/zunmql.f
@@ -245,7 +245,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'ZUNMQL', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = LWKOPT
       END IF
@@ -267,7 +267,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'ZUNMQL', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/zunmqr.f
+++ b/SRC/zunmqr.f
@@ -242,7 +242,7 @@
          NB = MIN( NBMAX, ILAENV( 1, 'ZUNMQR', SIDE // TRANS, M, N,
      $             K,
      $        -1 ) )
-         LWKOPT = NW*NB + TSIZE
+          LWKOPT = NW*NB + LDT*NB
          WORK( 1 ) = LWKOPT
       END IF
 *
@@ -264,7 +264,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'ZUNMQR', SIDE // TRANS, M, N,
      $                   K,
      $              -1 ) )

--- a/SRC/zunmrq.f
+++ b/SRC/zunmrq.f
@@ -246,7 +246,7 @@
             NB = MIN( NBMAX, ILAENV( 1, 'ZUNMRQ', SIDE // TRANS, M,
      $                N,
      $                               K, -1 ) )
-            LWKOPT = NW*NB + TSIZE
+             LWKOPT = NW*NB + LDT*NB
          END IF
          WORK( 1 ) = LWKOPT
       END IF
@@ -268,7 +268,7 @@
       LDWORK = NW
       IF( NB.GT.1 .AND. NB.LT.K ) THEN
          IF( LWORK.LT.LWKOPT ) THEN
-            NB = (LWORK-TSIZE) / LDWORK
+             NB = LWORK / (LDWORK + LDT)
             NBMIN = MAX( 2, ILAENV( 2, 'ZUNMRQ', SIDE // TRANS, M, N,
      $                   K,
      $                              -1 ) )


### PR DESCRIPTION
…ce for tiny M,N,K

The workspace query formula LWKOPT = NW*NB + TSIZE used TSIZE = LDT*NBMAX = 65*64 = 4160, a hardcoded constant.  The blocked algorithm only stores one T matrix block at a time (reused across loop iterations), so the per-iteration workspace is LDT*NB, not LDT*NBMAX.  For tiny M,N,K where a single block suffices (NB >= N or NB >= K), LWKOPT was always >= 4160 regardless of problem size.

Fix: change LWKOPT = NW*NB + TSIZE  ->  LWKOPT = NW*NB + LDT*NB.

The NB adjustment formula when LWORK is limited must consistently use the per-iteration T storage instead of TSIZE:

  NB = (LWORK - TSIZE) / LDWORK  ->  NB = LWORK / (LDWORK + LDT)

Applied to all 16 routines (s,d,c,z x {orm,unm}{qr,rq,lq,ql}).

Closes #546
