### PR TITLE
{s/c/d/z}larf{/1f/1l}: fix negative increment vector handling

### DIFF
--- a/SRC/clarf.f
+++ b/SRC/clarf.f
@@ -187,6 +187,11 @@
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILACLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         END IF
       END IF
 !     Note that lastc.eq.0 renders the BLAS operations null; no special
 !     case is needed at this level.
@@ -199,11 +204,11 @@
 *           w(1:lastc,1) := C(1:lastv,1:lastc)**H * v(1:lastv,1)
 *
             CALL CGEMV( 'Conjugate transpose', LASTV, LASTC, ONE,
-     $           C, LDC, V, INCV, ZERO, WORK, 1 )
+     $           C, LDC, V(I), INCV, ZERO, WORK, 1 )
 *
 *           C(1:lastv,1:lastc) := C(...) - v(1:lastv,1) * w(1:lastc,1)**H
 *
-            CALL CGERC( LASTV, LASTC, -TAU, V, INCV, WORK, 1, C,
+            CALL CGERC( LASTV, LASTC, -TAU, V(I), INCV, WORK, 1, C,
      $                  LDC )
          END IF
       ELSE
@@ -215,11 +220,11 @@
 *           w(1:lastc,1) := C(1:lastc,1:lastv) * v(1:lastv,1)
 *
             CALL CGEMV( 'No transpose', LASTC, LASTV, ONE, C, LDC,
-     $           V, INCV, ZERO, WORK, 1 )
+     $           V(I), INCV, ZERO, WORK, 1 )
 *
 *           C(1:lastc,1:lastv) := C(...) - w(1:lastc,1) * v(1:lastv,1)**H
 *
