### PR TITLE
Fix issue #1327

### DIFF
--- a/BLAS/SRC/caxpby.f
+++ b/BLAS/SRC/caxpby.f
@@ -109,7 +109,7 @@
 *     ..
       IF (N.LE.0) RETURN
 
-      IF (CA .EQ. (0.0,0.0) .AND. CB.NE.(0.0,0.0) .AND. INCY.GT.0) THEN
+      IF (CA .EQ. (0.0,0.0) .AND. INCY.GT.0) THEN
          CALL CSCAL(N, CB, CY, INCY)
          RETURN
       END IF

--- a/BLAS/SRC/caxpby.f
+++ b/BLAS/SRC/caxpby.f
@@ -109,7 +109,7 @@
 *     ..
       IF (N.LE.0) RETURN
 
-      IF (CA .EQ. (0.0,0.0) .AND. CB.NE.(0.0,0.0)) THEN
+      IF (CA .EQ. (0.0,0.0) .AND. CB.NE.(0.0,0.0) .AND. INCY.GT.0) THEN
          CALL CSCAL(N,CB, CY, INCY)
          RETURN
       END IF
@@ -139,6 +139,6 @@
 *
       RETURN
 *
-*     End of CAXBPY
+*     End of CAXPBY
 *
       END

--- a/BLAS/SRC/caxpby.f
+++ b/BLAS/SRC/caxpby.f
@@ -110,7 +110,7 @@
       IF (N.LE.0) RETURN
 
       IF (CA .EQ. (0.0,0.0) .AND. CB.NE.(0.0,0.0) .AND. INCY.GT.0) THEN
-         CALL CSCAL(N,CB, CY, INCY)
+         CALL CSCAL(N, CB, CY, INCY)
          RETURN
       END IF
 

--- a/BLAS/SRC/caxpby.f
+++ b/BLAS/SRC/caxpby.f
@@ -108,12 +108,13 @@
       INTEGER I,IX,IY
 *     ..
       IF (N.LE.0) RETURN
-
+*
+*     Scale if CA is zero - (note that SCAL does not handle INCY.LE.0)
       IF (CA .EQ. (0.0,0.0) .AND. INCY.GT.0) THEN
          CALL CSCAL(N, CB, CY, INCY)
          RETURN
       END IF
-
+*
       IF (INCX.EQ.1 .AND. INCY.EQ.1) THEN
 *
 *        code for both increments equal to 1

--- a/BLAS/SRC/daxpby.f
+++ b/BLAS/SRC/daxpby.f
@@ -111,13 +111,13 @@
       INTRINSIC MOD
 *     ..
       IF (N.LE.0) RETURN
-
-*     Scale if DA.EQ.0
+*
+*     Scale if DA is zero - (note that SCAL does not handle INCY.LE.0)
       IF (DA.EQ.0.0D0 .AND. INCY.GT.0) THEN
           CALL DSCAL(N, DB, DY, INCY)
           RETURN
       END IF
-
+*
       IF (INCX.EQ.1 .AND. INCY.EQ.1) THEN
 *
 *        code for both increments equal to 1

--- a/BLAS/SRC/daxpby.f
+++ b/BLAS/SRC/daxpby.f
@@ -113,7 +113,7 @@
       IF (N.LE.0) RETURN
 
 *     Scale if DA.EQ.0
-      IF (DA.EQ.0.0D0 .AND. DB.NE.0.0D0 .AND. INCY.GT.0) THEN
+      IF (DA.EQ.0.0D0 .AND. INCY.GT.0) THEN
           CALL DSCAL(N, DB, DY, INCY)
           RETURN
       END IF

--- a/BLAS/SRC/daxpby.f
+++ b/BLAS/SRC/daxpby.f
@@ -113,7 +113,7 @@
       IF (N.LE.0) RETURN
 
 *     Scale if DA.EQ.0
-      IF (DA.EQ.0.0D0 .AND. DB.NE.0.0D0) THEN
+      IF (DA.EQ.0.0D0 .AND. DB.NE.0.0D0 .AND. INCY.GT.0) THEN
           CALL DSCAL(N, DB, DY, INCY)
           RETURN
       END IF

--- a/BLAS/SRC/saxpby.f
+++ b/BLAS/SRC/saxpby.f
@@ -113,7 +113,7 @@
       IF (N.LE.0) RETURN
 
 *     Scale if SA.EQ.0
-      IF (SA.EQ.0.0E0 .AND. SB.NE.0.0E0 .AND. INCY.GT.0) THEN
+      IF (SA.EQ.0.0E0 .AND. INCY.GT.0) THEN
           CALL SSCAL(N, SB, SY, INCY)
           RETURN
       END IF

