### PR TITLE
Revert "*evr, *stevr: use fast CSTEMR path for partial eigenvalue ranges on I…"

### DIFF
--- a/SRC/cheevr.f
+++ b/SRC/cheevr.f
@@ -93,9 +93,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : CHEEVR calls CSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). CHEEVR
-*> calls SSTEBZ and CSTEIN on non-ieee machines.
+*> Note 1 : CHEEVR calls CSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> CHEEVR calls SSTEBZ and CSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of CSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -617,22 +618,20 @@
       CALL CHETRD( UPLO, N, A, LDA, RWORK( INDRD ), RWORK( INDRE ),
      $             WORK( INDTAU ), WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call SSTERF or CSTEMR and CUNMTR.
+*     If all eigenvalues are desired
+*     then call SSTERF or CSTEMR and CUNMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG.OR.TEST ) .AND. ( IEEEOK.EQ.1 ) ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL SCOPY( N, RWORK( INDRD ), 1, W, 1 )
-                CALL SCOPY( N-1, RWORK( INDRE ), 1,
-     $                      RWORK( INDREE ), 1 )
-                CALL SSTERF( N, W, RWORK( INDREE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL SCOPY( N, RWORK( INDRD ), 1, W, 1 )
+            CALL SCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
+            CALL SSTERF( N, W, RWORK( INDREE ), INFO )
          ELSE
             CALL SCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
             CALL SCOPY( N, RWORK( INDRD ), 1, RWORK( INDRDD ), 1 )
@@ -642,7 +641,7 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL CSTEMR( JOBZ, RANGE, N, RWORK( INDRDD ),
+            CALL CSTEMR( JOBZ, 'A', N, RWORK( INDRDD ),
      $                   RWORK( INDREE ), VL, VU, IL, IU, M, W,
      $                   Z, LDZ, N, ISUPPZ, TRYRAC,
      $                   RWORK( INDRWK ), LLRWORK,
@@ -658,11 +657,14 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call SSTEBZ and, if eigenvectors are desired, CSTEIN.

--- a/SRC/cheevr_2stage.f
+++ b/SRC/cheevr_2stage.f
@@ -92,9 +92,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : CHEEVR_2STAGE calls CSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). CHEEVR_2STAGE
-*> calls SSTEBZ and CSTEIN on non-ieee machines.
+*> Note 1 : CHEEVR_2STAGE calls CSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> CHEEVR_2STAGE calls SSTEBZ and CSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of CSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -661,22 +662,20 @@
      $                    WORK( INDHOUS ), LHTRD,
      $                    WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call SSTERF or CSTEMR and CUNMTR.
+*     If all eigenvalues are desired
+*     then call SSTERF or CSTEMR and CUNMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG.OR.TEST ) .AND. ( IEEEOK.EQ.1 ) ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL SCOPY( N, RWORK( INDRD ), 1, W, 1 )
-                CALL SCOPY( N-1, RWORK( INDRE ), 1,
-     $                      RWORK( INDREE ), 1 )
-                CALL SSTERF( N, W, RWORK( INDREE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL SCOPY( N, RWORK( INDRD ), 1, W, 1 )
+            CALL SCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
+            CALL SSTERF( N, W, RWORK( INDREE ), INFO )
          ELSE
             CALL SCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
             CALL SCOPY( N, RWORK( INDRD ), 1, RWORK( INDRDD ), 1 )
@@ -686,7 +685,7 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL CSTEMR( JOBZ, RANGE, N, RWORK( INDRDD ),
+            CALL CSTEMR( JOBZ, 'A', N, RWORK( INDRDD ),
      $                   RWORK( INDREE ), VL, VU, IL, IU, M, W,
      $                   Z, LDZ, N, ISUPPZ, TRYRAC,
      $                   RWORK( INDRWK ), LLRWORK,
@@ -702,11 +701,14 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call SSTEBZ and, if eigenvectors are desired, CSTEIN.

--- a/SRC/dstevr.f
+++ b/SRC/dstevr.f
@@ -67,9 +67,10 @@
 *> UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : DSTEVR calls DSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). DSTEVR
-*> calls DSTEBZ and DSTEIN on non-ieee machines.
+*> Note 1 : DSTEVR calls DSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> DSTEVR calls DSTEBZ and DSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of DSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -483,35 +484,34 @@
 *     try DSTEBZ.
 *
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG .OR. TEST ) .AND. IEEEOK.EQ.1 ) THEN
+         CALL DCOPY( N-1, E( 1 ), 1, WORK( 1 ), 1 )
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL DCOPY( N-1, E( 1 ), 1, WORK( 1 ), 1 )
-               CALL DCOPY( N, D, 1, W, 1 )
-               CALL DSTERF( N, W, WORK, INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 10
-               END IF
-               INFO = 0
-            END IF
+            CALL DCOPY( N, D, 1, W, 1 )
+            CALL DSTERF( N, W, WORK, INFO )
          ELSE
-            CALL DCOPY( N-1, E( 1 ), 1, WORK( 1 ), 1 )
             CALL DCOPY( N, D, 1, WORK( N+1 ), 1 )
             IF (ABSTOL .LE. TWO*N*EPS) THEN
                TRYRAC = .TRUE.
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL DSTEMR( JOBZ, RANGE, N, WORK( N+1 ), WORK, VL, VU,
-     $                   IL, IU, M, W, Z, LDZ, N, ISUPPZ, TRYRAC,
+            CALL DSTEMR( JOBZ, 'A', N, WORK( N+1 ), WORK, VL, VU, IL,
+     $                   IU, M, W, Z, LDZ, N, ISUPPZ, TRYRAC,
      $                   WORK( 2*N+1 ), LWORK-2*N, IWORK, LIWORK, INFO )
-            IF( INFO.EQ.0 ) THEN
-               GO TO 10
-            END IF
-            INFO = 0
+*
          END IF
+         IF( INFO.EQ.0 ) THEN
+            M = N
+            GO TO 10
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call DSTEBZ and, if eigenvectors are desired, DSTEIN.

--- a/SRC/dsyevr.f
+++ b/SRC/dsyevr.f
@@ -91,9 +91,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : DSYEVR calls DSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). DSYEVR
-*> calls DSTEBZ and DSTEIN on non-ieee machines.
+*> Note 1 : DSYEVR calls DSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> DSYEVR calls DSTEBZ and DSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of DSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -573,21 +574,15 @@
       CALL DSYTRD( UPLO, N, A, LDA, WORK( INDD ), WORK( INDE ),
      $             WORK( INDTAU ), WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call DSTERF or DSTEMR and DORMTR.
+*     If all eigenvalues are desired
+*     then call DSTERF or DSTEMR and DORMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      IF( ( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) ) .AND.
+     $    IEEEOK.EQ.1 ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL DCOPY( N, WORK( INDD ), 1, W, 1 )
-               CALL DCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
-               CALL DSTERF( N, W, WORK( INDEE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL DCOPY( N, WORK( INDD ), 1, W, 1 )
+            CALL DCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
+            CALL DSTERF( N, W, WORK( INDEE ), INFO )
          ELSE
             CALL DCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
             CALL DCOPY( N, WORK( INDD ), 1, WORK( INDDD ), 1 )
@@ -597,10 +592,10 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL DSTEMR( JOBZ, RANGE, N, WORK( INDDD ),
-     $                    WORK( INDEE ), VL, VU, IL, IU, M, W, Z, LDZ,
-     $                    N, ISUPPZ, TRYRAC, WORK( INDWK ), LWORK,
-     $                    IWORK, LIWORK, INFO )
+            CALL DSTEMR( JOBZ, 'A', N, WORK( INDDD ), WORK( INDEE ),
+     $                   VL, VU, IL, IU, M, W, Z, LDZ, N, ISUPPZ,
+     $                   TRYRAC, WORK( INDWK ), LWORK, IWORK, LIWORK,
+     $                   INFO )
 *
 *
 *
@@ -614,11 +609,16 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+*           Everything worked.  Skip DSTEBZ/DSTEIN.  IWORK(:) are
+*           undefined.
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call DSTEBZ and, if eigenvectors are desired, DSTEIN.

--- a/SRC/dsyevr_2stage.f
+++ b/SRC/dsyevr_2stage.f
@@ -89,9 +89,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : DSYEVR_2STAGE calls DSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). DSYEVR_2STAGE
-*> calls DSTEBZ and SSTEIN on non-ieee machines.
+*> Note 1 : DSYEVR_2STAGE calls DSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> DSYEVR_2STAGE calls DSTEBZ and SSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of DSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -623,21 +624,15 @@
      $                    WORK( INDE ), WORK( INDTAU ), WORK( INDHOUS ),
      $                    LHTRD, WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call DSTERF or DSTEMR and DORMTR.
+*     If all eigenvalues are desired
+*     then call DSTERF or DSTEMR and DORMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      IF( ( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) ) .AND.
+     $    IEEEOK.EQ.1 ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL DCOPY( N, WORK( INDD ), 1, W, 1 )
-               CALL DCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
-               CALL DSTERF( N, W, WORK( INDEE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL DCOPY( N, WORK( INDD ), 1, W, 1 )
+            CALL DCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
+            CALL DSTERF( N, W, WORK( INDEE ), INFO )
          ELSE
             CALL DCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
             CALL DCOPY( N, WORK( INDD ), 1, WORK( INDDD ), 1 )
@@ -647,10 +642,10 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL DSTEMR( JOBZ, RANGE, N, WORK( INDDD ),
-     $                    WORK( INDEE ), VL, VU, IL, IU, M, W, Z, LDZ,
-     $                    N, ISUPPZ, TRYRAC, WORK( INDWK ), LWORK,
-     $                    IWORK, LIWORK, INFO )
+            CALL DSTEMR( JOBZ, 'A', N, WORK( INDDD ), WORK( INDEE ),
+     $                   VL, VU, IL, IU, M, W, Z, LDZ, N, ISUPPZ,
+     $                   TRYRAC, WORK( INDWK ), LWORK, IWORK, LIWORK,
+     $                   INFO )
 *
 *
 *
@@ -664,11 +659,16 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+*           Everything worked.  Skip DSTEBZ/DSTEIN.  IWORK(:) are
+*           undefined.
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call DSTEBZ and, if eigenvectors are desired, DSTEIN.

--- a/SRC/sstevr.f
+++ b/SRC/sstevr.f
@@ -67,9 +67,10 @@
 *> UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : SSTEVR calls SSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). SSTEVR
-*> calls SSTEBZ and SSTEIN on non-ieee machines.
+*> Note 1 : SSTEVR calls SSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> SSTEVR calls SSTEBZ and SSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of SSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -485,35 +486,34 @@
 *     try SSTEBZ.
 *
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG .OR. TEST ) .AND. IEEEOK.EQ.1 ) THEN
+         CALL SCOPY( N-1, E( 1 ), 1, WORK( 1 ), 1 )
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL SCOPY( N-1, E( 1 ), 1, WORK( 1 ), 1 )
-               CALL SCOPY( N, D, 1, W, 1 )
-               CALL SSTERF( N, W, WORK, INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 10
-               END IF
-               INFO = 0
-            END IF
+            CALL SCOPY( N, D, 1, W, 1 )
+            CALL SSTERF( N, W, WORK, INFO )
          ELSE
-            CALL SCOPY( N-1, E( 1 ), 1, WORK( 1 ), 1 )
             CALL SCOPY( N, D, 1, WORK( N+1 ), 1 )
             IF (ABSTOL .LE. TWO*REAL( N )*EPS) THEN
                TRYRAC = .TRUE.
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL SSTEMR( JOBZ, RANGE, N, WORK( N+1 ), WORK, VL, VU,
-     $                   IL, IU, M, W, Z, LDZ, N, ISUPPZ, TRYRAC,
+            CALL SSTEMR( JOBZ, 'A', N, WORK( N+1 ), WORK, VL, VU, IL,
+     $                   IU, M, W, Z, LDZ, N, ISUPPZ, TRYRAC,
      $                   WORK( 2*N+1 ), LWORK-2*N, IWORK, LIWORK, INFO )
-            IF( INFO.EQ.0 ) THEN
-               GO TO 10
-            END IF
-            INFO = 0
+*
          END IF
+         IF( INFO.EQ.0 ) THEN
+            M = N
+            GO TO 10
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call SSTEBZ and, if eigenvectors are desired, SSTEIN.

--- a/SRC/ssyevr.f
+++ b/SRC/ssyevr.f
@@ -91,9 +91,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : SSYEVR calls SSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). SSYEVR
-*> calls SSTEBZ and SSTEIN on non-ieee machines.
+*> Note 1 : SSYEVR calls SSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> SSYEVR calls SSTEBZ and SSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of SSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -578,21 +579,20 @@
       CALL SSYTRD( UPLO, N, A, LDA, WORK( INDD ), WORK( INDE ),
      $             WORK( INDTAU ), WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call SSTERF or SSTEMR and SORMTR.
+*     If all eigenvalues are desired
+*     then call SSTERF or SSTEMR and SORMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG.OR.TEST ) .AND. ( IEEEOK.EQ.1 ) ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL SCOPY( N, WORK( INDD ), 1, W, 1 )
-               CALL SCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
-               CALL SSTERF( N, W, WORK( INDEE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL SCOPY( N, WORK( INDD ), 1, W, 1 )
+            CALL SCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
+            CALL SSTERF( N, W, WORK( INDEE ), INFO )
          ELSE
             CALL SCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
             CALL SCOPY( N, WORK( INDD ), 1, WORK( INDDD ), 1 )
@@ -602,10 +602,10 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL SSTEMR( JOBZ, RANGE, N, WORK( INDDD ),
-     $                    WORK( INDEE ), VL, VU, IL, IU, M, W, Z, LDZ,
-     $                    N, ISUPPZ, TRYRAC, WORK( INDWK ), LWORK,
-     $                    IWORK, LIWORK, INFO )
+            CALL SSTEMR( JOBZ, 'A', N, WORK( INDDD ), WORK( INDEE ),
+     $                   VL, VU, IL, IU, M, W, Z, LDZ, N, ISUPPZ,
+     $                   TRYRAC, WORK( INDWK ), LWORK, IWORK, LIWORK,
+     $                   INFO )
 *
 *
 *
@@ -619,11 +619,16 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+*           Everything worked.  Skip SSTEBZ/SSTEIN.  IWORK(:) are
+*           undefined.
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call SSTEBZ and, if eigenvectors are desired, SSTEIN.

--- a/SRC/ssyevr_2stage.f
+++ b/SRC/ssyevr_2stage.f
@@ -89,9 +89,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : SSYEVR_2STAGE calls SSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). SSYEVR_2STAGE
-*> calls SSTEBZ and SSTEIN on non-ieee machines.
+*> Note 1 : SSYEVR_2STAGE calls SSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> SSYEVR_2STAGE calls SSTEBZ and SSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of SSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -624,21 +625,20 @@
      $                    WORK( INDE ), WORK( INDTAU ), WORK( INDHOUS ),
      $                    LHTRD, WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call SSTERF or SSTEMR and SORMTR.
+*     If all eigenvalues are desired
+*     then call SSTERF or SSTEMR and SORMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG.OR.TEST ) .AND. ( IEEEOK.EQ.1 ) ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL SCOPY( N, WORK( INDD ), 1, W, 1 )
-               CALL SCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
-               CALL SSTERF( N, W, WORK( INDEE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL SCOPY( N, WORK( INDD ), 1, W, 1 )
+            CALL SCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
+            CALL SSTERF( N, W, WORK( INDEE ), INFO )
          ELSE
             CALL SCOPY( N-1, WORK( INDE ), 1, WORK( INDEE ), 1 )
             CALL SCOPY( N, WORK( INDD ), 1, WORK( INDDD ), 1 )
@@ -648,10 +648,10 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL SSTEMR( JOBZ, RANGE, N, WORK( INDDD ),
-     $                    WORK( INDEE ), VL, VU, IL, IU, M, W, Z, LDZ,
-     $                    N, ISUPPZ, TRYRAC, WORK( INDWK ), LWORK,
-     $                    IWORK, LIWORK, INFO )
+            CALL SSTEMR( JOBZ, 'A', N, WORK( INDDD ), WORK( INDEE ),
+     $                   VL, VU, IL, IU, M, W, Z, LDZ, N, ISUPPZ,
+     $                   TRYRAC, WORK( INDWK ), LWORK, IWORK, LIWORK,
+     $                   INFO )
 *
 *
 *
@@ -665,11 +665,16 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+*           Everything worked.  Skip SSTEBZ/SSTEIN.  IWORK(:) are
+*           undefined.
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call SSTEBZ and, if eigenvectors are desired, SSTEIN.

--- a/SRC/zheevr.f
+++ b/SRC/zheevr.f
@@ -93,9 +93,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : ZHEEVR calls ZSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). ZHEEVR
-*> calls DSTEBZ and ZSTEIN on non-ieee machines.
+*> Note 1 : ZHEEVR calls ZSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> ZHEEVR calls DSTEBZ and ZSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of ZSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -616,22 +617,20 @@
       CALL ZHETRD( UPLO, N, A, LDA, RWORK( INDRD ), RWORK( INDRE ),
      $             WORK( INDTAU ), WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call DSTERF or ZSTEMR and ZUNMTR.
+*     If all eigenvalues are desired
+*     then call DSTERF or ZSTEMR and ZUNMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG.OR.TEST ) .AND. ( IEEEOK.EQ.1 ) ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL DCOPY( N, RWORK( INDRD ), 1, W, 1 )
-                CALL DCOPY( N-1, RWORK( INDRE ), 1,
-     $                      RWORK( INDREE ), 1 )
-                CALL DSTERF( N, W, RWORK( INDREE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL DCOPY( N, RWORK( INDRD ), 1, W, 1 )
+            CALL DCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
+            CALL DSTERF( N, W, RWORK( INDREE ), INFO )
          ELSE
             CALL DCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
             CALL DCOPY( N, RWORK( INDRD ), 1, RWORK( INDRDD ), 1 )
@@ -641,7 +640,7 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL ZSTEMR( JOBZ, RANGE, N, RWORK( INDRDD ),
+            CALL ZSTEMR( JOBZ, 'A', N, RWORK( INDRDD ),
      $                   RWORK( INDREE ), VL, VU, IL, IU, M, W,
      $                   Z, LDZ, N, ISUPPZ, TRYRAC,
      $                   RWORK( INDRWK ), LLRWORK,
@@ -657,11 +656,14 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call DSTEBZ and, if eigenvectors are desired, ZSTEIN.

--- a/SRC/zheevr_2stage.f
+++ b/SRC/zheevr_2stage.f
@@ -92,9 +92,10 @@
 *>   UC Berkeley, May 1997.
 *>
 *>
-*> Note 1 : ZHEEVR_2STAGE calls ZSTEMR when possible (i.e., on machines
-*> which conform to the ieee-754 floating point standard). ZHEEVR_2STAGE
-*> calls DSTEBZ and ZSTEIN on non-ieee machines.
+*> Note 1 : ZHEEVR_2STAGE calls ZSTEMR when the full spectrum is requested
+*> on machines which conform to the ieee-754 floating point standard.
+*> ZHEEVR_2STAGE calls DSTEBZ and ZSTEIN on non-ieee machines and
+*> when partial spectrum requests are made.
 *>
 *> Normal execution of ZSTEMR may create NaNs and infinities and
 *> hence may abort due to a floating point exception in environments
@@ -661,22 +662,20 @@
      $                    WORK( INDHOUS ), LHTRD,
      $                    WORK( INDWK ), LLWORK, IINFO )
 *
-*     On IEEE-754 compliant machines, call DSTERF or ZSTEMR and ZUNMTR.
+*     If all eigenvalues are desired
+*     then call DSTERF or ZSTEMR and ZUNMTR.
 *
-      IF( IEEEOK.EQ.1 ) THEN
+      TEST = .FALSE.
+      IF( INDEIG ) THEN
+         IF( IL.EQ.1 .AND. IU.EQ.N ) THEN
+            TEST = .TRUE.
+         END IF
+      END IF
+      IF( ( ALLEIG.OR.TEST ) .AND. ( IEEEOK.EQ.1 ) ) THEN
          IF( .NOT.WANTZ ) THEN
-            IF( ALLEIG .OR. ( INDEIG .AND. IL.EQ.1 .AND. IU.EQ.N ) )
-     $      THEN
-               CALL DCOPY( N, RWORK( INDRD ), 1, W, 1 )
-                CALL DCOPY( N-1, RWORK( INDRE ), 1,
-     $                      RWORK( INDREE ), 1 )
-                CALL DSTERF( N, W, RWORK( INDREE ), INFO )
-               IF( INFO.EQ.0 ) THEN
-                  M = N
-                  GO TO 30
-               END IF
-               INFO = 0
-            END IF
+            CALL DCOPY( N, RWORK( INDRD ), 1, W, 1 )
+            CALL DCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
+            CALL DSTERF( N, W, RWORK( INDREE ), INFO )
          ELSE
             CALL DCOPY( N-1, RWORK( INDRE ), 1, RWORK( INDREE ), 1 )
             CALL DCOPY( N, RWORK( INDRD ), 1, RWORK( INDRDD ), 1 )
@@ -686,7 +685,7 @@
             ELSE
                TRYRAC = .FALSE.
             END IF
-            CALL ZSTEMR( JOBZ, RANGE, N, RWORK( INDRDD ),
+            CALL ZSTEMR( JOBZ, 'A', N, RWORK( INDRDD ),
      $                   RWORK( INDREE ), VL, VU, IL, IU, M, W,
      $                   Z, LDZ, N, ISUPPZ, TRYRAC,
      $                   RWORK( INDRWK ), LLRWORK,
@@ -702,11 +701,14 @@
      $                      WORK( INDTAU ), Z, LDZ, WORK( INDWKN ),
      $                      LLWRKN, IINFO )
             END IF
-            IF( INFO.EQ.0 ) THEN
-               GO TO 30
-            END IF
-            INFO = 0
          END IF
+*
+*
+         IF( INFO.EQ.0 ) THEN
+            M = N
+            GO TO 30
+         END IF
+         INFO = 0
       END IF
 *
 *     Otherwise, call DSTEBZ and, if eigenvectors are desired, ZSTEIN.


### PR DESCRIPTION
Reverts Reference-LAPACK/lapack#1295

This creates quite a few failures on my laptop and on @jprhyne's laptop. 
I am reverting this PR. Thanks to @jprhyne for doing the dissection to find the problematic PR.