### PR TITLE
{d/s}laed2/8: Increase deflation tolerance to match {d/s}lasd2/7

### DIFF
--- a/SRC/dlaed2.f
+++ b/SRC/dlaed2.f
@@ -313,7 +313,7 @@
       IMAX = IDAMAX( N, Z, 1 )
       JMAX = IDAMAX( N, D, 1 )
       EPS = DLAMCH( 'Epsilon' )
-      TOL = EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
+      TOL = EIGHT*EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the

--- a/SRC/dlaed8.f
+++ b/SRC/dlaed8.f
@@ -355,7 +355,7 @@
       IMAX = IDAMAX( N, Z, 1 )
       JMAX = IDAMAX( N, D, 1 )
       EPS = DLAMCH( 'Epsilon' )
-      TOL = EIGHT*EPS*ABS( D( JMAX ) )
+      TOL = EIGHT*EIGHT*EPS*ABS( D( JMAX ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the

--- a/SRC/slaed2.f
+++ b/SRC/slaed2.f
@@ -313,7 +313,7 @@
       IMAX = ISAMAX( N, Z, 1 )
       JMAX = ISAMAX( N, D, 1 )
       EPS = SLAMCH( 'Epsilon' )
-      TOL = EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
+      TOL = EIGHT*EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the

--- a/SRC/slaed8.f
+++ b/SRC/slaed8.f
@@ -355,7 +355,7 @@
       IMAX = ISAMAX( N, Z, 1 )
       JMAX = ISAMAX( N, D, 1 )
       EPS = SLAMCH( 'Epsilon' )
-      TOL = EIGHT*EPS*ABS( D( JMAX ) )
+      TOL = EIGHT*EIGHT*EPS*ABS( D( JMAX ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the


### PR DESCRIPTION
The eigenvalue divide-and-conquer helper routines DLAED2/SLAED2 and DLAED8/SLAED8 used a deflation tolerance of 8*EPS, while the SVD routines DLASD2/SLASD2 and DLASD7/SLASD7 now use 64*EPS (since PR #1286). The downstream eigenvector computation in DLAED3 divides by eigenvalue differences (DLAMBDA(I) - DLABMDA(J)), causing the same catastrophic cancellation when close eigenvalues escape deflation with the tighter tolerance.

Raise all four routines to 64*EPS (EIGHT*EIGHT*EPS), matching the SVD path, so close eigenvalues are deflated and the eigenvector computation remains stable.

Follow-up for #255

/cc @mgates3 