--- a/BLAS/SRC/saxpby.f
+++ b/BLAS/SRC/saxpby.f
@@ -113,7 +113,7 @@
       IF (N.LE.0) RETURN
 
 *     Scale if SA.EQ.0
-      IF (SA.EQ.0.0E0 .AND. SB.NE.0.0E0) THEN
+      IF (SA.EQ.0.0E0 .AND. SB.NE.0.0E0 .AND. INCY.GT.0) THEN
           CALL SSCAL(N, SB, SY, INCY)
           RETURN
       END IF

--- a/BLAS/SRC/saxpby.f
+++ b/BLAS/SRC/saxpby.f
@@ -111,14 +111,13 @@
       INTRINSIC MOD
 *     ..
       IF (N.LE.0) RETURN
-
-*     Scale if SA.EQ.0
+*
+*     Scale if SA is zero - (note that SCAL does not handle INCY.LE.0)
       IF (SA.EQ.0.0E0 .AND. INCY.GT.0) THEN
           CALL SSCAL(N, SB, SY, INCY)
           RETURN
       END IF
-
-
+*
       IF (INCX.EQ.1 .AND. INCY.EQ.1) THEN
 *
 *        code for both increments equal to 1

--- a/BLAS/SRC/zaxpby.f
+++ b/BLAS/SRC/zaxpby.f
@@ -110,7 +110,7 @@
       IF (N.LE.0) RETURN
 
 *     Scale if ZA .EQ. 0
-      IF ( ZA.EQ.(0.0D0,0.0D0) .AND. ZB.NE.(0.0D0,0.0D0)) THEN
+      IF ( ZA.EQ.(0.0D0,0.0D0) .AND. ZB.NE.(0.0D0,0.0D0) .AND. INCY.GT.0) THEN
         CALL ZSCAL(N, ZB, ZY, INCY)
         RETURN
       END IF
@@ -140,6 +140,6 @@
 *
       RETURN
 *
-*     End of ZAXBPY
+*     End of ZAXPBY
 *
       END

--- a/BLAS/SRC/zaxpby.f
+++ b/BLAS/SRC/zaxpby.f
@@ -110,7 +110,7 @@
       IF (N.LE.0) RETURN
 
 *     Scale if ZA .EQ. 0
-      IF ( ZA.EQ.(0.0D0,0.0D0) .AND. ZB.NE.(0.0D0,0.0D0) .AND. INCY.GT.0) THEN
+      IF ( ZA.EQ.(0.0D0,0.0D0) .AND. INCY.GT.0) THEN
         CALL ZSCAL(N, ZB, ZY, INCY)
         RETURN
       END IF

--- a/BLAS/SRC/zaxpby.f
+++ b/BLAS/SRC/zaxpby.f
@@ -108,13 +108,13 @@
       INTEGER I,IX,IY
 *     ..
       IF (N.LE.0) RETURN
-
-*     Scale if ZA .EQ. 0
+*
+*     Scale if ZA is zero - (note that SCAL does not handle INCY.LE.0)
       IF ( ZA.EQ.(0.0D0,0.0D0) .AND. INCY.GT.0) THEN
         CALL ZSCAL(N, ZB, ZY, INCY)
         RETURN
       END IF
-
+*
       IF (INCX.EQ.1 .AND. INCY.EQ.1) THEN
 *
 *        code for both increments equal to 1


### PR DESCRIPTION
Fix issue #1327

AXPBY(N, α, X, INCX, β, Y, INCY) calls SCAL(N, β, Y, INCY) in the case ( α.EQ.0 ) 

However, as pointed by @venovako in Iisue #1327, SCAL does not handle INCX ≤ 0 so the fix is that we only call SCAL when INCY > 0.

I also fixed the two typos pointed by @venovako

Also, for some reasons, AXPBY(N, α, X, INCX, β, Y, INCY) was not calling SCAL(N, β, Y, INCY) in the case ( α.EQ.0 ) .AND. ( β.EQ.0 ), but I think it is good to call SCAL in this case too so I removed the ( β.NE.0 ) condition.

I do not know why SCAL does not handle INCX ≤ 0. This is weird and maybe a better fix is to change the behavior of SCAL so that SCAL handles INCX ≤ 0. However the behavior seemed to be intentional as mentioned in the comment:
https://github.com/Reference-LAPACK/lapack/blob/c1c5b726be030d60dcd9c4afb74abfcb90189032/BLAS/SRC/cscal.f#L72
Anyone knows why?