-            CALL CGERC( LASTC, LASTV, -TAU, WORK, 1, V, INCV, C,
+            CALL CGERC( LASTC, LASTV, -TAU, WORK, 1, V(I), INCV, C,
      $                  LDC )
          END IF
       END IF

--- a/SRC/clarf1f.f
+++ b/SRC/clarf1f.f
@@ -147,7 +147,7 @@
 *     ..
 *     .. Local Scalars ..
       LOGICAL            APPLYLEFT
-      INTEGER            I, LASTV, LASTC
+      INTEGER            I, J, LASTV, LASTC
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CAXPY, CGEMV, CGERC, CSCAL
@@ -190,6 +190,11 @@
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILACLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I to point to V(2)
+         IF( INCV.GT.0 ) THEN
+            I = 1 + INCV
+         END IF
       END IF
       IF( LASTC.EQ.0 ) THEN
          RETURN
@@ -208,24 +213,24 @@
 *        w(1:lastc,1) := C(2:lastv,1:lastc)**H * v(2:lastv,1)
 *
          CALL CGEMV( 'Conjugate transpose', LASTV - 1, LASTC, ONE,
-     $               C( 2, 1 ), LDC, V( 1 + INCV ), INCV, ZERO,
+     $               C( 2, 1 ), LDC, V( I ), INCV, ZERO,
      $               WORK, 1 )
 *
 *        w(1:lastc,1) += v(1,1) * C(1,1:lastc)**H
 *
-         DO I = 1, LASTC
-            WORK( I ) = WORK( I ) + CONJG( C( 1, I ) )
+         DO J = 1, LASTC
+            WORK( J ) = WORK( J ) + CONJG( C( 1, J ) )
          END DO
 *
 *        C(1, 1:lastc) += - tau * v(1,1) * w(1:lastc,1)**H
 *
-         DO I = 1, LASTC
-            C( 1, I ) = C( 1, I ) - TAU * CONJG( WORK( I ) )
+         DO J = 1, LASTC
+            C( 1, J ) = C( 1, J ) - TAU * CONJG( WORK( J ) )
          END DO
 *
 *        C(2:lastv,1:lastc) += - tau * v(2:lastv,1) * w(1:lastc,1)**H
 *
-         CALL CGERC( LASTV - 1, LASTC, -TAU, V( 1 + INCV ), INCV,
+         CALL CGERC( LASTV - 1, LASTC, -TAU, V( I ), INCV,
      $               WORK, 1, C( 2, 1 ), LDC )
             END IF
       ELSE
@@ -242,7 +247,7 @@
 *           w(1:lastc,1) := C(1:lastc,2:lastv) * v(2:lastv,1)
 *
             CALL CGEMV( 'No transpose', LASTC, LASTV - 1, ONE,
-     $                  C( 1, 2 ), LDC, V( 1 + INCV ), INCV, ZERO,
+     $                  C( 1, 2 ), LDC, V( I ), INCV, ZERO,
      $                  WORK, 1 )
 *
 *           w(1:lastc,1) += v(1,1) * C(1:lastc,1)
@@ -256,7 +261,7 @@
 *           C(1:lastc,2:lastv) += - tau * w(1:lastc,1) * v(2:lastv)**H
 *
             CALL CGERC( LASTC, LASTV - 1, -TAU, WORK, 1,
-     $                  V( 1 + INCV ), INCV, C( 1, 2 ), LDC )
+     $                  V( I ), INCV, C( 1, 2 ), LDC )
          END IF
       END IF
       RETURN

--- a/SRC/clarf1l.f
+++ b/SRC/clarf1l.f
@@ -174,7 +174,11 @@
          ELSE
             LASTV = N
          END IF
-         I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         ELSE
+            I = 1 - (LASTV-1) * INCV
+         END IF
 !     Look for the last non-zero row in V.
          DO WHILE( LASTV.GT.FIRSTV .AND. V( I ).EQ.ZERO )
             FIRSTV = FIRSTV + 1
@@ -186,6 +190,11 @@
          ELSE
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILACLR(M, LASTV, C, LDC)
+         END IF
+!     Set index for V. If INCV > 0, then I points to the start of V.
+!     For INCV < 0, set I to point to V(M-1)
+         IF( INCV.LT.0 ) THEN
+            I = 1 - INCV
          END IF
       END IF
       IF( LASTC.EQ.0 ) THEN

--- a/SRC/dlarf.f
+++ b/SRC/dlarf.f
@@ -182,6 +182,11 @@
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILADLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         END IF
       END IF
 !     Note that lastc.eq.0 renders the BLAS operations null; no special
 !     case is needed at this level.
@@ -193,13 +198,14 @@
 *
 *           w(1:lastc,1) := C(1:lastv,1:lastc)**T * v(1:lastv,1)
 *
-            CALL DGEMV( 'Transpose', LASTV, LASTC, ONE, C, LDC, V,
+            CALL DGEMV( 'Transpose', LASTV, LASTC, ONE, C, LDC, V(I),
      $                  INCV,
      $           ZERO, WORK, 1 )
 *
 *           C(1:lastv,1:lastc) := C(...) - v(1:lastv,1) * w(1:lastc,1)**T
 *
-            CALL DGER( LASTV, LASTC, -TAU, V, INCV, WORK, 1, C, LDC )
+            CALL DGER( LASTV, LASTC, -TAU, V(I), INCV, WORK, 1, C,
+     $                 LDC )
          END IF
       ELSE
 *
@@ -210,11 +216,12 @@
 *           w(1:lastc,1) := C(1:lastc,1:lastv) * v(1:lastv,1)
 *
             CALL DGEMV( 'No transpose', LASTC, LASTV, ONE, C, LDC,
-     $           V, INCV, ZERO, WORK, 1 )
+     $           V(I), INCV, ZERO, WORK, 1 )
 *
 *           C(1:lastc,1:lastv) := C(...) - w(1:lastc,1) * v(1:lastv,1)**T
 *
-            CALL DGER( LASTC, LASTV, -TAU, WORK, 1, V, INCV, C, LDC )
+            CALL DGER( LASTC, LASTV, -TAU, WORK, 1, V(I), INCV, C,
+     $                 LDC )
          END IF
       END IF
       RETURN

--- a/SRC/dlarf1f.f
+++ b/SRC/dlarf1f.f
@@ -219,6 +219,11 @@
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILADLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I to point to V(2)
+         IF( INCV.GT.0 ) THEN
+            I = 1 + INCV
+         END IF
       END IF
       IF( LASTC.EQ.0 ) THEN
          RETURN
@@ -240,7 +245,7 @@
 *
             ! w(1:lastc,1) := C(2:lastv,1:lastc)**T * v(2:lastv,1)
             CALL DGEMV( 'Transpose', LASTV-1, LASTC, ONE, C(1+1,1),
-     $                  LDC, V(1+INCV), INCV, ZERO, WORK, 1)
+     $                  LDC, V(I), INCV, ZERO, WORK, 1)
             ! w(1:lastc,1) += C(1,1:lastc)**T * v(1,1) = C(1,1:lastc)**T
             CALL DAXPY(LASTC, ONE, C, LDC, WORK, 1)
 *
