### PR TITLE
Fix integer overflow in LAPACKE nancheck helpers for large matrices

### DIFF
--- a/LAPACKE/utils/lapacke_c_nancheck.c
+++ b/LAPACKE/utils/lapacke_c_nancheck.c
@@ -42,8 +42,8 @@ lapack_logical API_SUFFIX(LAPACKE_c_nancheck)( lapack_int n,
     if( incx == 0 ) return (lapack_logical) LAPACK_CISNAN( x[0] );
     inc = ( incx > 0 ) ? incx : -incx ;
 
-    for( i = 0; i < n*inc; i+=inc ) {
-        if( LAPACK_CISNAN( x[i] ) )
+    for( i = 0; i < n; i++ ) {
+        if( LAPACK_CISNAN( x[(size_t)i*inc] ) )
             return (lapack_logical) 1;
     }
     return (lapack_logical) 0;

--- a/LAPACKE/utils/lapacke_chp_nancheck.c
+++ b/LAPACKE/utils/lapacke_chp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_chp_nancheck)( lapack_int n,
                                       const lapack_complex_float *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_c_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_cpf_nancheck.c
+++ b/LAPACKE/utils/lapacke_cpf_nancheck.c
@@ -40,6 +40,6 @@
 lapack_logical API_SUFFIX(LAPACKE_cpf_nancheck)( lapack_int n,
                                       const lapack_complex_float *a )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_c_nancheck)( len, a, 1 );
 }

--- a/LAPACKE/utils/lapacke_cpp_nancheck.c
+++ b/LAPACKE/utils/lapacke_cpp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_cpp_nancheck)( lapack_int n,
                                       const lapack_complex_float *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_c_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_csp_nancheck.c
+++ b/LAPACKE/utils/lapacke_csp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_csp_nancheck)( lapack_int n,
                                       const lapack_complex_float *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_c_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_ctf_nancheck.c
+++ b/LAPACKE/utils/lapacke_ctf_nancheck.c
@@ -150,7 +150,7 @@ lapack_logical API_SUFFIX(LAPACKE_ctf_nancheck)( int matrix_layout, char transr,
         }
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_cge_nancheck)( LAPACK_COL_MAJOR, len, 1, a, len );
     }
 }

--- a/LAPACKE/utils/lapacke_ctp_nancheck.c
+++ b/LAPACKE/utils/lapacke_ctp_nancheck.c
@@ -76,7 +76,7 @@ lapack_logical API_SUFFIX(LAPACKE_ctp_nancheck)( int matrix_layout, char uplo, c
         return (lapack_logical) 0;
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_c_nancheck)( len, ap, 1 );
     }
 }

