### PR TITLE
Fixed wrong deallocation order in LAPACKE routines

### DIFF
--- a/LAPACKE/src/lapacke_cgejsv.c
+++ b/LAPACKE/src/lapacke_cgejsv.c
@@ -160,7 +160,7 @@ lapack_int API_SUFFIX(LAPACKE_cgejsv)( int matrix_layout, char joba, char jobu, 
     rwork = (float*)LAPACKE_malloc( sizeof(float) * lrwork );
     if( rwork == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
-        goto exit_level_3;
+        goto exit_level_2;
     }
     /* Call middle-level interface */
     info = API_SUFFIX(LAPACKE_cgejsv_work)( matrix_layout, joba, jobu, jobv, jobr, jobt,
@@ -174,10 +174,9 @@ lapack_int API_SUFFIX(LAPACKE_cgejsv)( int matrix_layout, char joba, char jobu, 
         istat[i] = iwork[i];
     }
     /* Release memory and exit */
-exit_level_3:
-    LAPACKE_free( cwork );
-exit_level_2:
     LAPACKE_free( rwork );
+exit_level_2:
+    LAPACKE_free( cwork );
 exit_level_1:
     LAPACKE_free( iwork );
 exit_level_0:

--- a/LAPACKE/src/lapacke_cgesvdx.c
+++ b/LAPACKE/src/lapacke_cgesvdx.c
@@ -73,12 +73,12 @@ lapack_int API_SUFFIX(LAPACKE_cgesvdx)( int matrix_layout, char jobu, char jobvt
         LAPACKE_malloc( sizeof(lapack_complex_float) * lwork );
     if( work == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
-        goto exit_level_1;
+        goto exit_level_0;
     }
     rwork = (float*)LAPACKE_malloc( sizeof(float) * lrwork );
     if( rwork == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
-        goto exit_level_2;
+        goto exit_level_1;
     }
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * MAX(1,(12*MIN(m,n))) );
     if( iwork == NULL ) {
@@ -96,9 +96,9 @@ lapack_int API_SUFFIX(LAPACKE_cgesvdx)( int matrix_layout, char jobu, char jobvt
     /* Release memory and exit */
     LAPACKE_free( iwork );
 exit_level_2:
-    LAPACKE_free( work );
-exit_level_1:
     LAPACKE_free( rwork );
+exit_level_1:
+    LAPACKE_free( work );
 exit_level_0:
     if( info == LAPACK_WORK_MEMORY_ERROR ) {
         API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_cgesvdx", info );

--- a/LAPACKE/src/lapacke_zgejsv.c
+++ b/LAPACKE/src/lapacke_zgejsv.c
@@ -160,7 +160,7 @@ lapack_int API_SUFFIX(LAPACKE_zgejsv)( int matrix_layout, char joba, char jobu, 
     rwork = (double*)LAPACKE_malloc( sizeof(double) * lrwork );
     if( rwork == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
-        goto exit_level_3;
+        goto exit_level_2;
     }
     /* Call middle-level interface */
     info = API_SUFFIX(LAPACKE_zgejsv_work)( matrix_layout, joba, jobu, jobv, jobr, jobt,
@@ -174,10 +174,9 @@ lapack_int API_SUFFIX(LAPACKE_zgejsv)( int matrix_layout, char joba, char jobu, 
         istat[i] = iwork[i];
     }
     /* Release memory and exit */
-exit_level_3:
-    LAPACKE_free( cwork );
-exit_level_2:
     LAPACKE_free( rwork );
+exit_level_2:
+    LAPACKE_free( cwork );
 exit_level_1:
     LAPACKE_free( iwork );
 exit_level_0:

--- a/LAPACKE/src/lapacke_zgesvdx.c
+++ b/LAPACKE/src/lapacke_zgesvdx.c
@@ -73,12 +73,12 @@ lapack_int API_SUFFIX(LAPACKE_zgesvdx)( int matrix_layout, char jobu, char jobvt
         LAPACKE_malloc( sizeof(lapack_complex_double) * lwork );
     if( work == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
-        goto exit_level_1;
+        goto exit_level_0;
     }
     rwork = (double*)LAPACKE_malloc( sizeof(double) * lrwork );
     if( rwork == NULL ) {
         info = LAPACK_WORK_MEMORY_ERROR;
-        goto exit_level_2;
+        goto exit_level_1;
     }
     iwork = (lapack_int*)LAPACKE_malloc( sizeof(lapack_int) * MAX(1,(12*MIN(m,n))) );
     if( iwork == NULL ) {
@@ -96,9 +96,9 @@ lapack_int API_SUFFIX(LAPACKE_zgesvdx)( int matrix_layout, char jobu, char jobvt
     /* Release memory and exit */
     LAPACKE_free( iwork );
 exit_level_2:
-    LAPACKE_free( work );
-exit_level_1:
     LAPACKE_free( rwork );
+exit_level_1:
+    LAPACKE_free( work );
 exit_level_0:
     if( info == LAPACK_WORK_MEMORY_ERROR ) {
         API_SUFFIX(LAPACKE_xerbla)( "LAPACKE_zgesvdx", info );


### PR DESCRIPTION
**Description**

Some arrays in the LAPACKE wrappers were deallocated during abnormal exits, even though their allocation failed or was skipped.