@@ -250,7 +255,7 @@
             !                  = C(...) - tau * w(1:lastc,1)**T
             CALL DAXPY(LASTC, -TAU, WORK, 1, C, LDC)
             ! C(2:lastv,1:lastc) := C(...) - tau * v(2:lastv,1)*w(1:lastc,1)**T
-            CALL DGER(LASTV-1, LASTC, -TAU, V(1+INCV), INCV, WORK, 1,
+            CALL DGER(LASTV-1, LASTC, -TAU, V(I), INCV, WORK, 1,
      $                  C(1+1,1), LDC)
          END IF
       ELSE
@@ -270,7 +275,7 @@
 *
             ! w(1:lastc,1) := C(1:lastc,2:lastv) * v(2:lastv,1)
             CALL DGEMV( 'No transpose', LASTC, LASTV-1, ONE, 
-     $         C(1,1+1), LDC, V(1+INCV), INCV, ZERO, WORK, 1 )
+     $         C(1,1+1), LDC, V(I), INCV, ZERO, WORK, 1 )
             ! w(1:lastc,1) += C(1:lastc,1) v(1,1) = C(1:lastc,1)
             CALL DAXPY(LASTC, ONE, C, 1, WORK, 1)
 *
@@ -280,7 +285,7 @@
             !                   = C(...) - tau * w(1:lastc,1)
             CALL DAXPY(LASTC, -TAU, WORK, 1, C, 1)
             ! C(1:lastc,2:lastv) := C(...) - tau * w(1:lastc,1) * v(2:lastv)**T
