### PR TITLE
add path for TRTRZ and UNMRZ in ILAENV

### DIFF
--- a/SRC/ilaenv.f
+++ b/SRC/ilaenv.f
@@ -276,6 +276,16 @@
          ELSE
              NB = 32
          END IF
+      ELSE IF( SUBNAM(2:6).EQ.'TZRZF' ) THEN
+         IF( SNAME ) THEN
+             NB = 64
+         ELSE
+             NB = 32
+         END IF
+      ELSE IF( SUBNAM(2:6).EQ.'ORMRZ' ) THEN
+             NB = 64
+      ELSE IF( SUBNAM(2:6).EQ.'UNMRZ' ) THEN
+             NB = 32
       ELSE IF( C2.EQ.'GE' ) THEN
          IF( C3.EQ.'TRF' ) THEN
             IF( SNAME ) THEN


### PR DESCRIPTION
This completes #1289

In #1289, @jschueller introduced dedicated paths for CTZRZF (NB2) and CUNMRZ (NB4) in GELSY
```diff
      INFO = 0
      NB1 = ILAENV( 1, 'CGEQRF', ' ', M, N, -1, -1 )
-      NB2 = ILAENV( 1, 'CGERQF', ' ', M, N, -1, -1 )
+      NB2 = ILAENV( 1, 'CTZRZF', ' ', M, N, -1, -1 )
      NB3 = ILAENV( 1, 'CUNMQR', ' ', M, N, NRHS, -1 )
-      NB4 = ILAENV( 1, 'CUNMRQ', ' ', M, N, NRHS, -1 )
+      NB4 = ILAENV( 1, 'CUNMRZ', ' ', M, N, NRHS, -1 )
      NB = MAX( NB1, NB2, NB3, NB4 )
      LWKOPT = MAX( 1, MN+2*N+NB*(N+1), 2*MN+NB*NRHS )
      WORK( 1 ) = CMPLX( LWKOPT )
```

But, as pointed out by @martin-frbg, https://github.com/Reference-LAPACK/lapack/pull/1289#issuecomment-4791782275, these paths did not exist in ILAENV. So then ILAENV was returning the default value of NB2 = 1 and NB4 = 1. 

We might accept the previous code (before PR #1289) as saying "the optimal block size for TZRZF is the same as the block size for GERQF", so we do not need to create a dedicated path for TZRZF in ILAENV, we simply call ILAENV with argument GERQF.

This commits keeps the PR as is and adds the two paths to ILAENV.

Note: It might feel "lazy" to drop the paths at the start like this. But I think it is better than hide the paths in a series of nested IFs. They are cons and pros to the nested IFs. I chose to drop it at the top. 