### PR TITLE
dstedc, sstedc: remove dead ICOMPZ.EQ.0 branch

### DIFF
--- a/SRC/dstedc.f
+++ b/SRC/dstedc.f
@@ -212,7 +212,6 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DGEMM, DLACPY, DLAED0, DLASCL, DLASET,
-     $                   DLASRT,
      $                   DSTEQR, DSTERF, DSWAP, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
@@ -437,33 +436,25 @@
 *
 *        endwhile
 *
-         IF( ICOMPZ.EQ.0 ) THEN
 *
-*          Use Quick Sort
+*        Use Selection Sort to minimize swaps of eigenvectors
 *
-           CALL DLASRT( 'I', N, D, INFO )
-*
-         ELSE
-*
-*          Use Selection Sort to minimize swaps of eigenvectors
-*
-           DO 40 II = 2, N
-              I = II - 1
-              K = I
-              P = D( I )
-              DO 30 J = II, N
-                 IF( D( J ).LT.P ) THEN
-                    K = J
-                    P = D( J )
-                 END IF
+          DO 40 II = 2, N
+             I = II - 1
+             K = I
+             P = D( I )
+             DO 30 J = II, N
+                IF( D( J ).LT.P ) THEN
+                   K = J
+                   P = D( J )
+                END IF
    30         CONTINUE
-              IF( K.NE.I ) THEN
-                 D( K ) = D( I )
-                 D( I ) = P
-                 CALL DSWAP( N, Z( 1, I ), 1, Z( 1, K ), 1 )
-              END IF
+             IF( K.NE.I ) THEN
+                D( K ) = D( I )
+                D( I ) = P
+                CALL DSWAP( N, Z( 1, I ), 1, Z( 1, K ), 1 )
+             END IF
    40      CONTINUE
-         END IF
       END IF
 *
    50 CONTINUE

--- a/SRC/sstedc.f
+++ b/SRC/sstedc.f
@@ -213,7 +213,6 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SGEMM, SLACPY, SLAED0, SLASCL, SLASET,
-     $                   SLASRT,
      $                   SSTEQR, SSTERF, SSWAP, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
@@ -438,33 +437,25 @@
 *
 *        endwhile
 *
-         IF( ICOMPZ.EQ.0 ) THEN
 *
-*          Use Quick Sort
+*        Use Selection Sort to minimize swaps of eigenvectors
 *
-           CALL SLASRT( 'I', N, D, INFO )
-*
-         ELSE
-*
-*          Use Selection Sort to minimize swaps of eigenvectors
-*
-           DO 40 II = 2, N
-              I = II - 1
-              K = I
-              P = D( I )
-              DO 30 J = II, N
-                 IF( D( J ).LT.P ) THEN
-                    K = J
-                    P = D( J )
-                 END IF
+          DO 40 II = 2, N
+             I = II - 1
+             K = I
+             P = D( I )
+             DO 30 J = II, N
+                IF( D( J ).LT.P ) THEN
+                   K = J
+                   P = D( J )
+                END IF
    30         CONTINUE
-              IF( K.NE.I ) THEN
-                 D( K ) = D( I )
-                 D( I ) = P
-                 CALL SSWAP( N, Z( 1, I ), 1, Z( 1, K ), 1 )
-              END IF
+             IF( K.NE.I ) THEN
+                D( K ) = D( I )
+                D( I ) = P
+                CALL SSWAP( N, Z( 1, I ), 1, Z( 1, K ), 1 )
+             END IF
    40      CONTINUE
-         END IF
       END IF
 *
    50 CONTINUE


### PR DESCRIPTION
The IF( ICOMPZ.EQ.0 ) block calling DLASRT/SLASRT quick sort after the endwhile loop is unreachable -- ICOMPZ.EQ.0 already exits via CALL DSTERF/CALL SSTERF + GO TO 50 earlier. Remove the dead branch and its external declaration, keeping only the selection sort path.

Closes #1143
