### PR TITLE
*chklq: fix test failures when NB=1 with M=N

### DIFF
--- a/TESTING/LIN/cchklq.f
+++ b/TESTING/LIN/cchklq.f
@@ -395,12 +395,19 @@
                            CALL CLACPY( 'Full', M, N, A, LDA, AF, LDA )
 *
                            SRNAMT = 'CGELS'
-                           CALL CGELS( 'No transpose', M, N, NRHS, AF,
+                            CALL CGELS( 'No transpose', M, N, NRHS, AF,
      $                                 LDA, X, LDA, WORK, LWORK, INFO )
+*
+*                          Re-factorize AF with CGELQF for subsequent
+*                          LQ tests which expect LQ factorization in AF.
+*
+                            CALL CLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                            CALL CGELQF( M, N, AF, LDA, TAU, WORK,
+     $                                   LWORK, INFO )
 *
 *                          Check error code from CGELS.
 *
-                           IF( INFO.NE.0 )
+                            IF( INFO.NE.0 )
      $                        CALL ALAERH( PATH, 'CGELS', INFO, 0, 'N',
      $                                     M, N, NRHS, -1, NB, IMAT,
      $                                     NFAIL, NERRS, NOUT )

--- a/TESTING/LIN/dchklq.f
+++ b/TESTING/LIN/dchklq.f
@@ -398,12 +398,19 @@
                            CALL DLACPY( 'Full', M, N, A, LDA, AF, LDA )
 *
                            SRNAMT = 'DGELS'
-                           CALL DGELS( 'No transpose', M, N, NRHS, AF,
+                            CALL DGELS( 'No transpose', M, N, NRHS, AF,
      $                                 LDA, X, LDA, WORK, LWORK, INFO )
+*
+*                          Re-factorize AF with DGELQF for subsequent
+*                          LQ tests which expect LQ factorization in AF.
+*
+                            CALL DLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                            CALL DGELQF( M, N, AF, LDA, TAU, WORK,
+     $                                   LWORK, INFO )
 *
 *                          Check error code from DGELS.
 *
-                           IF( INFO.NE.0 )
+                            IF( INFO.NE.0 )
      $                        CALL ALAERH( PATH, 'DGELS', INFO, 0, 'N',
      $                                     M, N, NRHS, -1, NB, IMAT,
      $                                     NFAIL, NERRS, NOUT )

--- a/TESTING/LIN/schklq.f
+++ b/TESTING/LIN/schklq.f
@@ -395,12 +395,19 @@
                            CALL SLACPY( 'Full', M, N, A, LDA, AF, LDA )
 *
                            SRNAMT = 'SGELS'
-                           CALL SGELS( 'No transpose', M, N, NRHS, AF,
+                            CALL SGELS( 'No transpose', M, N, NRHS, AF,
      $                                 LDA, X, LDA, WORK, LWORK, INFO )
+*
+*                          Re-factorize AF with SGELQF for subsequent
+*                          LQ tests which expect LQ factorization in AF.
+*
+                            CALL SLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                            CALL SGELQF( M, N, AF, LDA, TAU, WORK,
+     $                                   LWORK, INFO )
 *
 *                          Check error code from SGELS.
 *
-                           IF( INFO.NE.0 )
+                            IF( INFO.NE.0 )
      $                        CALL ALAERH( PATH, 'SGELS', INFO, 0, 'N',
      $                                     M, N, NRHS, -1, NB, IMAT,
      $                                     NFAIL, NERRS, NOUT )

--- a/TESTING/LIN/zchklq.f
+++ b/TESTING/LIN/zchklq.f
@@ -395,12 +395,19 @@
                            CALL ZLACPY( 'Full', M, N, A, LDA, AF, LDA )
 *
                            SRNAMT = 'ZGELS'
-                           CALL ZGELS( 'No transpose', M, N, NRHS, AF,
+                            CALL ZGELS( 'No transpose', M, N, NRHS, AF,
      $                                 LDA, X, LDA, WORK, LWORK, INFO )
+*
+*                          Re-factorize AF with ZGELQF for subsequent
+*                          LQ tests which expect LQ factorization in AF.
+*
+                            CALL ZLACPY( 'Full', M, N, A, LDA, AF, LDA )
+                            CALL ZGELQF( M, N, AF, LDA, TAU, WORK,
+     $                                   LWORK, INFO )
 *
 *                          Check error code from ZGELS.
 *
-                           IF( INFO.NE.0 )
+                            IF( INFO.NE.0 )
      $                        CALL ALAERH( PATH, 'ZGELS', INFO, 0, 'N',
      $                                     M, N, NRHS, -1, NB, IMAT,
      $                                     NFAIL, NERRS, NOUT )


### PR DESCRIPTION
The LQ test drivers (dchklq, schklq, cchklq, zchklq) called DGELS/SGELS which re-factorizes AF internally using GEQRF when M>=N. This corrupted the LQ factorization expected by subsequent LQT02/LQT03 calls on later K iterations, causing test(1) and test(2) failures.

Fix by re-copying A to AF and re-factorizing with GELQF after the GELS call, restoring the LQ factorization for the remaining tests.

Closes #973