-            CALL DGER( LASTC, LASTV-1, -TAU, WORK, 1, V(1+INCV),
+            CALL DGER( LASTC, LASTV-1, -TAU, WORK, 1, V(I),
      $                  INCV, C(1,1+1), LDC )
          END IF
       END IF

--- a/SRC/dlarf1l.f
+++ b/SRC/dlarf1l.f
@@ -167,7 +167,11 @@
          ELSE
             LASTV = N
          END IF
-         I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         ELSE
+            I = 1 - (LASTV-1) * INCV
+         END IF
 !     Look for the last non-zero row in V.
          DO WHILE( LASTV.GT.FIRSTV .AND. V( I ).EQ.ZERO )
             FIRSTV = FIRSTV + 1
@@ -179,6 +183,11 @@
          ELSE
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILADLR(M, LASTV, C, LDC)
+         END IF
+!     Set index for V. If INCV > 0, then I points to the start of V.
+!     For INCV < 0, set I to point to V(M-1)
+         IF( INCV.LT.0 ) THEN
+            I = 1 - INCV
          END IF
       END IF
       IF( LASTC.EQ.0 ) THEN

--- a/SRC/slarf.f
+++ b/SRC/slarf.f
@@ -182,6 +182,11 @@
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILASLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         END IF
       END IF
 !     Note that lastc.eq.0 renders the BLAS operations null; no special
 !     case is needed at this level.
@@ -193,13 +198,14 @@
 *
 *           w(1:lastc,1) := C(1:lastv,1:lastc)**T * v(1:lastv,1)
 *
-            CALL SGEMV( 'Transpose', LASTV, LASTC, ONE, C, LDC, V,
+            CALL SGEMV( 'Transpose', LASTV, LASTC, ONE, C, LDC, V(I),
      $                  INCV,
      $           ZERO, WORK, 1 )
 *
 *           C(1:lastv,1:lastc) := C(...) - v(1:lastv,1) * w(1:lastc,1)**T
 *
-            CALL SGER( LASTV, LASTC, -TAU, V, INCV, WORK, 1, C, LDC )
+            CALL SGER( LASTV, LASTC, -TAU, V(I), INCV, WORK, 1, C,
+     $                 LDC )
          END IF
       ELSE
 *
@@ -210,11 +216,12 @@
 *           w(1:lastc,1) := C(1:lastc,1:lastv) * v(1:lastv,1)
 *
             CALL SGEMV( 'No transpose', LASTC, LASTV, ONE, C, LDC,
-     $           V, INCV, ZERO, WORK, 1 )
+     $           V(I), INCV, ZERO, WORK, 1 )
 *
 *           C(1:lastc,1:lastv) := C(...) - w(1:lastc,1) * v(1:lastv,1)**T
 *
-            CALL SGER( LASTC, LASTV, -TAU, WORK, 1, V, INCV, C, LDC )
+            CALL SGER( LASTC, LASTV, -TAU, WORK, 1, V(I), INCV, C,
+     $                 LDC )
          END IF
       END IF
       RETURN

--- a/SRC/slarf1f.f
+++ b/SRC/slarf1f.f
@@ -183,6 +183,11 @@
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILASLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I to point to V(2)
+         IF( INCV.GT.0 ) THEN
+            I = 1 + INCV
+         END IF         
       END IF
       IF( LASTC.EQ.0 ) THEN
          RETURN
@@ -201,7 +206,7 @@
 *        w(1:lastc,1) := C(2:lastv,1:lastc)**T * v(2:lastv,1)
 *
          CALL SGEMV( 'Transpose', LASTV - 1, LASTC, ONE, C( 2, 1 ),
-     $               LDC, V( 1 + INCV ), INCV, ZERO, WORK, 1 )
+     $               LDC, V( I ), INCV, ZERO, WORK, 1 )
 *
 *        w(1:lastc,1) += v(1,1) * C(1,1:lastc)**T
 *
@@ -213,7 +218,7 @@
 *
 *        C(2:lastv,1:lastc) += - tau * v(2:lastv,1) * w(1:lastc,1)**T
 *
-         CALL SGER( LASTV - 1, LASTC, -TAU, V( 1 + INCV ), INCV,
+         CALL SGER( LASTV - 1, LASTC, -TAU, V( I ), INCV,
      $              WORK, 1, C( 2, 1 ), LDC )
             END IF
       ELSE
@@ -230,7 +235,7 @@
 *           w(1:lastc,1) := C(1:lastc,2:lastv) * v(2:lastv,1)
 *
             CALL SGEMV( 'No transpose', LASTC, LASTV - 1, ONE,
-     $                  C( 1, 2 ), LDC, V( 1 + INCV ), INCV, ZERO,
+     $                  C( 1, 2 ), LDC, V( I ), INCV, ZERO,
      $                  WORK, 1 )
 *
 *           w(1:lastc,1) += v(1,1) * C(1:lastc,1)
@@ -244,7 +249,7 @@
 *           C(1:lastc,2:lastv) += - tau * w(1:lastc,1) * v(2:lastv)**T
 *
             CALL SGER( LASTC, LASTV - 1, -TAU, WORK, 1,
-     $                 V( 1 + INCV ), INCV, C( 1, 2 ), LDC )
+     $                 V( I ), INCV, C( 1, 2 ), LDC )
          END IF
       END IF
       RETURN

