### PR TITLE
DLASQ3, SLASQ3: stop modifying QMAX

### DIFF
--- a/SRC/dlasq3.f
+++ b/SRC/dlasq3.f
@@ -89,7 +89,7 @@
 *>         Lower order part of SIGMA
 *> \endverbatim
 *>
-*> \param[in] QMAX
+*> \param[in,out] QMAX
 *> \verbatim
 *>          QMAX is DOUBLE PRECISION
 *>         Maximum value of q.

--- a/SRC/slasq3.f
+++ b/SRC/slasq3.f
@@ -89,7 +89,7 @@
 *>         Lower order part of SIGMA
 *> \endverbatim
 *>
-*> \param[in] QMAX
+*> \param[in,out] QMAX
 *> \verbatim
 *>          QMAX is REAL
 *>         Maximum value of q.


### PR DESCRIPTION
QMAX was documented as [in] but was written inside the qd-array reversal block. The caller recomputes QMAX immediately after the call, so the update has no useful effect. Remove it to match the documented intent

Closes #326
