### PR TITLE
lsame: simplify using IACHAR

### DIFF
--- a/BLAS/SRC/lsame.f
+++ b/BLAS/SRC/lsame.f
@@ -63,57 +63,22 @@
 * =====================================================================
 *
 *     .. Intrinsic Functions ..
-      INTRINSIC ICHAR
+      INTRINSIC IACHAR
 *     ..
 *     .. Local Scalars ..
-      INTEGER INTA,INTB,ZCODE
+      INTEGER INTA,INTB
 *     ..
-*
-*     Test if the characters are equal
 *
       LSAME = CA .EQ. CB
       IF (LSAME) RETURN
 *
-*     Now test for equivalence if both characters are alphabetic.
+*     Use IACHAR to get ASCII codes for case-insensitive comparison,
+*     regardless of the platform's native character encoding.
 *
-      ZCODE = ICHAR('Z')
-*
-*     Use 'Z' rather than 'A' so that ASCII can be detected on Prime
-*     machines, on which ICHAR returns a value with bit 8 set.
-*     ICHAR('A') on Prime machines returns 193 which is the same as
-*     ICHAR('A') on an EBCDIC machine.
-*
-      INTA = ICHAR(CA)
-      INTB = ICHAR(CB)
-*
-      IF (ZCODE.EQ.90 .OR. ZCODE.EQ.122) THEN
-*
-*        ASCII is assumed - ZCODE is the ASCII code of either lower or
-*        upper case 'Z'.
-*
-          IF (INTA.GE.97 .AND. INTA.LE.122) INTA = INTA - 32
-          IF (INTB.GE.97 .AND. INTB.LE.122) INTB = INTB - 32
-*
-      ELSE IF (ZCODE.EQ.233 .OR. ZCODE.EQ.169) THEN
-*
-*        EBCDIC is assumed - ZCODE is the EBCDIC code of either lower or
-*        upper case 'Z'.
-*
-          IF (INTA.GE.129 .AND. INTA.LE.137 .OR.
-     +        INTA.GE.145 .AND. INTA.LE.153 .OR.
-     +        INTA.GE.162 .AND. INTA.LE.169) INTA = INTA + 64
-          IF (INTB.GE.129 .AND. INTB.LE.137 .OR.
-     +        INTB.GE.145 .AND. INTB.LE.153 .OR.
-     +        INTB.GE.162 .AND. INTB.LE.169) INTB = INTB + 64
-*
-      ELSE IF (ZCODE.EQ.218 .OR. ZCODE.EQ.250) THEN
-*
-*        ASCII is assumed, on Prime machines - ZCODE is the ASCII code
-*        plus 128 of either lower or upper case 'Z'.
-*
-          IF (INTA.GE.225 .AND. INTA.LE.250) INTA = INTA - 32
-          IF (INTB.GE.225 .AND. INTB.LE.250) INTB = INTB - 32
-      END IF
+      INTA = IACHAR(CA)
+      INTB = IACHAR(CB)
+      IF (INTA.GE.65 .AND. INTA.LE.90) INTA = INTA + 32
+      IF (INTB.GE.65 .AND. INTB.LE.90) INTB = INTB + 32
       LSAME = INTA .EQ. INTB
 *
 *     RETURN

--- a/INSTALL/lsame.f
+++ b/INSTALL/lsame.f
@@ -58,59 +58,24 @@
 * =====================================================================
 *
 *     .. Intrinsic Functions ..
-      INTRINSIC          ICHAR
+      INTRINSIC          IACHAR
 *     ..
 *     .. Local Scalars ..
-      INTEGER            INTA, INTB, ZCODE
+      INTEGER            INTA, INTB
 *     ..
 *     .. Executable Statements ..
-*
-*     Test if the characters are equal
 *
       LSAME = CA.EQ.CB
       IF( LSAME )
      $   RETURN
 *
-*     Now test for equivalence if both characters are alphabetic.
+*     Use IACHAR to get ASCII codes for case-insensitive comparison,
+*     regardless of the platform's native character encoding.
 *
-      ZCODE = ICHAR( 'Z' )
-*
-*     Use 'Z' rather than 'A' so that ASCII can be detected on Prime
-*     machines, on which ICHAR returns a value with bit 8 set.
-*     ICHAR('A') on Prime machines returns 193 which is the same as
-*     ICHAR('A') on an EBCDIC machine.
-*
-      INTA = ICHAR( CA )
-      INTB = ICHAR( CB )
-*
-      IF( ZCODE.EQ.90 .OR. ZCODE.EQ.122 ) THEN
-*
-*        ASCII is assumed - ZCODE is the ASCII code of either lower or
-*        upper case 'Z'.
-*
-         IF( INTA.GE.97 .AND. INTA.LE.122 ) INTA = INTA - 32
-         IF( INTB.GE.97 .AND. INTB.LE.122 ) INTB = INTB - 32
-*
-      ELSE IF( ZCODE.EQ.233 .OR. ZCODE.EQ.169 ) THEN
-*
-*        EBCDIC is assumed - ZCODE is the EBCDIC code of either lower or
-*        upper case 'Z'.
-*
-         IF( INTA.GE.129 .AND. INTA.LE.137 .OR.
-     $       INTA.GE.145 .AND. INTA.LE.153 .OR.
-     $       INTA.GE.162 .AND. INTA.LE.169 ) INTA = INTA + 64
-         IF( INTB.GE.129 .AND. INTB.LE.137 .OR.
-     $       INTB.GE.145 .AND. INTB.LE.153 .OR.
-     $       INTB.GE.162 .AND. INTB.LE.169 ) INTB = INTB + 64
-*
-      ELSE IF( ZCODE.EQ.218 .OR. ZCODE.EQ.250 ) THEN
-*
-*        ASCII is assumed, on Prime machines - ZCODE is the ASCII code
-*        plus 128 of either lower or upper case 'Z'.
-*
-         IF( INTA.GE.225 .AND. INTA.LE.250 ) INTA = INTA - 32
-         IF( INTB.GE.225 .AND. INTB.LE.250 ) INTB = INTB - 32
-      END IF
+      INTA = IACHAR( CA )
+      INTB = IACHAR( CB )
+      IF( INTA.GE.65 .AND. INTA.LE.90 ) INTA = INTA + 32
+      IF( INTB.GE.65 .AND. INTB.LE.90 ) INTB = INTB + 32
       LSAME = INTA.EQ.INTB
 *
 *     RETURN


### PR DESCRIPTION
Replace ICHAR with the F95 intrinsic IACHAR, which always returns ASCII codes regardless of the platform's native character encoding. This eliminates the entire EBCDIC/Prime machine detection branch (logic testing ZCODE against ASCII/EBCDIC/Prime codes), producing shorter, simpler, and equivalent code.

Closes #701