--- a/SRC/slarf1l.f
+++ b/SRC/slarf1l.f
@@ -168,7 +168,11 @@
          ELSE
             LASTV = N
          END IF
-         I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         ELSE
+            I = 1 - (LASTV-1) * INCV
+         END IF
 !     Look for the last non-zero row in V.
          DO WHILE( LASTV.GT.FIRSTV .AND. V( I ).EQ.ZERO )
             FIRSTV = FIRSTV + 1
@@ -180,6 +184,11 @@
          ELSE
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILASLR(M, LASTV, C, LDC)
+         END IF
+!     Set index for V. If INCV > 0, then I points to the start of V.
+!     For INCV < 0, set I to point to V(M-1)
+         IF( INCV.LT.0 ) THEN
+            I = 1 - INCV
          END IF
       END IF
       IF( LASTC.EQ.0 ) THEN

--- a/SRC/zlarf.f
+++ b/SRC/zlarf.f
@@ -187,6 +187,11 @@
 *     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILAZLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         END IF
       END IF
 *     Note that lastc.eq.0 renders the BLAS operations null; no special
 *     case is needed at this level.
@@ -199,11 +204,11 @@
 *           w(1:lastc,1) := C(1:lastv,1:lastc)**H * v(1:lastv,1)
 *
             CALL ZGEMV( 'Conjugate transpose', LASTV, LASTC, ONE,
-     $           C, LDC, V, INCV, ZERO, WORK, 1 )
+     $           C, LDC, V(I), INCV, ZERO, WORK, 1 )
 *
 *           C(1:lastv,1:lastc) := C(...) - v(1:lastv,1) * w(1:lastc,1)**H
 *
-            CALL ZGERC( LASTV, LASTC, -TAU, V, INCV, WORK, 1, C,
+            CALL ZGERC( LASTV, LASTC, -TAU, V(I), INCV, WORK, 1, C,
      $                  LDC )
          END IF
       ELSE
@@ -215,11 +220,11 @@
 *           w(1:lastc,1) := C(1:lastc,1:lastv) * v(1:lastv,1)
 *
             CALL ZGEMV( 'No transpose', LASTC, LASTV, ONE, C, LDC,
-     $           V, INCV, ZERO, WORK, 1 )
+     $           V(I), INCV, ZERO, WORK, 1 )
 *
 *           C(1:lastc,1:lastv) := C(...) - w(1:lastc,1) * v(1:lastv,1)**H
 *
