### PR TITLE
Revert "{s/c/d/z}geqrf: document workspace query for empty matrices"

### DIFF
--- a/SRC/cgeqrf.f
+++ b/SRC/cgeqrf.f
@@ -102,8 +102,6 @@
 *>          only calculates the optimal size of the WORK array, returns
 *>          this value as the first entry of the WORK array, and no error
 *>          message related to LWORK is issued by XERBLA.
-*>          For an empty matrix (MIN(M,N) = 0), the workspace query
-*>          returns LWORK >= 1.
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/dgeqrf.f
+++ b/SRC/dgeqrf.f
@@ -102,8 +102,6 @@
 *>          only calculates the optimal size of the WORK array, returns
 *>          this value as the first entry of the WORK array, and no error
 *>          message related to LWORK is issued by XERBLA.
-*>          For an empty matrix (MIN(M,N) = 0), the workspace query
-*>          returns LWORK >= 1.
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/sgeqrf.f
+++ b/SRC/sgeqrf.f
@@ -102,8 +102,6 @@
 *>          only calculates the optimal size of the WORK array, returns
 *>          this value as the first entry of the WORK array, and no error
 *>          message related to LWORK is issued by XERBLA.
-*>          For an empty matrix (MIN(M,N) = 0), the workspace query
-*>          returns LWORK >= 1.
 *> \endverbatim
 *>
 *> \param[out] INFO

--- a/SRC/zgeqrf.f
+++ b/SRC/zgeqrf.f
@@ -102,8 +102,6 @@
 *>          only calculates the optimal size of the WORK array, returns
 *>          this value as the first entry of the WORK array, and no error
 *>          message related to LWORK is issued by XERBLA.
-*>          For an empty matrix (MIN(M,N) = 0), the workspace query
-*>          returns LWORK >= 1.
 *> \endverbatim
 *>
 *> \param[out] INFO


### PR DESCRIPTION
Reverts Reference-LAPACK/lapack#1304

See explanations at:
https://github.com/Reference-LAPACK/lapack/pull/1304#issuecomment-4924750230