### PR TITLE
sskewsyr2k: Fix formula comment

### DIFF
--- a/BLAS/SRC/dskewsyr2k.f
+++ b/BLAS/SRC/dskewsyr2k.f
@@ -300,7 +300,7 @@
 *
       IF (LSAME(TRANS,'N')) THEN
 *
-*        Form  C := alpha*A*B**T + alpha*B*A**T + C.
+*        Form  C := -alpha*A*B**T + alpha*B*A**T + C.
 *
           IF (UPPER) THEN
               DO 130 J = 1,N

--- a/BLAS/SRC/sskewsyr2k.f
+++ b/BLAS/SRC/sskewsyr2k.f
@@ -300,7 +300,7 @@
 *
       IF (LSAME(TRANS,'N')) THEN
 *
-*        Form  C := alpha*A*B**T + alpha*B*A**T + C.
+*        Form  C := -alpha*A*B**T + alpha*B*A**T + C.
 *
           IF (UPPER) THEN
               DO 130 J = 1,N


### PR DESCRIPTION
`dskewsyr2k.f:303` / `sskewsyr2k.f:303` — Comment describes wrong sign pattern

```fortran
! Form  C := alpha*A*B**T + alpha*B*A**T + C.
```

The documented operation is:
```
C := -alpha*A*B**T + alpha*B*A**T + beta*C
```

The comment is missing the negation on the first term. The actual code at lines 320-322 correctly computes `-A(I,L)*TEMP1 + B(I,L)*TEMP2` with the negation, but the misleading comment could cause confusion during maintenance.

