### PR TITLE
{s/c/d/z}geqrf: move quick return before workspace computation

### DIFF
--- a/SRC/cgeqrf.f
+++ b/SRC/cgeqrf.f
@@ -180,6 +180,14 @@
 *
       K = MIN( M, N )
       INFO = 0
+*
+*     Quick return if possible
+*
+      IF( K.EQ.0 ) THEN
+         WORK( 1 ) = 1
+         RETURN
+      END IF
+*
       NB = ILAENV( 1, 'CGEQRF', ' ', M, N, -1, -1 )
       LQUERY = ( LWORK.EQ.-1 )
       IF( M.LT.0 ) THEN
@@ -196,19 +204,8 @@
          CALL XERBLA( 'CGEQRF', -INFO )
          RETURN
       ELSE IF( LQUERY ) THEN
-         IF( K.EQ.0 ) THEN
-            LWKOPT = 1
-         ELSE
-            LWKOPT = N*NB
-         END IF
+         LWKOPT = N*NB
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
-         RETURN
-      END IF
-*
-*     Quick return if possible
-*
-      IF( K.EQ.0 ) THEN
-         WORK( 1 ) = 1
          RETURN
       END IF
 *

--- a/SRC/dgeqrf.f
+++ b/SRC/dgeqrf.f
@@ -179,6 +179,14 @@
 *
       K = MIN( M, N )
       INFO = 0
+*
+*     Quick return if possible
+*
+      IF( K.EQ.0 ) THEN
+         WORK( 1 ) = 1
+         RETURN
+      END IF
+*
       NB = ILAENV( 1, 'DGEQRF', ' ', M, N, -1, -1 )
       LQUERY = ( LWORK.EQ.-1 )
       IF( M.LT.0 ) THEN
@@ -195,19 +203,8 @@
          CALL XERBLA( 'DGEQRF', -INFO )
          RETURN
       ELSE IF( LQUERY ) THEN
-         IF( K.EQ.0 ) THEN
-            LWKOPT = 1
-         ELSE
-            LWKOPT = N*NB
-         END IF
+         LWKOPT = N*NB
          WORK( 1 ) = LWKOPT
-         RETURN
-      END IF
-*
-*     Quick return if possible
-*
-      IF( K.EQ.0 ) THEN
-         WORK( 1 ) = 1
          RETURN
       END IF
 *

--- a/SRC/sgeqrf.f
+++ b/SRC/sgeqrf.f
@@ -180,6 +180,14 @@
 *
       K = MIN( M, N )
       INFO = 0
+*
+*     Quick return if possible
+*
+      IF( K.EQ.0 ) THEN
+         WORK( 1 ) = 1
+         RETURN
+      END IF
+*
       NB = ILAENV( 1, 'SGEQRF', ' ', M, N, -1, -1 )
       LQUERY = ( LWORK.EQ.-1 )
       IF( M.LT.0 ) THEN
@@ -196,19 +204,8 @@
          CALL XERBLA( 'SGEQRF', -INFO )
          RETURN
       ELSE IF( LQUERY ) THEN
-         IF( K.EQ.0 ) THEN
-            LWKOPT = 1
-         ELSE
-            LWKOPT = N*NB
-         END IF
+         LWKOPT = N*NB
          WORK( 1 ) = SROUNDUP_LWORK(LWKOPT)
-         RETURN
-      END IF
-*
-*     Quick return if possible
-*     
-      IF( K.EQ.0 ) THEN
-         WORK( 1 ) = 1
          RETURN
       END IF
 *

--- a/SRC/zgeqrf.f
+++ b/SRC/zgeqrf.f
@@ -179,6 +179,14 @@
 *
       K = MIN( M, N )
       INFO = 0
+*
+*     Quick return if possible
+*
+      IF( K.EQ.0 ) THEN
+         WORK( 1 ) = 1
+         RETURN
+      END IF
+*
       NB = ILAENV( 1, 'ZGEQRF', ' ', M, N, -1, -1 )
       LQUERY = ( LWORK.EQ.-1 )
       IF( M.LT.0 ) THEN
@@ -195,19 +203,8 @@
          CALL XERBLA( 'ZGEQRF', -INFO )
          RETURN
       ELSE IF( LQUERY ) THEN
-         IF( K.EQ.0 ) THEN
-            LWKOPT = 1
-         ELSE
-            LWKOPT = N*NB
-         END IF
+         LWKOPT = N*NB
          WORK( 1 ) = LWKOPT
-         RETURN
-      END IF
-*
-*     Quick return if possible
-*
-      IF( K.EQ.0 ) THEN
-         WORK( 1 ) = 1
          RETURN
       END IF
 *


### PR DESCRIPTION
Move the quick return (K=0 -> WORK(1)=1) to immediately after INFO=0, before ILAENV and the workspace query computation.  This avoids unnecessary work for empty matrices and establishes WORK(1)=1 as the convention for MIN(M,N)=0.

see #257