### PR TITLE
*drgev: relax eigenvalue consistency test

### DIFF
--- a/TESTING/EIG/cdrgev.f
+++ b/TESTING/EIG/cdrgev.f
@@ -780,8 +780,14 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 5 ) = ULPINV
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do test (6): Compute eigenvalues and left eigenvectors,
@@ -800,8 +806,14 @@
             END IF
 *
             DO 130 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 6 ) = ULPINV
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -827,8 +839,14 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 7 ) = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N

--- a/TESTING/EIG/cdrgev3.f
+++ b/TESTING/EIG/cdrgev3.f
@@ -788,8 +788,14 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $              BETA1( J ) ) RESULT( 5 ) = ULPINV
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do the test (6): Compute eigenvalues and left eigenvectors,
@@ -809,10 +815,14 @@
 
 *
             DO 130 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR.
-     $              BETA( J ).NE.BETA1( J ) ) THEN
-                  RESULT( 6 ) = ULPINV
-               ENDIF
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -839,8 +849,14 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 7 ) = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N

--- a/TESTING/EIG/ddrgev.f
+++ b/TESTING/EIG/ddrgev.f
@@ -778,9 +778,18 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 5 )
-     $              = ULPINV
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do the test (6): Compute eigenvalues and left eigenvectors,
@@ -799,9 +808,18 @@
             END IF
 *
             DO 130 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 6 )
-     $              = ULPINV
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -827,9 +845,18 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 7 )
-     $              = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N

--- a/TESTING/EIG/ddrgev3.f
+++ b/TESTING/EIG/ddrgev3.f
@@ -813,9 +813,18 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 5 )
-     $              = ULPINV
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do the test (6): Compute eigenvalues and left eigenvectors,
@@ -834,9 +843,18 @@
             END IF
 *
             DO 130 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 6 )
-     $              = ULPINV
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -862,9 +880,18 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )RESULT( 7 )
-     $              = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N

--- a/TESTING/EIG/sdrgev.f
+++ b/TESTING/EIG/sdrgev.f
@@ -778,9 +778,18 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )
-     $             RESULT( 5 ) = ULPINV
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do the test (6): Compute eigenvalues and left eigenvectors,
@@ -799,9 +808,18 @@
             END IF
 *
             DO 130 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )
-     $             RESULT( 6 ) = ULPINV
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -827,9 +845,18 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )
-     $             RESULT( 7 ) = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N

--- a/TESTING/EIG/sdrgev3.f
+++ b/TESTING/EIG/sdrgev3.f
@@ -786,10 +786,14 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR.
-     $             BETA( J ).NE. BETA1( J ) ) THEN
-                  RESULT( 5 ) = ULPINV
-               END IF
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do the test (6): Compute eigenvalues and left eigenvectors,
@@ -808,9 +812,18 @@
             END IF
 *
             DO 130 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )
-     $             RESULT( 6 ) = ULPINV
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -836,9 +849,18 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHAR( J ).NE.ALPHR1( J ) .OR. ALPHAI( J ).NE.
-     $             ALPHI1( J ) .OR. BETA( J ).NE.BETA1( J ) )
-     $             RESULT( 7 ) = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAR( J ) - ALPHR1( J ) )
+     $             / MAX( ABS( ALPHAR( J ) ), ABS( ALPHR1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHAI( J ) - ALPHI1( J ) )
+     $             / MAX( ABS( ALPHAI( J ) ), ABS( ALPHI1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N

--- a/TESTING/EIG/zdrgev.f
+++ b/TESTING/EIG/zdrgev.f
@@ -780,8 +780,14 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 5 ) = ULPINV
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do test (6): Compute eigenvalues and left eigenvectors,
@@ -800,8 +806,14 @@
             END IF
 *
             DO 130 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 6 ) = ULPINV
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -827,8 +839,14 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 7 ) = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N

--- a/TESTING/EIG/zdrgev3.f
+++ b/TESTING/EIG/zdrgev3.f
@@ -788,8 +788,14 @@
             END IF
 *
             DO 120 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 5 ) = ULPINV
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 5 ) = MAX( RESULT( 5 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   120       CONTINUE
 *
 *           Do test (6): Compute eigenvalues and left eigenvectors,
@@ -808,8 +814,14 @@
             END IF
 *
             DO 130 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 6 ) = ULPINV
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 6 ) = MAX( RESULT( 6 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   130       CONTINUE
 *
             DO 150 J = 1, N
@@ -835,8 +847,14 @@
             END IF
 *
             DO 160 J = 1, N
-               IF( ALPHA( J ).NE.ALPHA1( J ) .OR. BETA( J ).NE.
-     $             BETA1( J ) )RESULT( 7 ) = ULPINV
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( ALPHA( J ) - ALPHA1( J ) )
+     $             / MAX( ABS( ALPHA( J ) ), ABS( ALPHA1( J ) ),
+     $                    SAFMIN ) )
+               RESULT( 7 ) = MAX( RESULT( 7 ),
+     $             ABS( BETA( J ) - BETA1( J ) )
+     $             / MAX( ABS( BETA( J ) ), ABS( BETA1( J ) ),
+     $                    SAFMIN ) )
   160       CONTINUE
 *
             DO 180 J = 1, N


### PR DESCRIPTION
The ZGGEV/DGGEV/SGGEV/CGGEV test drivers compared eigenvalues from full (both L/R eigenvectors) and partial (eigenvalues only) computations using exact Fortran .NE. This is fragile because the QZ algorithm applies orthogonal transformations to a different scope of columns depending on the JOB parameter ('S' vs 'E'), causing 1-ULP differences in eigenvalues on some architectures.

Replace the binary ULPINV sentinel with a relative tolerance comparison: RESULT(5/6/7) now reports the maximum relative difference across ALPHA/ALPHAI/BETA, which is compared against the regular THRESH threshold.  Fixes the spurious failure on Intel Xeon E5-2698 v4 and other platforms.

Closes #744