--- a/LAPACKE/utils/lapacke_ctr_nancheck.c
+++ b/LAPACKE/utils/lapacke_ctr_nancheck.c
@@ -68,14 +68,14 @@ lapack_logical API_SUFFIX(LAPACKE_ctr_nancheck)( int matrix_layout, char uplo, c
     if( ( colmaj || lower ) && !( colmaj && lower ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < MIN( j+1-st, lda ); i++ ) {
-                if( LAPACK_CISNAN( a[i+j*lda] ) )
+                if( LAPACK_CISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }
     } else {
         for( j = 0; j < n-st; j++ ) {
             for( i = j+st; i < MIN( n, lda ); i++ ) {
-                if( LAPACK_CISNAN( a[i+j*lda] ) )
+                if( LAPACK_CISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }

--- a/LAPACKE/utils/lapacke_ctz_nancheck.c
+++ b/LAPACKE/utils/lapacke_ctz_nancheck.c
@@ -103,27 +103,27 @@ lapack_logical API_SUFFIX(LAPACKE_ctz_nancheck)( int matrix_layout, char direct,
     }
 
     /* Initial offsets and sizes of triangular and rectangular parts */
-    lapack_int tri_offset = 0;
+    int64_t tri_offset = 0;
     lapack_int tri_n = MIN(m,n);
-    lapack_int rect_offset = -1;
+    int64_t rect_offset = -1;
     lapack_int rect_m = ( m > n ) ? m - n : m;
     lapack_int rect_n = ( n > m ) ? n - m : n;
 
     /* Fix offsets depending on the shape of the matrix */
     if( front ) {
         if( lower && m > n ) {
-            rect_offset = tri_n * ( !colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( !colmaj ? lda : 1 );
         } else if( !lower && n > m ) {
-            rect_offset = tri_n * ( colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( colmaj ? lda : 1 );
         }
     } else {
         if( m > n ) {
-            tri_offset = rect_m * ( !colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_m * ( !colmaj ? lda : 1 );
             if( !lower ) {
                 rect_offset = 0;
             }
         } else if( n > m ) {
-            tri_offset = rect_n * ( colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_n * ( colmaj ? lda : 1 );
             if( lower ) {
                 rect_offset = 0;
             }

--- a/LAPACKE/utils/lapacke_d_nancheck.c
+++ b/LAPACKE/utils/lapacke_d_nancheck.c
@@ -42,8 +42,8 @@ lapack_logical API_SUFFIX(LAPACKE_d_nancheck)( lapack_int n,
     if( incx == 0 ) return (lapack_logical) LAPACK_DISNAN( x[0] );
     inc = ( incx > 0 ) ? incx : -incx ;
 
-    for( i = 0; i < n*inc; i+=inc ) {
-        if( LAPACK_DISNAN( x[i] ) )
+    for( i = 0; i < n; i++ ) {
+        if( LAPACK_DISNAN( x[(size_t)i*inc] ) )
             return (lapack_logical) 1;
     }
     return (lapack_logical) 0;

--- a/LAPACKE/utils/lapacke_dpf_nancheck.c
+++ b/LAPACKE/utils/lapacke_dpf_nancheck.c
@@ -40,6 +40,6 @@
 lapack_logical API_SUFFIX(LAPACKE_dpf_nancheck)( lapack_int n,
                                       const double *a )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_d_nancheck)( len, a, 1 );
 }

--- a/LAPACKE/utils/lapacke_dpp_nancheck.c
+++ b/LAPACKE/utils/lapacke_dpp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_dpp_nancheck)( lapack_int n,
                                       const double *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_d_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_dsp_nancheck.c
+++ b/LAPACKE/utils/lapacke_dsp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_dsp_nancheck)( lapack_int n,
                                       const double *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_d_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_dtf_nancheck.c
+++ b/LAPACKE/utils/lapacke_dtf_nancheck.c
@@ -150,7 +150,7 @@ lapack_logical API_SUFFIX(LAPACKE_dtf_nancheck)( int matrix_layout, char transr,
         }
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_dge_nancheck)( LAPACK_COL_MAJOR, len, 1, a, len );
     }
 }

--- a/LAPACKE/utils/lapacke_dtp_nancheck.c
+++ b/LAPACKE/utils/lapacke_dtp_nancheck.c
@@ -76,7 +76,7 @@ lapack_logical API_SUFFIX(LAPACKE_dtp_nancheck)( int matrix_layout, char uplo, c
         return (lapack_logical) 0;
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_d_nancheck)( len, ap, 1 );
     }
 }

--- a/LAPACKE/utils/lapacke_dtr_nancheck.c
+++ b/LAPACKE/utils/lapacke_dtr_nancheck.c
@@ -68,14 +68,14 @@ lapack_logical API_SUFFIX(LAPACKE_dtr_nancheck)( int matrix_layout, char uplo, c
     if( ( colmaj || lower ) && !( colmaj && lower ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < MIN( j+1-st, lda ); i++ ) {
-                if( LAPACK_DISNAN( a[i+j*lda] ) )
+                if( LAPACK_DISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }
     } else {
         for( j = 0; j < n-st; j++ ) {
             for( i = j+st; i < MIN( n, lda ); i++ ) {
-                if( LAPACK_DISNAN( a[i+j*lda] ) )
+                if( LAPACK_DISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }

--- a/LAPACKE/utils/lapacke_dtz_nancheck.c
+++ b/LAPACKE/utils/lapacke_dtz_nancheck.c
@@ -102,27 +102,27 @@ lapack_logical API_SUFFIX(LAPACKE_dtz_nancheck)( int matrix_layout, char direct,
     }
 
     /* Initial offsets and sizes of triangular and rectangular parts */
-    lapack_int tri_offset = 0;
+    int64_t tri_offset = 0;
     lapack_int tri_n = MIN(m,n);
-    lapack_int rect_offset = -1;
+    int64_t rect_offset = -1;
     lapack_int rect_m = ( m > n ) ? m - n : m;
     lapack_int rect_n = ( n > m ) ? n - m : n;
 
     /* Fix offsets depending on the shape of the matrix */
     if( front ) {
         if( lower && m > n ) {
-            rect_offset = tri_n * ( !colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( !colmaj ? lda : 1 );
         } else if( !lower && n > m ) {
-            rect_offset = tri_n * ( colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( colmaj ? lda : 1 );
         }
     } else {
         if( m > n ) {
-            tri_offset = rect_m * ( !colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_m * ( !colmaj ? lda : 1 );
             if( !lower ) {
                 rect_offset = 0;
             }
         } else if( n > m ) {
-            tri_offset = rect_n * ( colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_n * ( colmaj ? lda : 1 );
             if( lower ) {
                 rect_offset = 0;
             }

--- a/LAPACKE/utils/lapacke_s_nancheck.c
+++ b/LAPACKE/utils/lapacke_s_nancheck.c
@@ -42,8 +42,8 @@ lapack_logical API_SUFFIX(LAPACKE_s_nancheck)( lapack_int n,
     if( incx == 0 ) return (lapack_logical) LAPACK_SISNAN( x[0] );
     inc = ( incx > 0 ) ? incx : -incx ;
 
-    for( i = 0; i < n*inc; i+=inc ) {
-        if( LAPACK_SISNAN( x[i] ) )
+    for( i = 0; i < n; i++ ) {
+        if( LAPACK_SISNAN( x[(size_t)i*inc] ) )
             return (lapack_logical) 1;
     }
     return (lapack_logical) 0;

--- a/LAPACKE/utils/lapacke_spf_nancheck.c
+++ b/LAPACKE/utils/lapacke_spf_nancheck.c
@@ -40,6 +40,6 @@
 lapack_logical API_SUFFIX(LAPACKE_spf_nancheck)( lapack_int n,
                                       const float *a )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_s_nancheck)( len, a, 1 );
 }

--- a/LAPACKE/utils/lapacke_spp_nancheck.c
+++ b/LAPACKE/utils/lapacke_spp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_spp_nancheck)( lapack_int n,
                                       const float *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_s_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_ssp_nancheck.c
+++ b/LAPACKE/utils/lapacke_ssp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_ssp_nancheck)( lapack_int n,
                                       const float *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_s_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_stf_nancheck.c
+++ b/LAPACKE/utils/lapacke_stf_nancheck.c
@@ -151,7 +151,7 @@ lapack_logical API_SUFFIX(LAPACKE_stf_nancheck)( int matrix_layout, char transr,
         }
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_sge_nancheck)( LAPACK_COL_MAJOR, len, 1, a, len );
     }
 }

--- a/LAPACKE/utils/lapacke_stp_nancheck.c
+++ b/LAPACKE/utils/lapacke_stp_nancheck.c
@@ -76,7 +76,7 @@ lapack_logical API_SUFFIX(LAPACKE_stp_nancheck)( int matrix_layout, char uplo, c
         return (lapack_logical) 0;
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_s_nancheck)( len, ap, 1 );
     }
 }

--- a/LAPACKE/utils/lapacke_str_nancheck.c
+++ b/LAPACKE/utils/lapacke_str_nancheck.c
@@ -68,14 +68,14 @@ lapack_logical API_SUFFIX(LAPACKE_str_nancheck)( int matrix_layout, char uplo, c
     if( ( colmaj || lower ) && !( colmaj && lower ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < MIN( j+1-st, lda ); i++ ) {
-                if( LAPACK_SISNAN( a[i+j*lda] ) )
+                if( LAPACK_SISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }
     } else {
         for( j = 0; j < n-st; j++ ) {
             for( i = j+st; i < MIN( n, lda ); i++ ) {
-                if( LAPACK_SISNAN( a[i+j*lda] ) )
+                if( LAPACK_SISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }

--- a/LAPACKE/utils/lapacke_stz_nancheck.c
+++ b/LAPACKE/utils/lapacke_stz_nancheck.c
@@ -102,27 +102,27 @@ lapack_logical API_SUFFIX(LAPACKE_stz_nancheck)( int matrix_layout, char direct,
     }
 
     /* Initial offsets and sizes of triangular and rectangular parts */
-    lapack_int tri_offset = 0;
+    int64_t tri_offset = 0;
     lapack_int tri_n = MIN(m,n);
-    lapack_int rect_offset = -1;
+    int64_t rect_offset = -1;
     lapack_int rect_m = ( m > n ) ? m - n : m;
     lapack_int rect_n = ( n > m ) ? n - m : n;
 
     /* Fix offsets depending on the shape of the matrix */
     if( front ) {
         if( lower && m > n ) {
-            rect_offset = tri_n * ( !colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( !colmaj ? lda : 1 );
         } else if( !lower && n > m ) {
-            rect_offset = tri_n * ( colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( colmaj ? lda : 1 );
         }
     } else {
         if( m > n ) {
-            tri_offset = rect_m * ( !colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_m * ( !colmaj ? lda : 1 );
             if( !lower ) {
                 rect_offset = 0;
             }
         } else if( n > m ) {
-            tri_offset = rect_n * ( colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_n * ( colmaj ? lda : 1 );
             if( lower ) {
                 rect_offset = 0;
             }

--- a/LAPACKE/utils/lapacke_z_nancheck.c
+++ b/LAPACKE/utils/lapacke_z_nancheck.c
@@ -42,8 +42,8 @@ lapack_logical API_SUFFIX(LAPACKE_z_nancheck)( lapack_int n,
     if( incx == 0 ) return (lapack_logical) LAPACK_ZISNAN( x[0] );
     inc = ( incx > 0 ) ? incx : -incx ;
 
-    for( i = 0; i < n*inc; i+=inc ) {
-        if( LAPACK_ZISNAN( x[i] ) )
+    for( i = 0; i < n; i++ ) {
+        if( LAPACK_ZISNAN( x[(size_t)i*inc] ) )
             return (lapack_logical) 1;
     }
     return (lapack_logical) 0;

--- a/LAPACKE/utils/lapacke_zhp_nancheck.c
+++ b/LAPACKE/utils/lapacke_zhp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_zhp_nancheck)( lapack_int n,
                                       const lapack_complex_double *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_z_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_zpf_nancheck.c
+++ b/LAPACKE/utils/lapacke_zpf_nancheck.c
@@ -40,6 +40,6 @@
 lapack_logical API_SUFFIX(LAPACKE_zpf_nancheck)( lapack_int n,
                                       const lapack_complex_double *a )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_z_nancheck)( len, a, 1 );
 }

--- a/LAPACKE/utils/lapacke_zpp_nancheck.c
+++ b/LAPACKE/utils/lapacke_zpp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_zpp_nancheck)( lapack_int n,
                                       const lapack_complex_double *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_z_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_zsp_nancheck.c
+++ b/LAPACKE/utils/lapacke_zsp_nancheck.c
@@ -39,6 +39,6 @@
 lapack_logical API_SUFFIX(LAPACKE_zsp_nancheck)( lapack_int n,
                                       const lapack_complex_double *ap )
 {
-    lapack_int len = n*(n+1)/2;
+    lapack_int len = (lapack_int)(((size_t)n*(n+1))/2);
     return API_SUFFIX(LAPACKE_z_nancheck)( len, ap, 1 );
 }

--- a/LAPACKE/utils/lapacke_ztf_nancheck.c
+++ b/LAPACKE/utils/lapacke_ztf_nancheck.c
@@ -151,7 +151,7 @@ lapack_logical API_SUFFIX(LAPACKE_ztf_nancheck)( int matrix_layout, char transr,
         }
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_zge_nancheck)( LAPACK_COL_MAJOR, len, 1, a, len );
     }
 }

--- a/LAPACKE/utils/lapacke_ztp_nancheck.c
+++ b/LAPACKE/utils/lapacke_ztp_nancheck.c
@@ -76,7 +76,7 @@ lapack_logical API_SUFFIX(LAPACKE_ztp_nancheck)( int matrix_layout, char uplo, c
         return (lapack_logical) 0;
     } else {
         /* Non-unit case - just check whole array for NaNs. */
-        len = n*(n+1)/2;
+        len = (lapack_int)(((size_t)n*(n+1))/2);
         return API_SUFFIX(LAPACKE_z_nancheck)( len, ap, 1 );
     }
 }

--- a/LAPACKE/utils/lapacke_ztr_nancheck.c
+++ b/LAPACKE/utils/lapacke_ztr_nancheck.c
@@ -68,14 +68,14 @@ lapack_logical API_SUFFIX(LAPACKE_ztr_nancheck)( int matrix_layout, char uplo, c
     if( ( colmaj || lower ) && !( colmaj && lower ) ) {
         for( j = st; j < n; j++ ) {
             for( i = 0; i < MIN( j+1-st, lda ); i++ ) {
-                if( LAPACK_ZISNAN( a[i+j*lda] ) )
+                if( LAPACK_ZISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }
     } else {
         for( j = 0; j < n-st; j++ ) {
             for( i = j+st; i < MIN( n, lda ); i++ ) {
-                if( LAPACK_ZISNAN( a[i+j*lda] ) )
+                if( LAPACK_ZISNAN( a[i+(size_t)j*lda] ) )
                     return (lapack_logical) 1;
             }
         }

--- a/LAPACKE/utils/lapacke_ztz_nancheck.c
+++ b/LAPACKE/utils/lapacke_ztz_nancheck.c
@@ -103,27 +103,27 @@ lapack_logical API_SUFFIX(LAPACKE_ztz_nancheck)( int matrix_layout, char direct,
     }
 
     /* Initial offsets and sizes of triangular and rectangular parts */
-    lapack_int tri_offset = 0;
+    int64_t tri_offset = 0;
     lapack_int tri_n = MIN(m,n);
-    lapack_int rect_offset = -1;
+    int64_t rect_offset = -1;
     lapack_int rect_m = ( m > n ) ? m - n : m;
     lapack_int rect_n = ( n > m ) ? n - m : n;
 
     /* Fix offsets depending on the shape of the matrix */
     if( front ) {
         if( lower && m > n ) {
-            rect_offset = tri_n * ( !colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( !colmaj ? lda : 1 );
         } else if( !lower && n > m ) {
-            rect_offset = tri_n * ( colmaj ? lda : 1 );
+            rect_offset = (int64_t)tri_n * ( colmaj ? lda : 1 );
         }
     } else {
         if( m > n ) {
-            tri_offset = rect_m * ( !colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_m * ( !colmaj ? lda : 1 );
             if( !lower ) {
                 rect_offset = 0;
             }
         } else if( n > m ) {
-            tri_offset = rect_n * ( colmaj ? lda : 1 );
+            tri_offset = (int64_t)rect_n * ( colmaj ? lda : 1 );
             if( lower ) {
                 rect_offset = 0;
             }


### PR DESCRIPTION
Hit this while running Cholesky on a 47000x47000 matrix through OpenBLAS: `LAPACKE_dpotrf` segfaults in `LAPACKE_dtr_nancheck` before the factorization even starts, because `j*lda` overflows 32-bit `lapack_int` once `n = lda >= 46341`.

The `ge`/`gb`/`tp`/`tf` helpers already cast to `size_t`, but a few others were missed:

- `?tr_nancheck`: `a[i+j*lda]` (this is the potrf path, also used by the po/sy/he checks)
- `?_nancheck`: the `n*inc` loop bound overflows when called with a large stride (e.g. from the hs/tf checks)
- `?sp`/`?pp`/`?pf`/`?hp`/`?tp`/`?tf`: `len = n*(n+1)/2` overflows, the check then silently passes NaNs through
- `?tz_nancheck`: the part offsets overflow, widened to `int64_t` to keep the -1 sentinel

This bug also affects OpenBLAS (it vendors these files) - identical fix in OpenMathLib/OpenBLAS#5835.

Tested with UBSan at n = 47000: the old code reports signed integer overflow and either segfaults (tr, tz) or misses a planted NaN (vector, packed); the fixed code finds the NaN in all cases. Old and new give identical results on a sweep of small sizes covering all layouts/uplo/diag/shapes with a NaN at every position.