### PR TITLE
TGSJA: replace HUGE intrinsic with LAMCH('O')

### DIFF
--- a/SRC/ctgsja.f
+++ b/SRC/ctgsja.f
@@ -413,7 +413,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      REAL               SLAMCH
+      EXTERNAL           LSAME, SLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CCOPY, CLAGS2, CLAPLL, CLASET, CROT,
@@ -421,10 +422,11 @@
      $                   SLARTG, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, CONJG, MAX, MIN, REAL, HUGE
-      PARAMETER          ( HUGENUM = HUGE(ZERO) )
+      INTRINSIC          ABS, CONJG, MAX, MIN, REAL
 *     ..
 *     .. Executable Statements ..
+*
+      HUGENUM = SLAMCH( 'O' )
 *
 *     Decode and test the input parameters
 *

--- a/SRC/dtgsja.f
+++ b/SRC/dtgsja.f
@@ -408,7 +408,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DLAMCH
+      EXTERNAL           LSAME, DLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DCOPY, DLAGS2, DLAPLL, DLARTG, DLASET,
@@ -416,10 +417,11 @@
      $                   DSCAL, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, MAX, MIN, HUGE
-      PARAMETER          ( HUGENUM = HUGE(ZERO) )
+      INTRINSIC          ABS, MAX, MIN
 *     ..
 *     .. Executable Statements ..
+*
+      HUGENUM = DLAMCH( 'O' )
 *
 *     Decode and test the input parameters
 *

--- a/SRC/stgsja.f
+++ b/SRC/stgsja.f
@@ -408,7 +408,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      REAL               SLAMCH
+      EXTERNAL           LSAME, SLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SCOPY, SLAGS2, SLAPLL, SLARTG, SLASET,
@@ -416,10 +417,11 @@
      $                   SSCAL, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, MAX, MIN, HUGE
-      PARAMETER          ( HUGENUM = HUGE(ZERO) )
+      INTRINSIC          ABS, MAX, MIN
 *     ..
 *     .. Executable Statements ..
+*
+      HUGENUM = SLAMCH( 'O' )
 *
 *     Decode and test the input parameters
 *

--- a/SRC/ztgsja.f
+++ b/SRC/ztgsja.f
@@ -413,7 +413,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DLAMCH
+      EXTERNAL           LSAME, DLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DLARTG, XERBLA, ZCOPY, ZDSCAL, ZLAGS2,
@@ -421,10 +422,11 @@
      $                   ZLASET, ZROT
 *     ..
 *     .. Intrinsic Functions ..
-      INTRINSIC          ABS, DBLE, DCONJG, MAX, MIN, HUGE
-      PARAMETER          ( HUGENUM = HUGE(ZERO) )
+      INTRINSIC          ABS, DBLE, DCONJG, MAX, MIN
 *     ..
 *     .. Executable Statements ..
+*
+      HUGENUM = DLAMCH( 'O' )
 *
 *     Decode and test the input parameters
 *


### PR DESCRIPTION
Replace the Fortran intrinsic HUGE with SLAMCH('O')/DLAMCH('O') for consistency with the rest of LAPACK.  HUGENUM is changed from a compile-time PARAMETER to a runtime assignment since LAMCH is a function call.

Closes #608
