### PR TITLE
Scale FAIL with SPDIAM in xLARRF. Fixes #995.

### DIFF
--- a/SRC/dlarrf.f
+++ b/SRC/dlarrf.f
@@ -465,7 +465,7 @@
       ELSE
 *        None of the representations investigated satisfied our
 *        criteria. Take the best one we found.
-         IF((SMLGROWTH.LT.FAIL).OR.NOFAIL) THEN
+         IF((SMLGROWTH.LT.FAIL*SPDIAM).OR.NOFAIL) THEN
             LSIGMA = BESTSHIFT
             RSIGMA = BESTSHIFT
             FORCER = .TRUE.

--- a/SRC/slarrf.f
+++ b/SRC/slarrf.f
@@ -465,7 +465,7 @@
       ELSE
 *        None of the representations investigated satisfied our
 *        criteria. Take the best one we found.
-         IF((SMLGROWTH.LT.FAIL).OR.NOFAIL) THEN
+         IF((SMLGROWTH.LT.FAIL*SPDIAM).OR.NOFAIL) THEN
             LSIGMA = BESTSHIFT
             RSIGMA = BESTSHIFT
             FORCER = .TRUE.


### PR DESCRIPTION
**Description**

As discussed in #995, a failure to correctly compare the relative error scale `FAIL` and the absolute `SMLGROWTH` led to unexpected failure of xLARFF when the input is scaled well away from 1. This led to eigensolver routines such as `ZHEEVR` running up to 20x slower when given input scaled away from 1 by a large factor (e.g. 1e12). Example matrices can be generate with the following code: https://gist.github.com/amilsted/24e77bc77a39dbbcabf718a3ce5b5fe3

This fix eliminates the eigensolve slowdown due to xLARFF failure in the tested cases.

Closes #995.