### PR TITLE
Remove IF statement related to initial zeros in X for triangular multiplications and solves ( tbmv, tbsv, tpmv, tpsv, trmm, trmv, trsm, and trsv )

### DIFF
--- a/BLAS/SRC/ctbmv.f
+++ b/BLAS/SRC/ctbmv.f
@@ -198,10 +198,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX ZERO
-      PARAMETER (ZERO= (0.0E+0,0.0E+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX TEMP
@@ -272,28 +268,24 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = KPLUS1 - J
-                          DO 10 I = MAX(1,J-K),J - 1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = KPLUS1 - J
+                      DO 10 I = MAX(1,J-K),J - 1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = KPLUS1 - J
-                          DO 30 I = MAX(1,J-K),J - 1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = KPLUS1 - J
+                      DO 30 I = MAX(1,J-K),J - 1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
                       JX = JX + INCX
                       IF (J.GT.K) KX = KX + INCX
    40             CONTINUE
@@ -301,29 +293,25 @@
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = 1 - J
-                          DO 50 I = MIN(N,J+K),J + 1,-1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = 1 - J
+                      DO 50 I = MIN(N,J+K),J + 1,-1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(1,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = 1 - J
-                          DO 70 I = MIN(N,J+K),J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = 1 - J
+                      DO 70 I = MIN(N,J+K),J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(1,J)
                       JX = JX - INCX
                       IF ((N-J).GE.K) KX = KX - INCX
    80             CONTINUE

--- a/BLAS/SRC/ctbsv.f
+++ b/BLAS/SRC/ctbsv.f
@@ -201,10 +201,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX ZERO
-      PARAMETER (ZERO= (0.0E+0,0.0E+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX TEMP
@@ -275,59 +271,51 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,MAX(1,J-K),-1
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   10                     CONTINUE
-                      END IF
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
+                      TEMP = X(J)
+                      DO 10 I = J - 1,MAX(1,J-K),-1
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   10                 CONTINUE
    20             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 40 J = N,1,-1
                       KX = KX - INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
-                          TEMP = X(JX)
-                          DO 30 I = J - 1,MAX(1,J-K),-1
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX - INCX
-   30                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
+                      TEMP = X(JX)
+                      DO 30 I = J - 1,MAX(1,J-K),-1
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX - INCX
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          L = 1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(1,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,MIN(N,J+K)
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   50                     CONTINUE
-                      END IF
+                      L = 1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(1,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,MIN(N,J+K)
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
                       KX = KX + INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = 1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(1,J)
-                          TEMP = X(JX)
-                          DO 70 I = J + 1,MIN(N,J+K)
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX + INCX
-   70                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = 1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(1,J)
+                      TEMP = X(JX)
+                      DO 70 I = J + 1,MIN(N,J+K)
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX + INCX
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/ctpmv.f
+++ b/BLAS/SRC/ctpmv.f
@@ -154,10 +154,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX ZERO
-      PARAMETER (ZERO= (0.0E+0,0.0E+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX TEMP
@@ -224,29 +220,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K + 1
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K + 1
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
                       KK = KK + J
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 K = KK,KK + J - 2
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 K = KK,KK + J - 2
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
                       JX = JX + INCX
                       KK = KK + J
    40             CONTINUE
@@ -255,30 +247,26 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K - 1
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K - 1
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
                       KK = KK - (N-J+1)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 K = KK,KK - (N- (J+1)),-1
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 K = KK,KK - (N- (J+1)),-1
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
                       JX = JX - INCX
                       KK = KK - (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/ctpsv.f
+++ b/BLAS/SRC/ctpsv.f
@@ -156,10 +156,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX ZERO
-      PARAMETER (ZERO= (0.0E+0,0.0E+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX TEMP
@@ -226,29 +222,25 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK - 1
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K - 1
-   10                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK - 1
+                      DO 10 I = J - 1,1,-1
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K - 1
+   10                 CONTINUE
                       KK = KK - J
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 K = KK - 1,KK - J + 1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 K = KK - 1,KK - J + 1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   30                 CONTINUE
                       JX = JX - INCX
                       KK = KK - J
    40             CONTINUE
@@ -257,29 +249,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK + 1
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K + 1
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK + 1
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K + 1
+   50                 CONTINUE
                       KK = KK + (N-J+1)
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 K = KK + 1,KK + N - J
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 K = KK + 1,KK + N - J
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   70                 CONTINUE
                       JX = JX + INCX
                       KK = KK + (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/ctrmm.f
+++ b/BLAS/SRC/ctrmm.f
@@ -276,27 +276,23 @@
               IF (UPPER) THEN
                   DO 50 J = 1,N
                       DO 40 K = 1,M
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              DO 30 I = 1,K - 1
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   30                         CONTINUE
-                              IF (NOUNIT) TEMP = TEMP*A(K,K)
-                              B(K,J) = TEMP
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          DO 30 I = 1,K - 1
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   30                     CONTINUE
+                          IF (NOUNIT) TEMP = TEMP*A(K,K)
+                          B(K,J) = TEMP
    40                 CONTINUE
    50             CONTINUE
               ELSE
                   DO 80 J = 1,N
                       DO 70 K = M,1,-1
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              B(K,J) = TEMP
-                              IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
-                              DO 60 I = K + 1,M
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   60                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          B(K,J) = TEMP
+                          IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
+                          DO 60 I = K + 1,M
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   60                     CONTINUE
    70                 CONTINUE
    80             CONTINUE
               END IF

--- a/BLAS/SRC/ctrmm.f
+++ b/BLAS/SRC/ctrmm.f
@@ -351,12 +351,10 @@
                           B(I,J) = TEMP*B(I,J)
   170                 CONTINUE
                       DO 190 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 180 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  180                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 180 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  180                     CONTINUE
   190                 CONTINUE
   200             CONTINUE
               ELSE
@@ -367,12 +365,10 @@
                           B(I,J) = TEMP*B(I,J)
   210                 CONTINUE
                       DO 230 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 220 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  220                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 220 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  220                     CONTINUE
   230                 CONTINUE
   240             CONTINUE
               END IF
@@ -383,16 +379,14 @@
               IF (UPPER) THEN
                   DO 280 K = 1,N
                       DO 260 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = ALPHA*A(J,K)
-                              ELSE
-                                  TEMP = ALPHA*CONJG(A(J,K))
-                              END IF
-                              DO 250 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  250                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = ALPHA*A(J,K)
+                          ELSE
+                              TEMP = ALPHA*CONJG(A(J,K))
                           END IF
+                          DO 250 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  250                     CONTINUE
   260                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) THEN
@@ -411,16 +405,14 @@
               ELSE
                   DO 320 K = N,1,-1
                       DO 300 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = ALPHA*A(J,K)
-                              ELSE
-                                  TEMP = ALPHA*CONJG(A(J,K))
-                              END IF
-                              DO 290 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  290                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = ALPHA*A(J,K)
+                          ELSE
+                              TEMP = ALPHA*CONJG(A(J,K))
                           END IF
+                          DO 290 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  290                     CONTINUE
   300                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) THEN

--- a/BLAS/SRC/ctrmv.f
+++ b/BLAS/SRC/ctrmv.f
@@ -159,10 +159,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX ZERO
-      PARAMETER (ZERO= (0.0E+0,0.0E+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX TEMP
@@ -230,53 +226,45 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*A(I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*A(I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 I = 1,J - 1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 I = 1,J - 1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX + INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*A(I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*A(I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 I = N,J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 I = N,J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX - INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/ctrsm.f
+++ b/BLAS/SRC/ctrsm.f
@@ -210,8 +210,6 @@
       LOGICAL LSIDE,NOCONJ,NOUNIT,UPPER
 *     ..
 *     .. Parameters ..
-      COMPLEX ONE
-      PARAMETER (ONE= (1.0E+0,0.0E+0))
       COMPLEX ZERO
       PARAMETER (ZERO= (0.0E+0,0.0E+0))
 *     ..
@@ -360,9 +358,8 @@
   200                     CONTINUE
   210                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 220 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   220                     CONTINUE
                       END IF
   230             CONTINUE
@@ -377,9 +374,8 @@
   250                     CONTINUE
   260                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 270 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   270                     CONTINUE
                       END IF
   280             CONTINUE
@@ -393,13 +389,14 @@
                   DO 330 K = N,1,-1
                       IF (NOUNIT) THEN
                           IF (NOCONJ) THEN
-                              TEMP = ONE/A(K,K)
+                              DO 290 I = 1,M
+                                  B(I,K) = B(I,K)/A(K,K)
+  290                         CONTINUE
                           ELSE
-                              TEMP = ONE/CONJG(A(K,K))
+                              DO 390 I = 1,M
+                                  B(I,K) = B(I,K)/CONJG(A(K,K))
+  390                         CONTINUE
                           END IF
-                          DO 290 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
-  290                     CONTINUE
                       END IF
                       DO 310 J = 1,K - 1
                           IF (NOCONJ) THEN
@@ -419,13 +416,14 @@
                   DO 380 K = 1,N
                       IF (NOUNIT) THEN
                           IF (NOCONJ) THEN
-                              TEMP = ONE/A(K,K)
+                              DO 340 I = 1,M
+                                  B(I,K) = B(I,K)/A(K,K)
+  340                         CONTINUE
                           ELSE
-                              TEMP = ONE/CONJG(A(K,K))
+                              DO 400 I = 1,M
+                                  B(I,K) = B(I,K)/CONJG(A(K,K))
+  400                         CONTINUE
                           END IF
-                          DO 340 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
-  340                     CONTINUE
                       END IF
                       DO 360 J = K + 1,N
                           IF (NOCONJ) THEN

--- a/BLAS/SRC/ctrsm.f
+++ b/BLAS/SRC/ctrsm.f
@@ -278,11 +278,9 @@
 *
               IF (UPPER) THEN
                   DO 60 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 30 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-   30                     CONTINUE
-                      END IF
+                       DO 30 I = 1,M
+                           B(I,J) = ALPHA*B(I,J)
+   30                  CONTINUE
                        DO 50 K = M,1,-1
                            IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
                            DO 40 I = 1,K - 1
@@ -292,11 +290,9 @@
    60             CONTINUE
                ELSE
                    DO 100 J = 1,N
-                       IF (ALPHA.NE.ONE) THEN
-                           DO 70 I = 1,M
-                               B(I,J) = ALPHA*B(I,J)
-   70                     CONTINUE
-                       END IF
+                       DO 70 I = 1,M
+                           B(I,J) = ALPHA*B(I,J)
+   70                  CONTINUE
                        DO 90 K = 1,M
                            IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
                            DO 80 I = K + 1,M
@@ -355,11 +351,9 @@
 *
               IF (UPPER) THEN
                   DO 230 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 190 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  190                     CONTINUE
-                      END IF
+                      DO 190 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  190                 CONTINUE
                       DO 210 K = 1,J - 1
                           IF (A(K,J).NE.ZERO) THEN
                               DO 200 I = 1,M
@@ -376,11 +370,9 @@
   230             CONTINUE
               ELSE
                   DO 280 J = N,1,-1
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 240 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  240                     CONTINUE
-                      END IF
+                      DO 240 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  240                 CONTINUE
                       DO 260 K = J + 1,N
                           IF (A(K,J).NE.ZERO) THEN
                               DO 250 I = 1,M
@@ -425,11 +417,9 @@
   300                         CONTINUE
                           END IF
   310                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 320 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  320                     CONTINUE
-                      END IF
+                      DO 320 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  320                 CONTINUE
   330             CONTINUE
               ELSE
                   DO 380 K = 1,N
@@ -455,11 +445,9 @@
   350                         CONTINUE
                           END IF
   360                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 370 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  370                     CONTINUE
-                      END IF
+                      DO 370 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  370                 CONTINUE
   380             CONTINUE
               END IF
           END IF

--- a/BLAS/SRC/ctrsm.f
+++ b/BLAS/SRC/ctrsm.f
@@ -355,11 +355,9 @@
                           B(I,J) = ALPHA*B(I,J)
   190                 CONTINUE
                       DO 210 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 200 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  200                         CONTINUE
-                          END IF
+                          DO 200 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  200                     CONTINUE
   210                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -374,11 +372,9 @@
                           B(I,J) = ALPHA*B(I,J)
   240                 CONTINUE
                       DO 260 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 250 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  250                         CONTINUE
-                          END IF
+                          DO 250 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  250                     CONTINUE
   260                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -406,16 +402,14 @@
   290                     CONTINUE
                       END IF
                       DO 310 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = A(J,K)
-                              ELSE
-                                  TEMP = CONJG(A(J,K))
-                              END IF
-                              DO 300 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  300                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = A(J,K)
+                          ELSE
+                              TEMP = CONJG(A(J,K))
                           END IF
+                          DO 300 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  300                     CONTINUE
   310                 CONTINUE
                       DO 320 I = 1,M
                           B(I,K) = ALPHA*B(I,K)
@@ -434,16 +428,14 @@
   340                     CONTINUE
                       END IF
                       DO 360 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = A(J,K)
-                              ELSE
-                                  TEMP = CONJG(A(J,K))
-                              END IF
-                              DO 350 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  350                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = A(J,K)
+                          ELSE
+                              TEMP = CONJG(A(J,K))
                           END IF
+                          DO 350 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  350                     CONTINUE
   360                 CONTINUE
                       DO 370 I = 1,M
                           B(I,K) = ALPHA*B(I,K)

--- a/BLAS/SRC/ctrsv.f
+++ b/BLAS/SRC/ctrsv.f
@@ -161,10 +161,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX ZERO
-      PARAMETER (ZERO= (0.0E+0,0.0E+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX TEMP
@@ -232,52 +228,44 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*A(I,J)
-   10                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/A(J,J)
+                      TEMP = X(J)
+                      DO 10 I = J - 1,1,-1
+                          X(I) = X(I) - TEMP*A(I,J)
+   10                 CONTINUE
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 I = J - 1,1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 I = J - 1,1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*A(I,J)
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/A(J,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*A(I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 I = J + 1,N
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 I = J + 1,N
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/dtbmv.f
+++ b/BLAS/SRC/dtbmv.f
@@ -198,10 +198,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      DOUBLE PRECISION ZERO
-      PARAMETER (ZERO=0.0D+0)
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION TEMP
@@ -271,28 +267,24 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = KPLUS1 - J
-                          DO 10 I = MAX(1,J-K),J - 1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = KPLUS1 - J
+                      DO 10 I = MAX(1,J-K),J - 1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = KPLUS1 - J
-                          DO 30 I = MAX(1,J-K),J - 1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = KPLUS1 - J
+                      DO 30 I = MAX(1,J-K),J - 1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
                       JX = JX + INCX
                       IF (J.GT.K) KX = KX + INCX
    40             CONTINUE
@@ -300,29 +292,25 @@
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = 1 - J
-                          DO 50 I = MIN(N,J+K),J + 1,-1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = 1 - J
+                      DO 50 I = MIN(N,J+K),J + 1,-1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(1,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = 1 - J
-                          DO 70 I = MIN(N,J+K),J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = 1 - J
+                      DO 70 I = MIN(N,J+K),J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(1,J)
                       JX = JX - INCX
                       IF ((N-J).GE.K) KX = KX - INCX
    80             CONTINUE

--- a/BLAS/SRC/dtbsv.f
+++ b/BLAS/SRC/dtbsv.f
@@ -201,10 +201,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      DOUBLE PRECISION ZERO
-      PARAMETER (ZERO=0.0D+0)
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION TEMP
@@ -274,59 +270,51 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,MAX(1,J-K),-1
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   10                     CONTINUE
-                      END IF
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
+                      TEMP = X(J)
+                      DO 10 I = J - 1,MAX(1,J-K),-1
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   10                 CONTINUE
    20             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 40 J = N,1,-1
                       KX = KX - INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
-                          TEMP = X(JX)
-                          DO 30 I = J - 1,MAX(1,J-K),-1
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX - INCX
-   30                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
+                      TEMP = X(JX)
+                      DO 30 I = J - 1,MAX(1,J-K),-1
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX - INCX
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          L = 1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(1,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,MIN(N,J+K)
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   50                     CONTINUE
-                      END IF
+                      L = 1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(1,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,MIN(N,J+K)
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
                       KX = KX + INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = 1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(1,J)
-                          TEMP = X(JX)
-                          DO 70 I = J + 1,MIN(N,J+K)
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX + INCX
-   70                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = 1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(1,J)
+                      TEMP = X(JX)
+                      DO 70 I = J + 1,MIN(N,J+K)
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX + INCX
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/dtpmv.f
+++ b/BLAS/SRC/dtpmv.f
@@ -154,10 +154,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      DOUBLE PRECISION ZERO
-      PARAMETER (ZERO=0.0D+0)
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION TEMP
@@ -220,29 +216,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K + 1
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K + 1
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
                       KK = KK + J
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 K = KK,KK + J - 2
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 K = KK,KK + J - 2
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
                       JX = JX + INCX
                       KK = KK + J
    40             CONTINUE
@@ -251,30 +243,26 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K - 1
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K - 1
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
                       KK = KK - (N-J+1)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 K = KK,KK - (N- (J+1)),-1
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 K = KK,KK - (N- (J+1)),-1
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
                       JX = JX - INCX
                       KK = KK - (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/dtpsv.f
+++ b/BLAS/SRC/dtpsv.f
@@ -156,10 +156,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      DOUBLE PRECISION ZERO
-      PARAMETER (ZERO=0.0D+0)
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION TEMP
@@ -222,29 +218,25 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK - 1
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K - 1
-   10                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK - 1
+                      DO 10 I = J - 1,1,-1
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K - 1
+   10                 CONTINUE
                       KK = KK - J
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 K = KK - 1,KK - J + 1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 K = KK - 1,KK - J + 1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   30                 CONTINUE
                       JX = JX - INCX
                       KK = KK - J
    40             CONTINUE
@@ -253,29 +245,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK + 1
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K + 1
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK + 1
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K + 1
+   50                 CONTINUE
                       KK = KK + (N-J+1)
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 K = KK + 1,KK + N - J
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 K = KK + 1,KK + N - J
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   70                 CONTINUE
                       JX = JX + INCX
                       KK = KK + (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/dtrmm.f
+++ b/BLAS/SRC/dtrmm.f
@@ -334,12 +334,10 @@
                           B(I,J) = TEMP*B(I,J)
   150                 CONTINUE
                       DO 170 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 160 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  160                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 160 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  160                     CONTINUE
   170                 CONTINUE
   180             CONTINUE
               ELSE
@@ -350,12 +348,10 @@
                           B(I,J) = TEMP*B(I,J)
   190                 CONTINUE
                       DO 210 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 200 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  200                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 200 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  200                     CONTINUE
   210                 CONTINUE
   220             CONTINUE
               END IF
@@ -366,12 +362,10 @@
               IF (UPPER) THEN
                   DO 260 K = 1,N
                       DO 240 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = ALPHA*A(J,K)
-                              DO 230 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  230                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(J,K)
+                          DO 230 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  230                     CONTINUE
   240                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) TEMP = TEMP*A(K,K)
@@ -384,12 +378,10 @@
               ELSE
                   DO 300 K = N,1,-1
                       DO 280 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = ALPHA*A(J,K)
-                              DO 270 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  270                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(J,K)
+                          DO 270 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  270                     CONTINUE
   280                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) TEMP = TEMP*A(K,K)

--- a/BLAS/SRC/dtrmm.f
+++ b/BLAS/SRC/dtrmm.f
@@ -273,27 +273,23 @@
               IF (UPPER) THEN
                   DO 50 J = 1,N
                       DO 40 K = 1,M
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              DO 30 I = 1,K - 1
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   30                         CONTINUE
-                              IF (NOUNIT) TEMP = TEMP*A(K,K)
-                              B(K,J) = TEMP
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          DO 30 I = 1,K - 1
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   30                     CONTINUE
+                          IF (NOUNIT) TEMP = TEMP*A(K,K)
+                          B(K,J) = TEMP
    40                 CONTINUE
    50             CONTINUE
               ELSE
                   DO 80 J = 1,N
                       DO 70 K = M,1,-1
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              B(K,J) = TEMP
-                              IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
-                              DO 60 I = K + 1,M
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   60                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          B(K,J) = TEMP
+                          IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
+                          DO 60 I = K + 1,M
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   60                     CONTINUE
    70                 CONTINUE
    80             CONTINUE
               END IF

--- a/BLAS/SRC/dtrmv.f
+++ b/BLAS/SRC/dtrmv.f
@@ -159,10 +159,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      DOUBLE PRECISION ZERO
-      PARAMETER (ZERO=0.0D+0)
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION TEMP
@@ -229,53 +225,45 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*A(I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*A(I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 I = 1,J - 1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 I = 1,J - 1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX + INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*A(I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*A(I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 I = N,J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 I = N,J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX - INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/dtrsm.f
+++ b/BLAS/SRC/dtrsm.f
@@ -211,8 +211,8 @@
       LOGICAL LSIDE,NOUNIT,UPPER
 *     ..
 *     .. Parameters ..
-      DOUBLE PRECISION ONE,ZERO
-      PARAMETER (ONE=1.0D+0,ZERO=0.0D+0)
+      DOUBLE PRECISION ZERO
+      PARAMETER (ZERO=0.0D+0)
 *     ..
 *
 *     Test the input parameters.
@@ -343,9 +343,8 @@
   180                     CONTINUE
   190                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 200 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   200                     CONTINUE
                       END IF
   210             CONTINUE
@@ -360,9 +359,8 @@
   230                     CONTINUE
   240                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 250 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   250                     CONTINUE
                       END IF
   260             CONTINUE
@@ -374,9 +372,8 @@
               IF (UPPER) THEN
                   DO 310 K = N,1,-1
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(K,K)
                           DO 270 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
+                              B(I,K) = B(I,K)/A(K,K)
   270                     CONTINUE
                       END IF
                       DO 290 J = 1,K - 1
@@ -392,9 +389,8 @@
               ELSE
                   DO 360 K = 1,N
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(K,K)
                           DO 320 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
+                              B(I,K) = B(I,K)/A(K,K)
   320                     CONTINUE
                       END IF
                       DO 340 J = K + 1,N

--- a/BLAS/SRC/dtrsm.f
+++ b/BLAS/SRC/dtrsm.f
@@ -338,11 +338,9 @@
                           B(I,J) = ALPHA*B(I,J)
   170                 CONTINUE
                       DO 190 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 180 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  180                         CONTINUE
-                          END IF
+                          DO 180 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  180                     CONTINUE
   190                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -357,11 +355,9 @@
                           B(I,J) = ALPHA*B(I,J)
   220                 CONTINUE
                       DO 240 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 230 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  230                         CONTINUE
-                          END IF
+                          DO 230 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  230                     CONTINUE
   240                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -384,12 +380,10 @@
   270                     CONTINUE
                       END IF
                       DO 290 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = A(J,K)
-                              DO 280 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  280                         CONTINUE
-                          END IF
+                          TEMP = A(J,K)
+                          DO 280 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  280                     CONTINUE
   290                 CONTINUE
                       DO 300 I = 1,M
                           B(I,K) = ALPHA*B(I,K)
@@ -404,12 +398,10 @@
   320                     CONTINUE
                       END IF
                       DO 340 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = A(J,K)
-                              DO 330 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  330                         CONTINUE
-                          END IF
+                          TEMP = A(J,K)
+                          DO 330 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  330                     CONTINUE
   340                 CONTINUE
                       DO 350 I = 1,M
                           B(I,K) = ALPHA*B(I,K)

--- a/BLAS/SRC/dtrsm.f
+++ b/BLAS/SRC/dtrsm.f
@@ -276,11 +276,9 @@
 *
               IF (UPPER) THEN
                   DO 60 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 30 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-   30                     CONTINUE
-                      END IF
+                       DO 30 I = 1,M
+                           B(I,J) = ALPHA*B(I,J)
+   30                  CONTINUE
                        DO 50 K = M,1,-1
                            IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
                            DO 40 I = 1,K - 1
@@ -290,11 +288,9 @@
    60             CONTINUE
               ELSE
                   DO 100 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 70 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-   70                     CONTINUE
-                      END IF
+                       DO 70 I = 1,M
+                           B(I,J) = ALPHA*B(I,J)
+   70                  CONTINUE
                        DO 90 K = 1,M
                            IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
                            DO 80 I = K + 1,M
@@ -338,11 +334,9 @@
 *
               IF (UPPER) THEN
                   DO 210 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 170 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  170                     CONTINUE
-                      END IF
+                      DO 170 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  170                 CONTINUE
                       DO 190 K = 1,J - 1
                           IF (A(K,J).NE.ZERO) THEN
                               DO 180 I = 1,M
@@ -359,11 +353,9 @@
   210             CONTINUE
               ELSE
                   DO 260 J = N,1,-1
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 220 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  220                     CONTINUE
-                      END IF
+                      DO 220 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  220                 CONTINUE
                       DO 240 K = J + 1,N
                           IF (A(K,J).NE.ZERO) THEN
                               DO 230 I = 1,M
@@ -399,11 +391,9 @@
   280                         CONTINUE
                           END IF
   290                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 300 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  300                     CONTINUE
-                      END IF
+                      DO 300 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  300                 CONTINUE
   310             CONTINUE
               ELSE
                   DO 360 K = 1,N
@@ -421,11 +411,9 @@
   330                         CONTINUE
                           END IF
   340                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 350 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  350                     CONTINUE
-                      END IF
+                      DO 350 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  350                 CONTINUE
   360             CONTINUE
               END IF
           END IF

--- a/BLAS/SRC/dtrsm.f
+++ b/BLAS/SRC/dtrsm.f
@@ -377,9 +377,8 @@
   270                     CONTINUE
                       END IF
                       DO 290 J = 1,K - 1
-                          TEMP = A(J,K)
                           DO 280 I = 1,M
-                              B(I,J) = B(I,J) - TEMP*B(I,K)
+                              B(I,J) = B(I,J) - A(J,K)*B(I,K)
   280                     CONTINUE
   290                 CONTINUE
                       DO 300 I = 1,M
@@ -394,9 +393,8 @@
   320                     CONTINUE
                       END IF
                       DO 340 J = K + 1,N
-                          TEMP = A(J,K)
                           DO 330 I = 1,M
-                              B(I,J) = B(I,J) - TEMP*B(I,K)
+                              B(I,J) = B(I,J) - A(J,K)*B(I,K)
   330                     CONTINUE
   340                 CONTINUE
                       DO 350 I = 1,M

--- a/BLAS/SRC/dtrsv.f
+++ b/BLAS/SRC/dtrsv.f
@@ -155,10 +155,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      DOUBLE PRECISION ZERO
-      PARAMETER (ZERO=0.0D+0)
 *     ..
 *     .. Local Scalars ..
       DOUBLE PRECISION TEMP
@@ -225,52 +221,44 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*A(I,J)
-   10                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/A(J,J)
+                      TEMP = X(J)
+                      DO 10 I = J - 1,1,-1
+                          X(I) = X(I) - TEMP*A(I,J)
+   10                 CONTINUE
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 I = J - 1,1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 I = J - 1,1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*A(I,J)
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/A(J,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*A(I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 I = J + 1,N
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 I = J + 1,N
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/stbmv.f
+++ b/BLAS/SRC/stbmv.f
@@ -198,10 +198,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      REAL ZERO
-      PARAMETER (ZERO=0.0E+0)
 *     ..
 *     .. Local Scalars ..
       REAL TEMP
@@ -271,28 +267,24 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = KPLUS1 - J
-                          DO 10 I = MAX(1,J-K),J - 1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = KPLUS1 - J
+                      DO 10 I = MAX(1,J-K),J - 1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = KPLUS1 - J
-                          DO 30 I = MAX(1,J-K),J - 1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = KPLUS1 - J
+                      DO 30 I = MAX(1,J-K),J - 1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
                       JX = JX + INCX
                       IF (J.GT.K) KX = KX + INCX
    40             CONTINUE
@@ -300,29 +292,25 @@
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = 1 - J
-                          DO 50 I = MIN(N,J+K),J + 1,-1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = 1 - J
+                      DO 50 I = MIN(N,J+K),J + 1,-1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(1,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = 1 - J
-                          DO 70 I = MIN(N,J+K),J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = 1 - J
+                      DO 70 I = MIN(N,J+K),J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(1,J)
                       JX = JX - INCX
                       IF ((N-J).GE.K) KX = KX - INCX
    80             CONTINUE

--- a/BLAS/SRC/stbsv.f
+++ b/BLAS/SRC/stbsv.f
@@ -201,10 +201,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      REAL ZERO
-      PARAMETER (ZERO=0.0E+0)
 *     ..
 *     .. Local Scalars ..
       REAL TEMP
@@ -274,59 +270,51 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,MAX(1,J-K),-1
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   10                     CONTINUE
-                      END IF
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
+                      TEMP = X(J)
+                      DO 10 I = J - 1,MAX(1,J-K),-1
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   10                 CONTINUE
    20             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 40 J = N,1,-1
                       KX = KX - INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
-                          TEMP = X(JX)
-                          DO 30 I = J - 1,MAX(1,J-K),-1
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX - INCX
-   30                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
+                      TEMP = X(JX)
+                      DO 30 I = J - 1,MAX(1,J-K),-1
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX - INCX
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          L = 1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(1,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,MIN(N,J+K)
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   50                     CONTINUE
-                      END IF
+                      L = 1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(1,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,MIN(N,J+K)
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
                       KX = KX + INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = 1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(1,J)
-                          TEMP = X(JX)
-                          DO 70 I = J + 1,MIN(N,J+K)
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX + INCX
-   70                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = 1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(1,J)
+                      TEMP = X(JX)
+                      DO 70 I = J + 1,MIN(N,J+K)
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX + INCX
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/stpmv.f
+++ b/BLAS/SRC/stpmv.f
@@ -154,10 +154,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      REAL ZERO
-      PARAMETER (ZERO=0.0E+0)
 *     ..
 *     .. Local Scalars ..
       REAL TEMP
@@ -220,29 +216,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K + 1
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K + 1
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
                       KK = KK + J
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 K = KK,KK + J - 2
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 K = KK,KK + J - 2
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
                       JX = JX + INCX
                       KK = KK + J
    40             CONTINUE
@@ -251,30 +243,26 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K - 1
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K - 1
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
                       KK = KK - (N-J+1)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 K = KK,KK - (N- (J+1)),-1
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 K = KK,KK - (N- (J+1)),-1
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
                       JX = JX - INCX
                       KK = KK - (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/stpsv.f
+++ b/BLAS/SRC/stpsv.f
@@ -156,10 +156,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      REAL ZERO
-      PARAMETER (ZERO=0.0E+0)
 *     ..
 *     .. Local Scalars ..
       REAL TEMP
@@ -222,29 +218,25 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK - 1
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K - 1
-   10                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK - 1
+                      DO 10 I = J - 1,1,-1
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K - 1
+   10                 CONTINUE
                       KK = KK - J
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 K = KK - 1,KK - J + 1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 K = KK - 1,KK - J + 1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   30                 CONTINUE
                       JX = JX - INCX
                       KK = KK - J
    40             CONTINUE
@@ -253,29 +245,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK + 1
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K + 1
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK + 1
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K + 1
+   50                 CONTINUE
                       KK = KK + (N-J+1)
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 K = KK + 1,KK + N - J
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 K = KK + 1,KK + N - J
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   70                 CONTINUE
                       JX = JX + INCX
                       KK = KK + (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/strmm.f
+++ b/BLAS/SRC/strmm.f
@@ -334,12 +334,10 @@
                           B(I,J) = TEMP*B(I,J)
   150                 CONTINUE
                       DO 170 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 160 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  160                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 160 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  160                     CONTINUE
   170                 CONTINUE
   180             CONTINUE
               ELSE
@@ -350,12 +348,10 @@
                           B(I,J) = TEMP*B(I,J)
   190                 CONTINUE
                       DO 210 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 200 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  200                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 200 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  200                     CONTINUE
   210                 CONTINUE
   220             CONTINUE
               END IF
@@ -366,12 +362,10 @@
               IF (UPPER) THEN
                   DO 260 K = 1,N
                       DO 240 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = ALPHA*A(J,K)
-                              DO 230 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  230                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(J,K)
+                          DO 230 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  230                     CONTINUE
   240                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) TEMP = TEMP*A(K,K)
@@ -384,12 +378,10 @@
               ELSE
                   DO 300 K = N,1,-1
                       DO 280 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = ALPHA*A(J,K)
-                              DO 270 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  270                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(J,K)
+                          DO 270 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  270                     CONTINUE
   280                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) TEMP = TEMP*A(K,K)

--- a/BLAS/SRC/strmm.f
+++ b/BLAS/SRC/strmm.f
@@ -273,27 +273,23 @@
               IF (UPPER) THEN
                   DO 50 J = 1,N
                       DO 40 K = 1,M
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              DO 30 I = 1,K - 1
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   30                         CONTINUE
-                              IF (NOUNIT) TEMP = TEMP*A(K,K)
-                              B(K,J) = TEMP
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          DO 30 I = 1,K - 1
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   30                     CONTINUE
+                          IF (NOUNIT) TEMP = TEMP*A(K,K)
+                          B(K,J) = TEMP
    40                 CONTINUE
    50             CONTINUE
               ELSE
                   DO 80 J = 1,N
                       DO 70 K = M,1,-1
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              B(K,J) = TEMP
-                              IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
-                              DO 60 I = K + 1,M
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   60                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          B(K,J) = TEMP
+                          IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
+                          DO 60 I = K + 1,M
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   60                     CONTINUE
    70                 CONTINUE
    80             CONTINUE
               END IF

--- a/BLAS/SRC/strmv.f
+++ b/BLAS/SRC/strmv.f
@@ -159,10 +159,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      REAL ZERO
-      PARAMETER (ZERO=0.0E+0)
 *     ..
 *     .. Local Scalars ..
       REAL TEMP
@@ -229,53 +225,45 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*A(I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*A(I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 I = 1,J - 1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 I = 1,J - 1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX + INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*A(I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*A(I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 I = N,J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 I = N,J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX - INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/strsm.f
+++ b/BLAS/SRC/strsm.f
@@ -338,11 +338,9 @@
                           B(I,J) = ALPHA*B(I,J)
   170                 CONTINUE
                       DO 190 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 180 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  180                         CONTINUE
-                          END IF
+                          DO 180 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  180                     CONTINUE
   190                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -357,11 +355,9 @@
                           B(I,J) = ALPHA*B(I,J)
   220                 CONTINUE
                       DO 240 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 230 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  230                         CONTINUE
-                          END IF
+                          DO 230 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  230                     CONTINUE
   240                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -384,12 +380,10 @@
   270                     CONTINUE
                       END IF
                       DO 290 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = A(J,K)
-                              DO 280 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  280                         CONTINUE
-                          END IF
+                          TEMP = A(J,K)
+                          DO 280 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  280                     CONTINUE
   290                 CONTINUE
                       DO 300 I = 1,M
                           B(I,K) = ALPHA*B(I,K)
@@ -404,12 +398,10 @@
   320                     CONTINUE
                       END IF
                       DO 340 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              TEMP = A(J,K)
-                              DO 330 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  330                         CONTINUE
-                          END IF
+                          TEMP = A(J,K)
+                          DO 330 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  330                     CONTINUE
   340                 CONTINUE
                       DO 350 I = 1,M
                           B(I,K) = ALPHA*B(I,K)

--- a/BLAS/SRC/strsm.f
+++ b/BLAS/SRC/strsm.f
@@ -276,31 +276,27 @@
 *
               IF (UPPER) THEN
                   DO 60 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 30 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-   30                     CONTINUE
-                      END IF
-                       DO 50 K = M,1,-1
-                           IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
-                           DO 40 I = 1,K - 1
-                               B(I,J) = B(I,J) - B(K,J)*A(I,K)
+                      DO 30 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+   30                 CONTINUE
+                      DO 50 K = M,1,-1
+                          IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
+                          DO 40 I = 1,K - 1
+                              B(I,J) = B(I,J) - B(K,J)*A(I,K)
    40                     CONTINUE
    50                 CONTINUE
    60             CONTINUE
-               ELSE
-                   DO 100 J = 1,N
-                       IF (ALPHA.NE.ONE) THEN
-                           DO 70 I = 1,M
-                               B(I,J) = ALPHA*B(I,J)
-   70                     CONTINUE
-                       END IF
-                       DO 90 K = 1,M
-                           IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
-                           DO 80 I = K + 1,M
-                               B(I,J) = B(I,J) - B(K,J)*A(I,K)
+              ELSE
+                  DO 100 J = 1,N
+                      DO 70 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+   70                 CONTINUE
+                      DO 90 K = 1,M
+                          IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
+                          DO 80 I = K + 1,M
+                              B(I,J) = B(I,J) - B(K,J)*A(I,K)
    80                     CONTINUE
-   90                 CONTINUE
+   90                CONTINUE
   100             CONTINUE
               END IF
           ELSE
@@ -338,11 +334,9 @@
 *
               IF (UPPER) THEN
                   DO 210 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 170 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  170                     CONTINUE
-                      END IF
+                      DO 170 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  170                 CONTINUE
                       DO 190 K = 1,J - 1
                           IF (A(K,J).NE.ZERO) THEN
                               DO 180 I = 1,M
@@ -359,11 +353,9 @@
   210             CONTINUE
               ELSE
                   DO 260 J = N,1,-1
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 220 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  220                     CONTINUE
-                      END IF
+                      DO 220 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  220                 CONTINUE
                       DO 240 K = J + 1,N
                           IF (A(K,J).NE.ZERO) THEN
                               DO 230 I = 1,M
@@ -399,11 +391,9 @@
   280                         CONTINUE
                           END IF
   290                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 300 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  300                     CONTINUE
-                      END IF
+                      DO 300 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  300                 CONTINUE
   310             CONTINUE
               ELSE
                   DO 360 K = 1,N
@@ -421,11 +411,9 @@
   330                         CONTINUE
                           END IF
   340                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 350 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  350                     CONTINUE
-                      END IF
+                      DO 350 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  350                 CONTINUE
   360             CONTINUE
               END IF
           END IF

--- a/BLAS/SRC/strsm.f
+++ b/BLAS/SRC/strsm.f
@@ -377,9 +377,8 @@
   270                     CONTINUE
                       END IF
                       DO 290 J = 1,K - 1
-                          TEMP = A(J,K)
                           DO 280 I = 1,M
-                              B(I,J) = B(I,J) - TEMP*B(I,K)
+                              B(I,J) = B(I,J) - A(J,K)*B(I,K)
   280                     CONTINUE
   290                 CONTINUE
                       DO 300 I = 1,M
@@ -394,9 +393,8 @@
   320                     CONTINUE
                       END IF
                       DO 340 J = K + 1,N
-                          TEMP = A(J,K)
                           DO 330 I = 1,M
-                              B(I,J) = B(I,J) - TEMP*B(I,K)
+                              B(I,J) = B(I,J) - A(J,K)*B(I,K)
   330                     CONTINUE
   340                 CONTINUE
                       DO 350 I = 1,M

--- a/BLAS/SRC/strsm.f
+++ b/BLAS/SRC/strsm.f
@@ -211,8 +211,8 @@
       LOGICAL LSIDE,NOUNIT,UPPER
 *     ..
 *     .. Parameters ..
-      REAL ONE,ZERO
-      PARAMETER (ONE=1.0E+0,ZERO=0.0E+0)
+      REAL ZERO
+      PARAMETER (ZERO=0.0E+0)
 *     ..
 *
 *     Test the input parameters.
@@ -343,9 +343,8 @@
   180                     CONTINUE
   190                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 200 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   200                     CONTINUE
                       END IF
   210             CONTINUE
@@ -360,9 +359,8 @@
   230                     CONTINUE
   240                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 250 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   250                     CONTINUE
                       END IF
   260             CONTINUE
@@ -374,9 +372,8 @@
               IF (UPPER) THEN
                   DO 310 K = N,1,-1
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(K,K)
                           DO 270 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
+                              B(I,K) = B(I,K)/A(K,K)
   270                     CONTINUE
                       END IF
                       DO 290 J = 1,K - 1
@@ -392,9 +389,8 @@
               ELSE
                   DO 360 K = 1,N
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(K,K)
                           DO 320 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
+                              B(I,K) = B(I,K)/A(K,K)
   320                     CONTINUE
                       END IF
                       DO 340 J = K + 1,N

--- a/BLAS/SRC/strsv.f
+++ b/BLAS/SRC/strsv.f
@@ -161,10 +161,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      REAL ZERO
-      PARAMETER (ZERO=0.0E+0)
 *     ..
 *     .. Local Scalars ..
       REAL TEMP
@@ -231,52 +227,44 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*A(I,J)
-   10                     CONTINUE
-                      END IF
+                        IF (NOUNIT) X(J) = X(J)/A(J,J)
+                        TEMP = X(J)
+                        DO 10 I = J - 1,1,-1
+                            X(I) = X(I) - TEMP*A(I,J)
+   10                   CONTINUE
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 I = J - 1,1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 I = J - 1,1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*A(I,J)
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/A(J,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*A(I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 I = J + 1,N
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 I = J + 1,N
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/ztbmv.f
+++ b/BLAS/SRC/ztbmv.f
@@ -198,10 +198,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX*16 ZERO
-      PARAMETER (ZERO= (0.0D+0,0.0D+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16 TEMP
@@ -272,28 +268,24 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = KPLUS1 - J
-                          DO 10 I = MAX(1,J-K),J - 1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = KPLUS1 - J
+                      DO 10 I = MAX(1,J-K),J - 1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(KPLUS1,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = KPLUS1 - J
-                          DO 30 I = MAX(1,J-K),J - 1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = KPLUS1 - J
+                      DO 30 I = MAX(1,J-K),J - 1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(KPLUS1,J)
                       JX = JX + INCX
                       IF (J.GT.K) KX = KX + INCX
    40             CONTINUE
@@ -301,29 +293,25 @@
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          L = 1 - J
-                          DO 50 I = MIN(N,J+K),J + 1,-1
-                              X(I) = X(I) + TEMP*A(L+I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(1,J)
-                      END IF
+                      TEMP = X(J)
+                      L = 1 - J
+                      DO 50 I = MIN(N,J+K),J + 1,-1
+                          X(I) = X(I) + TEMP*A(L+I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(1,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          L = 1 - J
-                          DO 70 I = MIN(N,J+K),J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(L+I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(1,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      L = 1 - J
+                      DO 70 I = MIN(N,J+K),J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(L+I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(1,J)
                       JX = JX - INCX
                       IF ((N-J).GE.K) KX = KX - INCX
    80             CONTINUE

--- a/BLAS/SRC/ztbsv.f
+++ b/BLAS/SRC/ztbsv.f
@@ -201,10 +201,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX*16 ZERO
-      PARAMETER (ZERO= (0.0D+0,0.0D+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16 TEMP
@@ -275,59 +271,51 @@
               KPLUS1 = K + 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,MAX(1,J-K),-1
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   10                     CONTINUE
-                      END IF
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(KPLUS1,J)
+                      TEMP = X(J)
+                      DO 10 I = J - 1,MAX(1,J-K),-1
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   10                 CONTINUE
    20             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 40 J = N,1,-1
                       KX = KX - INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = KPLUS1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
-                          TEMP = X(JX)
-                          DO 30 I = J - 1,MAX(1,J-K),-1
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX - INCX
-   30                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = KPLUS1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(KPLUS1,J)
+                      TEMP = X(JX)
+                      DO 30 I = J - 1,MAX(1,J-K),-1
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX - INCX
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          L = 1 - J
-                          IF (NOUNIT) X(J) = X(J)/A(1,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,MIN(N,J+K)
-                              X(I) = X(I) - TEMP*A(L+I,J)
-   50                     CONTINUE
-                      END IF
+                      L = 1 - J
+                      IF (NOUNIT) X(J) = X(J)/A(1,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,MIN(N,J+K)
+                          X(I) = X(I) - TEMP*A(L+I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
                       KX = KX + INCX
-                      IF (X(JX).NE.ZERO) THEN
-                          IX = KX
-                          L = 1 - J
-                          IF (NOUNIT) X(JX) = X(JX)/A(1,J)
-                          TEMP = X(JX)
-                          DO 70 I = J + 1,MIN(N,J+K)
-                              X(IX) = X(IX) - TEMP*A(L+I,J)
-                              IX = IX + INCX
-   70                     CONTINUE
-                      END IF
+                      IX = KX
+                      L = 1 - J
+                      IF (NOUNIT) X(JX) = X(JX)/A(1,J)
+                      TEMP = X(JX)
+                      DO 70 I = J + 1,MIN(N,J+K)
+                          X(IX) = X(IX) - TEMP*A(L+I,J)
+                          IX = IX + INCX
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/ztpmv.f
+++ b/BLAS/SRC/ztpmv.f
@@ -154,10 +154,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX*16 ZERO
-      PARAMETER (ZERO= (0.0D+0,0.0D+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16 TEMP
@@ -224,29 +220,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K + 1
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K + 1
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK+J-1)
                       KK = KK + J
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 K = KK,KK + J - 2
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 K = KK,KK + J - 2
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK+J-1)
                       JX = JX + INCX
                       KK = KK + J
    40             CONTINUE
@@ -255,30 +247,26 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          K = KK
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*AP(K)
-                              K = K - 1
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(J)
+                      K = KK
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*AP(K)
+                          K = K - 1
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*AP(KK-N+J)
                       KK = KK - (N-J+1)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 K = KK,KK - (N- (J+1)),-1
-                              X(IX) = X(IX) + TEMP*AP(K)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 K = KK,KK - (N- (J+1)),-1
+                          X(IX) = X(IX) + TEMP*AP(K)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*AP(KK-N+J)
                       JX = JX - INCX
                       KK = KK - (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/ztpsv.f
+++ b/BLAS/SRC/ztpsv.f
@@ -156,10 +156,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX*16 ZERO
-      PARAMETER (ZERO= (0.0D+0,0.0D+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16 TEMP
@@ -226,29 +222,25 @@
               KK = (N* (N+1))/2
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK - 1
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K - 1
-   10                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK - 1
+                      DO 10 I = J - 1,1,-1
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K - 1
+   10                 CONTINUE
                       KK = KK - J
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 K = KK - 1,KK - J + 1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 K = KK - 1,KK - J + 1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   30                 CONTINUE
                       JX = JX - INCX
                       KK = KK - J
    40             CONTINUE
@@ -257,29 +249,25 @@
               KK = 1
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/AP(KK)
-                          TEMP = X(J)
-                          K = KK + 1
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*AP(K)
-                              K = K + 1
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/AP(KK)
+                      TEMP = X(J)
+                      K = KK + 1
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*AP(K)
+                          K = K + 1
+   50                 CONTINUE
                       KK = KK + (N-J+1)
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/AP(KK)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 K = KK + 1,KK + N - J
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*AP(K)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/AP(KK)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 K = KK + 1,KK + N - J
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*AP(K)
+   70                 CONTINUE
                       JX = JX + INCX
                       KK = KK + (N-J+1)
    80             CONTINUE

--- a/BLAS/SRC/ztrmm.f
+++ b/BLAS/SRC/ztrmm.f
@@ -351,12 +351,10 @@
                           B(I,J) = TEMP*B(I,J)
   170                 CONTINUE
                       DO 190 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 180 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  180                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 180 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  180                     CONTINUE
   190                 CONTINUE
   200             CONTINUE
               ELSE
@@ -367,12 +365,10 @@
                           B(I,J) = TEMP*B(I,J)
   210                 CONTINUE
                       DO 230 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*A(K,J)
-                              DO 220 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  220                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*A(K,J)
+                          DO 220 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  220                     CONTINUE
   230                 CONTINUE
   240             CONTINUE
               END IF
@@ -383,16 +379,14 @@
               IF (UPPER) THEN
                   DO 280 K = 1,N
                       DO 260 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = ALPHA*A(J,K)
-                              ELSE
-                                  TEMP = ALPHA*DCONJG(A(J,K))
-                              END IF
-                              DO 250 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  250                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = ALPHA*A(J,K)
+                          ELSE
+                              TEMP = ALPHA*DCONJG(A(J,K))
                           END IF
+                          DO 250 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  250                     CONTINUE
   260                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) THEN
@@ -411,16 +405,14 @@
               ELSE
                   DO 320 K = N,1,-1
                       DO 300 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = ALPHA*A(J,K)
-                              ELSE
-                                  TEMP = ALPHA*DCONJG(A(J,K))
-                              END IF
-                              DO 290 I = 1,M
-                                  B(I,J) = B(I,J) + TEMP*B(I,K)
-  290                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = ALPHA*A(J,K)
+                          ELSE
+                              TEMP = ALPHA*DCONJG(A(J,K))
                           END IF
+                          DO 290 I = 1,M
+                              B(I,J) = B(I,J) + TEMP*B(I,K)
+  290                     CONTINUE
   300                 CONTINUE
                       TEMP = ALPHA
                       IF (NOUNIT) THEN

--- a/BLAS/SRC/ztrmm.f
+++ b/BLAS/SRC/ztrmm.f
@@ -276,27 +276,23 @@
               IF (UPPER) THEN
                   DO 50 J = 1,N
                       DO 40 K = 1,M
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              DO 30 I = 1,K - 1
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   30                         CONTINUE
-                              IF (NOUNIT) TEMP = TEMP*A(K,K)
-                              B(K,J) = TEMP
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          DO 30 I = 1,K - 1
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   30                     CONTINUE
+                          IF (NOUNIT) TEMP = TEMP*A(K,K)
+                          B(K,J) = TEMP
    40                 CONTINUE
    50             CONTINUE
               ELSE
                   DO 80 J = 1,N
                       DO 70 K = M,1,-1
-                          IF (B(K,J).NE.ZERO) THEN
-                              TEMP = ALPHA*B(K,J)
-                              B(K,J) = TEMP
-                              IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
-                              DO 60 I = K + 1,M
-                                  B(I,J) = B(I,J) + TEMP*A(I,K)
-   60                         CONTINUE
-                          END IF
+                          TEMP = ALPHA*B(K,J)
+                          B(K,J) = TEMP
+                          IF (NOUNIT) B(K,J) = B(K,J)*A(K,K)
+                          DO 60 I = K + 1,M
+                              B(I,J) = B(I,J) + TEMP*A(I,K)
+   60                     CONTINUE
    70                 CONTINUE
    80             CONTINUE
               END IF

--- a/BLAS/SRC/ztrmv.f
+++ b/BLAS/SRC/ztrmv.f
@@ -159,10 +159,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX*16 ZERO
-      PARAMETER (ZERO= (0.0D+0,0.0D+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16 TEMP
@@ -230,53 +226,45 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 10 I = 1,J - 1
-                              X(I) = X(I) + TEMP*A(I,J)
-   10                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 10 I = 1,J - 1
+                          X(I) = X(I) + TEMP*A(I,J)
+   10                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    20             CONTINUE
               ELSE
                   JX = KX
                   DO 40 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 30 I = 1,J - 1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX + INCX
-   30                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 30 I = 1,J - 1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX + INCX
+   30                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX + INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          TEMP = X(J)
-                          DO 50 I = N,J + 1,-1
-                              X(I) = X(I) + TEMP*A(I,J)
-   50                     CONTINUE
-                          IF (NOUNIT) X(J) = X(J)*A(J,J)
-                      END IF
+                      TEMP = X(J)
+                      DO 50 I = N,J + 1,-1
+                          X(I) = X(I) + TEMP*A(I,J)
+   50                 CONTINUE
+                      IF (NOUNIT) X(J) = X(J)*A(J,J)
    60             CONTINUE
               ELSE
                   KX = KX + (N-1)*INCX
                   JX = KX
                   DO 80 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          TEMP = X(JX)
-                          IX = KX
-                          DO 70 I = N,J + 1,-1
-                              X(IX) = X(IX) + TEMP*A(I,J)
-                              IX = IX - INCX
-   70                     CONTINUE
-                          IF (NOUNIT) X(JX) = X(JX)*A(J,J)
-                      END IF
+                      TEMP = X(JX)
+                      IX = KX
+                      DO 70 I = N,J + 1,-1
+                          X(IX) = X(IX) + TEMP*A(I,J)
+                          IX = IX - INCX
+   70                 CONTINUE
+                      IF (NOUNIT) X(JX) = X(JX)*A(J,J)
                       JX = JX - INCX
    80             CONTINUE
               END IF

--- a/BLAS/SRC/ztrsm.f
+++ b/BLAS/SRC/ztrsm.f
@@ -278,11 +278,9 @@
 *
               IF (UPPER) THEN
                   DO 60 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 30 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-   30                     CONTINUE
-                      END IF
+                       DO 30 I = 1,M
+                           B(I,J) = ALPHA*B(I,J)
+   30                  CONTINUE
                        DO 50 K = M,1,-1
                            IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
                            DO 40 I = 1,K - 1
@@ -292,11 +290,9 @@
    60             CONTINUE
                ELSE
                    DO 100 J = 1,N
-                       IF (ALPHA.NE.ONE) THEN
-                           DO 70 I = 1,M
-                               B(I,J) = ALPHA*B(I,J)
-   70                     CONTINUE
-                       END IF
+                       DO 70 I = 1,M
+                           B(I,J) = ALPHA*B(I,J)
+   70                  CONTINUE
                        DO 90 K = 1,M
                            IF (NOUNIT) B(K,J) = B(K,J)/A(K,K)
                            DO 80 I = K + 1,M
@@ -355,11 +351,9 @@
 *
               IF (UPPER) THEN
                   DO 230 J = 1,N
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 190 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  190                     CONTINUE
-                      END IF
+                      DO 190 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  190                 CONTINUE
                       DO 210 K = 1,J - 1
                           IF (A(K,J).NE.ZERO) THEN
                               DO 200 I = 1,M
@@ -376,11 +370,9 @@
   230             CONTINUE
               ELSE
                   DO 280 J = N,1,-1
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 240 I = 1,M
-                              B(I,J) = ALPHA*B(I,J)
-  240                     CONTINUE
-                      END IF
+                      DO 240 I = 1,M
+                          B(I,J) = ALPHA*B(I,J)
+  240                 CONTINUE
                       DO 260 K = J + 1,N
                           IF (A(K,J).NE.ZERO) THEN
                               DO 250 I = 1,M
@@ -425,11 +417,9 @@
   300                         CONTINUE
                           END IF
   310                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 320 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  320                     CONTINUE
-                      END IF
+                      DO 320 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  320                 CONTINUE
   330             CONTINUE
               ELSE
                   DO 380 K = 1,N
@@ -455,11 +445,9 @@
   350                         CONTINUE
                           END IF
   360                 CONTINUE
-                      IF (ALPHA.NE.ONE) THEN
-                          DO 370 I = 1,M
-                              B(I,K) = ALPHA*B(I,K)
-  370                     CONTINUE
-                      END IF
+                      DO 370 I = 1,M
+                          B(I,K) = ALPHA*B(I,K)
+  370                 CONTINUE
   380             CONTINUE
               END IF
           END IF

--- a/BLAS/SRC/ztrsm.f
+++ b/BLAS/SRC/ztrsm.f
@@ -355,11 +355,9 @@
                           B(I,J) = ALPHA*B(I,J)
   190                 CONTINUE
                       DO 210 K = 1,J - 1
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 200 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  200                         CONTINUE
-                          END IF
+                          DO 200 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  200                     CONTINUE
   210                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -374,11 +372,9 @@
                           B(I,J) = ALPHA*B(I,J)
   240                 CONTINUE
                       DO 260 K = J + 1,N
-                          IF (A(K,J).NE.ZERO) THEN
-                              DO 250 I = 1,M
-                                  B(I,J) = B(I,J) - A(K,J)*B(I,K)
-  250                         CONTINUE
-                          END IF
+                          DO 250 I = 1,M
+                              B(I,J) = B(I,J) - A(K,J)*B(I,K)
+  250                     CONTINUE
   260                 CONTINUE
                       IF (NOUNIT) THEN
                           TEMP = ONE/A(J,J)
@@ -406,16 +402,14 @@
   290                     CONTINUE
                       END IF
                       DO 310 J = 1,K - 1
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = A(J,K)
-                              ELSE
-                                  TEMP = DCONJG(A(J,K))
-                              END IF
-                              DO 300 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  300                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = A(J,K)
+                          ELSE
+                              TEMP = DCONJG(A(J,K))
                           END IF
+                          DO 300 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  300                     CONTINUE
   310                 CONTINUE
                       DO 320 I = 1,M
                           B(I,K) = ALPHA*B(I,K)
@@ -434,16 +428,14 @@
   340                     CONTINUE
                       END IF
                       DO 360 J = K + 1,N
-                          IF (A(J,K).NE.ZERO) THEN
-                              IF (NOCONJ) THEN
-                                  TEMP = A(J,K)
-                              ELSE
-                                  TEMP = DCONJG(A(J,K))
-                              END IF
-                              DO 350 I = 1,M
-                                  B(I,J) = B(I,J) - TEMP*B(I,K)
-  350                         CONTINUE
+                          IF (NOCONJ) THEN
+                              TEMP = A(J,K)
+                          ELSE
+                              TEMP = DCONJG(A(J,K))
                           END IF
+                          DO 350 I = 1,M
+                              B(I,J) = B(I,J) - TEMP*B(I,K)
+  350                     CONTINUE
   360                 CONTINUE
                       DO 370 I = 1,M
                           B(I,K) = ALPHA*B(I,K)

--- a/BLAS/SRC/ztrsm.f
+++ b/BLAS/SRC/ztrsm.f
@@ -210,8 +210,6 @@
       LOGICAL LSIDE,NOCONJ,NOUNIT,UPPER
 *     ..
 *     .. Parameters ..
-      COMPLEX*16 ONE
-      PARAMETER (ONE= (1.0D+0,0.0D+0))
       COMPLEX*16 ZERO
       PARAMETER (ZERO= (0.0D+0,0.0D+0))
 *     ..
@@ -360,9 +358,8 @@
   200                     CONTINUE
   210                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 220 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   220                     CONTINUE
                       END IF
   230             CONTINUE
@@ -377,9 +374,8 @@
   250                     CONTINUE
   260                 CONTINUE
                       IF (NOUNIT) THEN
-                          TEMP = ONE/A(J,J)
                           DO 270 I = 1,M
-                              B(I,J) = TEMP*B(I,J)
+                              B(I,J) = B(I,J)/A(J,J)
   270                     CONTINUE
                       END IF
   280             CONTINUE
@@ -393,13 +389,14 @@
                   DO 330 K = N,1,-1
                       IF (NOUNIT) THEN
                           IF (NOCONJ) THEN
-                              TEMP = ONE/A(K,K)
+                              DO 290 I = 1,M
+                                  B(I,K) = B(I,K)/A(K,K)
+  290                         CONTINUE
                           ELSE
-                              TEMP = ONE/DCONJG(A(K,K))
+                              DO 390 I = 1,M
+                                  B(I,K) = B(I,K)/DCONJG(A(K,K))
+  390                         CONTINUE
                           END IF
-                          DO 290 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
-  290                     CONTINUE
                       END IF
                       DO 310 J = 1,K - 1
                           IF (NOCONJ) THEN
@@ -419,13 +416,14 @@
                   DO 380 K = 1,N
                       IF (NOUNIT) THEN
                           IF (NOCONJ) THEN
-                              TEMP = ONE/A(K,K)
+                              DO 340 I = 1,M
+                                  B(I,K) = B(I,K)/A(K,K)
+  340                         CONTINUE
                           ELSE
-                              TEMP = ONE/DCONJG(A(K,K))
+                              DO 400 I = 1,M
+                                  B(I,K) = B(I,K)/DCONJG(A(K,K))
+  400                         CONTINUE
                           END IF
-                          DO 340 I = 1,M
-                              B(I,K) = TEMP*B(I,K)
-  340                     CONTINUE
                       END IF
                       DO 360 J = K + 1,N
                           IF (NOCONJ) THEN

--- a/BLAS/SRC/ztrsv.f
+++ b/BLAS/SRC/ztrsv.f
@@ -161,10 +161,6 @@
 *     ..
 *
 *  =====================================================================
-*
-*     .. Parameters ..
-      COMPLEX*16 ZERO
-      PARAMETER (ZERO= (0.0D+0,0.0D+0))
 *     ..
 *     .. Local Scalars ..
       COMPLEX*16 TEMP
@@ -232,52 +228,44 @@
           IF (LSAME(UPLO,'U')) THEN
               IF (INCX.EQ.1) THEN
                   DO 20 J = N,1,-1
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 10 I = J - 1,1,-1
-                              X(I) = X(I) - TEMP*A(I,J)
-   10                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/A(J,J)
+                      TEMP = X(J)
+                      DO 10 I = J - 1,1,-1
+                          X(I) = X(I) - TEMP*A(I,J)
+   10                 CONTINUE
    20             CONTINUE
               ELSE
                   JX = KX + (N-1)*INCX
                   DO 40 J = N,1,-1
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 30 I = J - 1,1,-1
-                              IX = IX - INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   30                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 30 I = J - 1,1,-1
+                          IX = IX - INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   30                 CONTINUE
                       JX = JX - INCX
    40             CONTINUE
               END IF
           ELSE
               IF (INCX.EQ.1) THEN
                   DO 60 J = 1,N
-                      IF (X(J).NE.ZERO) THEN
-                          IF (NOUNIT) X(J) = X(J)/A(J,J)
-                          TEMP = X(J)
-                          DO 50 I = J + 1,N
-                              X(I) = X(I) - TEMP*A(I,J)
-   50                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(J) = X(J)/A(J,J)
+                      TEMP = X(J)
+                      DO 50 I = J + 1,N
+                          X(I) = X(I) - TEMP*A(I,J)
+   50                 CONTINUE
    60             CONTINUE
               ELSE
                   JX = KX
                   DO 80 J = 1,N
-                      IF (X(JX).NE.ZERO) THEN
-                          IF (NOUNIT) X(JX) = X(JX)/A(J,J)
-                          TEMP = X(JX)
-                          IX = JX
-                          DO 70 I = J + 1,N
-                              IX = IX + INCX
-                              X(IX) = X(IX) - TEMP*A(I,J)
-   70                     CONTINUE
-                      END IF
+                      IF (NOUNIT) X(JX) = X(JX)/A(J,J)
+                      TEMP = X(JX)
+                      IX = JX
+                      DO 70 I = J + 1,N
+                          IX = IX + INCX
+                          X(IX) = X(IX) - TEMP*A(I,J)
+   70                 CONTINUE
                       JX = JX + INCX
    80             CONTINUE
               END IF


### PR DESCRIPTION
Remove IF statement related to initial zeros in B or X for triangular multiplications and solves. 
So that's: TBMV, TBSV, TPMV, TBSV, TRMV, TRSV, TRMM, and TRMV.
Note that TRMM is somewhat already done in PR #1301. 
For a rationale, see discussion at #636.
There is also a few removals of IF statements for ZEROs in A(I,J) for TRSM and TRMM. 

Skipping these multiplications saves FLOPs but the issues are (1) it short-circuits proper NaN propagations, and (2) it is not done consistently across variants of a routine, so a variant would propagate, while another variant would not. With this PR, all variants propagate consistently.

The changes that made me pause are the changes in TRSM from 
```fortran
                         TEMP = ONE/A(J,J)
                          DO 220 I = 1,M
                              B(I,J) = TEMP*B(I,J)
  220                     CONTINUE
```
to
```fortran
                          DO 220 I = 1,M
                              B(I,J) = B(I,J)/A(J,J)
  220                     CONTINUE
```
See [#e8785e4](https://github.com/Reference-LAPACK/lapack/commit/e8785e4e1ef2875d5a09b27427b00a60c3d95be6). On the one hand `B(I,J) = B(I,J)/A(J,J)` behaves better with subnormal numbers, on the other hand, we could consider that we do not want to bother with subnormal numbers on the diagonal of a triangular matrix. In any case, (1) the behavior was not consistent for all variants of TRSM and (2) the behavior of Level 3 BLAS TRSM was not consistent with the behavior of the three Level 2 BLAS triangular solvers: TRSV, TPSV and TBSV. With this PR, the behavior is consistent across the board. 