-            CALL ZGERC( LASTC, LASTV, -TAU, WORK, 1, V, INCV, C,
+            CALL ZGERC( LASTC, LASTV, -TAU, WORK, 1, V(I), INCV, C,
      $                  LDC )
          END IF
       END IF

--- a/SRC/zlarf1f.f
+++ b/SRC/zlarf1f.f
@@ -222,6 +222,11 @@
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILAZLR(M, LASTV, C, LDC)
          END IF
+!     Set index for V. If INCV < 0, then I points to the end of V. 
+!     For INCV > 0, set I to point to V(2)
+         IF( INCV.GT.0 ) THEN
+            I = 1 + INCV
+         END IF
       END IF
       IF( LASTC.EQ.0 ) THEN
          RETURN
@@ -244,13 +249,13 @@
                ! w = C_1**H + C_2**Hv_2
                ! w = C_2**Hv_2
                CALL ZGEMV( 'Conjugate transpose', LASTV - 1,
-     $               LASTC, ONE, C( 1+1, 1 ), LDC, V( 1 + INCV ),
+     $               LASTC, ONE, C( 1+1, 1 ), LDC, V( I ),
      $               INCV, ZERO, WORK, 1 )
 *
 *              w(1:lastc,1) += v(1,1) * C(1,1:lastc)**H
 *
-               DO I = 1, LASTC
-                  WORK( I ) = WORK( I ) + DCONJG( C( 1, I ) )
+               DO J = 1, LASTC
+                  WORK( J ) = WORK( J ) + DCONJG( C( 1, J ) )
                END DO
 *
 *           C(1:lastv,1:lastc) := C(...) - tau * v(1:lastv,1) * w(1:lastc,1)**H
@@ -258,13 +263,13 @@
             ! C(1, 1:lastc)   := C(...) - tau * v(1,1) * w(1:lastc,1)**H
             !                  = C(...) - tau * Conj(w(1:lastc,1))
             ! This is essentially a zaxpyc
-               DO I = 1, LASTC
-                  C( 1, I ) = C( 1, I ) - TAU * DCONJG( WORK( I ) )
+               DO J = 1, LASTC
+                  C( 1, J ) = C( 1, J ) - TAU * DCONJG( WORK( J ) )
                END DO
 *
 *        C(2:lastv,1:lastc) += - tau * v(2:lastv,1) * w(1:lastc,1)**H
 *
-               CALL ZGERC( LASTV - 1, LASTC, -TAU, V( 1 + INCV ),
+               CALL ZGERC( LASTV - 1, LASTC, -TAU, V( I ),
      $               INCV, WORK, 1, C( 1+1, 1 ), LDC )
             END IF
       ELSE
@@ -281,7 +286,7 @@
 *
                ! w(1:lastc,1) := C(1:lastc,2:lastv) * v(2:lastv,1)
                CALL ZGEMV( 'No transpose', LASTC, LASTV-1, ONE, 
-     $            C(1,1+1), LDC, V(1+INCV), INCV, ZERO, WORK, 1 )
+     $            C(1,1+1), LDC, V(I), INCV, ZERO, WORK, 1 )
                ! w(1:lastc,1) += C(1:lastc,1) v(1,1) = C(1:lastc,1)
                CALL ZAXPY(LASTC, ONE, C, 1, WORK, 1)
 *
@@ -291,7 +296,7 @@
                !                   = C(...) - tau * w(1:lastc,1)
                CALL ZAXPY(LASTC, -TAU, WORK, 1, C, 1)
                ! C(1:lastc,2:lastv) := C(...) - tau * w(1:lastc,1) * v(2:lastv)**T
-               CALL ZGERC( LASTC, LASTV-1, -TAU, WORK, 1, V(1+INCV),
+               CALL ZGERC( LASTC, LASTV-1, -TAU, WORK, 1, V(I),
      $                     INCV, C(1,1+1), LDC )
             END IF
       END IF

--- a/SRC/zlarf1l.f
+++ b/SRC/zlarf1l.f
@@ -177,7 +177,11 @@
          ELSE
             LASTV = N
          END IF
-         I = 1
+         IF( INCV.GT.0 ) THEN
+            I = 1
+         ELSE
+            I = 1 - (LASTV-1) * INCV
+         END IF
 !     Look for the last non-zero row in V.
          DO WHILE( LASTV.GT.FIRSTV .AND. V( I ).EQ.ZERO )
             FIRSTV = FIRSTV + 1
@@ -189,6 +193,11 @@
          ELSE
 !     Scan for the last non-zero row in C(:,1:lastv).
             LASTC = ILAZLR(M, LASTV, C, LDC)
+         END IF
+!     Set index for V. If INCV > 0, then I points to the start of V.
+!     For INCV < 0, set I to point to V(M-1)
+         IF( INCV.LT.0 ) THEN
+            I = 1 - INCV
          END IF
       END IF
       IF( LASTC.EQ.0 ) THEN


### PR DESCRIPTION
Added correct handling of input vector V with negative increments.

Closes: #1314 