### PR TITLE
Fix mixed enum and integer sign change warnings

### DIFF
--- a/CBLAS/include/cblas_test.h
+++ b/CBLAS/include/cblas_test.h
@@ -22,16 +22,24 @@
   #define FORTRAN_STRLEN size_t
 #endif
 
-#define  TRUE           1
-#define  PASSED         1
-#define  TEST_ROW_MJR	1
+#define TRUE         1
+#define PASSED       1
+#define TEST_ROW_MJR 1
 
-#define  FALSE          0
-#define  FAILED         0
-#define  TEST_COL_MJR	0
+#define FALSE        0
+#define FAILED       0
+#define TEST_COL_MJR 0
 
-#define  INVALID       -1
-#define  UNDEFINED     -1
+#define INVALID           ((CBLAS_INT)-1)
+
+/* Zero is outside the range of every CBLAS enum.  Keep the enum sentinels
+ * explicitly typed so that compilers do not diagnose an implicit conversion
+ * from the signed integer sentinel above. */
+#define INVALID_LAYOUT    ((CBLAS_LAYOUT)0)
+#define INVALID_TRANSPOSE ((CBLAS_TRANSPOSE)0)
+#define INVALID_UPLO      ((CBLAS_UPLO)0)
+#define INVALID_DIAG      ((CBLAS_DIAG)0)
+#define INVALID_SIDE      ((CBLAS_SIDE)0)
 
 typedef struct { float real; float imag; } CBLAS_TEST_COMPLEX;
 typedef struct { double real; double imag; } CBLAS_TEST_ZOMPLEX;

--- a/CBLAS/testing/auxiliary.c
+++ b/CBLAS/testing/auxiliary.c
@@ -12,7 +12,7 @@ void get_transpose_type(char *type, CBLAS_TRANSPOSE *trans) {
         *trans = CblasTrans;
   else if( (strncmp( type,"c",1 )==0)||(strncmp( type,"C",1 )==0) )
         *trans = CblasConjTrans;
-  else *trans = UNDEFINED;
+  else *trans = INVALID_TRANSPOSE;
 }
 
 void get_uplo_type(char *type, CBLAS_UPLO *uplo) {
@@ -20,19 +20,19 @@ void get_uplo_type(char *type, CBLAS_UPLO *uplo) {
         *uplo = CblasUpper;
   else if( (strncmp( type,"l",1 )==0)||(strncmp( type,"L",1 )==0) )
         *uplo = CblasLower;
-  else *uplo = UNDEFINED;
+  else *uplo = INVALID_UPLO;
 }
 void get_diag_type(char *type, CBLAS_DIAG *diag) {
   if( (strncmp( type,"u",1 )==0)||(strncmp( type,"U",1 )==0) )
         *diag = CblasUnit;
   else if( (strncmp( type,"n",1 )==0)||(strncmp( type,"N",1 )==0) )
         *diag = CblasNonUnit;
-  else *diag = UNDEFINED;
+  else *diag = INVALID_DIAG;
 }
 void get_side_type(char *type, CBLAS_SIDE *side) {
   if( (strncmp( type,"l",1 )==0)||(strncmp( type,"L",1 )==0) )
         *side = CblasLeft;
   else if( (strncmp( type,"r",1 )==0)||(strncmp( type,"R",1 )==0) )
         *side = CblasRight;
-  else *side = UNDEFINED;
+  else *side = INVALID_SIDE;
 }

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -64,11 +64,11 @@ void F77_c2chke(char *rout
    if (strncmp( sf,"cblas_cgemv",11)==0) {
       cblas_rout = "cblas_cgemv";
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemv)(INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cgemv)(INVALID_LAYOUT, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_cgemv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -93,7 +93,7 @@ void F77_c2chke(char *rout
       chkxer();
 
       cblas_info = 2; RowMajorStrg = TRUE; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_cgemv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_cgemv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -119,11 +119,11 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_cgbmv",11)==0) {
       cblas_rout = "cblas_cgbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgbmv)(INVALID, CblasNoTrans, 0, 0, 0, 0,
+      API_SUFFIX(cblas_cgbmv)(INVALID_LAYOUT, CblasNoTrans, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgbmv)(CblasColMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_cgbmv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -155,7 +155,7 @@ void F77_c2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_cgbmv)(CblasRowMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_cgbmv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -189,11 +189,11 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_chemv",11)==0) {
       cblas_rout = "cblas_chemv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chemv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_chemv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chemv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_chemv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -213,7 +213,7 @@ void F77_c2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_chemv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_chemv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -235,11 +235,11 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_chbmv",11)==0) {
       cblas_rout = "cblas_chbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chbmv)(INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_chbmv)(INVALID_LAYOUT, CblasUpper, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chbmv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_chbmv)(CblasColMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -263,7 +263,7 @@ void F77_c2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_chbmv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_chbmv)(CblasRowMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -289,11 +289,11 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_chpmv",11)==0) {
       cblas_rout = "cblas_chpmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpmv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_chpmv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpmv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_chpmv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -309,7 +309,7 @@ void F77_c2chke(char *rout
                   ALPHA, A, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_chpmv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_chpmv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -327,20 +327,20 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_ctrmv",11)==0) {
       cblas_rout = "cblas_ctrmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctrmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctrmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctrmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -355,16 +355,16 @@ void F77_c2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctrmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctrmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctrmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctrmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctrmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctrmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -381,20 +381,20 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_ctbmv",11)==0) {
       cblas_rout = "cblas_ctbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctbmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctbmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctbmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctbmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctbmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctbmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -413,16 +413,16 @@ void F77_c2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctbmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctbmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctbmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctbmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -443,20 +443,20 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_ctpmv",11)==0) {
       cblas_rout = "cblas_ctpmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctpmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctpmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctpmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctpmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctpmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctpmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -467,16 +467,16 @@ void F77_c2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctpmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctpmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctpmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctpmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -489,20 +489,20 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_ctrsv",11)==0) {
       cblas_rout = "cblas_ctrsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctrsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctrsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctrsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -517,16 +517,16 @@ void F77_c2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctrsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctrsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctrsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctrsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctrsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctrsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -543,20 +543,20 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_ctbsv",11)==0) {
       cblas_rout = "cblas_ctbsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctbsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctbsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctbsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctbsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctbsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctbsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -575,16 +575,16 @@ void F77_c2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctbsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctbsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctbsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctbsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -605,20 +605,20 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_ctpsv",11)==0) {
       cblas_rout = "cblas_ctpsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctpsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctpsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctpsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctpsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctpsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctpsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -629,16 +629,16 @@ void F77_c2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctpsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctpsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ctpsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctpsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -651,7 +651,7 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_cgeru",10)==0) {
       cblas_rout = "cblas_cgeru";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgeru)(INVALID, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_cgeru)(INVALID_LAYOUT, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_cgeru)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
@@ -686,7 +686,7 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_cgerc",10)==0) {
       cblas_rout = "cblas_cgerc";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgerc)(INVALID, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_cgerc)(INVALID_LAYOUT, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_cgerc)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
@@ -721,10 +721,10 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_cher2",11)==0) {
       cblas_rout = "cblas_cher2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cher2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_cher2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cher2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_cher2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_cher2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -739,7 +739,7 @@ void F77_c2chke(char *rout
       API_SUFFIX(cblas_cher2)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_cher2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_cher2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_cher2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -756,10 +756,10 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_chpr2",11)==0) {
       cblas_rout = "cblas_chpr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_chpr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_chpr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_chpr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -771,7 +771,7 @@ void F77_c2chke(char *rout
       API_SUFFIX(cblas_chpr2)(CblasColMajor, CblasUpper, 0, ALPHA, X, 1, Y, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_chpr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_chpr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_chpr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -785,10 +785,10 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_cher",10)==0) {
       cblas_rout = "cblas_cher";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cher)(INVALID, CblasUpper, 0, RALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_cher)(INVALID_LAYOUT, CblasUpper, 0, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cher)(CblasColMajor, INVALID, 0, RALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_cher)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_cher)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A, 1 );
@@ -800,7 +800,7 @@ void F77_c2chke(char *rout
       API_SUFFIX(cblas_cher)(CblasColMajor, CblasUpper, 2, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_cher)(CblasRowMajor, INVALID, 0, RALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_cher)(CblasRowMajor, INVALID_UPLO, 0, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_cher)(CblasRowMajor, CblasUpper, INVALID, RALPHA, X, 1, A, 1 );
@@ -814,10 +814,10 @@ void F77_c2chke(char *rout
    } else if (strncmp( sf,"cblas_chpr",10)==0) {
       cblas_rout = "cblas_chpr";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr)(INVALID, CblasUpper, 0, RALPHA, X, 1, A );
+      API_SUFFIX(cblas_chpr)(INVALID_LAYOUT, CblasUpper, 0, RALPHA, X, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr)(CblasColMajor, INVALID, 0, RALPHA, X, 1, A );
+      API_SUFFIX(cblas_chpr)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_chpr)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A );
@@ -826,7 +826,7 @@ void F77_c2chke(char *rout
       API_SUFFIX(cblas_chpr)(CblasColMajor, CblasUpper, 0, RALPHA, X, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr)(CblasColMajor, INVALID, 0, RALPHA, X, 1, A );
+      API_SUFFIX(cblas_chpr)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_chpr)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A );

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -66,63 +66,63 @@ void  F77_c3chke(char *  rout
       cblas_rout = "cblas_cgemmtr"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasUpper, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasUpper, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemmtr)( INVALID, CblasLower, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, CblasLower, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_cgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -296,35 +296,35 @@ void  F77_c3chke(char *  rout
       cblas_rout = "cblas_cgemm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemm)( INVALID,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemm)( INVALID,  CblasNoTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemm)( INVALID,  CblasTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( INVALID_LAYOUT,  CblasTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_cgemm)( INVALID,  CblasTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( INVALID_LAYOUT,  CblasTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemm)( CblasColMajor,  INVALID, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemm)( CblasColMajor,  INVALID, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemm)( CblasColMajor,  CblasNoTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( CblasColMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cgemm)( CblasColMajor,  CblasTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_cgemm)( CblasColMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -523,15 +523,15 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_chemm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_chemm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_chemm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chemm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_chemm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chemm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_chemm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -699,15 +699,15 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_csymm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_csymm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_csymm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_csymm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_csymm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_csymm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_csymm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -875,24 +875,24 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_ctrmm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_ctrmm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctrmm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrmm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctrmm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrmm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctrmm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctrmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1155,24 +1155,24 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_ctrsm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_ctrsm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctrsm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrsm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ctrsm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrsm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ctrsm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ctrsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ctrsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1435,11 +1435,11 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_cherk"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_cherk)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cherk)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                   RALPHA, A, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cherk)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cherk)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                   RALPHA, A, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -1547,11 +1547,11 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_csyrk"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_csyrk)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_csyrk)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_csyrk)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_csyrk)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -1659,11 +1659,11 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_cher2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_cher2k)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cher2k)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_cher2k)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_cher2k)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -1803,11 +1803,11 @@ void  F77_c3chke(char *  rout
             cblas_rout = "cblas_csyr2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_csyr2k)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_csyr2k)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_csyr2k)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_csyr2k)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;

--- a/CBLAS/testing/c_cblas2.c
+++ b/CBLAS/testing/c_cblas2.c
@@ -38,7 +38,7 @@ void F77_cgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n,
      API_SUFFIX(cblas_cgemv)( CblasColMajor, trans,
                   *m, *n, alpha, a, *lda, x, *incx, beta, y, *incy );
   else
-     API_SUFFIX(cblas_cgemv)( UNDEFINED, trans,
+     API_SUFFIX(cblas_cgemv)( INVALID_LAYOUT, trans,
                   *m, *n, alpha, a, *lda, x, *incx, beta, y, *incy );
 }
 
@@ -89,7 +89,7 @@ void F77_cgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_cgbmv)( CblasColMajor, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
 		  *incx, beta, y, *incy );
   else
-     API_SUFFIX(cblas_cgbmv)( UNDEFINED, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
+     API_SUFFIX(cblas_cgbmv)( INVALID_LAYOUT, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
 		  *incx, beta, y, *incy );
 }
 
@@ -119,7 +119,7 @@ void F77_cgeru(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_COMPLEX
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_cgeru)( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
   else
-     API_SUFFIX(cblas_cgeru)( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+     API_SUFFIX(cblas_cgeru)( INVALID_LAYOUT, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
 }
 
 void F77_cgerc(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
@@ -147,7 +147,7 @@ void F77_cgerc(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_COMPLEX
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_cgerc)( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
   else
-     API_SUFFIX(cblas_cgerc)( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+     API_SUFFIX(cblas_cgerc)( INVALID_LAYOUT, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
 }
 
 void F77_chemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
@@ -180,7 +180,7 @@ void F77_chemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
      API_SUFFIX(cblas_chemv)( CblasColMajor, uplo, *n, alpha, a, *lda, x, *incx,
 	   beta, y, *incy );
   else
-     API_SUFFIX(cblas_chemv)( UNDEFINED, uplo, *n, alpha, a, *lda, x, *incx,
+     API_SUFFIX(cblas_chemv)( INVALID_LAYOUT, uplo, *n, alpha, a, *lda, x, *incx,
 	   beta, y, *incy );
 }
 
@@ -202,7 +202,7 @@ CBLAS_INT i,irow,j,jcol,LDA;
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_chbmv)(CblasRowMajor, UNDEFINED, *n, *k, alpha, a, *lda, x,
+        API_SUFFIX(cblas_chbmv)(CblasRowMajor, INVALID_UPLO, *n, *k, alpha, a, *lda, x,
 		 *incx, beta, y, *incy );
      else {
         LDA = *k+2;
@@ -248,7 +248,7 @@ CBLAS_INT i,irow,j,jcol,LDA;
      API_SUFFIX(cblas_chbmv)(CblasColMajor, uplo, *n, *k, alpha, a, *lda, x, *incx,
                  beta, y, *incy );
    else
-     API_SUFFIX(cblas_chbmv)(UNDEFINED, uplo, *n, *k, alpha, a, *lda, x, *incx,
+     API_SUFFIX(cblas_chbmv)(INVALID_LAYOUT, uplo, *n, *k, alpha, a, *lda, x, *incx,
                  beta, y, *incy );
 }
 
@@ -267,7 +267,7 @@ void F77_chpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
   get_uplo_type(uplow,&uplo);
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_chpmv)(CblasRowMajor, UNDEFINED, *n, alpha, ap, x, *incx,
+        API_SUFFIX(cblas_chpmv)(CblasRowMajor, INVALID_UPLO, *n, alpha, ap, x, *incx,
 	         beta, y, *incy);
      else {
         LDA = *n;
@@ -308,7 +308,7 @@ void F77_chpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
      API_SUFFIX(cblas_chpmv)( CblasColMajor, uplo, *n, alpha, ap, x, *incx, beta, y,
                   *incy );
   else
-     API_SUFFIX(cblas_chpmv)( UNDEFINED, uplo, *n, alpha, ap, x, *incx, beta, y,
+     API_SUFFIX(cblas_chpmv)( INVALID_LAYOUT, uplo, *n, alpha, ap, x, *incx, beta, y,
                   *incy );
 }
 
@@ -331,7 +331,7 @@ void F77_ctbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ctbmv)(CblasRowMajor, UNDEFINED, trans, diag, *n, *k, a, *lda,
+        API_SUFFIX(cblas_ctbmv)(CblasRowMajor, INVALID_UPLO, trans, diag, *n, *k, a, *lda,
 	x, *incx);
      else {
         LDA = *k+2;
@@ -376,7 +376,7 @@ void F77_ctbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
    else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ctbmv)(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
    else
-     API_SUFFIX(cblas_ctbmv)(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+     API_SUFFIX(cblas_ctbmv)(INVALID_LAYOUT, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
 }
 
 void F77_ctbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -399,7 +399,7 @@ void F77_ctbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ctbsv)(CblasRowMajor, UNDEFINED, trans, diag, *n, *k, a, *lda, x,
+        API_SUFFIX(cblas_ctbsv)(CblasRowMajor, INVALID_UPLO, trans, diag, *n, *k, a, *lda, x,
 	         *incx);
      else {
         LDA = *k+2;
@@ -444,7 +444,7 @@ void F77_ctbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ctbsv)(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
   else
-     API_SUFFIX(cblas_ctbsv)(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+     API_SUFFIX(cblas_ctbsv)(INVALID_LAYOUT, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
 }
 
 void F77_ctpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -465,7 +465,7 @@ void F77_ctpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ctpmv)( CblasRowMajor, UNDEFINED, trans, diag, *n, ap, x, *incx );
+        API_SUFFIX(cblas_ctpmv)( CblasRowMajor, INVALID_UPLO, trans, diag, *n, ap, x, *incx );
      else {
         LDA = *n;
         A=(CBLAS_TEST_COMPLEX*)malloc(LDA*LDA*sizeof(CBLAS_TEST_COMPLEX));
@@ -503,7 +503,7 @@ void F77_ctpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ctpmv)( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
   else
-     API_SUFFIX(cblas_ctpmv)( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
+     API_SUFFIX(cblas_ctpmv)( INVALID_LAYOUT, uplo, trans, diag, *n, ap, x, *incx );
 }
 
 void F77_ctpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -524,7 +524,7 @@ void F77_ctpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ctpsv)( CblasRowMajor, UNDEFINED, trans, diag, *n, ap, x, *incx );
+        API_SUFFIX(cblas_ctpsv)( CblasRowMajor, INVALID_UPLO, trans, diag, *n, ap, x, *incx );
      else {
         LDA = *n;
         A=(CBLAS_TEST_COMPLEX*)malloc(LDA*LDA*sizeof(CBLAS_TEST_COMPLEX));
@@ -562,7 +562,7 @@ void F77_ctpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ctpsv)( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
   else
-     API_SUFFIX(cblas_ctpsv)( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
+     API_SUFFIX(cblas_ctpsv)( INVALID_LAYOUT, uplo, trans, diag, *n, ap, x, *incx );
 }
 
 void F77_ctrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -596,7 +596,7 @@ void F77_ctrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ctrmv)(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx);
   else
-     API_SUFFIX(cblas_ctrmv)(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
+     API_SUFFIX(cblas_ctrmv)(INVALID_LAYOUT, uplo, trans, diag, *n, a, *lda, x, *incx);
 }
 void F77_ctrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
        CBLAS_INT *n, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_COMPLEX *x,
@@ -629,7 +629,7 @@ void F77_ctrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
    else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ctrsv)(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx );
    else
-     API_SUFFIX(cblas_ctrsv)(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx );
+     API_SUFFIX(cblas_ctrsv)(INVALID_LAYOUT, uplo, trans, diag, *n, a, *lda, x, *incx );
 }
 
 void F77_chpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
@@ -646,7 +646,7 @@ void F77_chpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_chpr)(CblasRowMajor, UNDEFINED, *n, *alpha, x, *incx, ap );
+        API_SUFFIX(cblas_chpr)(CblasRowMajor, INVALID_UPLO, *n, *alpha, x, *incx, ap );
      else {
         LDA = *n;
         A = (CBLAS_TEST_COMPLEX* )malloc(LDA*LDA*sizeof(CBLAS_TEST_COMPLEX ) );
@@ -708,7 +708,7 @@ void F77_chpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_chpr)(CblasColMajor, uplo, *n, *alpha, x, *incx, ap );
   else
-     API_SUFFIX(cblas_chpr)(UNDEFINED, uplo, *n, *alpha, x, *incx, ap );
+     API_SUFFIX(cblas_chpr)(INVALID_LAYOUT, uplo, *n, *alpha, x, *incx, ap );
 }
 
 void F77_chpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
@@ -726,7 +726,7 @@ void F77_chpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_chpr2)( CblasRowMajor, UNDEFINED, *n, alpha, x, *incx, y,
+        API_SUFFIX(cblas_chpr2)( CblasRowMajor, INVALID_UPLO, *n, alpha, x, *incx, y,
 		     *incy, ap );
      else {
         LDA = *n;
@@ -789,7 +789,7 @@ void F77_chpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_chpr2)( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, ap );
   else
-     API_SUFFIX(cblas_chpr2)( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, ap );
+     API_SUFFIX(cblas_chpr2)( INVALID_LAYOUT, uplo, *n, alpha, x, *incx, y, *incy, ap );
 }
 
 void F77_cher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
@@ -825,7 +825,7 @@ void F77_cher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, float *alpha,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_cher)( CblasColMajor, uplo, *n, *alpha, x, *incx, a, *lda );
   else
-     API_SUFFIX(cblas_cher)( UNDEFINED, uplo, *n, *alpha, x, *incx, a, *lda );
+     API_SUFFIX(cblas_cher)( INVALID_LAYOUT, uplo, *n, *alpha, x, *incx, a, *lda );
 }
 
 void F77_cher2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX *alpha,
@@ -863,5 +863,5 @@ void F77_cher2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_COMPLEX 
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_cher2)( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
   else
-     API_SUFFIX(cblas_cher2)( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
+     API_SUFFIX(cblas_cher2)( INVALID_LAYOUT, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
 }

--- a/CBLAS/testing/c_cblas3.c
+++ b/CBLAS/testing/c_cblas3.c
@@ -9,7 +9,6 @@
 #include "cblas_test.h"
 #define  TEST_COL_MJR	0
 #define  TEST_ROW_MJR	1
-#define  UNDEFINED     -1
 
 void F77_cgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
      CBLAS_INT *k, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,
@@ -88,7 +87,7 @@ void F77_cgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
      API_SUFFIX(cblas_cgemm)( CblasColMajor, transa, transb, *m, *n, *k, alpha, a, *lda,
                   b, *ldb, beta, c, *ldc );
   else
-     API_SUFFIX(cblas_cgemm)( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+     API_SUFFIX(cblas_cgemm)( INVALID_LAYOUT, transa, transb, *m, *n, *k, alpha, a, *lda,
                   b, *ldb, beta, c, *ldc );
 }
 
@@ -167,7 +166,7 @@ void F77_cgemmtr(CBLAS_INT *layout, char *uplop, char *transpa, char *transpb, C
      API_SUFFIX(cblas_cgemmtr)( CblasColMajor, uplo, transa, transb, *n, *k, alpha, a, *lda,
                   b, *ldb, beta, c, *ldc );
   else
-     API_SUFFIX(cblas_cgemmtr)( UNDEFINED, uplo, transa, transb, *n, *k, alpha, a, *lda,
+     API_SUFFIX(cblas_cgemmtr)( INVALID_LAYOUT, uplo, transa, transb, *n, *k, alpha, a, *lda,
                   b, *ldb, beta, c, *ldc );
 }
 
@@ -237,7 +236,7 @@ void F77_chemm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
      API_SUFFIX(cblas_chemm)( CblasColMajor, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
   else
-     API_SUFFIX(cblas_chemm)( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_chemm)( INVALID_LAYOUT, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
 }
 void F77_csymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
@@ -295,7 +294,7 @@ void F77_csymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
      API_SUFFIX(cblas_csymm)( CblasColMajor, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
   else
-     API_SUFFIX(cblas_csymm)( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_csymm)( INVALID_LAYOUT, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
 }
 
@@ -355,7 +354,7 @@ void F77_cherk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
      API_SUFFIX(cblas_cherk)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
   else
-     API_SUFFIX(cblas_cherk)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+     API_SUFFIX(cblas_cherk)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
 }
 
@@ -415,7 +414,7 @@ void F77_csyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
      API_SUFFIX(cblas_csyrk)(CblasColMajor, uplo, trans, *n, *k, alpha, a, *lda, beta,
 	         c, *ldc );
   else
-     API_SUFFIX(cblas_csyrk)(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda, beta,
+     API_SUFFIX(cblas_csyrk)(INVALID_LAYOUT, uplo, trans, *n, *k, alpha, a, *lda, beta,
 	         c, *ldc );
 }
 void F77_cher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
@@ -483,7 +482,7 @@ void F77_cher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_cher2k)(CblasColMajor, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_cher2k)(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+     API_SUFFIX(cblas_cher2k)(INVALID_LAYOUT, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
 }
 void F77_csyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
@@ -551,7 +550,7 @@ void F77_csyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_csyr2k)(CblasColMajor, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, beta, c, *ldc );
   else
-     API_SUFFIX(cblas_csyr2k)(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+     API_SUFFIX(cblas_csyr2k)(INVALID_LAYOUT, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, beta, c, *ldc );
 }
 void F77_ctrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
@@ -613,7 +612,7 @@ void F77_ctrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_ctrmm)(CblasColMajor, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_ctrmm)(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+     API_SUFFIX(cblas_ctrmm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
 }
 
@@ -676,6 +675,6 @@ void F77_ctrsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_ctrsm)(CblasColMajor, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_ctrsm)(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+     API_SUFFIX(cblas_ctrsm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
 }

--- a/CBLAS/testing/c_cblas3.c
+++ b/CBLAS/testing/c_cblas3.c
@@ -7,8 +7,6 @@
 #include <stdlib.h>
 #include "cblas.h"
 #include "cblas_test.h"
-#define  TEST_COL_MJR	0
-#define  TEST_ROW_MJR	1
 
 void F77_cgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
      CBLAS_INT *k, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, CBLAS_INT *lda,

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -63,11 +63,11 @@ void F77_d2chke(char *rout
    if (strncmp( sf,"cblas_dgemv",11)==0) {
       cblas_rout = "cblas_dgemv";
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemv)(INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_dgemv)(INVALID_LAYOUT, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_dgemv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -92,7 +92,7 @@ void F77_d2chke(char *rout
       chkxer();
 
       cblas_info = 2; RowMajorStrg = TRUE; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dgemv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_dgemv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -118,11 +118,11 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dgbmv",11)==0) {
       cblas_rout = "cblas_dgbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgbmv)(INVALID, CblasNoTrans, 0, 0, 0, 0,
+      API_SUFFIX(cblas_dgbmv)(INVALID_LAYOUT, CblasNoTrans, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgbmv)(CblasColMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_dgbmv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -154,7 +154,7 @@ void F77_d2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dgbmv)(CblasRowMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_dgbmv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -188,11 +188,11 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dsymv",11)==0) {
       cblas_rout = "cblas_dsymv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsymv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_dsymv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsymv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_dsymv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -212,7 +212,7 @@ void F77_d2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dsymv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_dsymv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -234,11 +234,11 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dskewsymv",15)==0) {
       cblas_rout = "cblas_dskewsymv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsymv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_dskewsymv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsymv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_dskewsymv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -258,7 +258,7 @@ void F77_d2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dskewsymv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_dskewsymv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -280,11 +280,11 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dsbmv",11)==0) {
       cblas_rout = "cblas_dsbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsbmv)(INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_dsbmv)(INVALID_LAYOUT, CblasUpper, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsbmv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_dsbmv)(CblasColMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -308,7 +308,7 @@ void F77_d2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dsbmv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_dsbmv)(CblasRowMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -334,11 +334,11 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dspmv",11)==0) {
       cblas_rout = "cblas_dspmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspmv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_dspmv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspmv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_dspmv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -354,7 +354,7 @@ void F77_d2chke(char *rout
                   ALPHA, A, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dspmv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_dspmv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -372,20 +372,20 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dtrmv",11)==0) {
       cblas_rout = "cblas_dtrmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtrmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtrmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtrmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -400,16 +400,16 @@ void F77_d2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtrmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtrmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtrmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtrmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtrmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtrmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -426,20 +426,20 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dtbmv",11)==0) {
       cblas_rout = "cblas_dtbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtbmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtbmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtbmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtbmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtbmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtbmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -458,16 +458,16 @@ void F77_d2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtbmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtbmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtbmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtbmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -488,20 +488,20 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dtpmv",11)==0) {
       cblas_rout = "cblas_dtpmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtpmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtpmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtpmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtpmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtpmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtpmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -512,16 +512,16 @@ void F77_d2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtpmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtpmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtpmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtpmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -534,20 +534,20 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dtrsv",11)==0) {
       cblas_rout = "cblas_dtrsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtrsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtrsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtrsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -562,16 +562,16 @@ void F77_d2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtrsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtrsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtrsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtrsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtrsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtrsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -588,20 +588,20 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dtbsv",11)==0) {
       cblas_rout = "cblas_dtbsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtbsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtbsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtbsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtbsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtbsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtbsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -620,16 +620,16 @@ void F77_d2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtbsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtbsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtbsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtbsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -650,20 +650,20 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dtpsv",11)==0) {
       cblas_rout = "cblas_dtpsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtpsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtpsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtpsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtpsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtpsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtpsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -674,16 +674,16 @@ void F77_d2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtpsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtpsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dtpsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtpsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -696,7 +696,7 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dger",10)==0) {
       cblas_rout = "cblas_dger";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dger)(INVALID, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_dger)(INVALID_LAYOUT, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dger)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
@@ -731,10 +731,10 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dsyr2",11)==0) {
       cblas_rout = "cblas_dsyr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_dsyr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_dsyr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dsyr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -749,7 +749,7 @@ void F77_d2chke(char *rout
       API_SUFFIX(cblas_dsyr2)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dsyr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_dsyr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dsyr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -766,10 +766,10 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dskewsyr2",15)==0) {
       cblas_rout = "cblas_dskewsyr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsyr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_dskewsyr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsyr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_dskewsyr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dskewsyr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -784,7 +784,7 @@ void F77_d2chke(char *rout
       API_SUFFIX(cblas_dskewsyr2)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dskewsyr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_dskewsyr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dskewsyr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -801,10 +801,10 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dspr2",11)==0) {
       cblas_rout = "cblas_dspr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_dspr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_dspr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dspr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -816,7 +816,7 @@ void F77_d2chke(char *rout
       API_SUFFIX(cblas_dspr2)(CblasColMajor, CblasUpper, 0, ALPHA, X, 1, Y, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dspr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_dspr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dspr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -830,10 +830,10 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dsyr",10)==0) {
       cblas_rout = "cblas_dsyr";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyr)(INVALID, CblasUpper, 0, ALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_dsyr)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyr)(CblasColMajor, INVALID, 0, ALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_dsyr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dsyr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A, 1 );
@@ -845,7 +845,7 @@ void F77_d2chke(char *rout
       API_SUFFIX(cblas_dsyr)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dsyr)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_dsyr)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dsyr)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, A, 1 );
@@ -859,10 +859,10 @@ void F77_d2chke(char *rout
    } else if (strncmp( sf,"cblas_dspr",10)==0) {
       cblas_rout = "cblas_dspr";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr)(INVALID, CblasUpper, 0, ALPHA, X, 1, A );
+      API_SUFFIX(cblas_dspr)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr)(CblasColMajor, INVALID, 0, ALPHA, X, 1, A );
+      API_SUFFIX(cblas_dspr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dspr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A );
@@ -871,7 +871,7 @@ void F77_d2chke(char *rout
       API_SUFFIX(cblas_dspr)(CblasColMajor, CblasUpper, 0, ALPHA, X, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr)(CblasColMajor, INVALID, 0, ALPHA, X, 1, A );
+      API_SUFFIX(cblas_dspr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dspr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A );

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -64,63 +64,63 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dgemmtr"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasUpper, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasUpper, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemmtr)( INVALID, CblasLower, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, CblasLower, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_dgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -294,35 +294,35 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dgemm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemm)( INVALID,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemm)( INVALID,  CblasNoTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemm)( INVALID,  CblasTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( INVALID_LAYOUT,  CblasTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_dgemm)( INVALID,  CblasTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( INVALID_LAYOUT,  CblasTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemm)( CblasColMajor,  INVALID, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemm)( CblasColMajor,  INVALID, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemm)( CblasColMajor,  CblasNoTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( CblasColMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dgemm)( CblasColMajor,  CblasTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_dgemm)( CblasColMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -522,15 +522,15 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dsymm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dsymm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_dsymm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsymm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_dsymm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsymm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_dsymm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -698,15 +698,15 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dskewsymm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dskewsymm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_dskewsymm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsymm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_dskewsymm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsymm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_dskewsymm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -874,24 +874,24 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dtrmm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dtrmm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtrmm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrmm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtrmm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrmm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtrmm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtrmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1154,24 +1154,24 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dtrsm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dtrsm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtrsm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrsm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dtrsm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrsm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dtrsm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dtrsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_dtrsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1435,15 +1435,15 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dsyrk"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dsyrk)( INVALID,  CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dsyrk)( INVALID_LAYOUT,  CblasUpper, CblasNoTrans,
                    0, 0, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyrk)( CblasColMajor,  INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dsyrk)( CblasColMajor,  INVALID_UPLO, CblasNoTrans,
                    0, 0, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyrk)( CblasColMajor,  CblasUpper, INVALID,
+      API_SUFFIX(cblas_dsyrk)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE,
                    0, 0, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -1547,15 +1547,15 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dsyr2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dsyr2k)( INVALID,  CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dsyr2k)( INVALID_LAYOUT,  CblasUpper, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyr2k)( CblasColMajor,  INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dsyr2k)( CblasColMajor,  INVALID_UPLO, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dsyr2k)( CblasColMajor,  CblasUpper, INVALID,
+      API_SUFFIX(cblas_dsyr2k)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -1690,15 +1690,15 @@ void F77_d3chke(char *rout
       cblas_rout = "cblas_dskewsyr2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_dskewsyr2k)( INVALID,  CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_dskewsyr2k)( INVALID_LAYOUT,  CblasUpper, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsyr2k)( CblasColMajor,  INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_dskewsyr2k)( CblasColMajor,  INVALID_UPLO, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dskewsyr2k)( CblasColMajor,  CblasUpper, INVALID,
+      API_SUFFIX(cblas_dskewsyr2k)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;

--- a/CBLAS/testing/c_dblas2.c
+++ b/CBLAS/testing/c_dblas2.c
@@ -35,7 +35,7 @@ void F77_dgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, doub
      API_SUFFIX(cblas_dgemv)( CblasColMajor, trans,
 		  *m, *n, *alpha, a, *lda, x, *incx, *beta, y, *incy );
   else
-     API_SUFFIX(cblas_dgemv)( UNDEFINED, trans,
+     API_SUFFIX(cblas_dgemv)( INVALID_LAYOUT, trans,
 		  *m, *n, *alpha, a, *lda, x, *incx, *beta, y, *incy );
 }
 
@@ -92,7 +92,7 @@ void F77_dtrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_dtrmv)(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx);
   else {
-     API_SUFFIX(cblas_dtrmv)(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
+     API_SUFFIX(cblas_dtrmv)(INVALID_LAYOUT, uplo, trans, diag, *n, a, *lda, x, *incx);
   }
 }
 

--- a/CBLAS/testing/c_dblas3.c
+++ b/CBLAS/testing/c_dblas3.c
@@ -9,7 +9,6 @@
 #include "cblas_test.h"
 #define  TEST_COL_MJR	0
 #define  TEST_ROW_MJR	1
-#define  UNDEFINED     -1
 
 void F77_dgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
               CBLAS_INT *k, double *alpha, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb,
@@ -74,7 +73,7 @@ void F77_dgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
      API_SUFFIX(cblas_dgemm)( CblasColMajor, transa, transb, *m, *n, *k, *alpha, a, *lda,
                   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_dgemm)( UNDEFINED, transa, transb, *m, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_dgemm)( INVALID_LAYOUT, transa, transb, *m, *n, *k, *alpha, a, *lda,
                   b, *ldb, *beta, c, *ldc );
 }
 
@@ -148,7 +147,7 @@ void F77_dgemmtr(CBLAS_INT *layout, char *uplop, char *transpa, char *transpb, C
                   b, *ldb, *beta, c, *ldc );
   }
   else
-     API_SUFFIX(cblas_dgemmtr)( UNDEFINED, uplo, transa, transb, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_dgemmtr)( INVALID_LAYOUT, uplo, transa, transb, *n, *k, *alpha, a, *lda,
                   b, *ldb, *beta, c, *ldc );
 }
 
@@ -210,7 +209,7 @@ void F77_dsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
      API_SUFFIX(cblas_dsymm)( CblasColMajor, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_dsymm)( UNDEFINED, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_dsymm)( INVALID_LAYOUT, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
 }
 
@@ -268,7 +267,7 @@ void F77_dskewsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBL
      API_SUFFIX(cblas_dskewsymm)( CblasColMajor, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_dskewsymm)( UNDEFINED, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_dskewsymm)( INVALID_LAYOUT, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
 }
 
@@ -320,7 +319,7 @@ void F77_dsyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
      API_SUFFIX(cblas_dsyrk)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
   else
-     API_SUFFIX(cblas_dsyrk)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+     API_SUFFIX(cblas_dsyrk)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
 }
 
@@ -380,7 +379,7 @@ void F77_dsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_dsyr2k)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_dsyr2k)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_dsyr2k)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
 }
 void F77_dskewsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
@@ -439,7 +438,7 @@ void F77_dskewsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, 
      API_SUFFIX(cblas_dskewsyr2k)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_dskewsyr2k)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_dskewsyr2k)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
 }
 void F77_dtrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
@@ -493,7 +492,7 @@ void F77_dtrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_dtrmm)(CblasColMajor, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_dtrmm)(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+     API_SUFFIX(cblas_dtrmm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
 }
 
@@ -548,6 +547,6 @@ void F77_dtrsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_dtrsm)(CblasColMajor, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_dtrsm)(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+     API_SUFFIX(cblas_dtrsm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
 }

--- a/CBLAS/testing/c_dblas3.c
+++ b/CBLAS/testing/c_dblas3.c
@@ -7,8 +7,6 @@
 #include <stdlib.h>
 #include "cblas.h"
 #include "cblas_test.h"
-#define  TEST_COL_MJR	0
-#define  TEST_ROW_MJR	1
 
 void F77_dgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
               CBLAS_INT *k, double *alpha, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb,

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -63,11 +63,11 @@ void F77_s2chke(char *rout
    if (strncmp( sf,"cblas_sgemv",11)==0) {
       cblas_rout = "cblas_sgemv";
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemv)(INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_sgemv)(INVALID_LAYOUT, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_sgemv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -92,7 +92,7 @@ void F77_s2chke(char *rout
       chkxer();
 
       cblas_info = 2; RowMajorStrg = TRUE; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sgemv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_sgemv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -118,11 +118,11 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_sgbmv",11)==0) {
       cblas_rout = "cblas_sgbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgbmv)(INVALID, CblasNoTrans, 0, 0, 0, 0,
+      API_SUFFIX(cblas_sgbmv)(INVALID_LAYOUT, CblasNoTrans, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgbmv)(CblasColMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_sgbmv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -154,7 +154,7 @@ void F77_s2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sgbmv)(CblasRowMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_sgbmv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -188,11 +188,11 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_ssymv",11)==0) {
       cblas_rout = "cblas_ssymv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssymv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_ssymv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssymv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_ssymv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -212,7 +212,7 @@ void F77_s2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ssymv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_ssymv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -234,11 +234,11 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_sskewsymv",15)==0) {
       cblas_rout = "cblas_sskewsymv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsymv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_sskewsymv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsymv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_sskewsymv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -258,7 +258,7 @@ void F77_s2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sskewsymv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_sskewsymv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -280,11 +280,11 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_ssbmv",11)==0) {
       cblas_rout = "cblas_ssbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssbmv)(INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_ssbmv)(INVALID_LAYOUT, CblasUpper, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssbmv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_ssbmv)(CblasColMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -308,7 +308,7 @@ void F77_s2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ssbmv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_ssbmv)(CblasRowMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -334,11 +334,11 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_sspmv",11)==0) {
       cblas_rout = "cblas_sspmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspmv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_sspmv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspmv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_sspmv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -354,7 +354,7 @@ void F77_s2chke(char *rout
                   ALPHA, A, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sspmv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_sspmv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -372,20 +372,20 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_strmv",11)==0) {
       cblas_rout = "cblas_strmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_strmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_strmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_strmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -400,16 +400,16 @@ void F77_s2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_strmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_strmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_strmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_strmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_strmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_strmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -426,20 +426,20 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_stbmv",11)==0) {
       cblas_rout = "cblas_stbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stbmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_stbmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stbmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stbmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stbmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stbmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -458,16 +458,16 @@ void F77_s2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stbmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stbmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stbmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stbmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -488,20 +488,20 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_stpmv",11)==0) {
       cblas_rout = "cblas_stpmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stpmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_stpmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stpmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stpmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stpmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stpmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -512,16 +512,16 @@ void F77_s2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stpmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stpmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stpmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stpmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -534,20 +534,20 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_strsv",11)==0) {
       cblas_rout = "cblas_strsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_strsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_strsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_strsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -562,16 +562,16 @@ void F77_s2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_strsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_strsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_strsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_strsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_strsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_strsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -588,20 +588,20 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_stbsv",11)==0) {
       cblas_rout = "cblas_stbsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stbsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_stbsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stbsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stbsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stbsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stbsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -620,16 +620,16 @@ void F77_s2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stbsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stbsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stbsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stbsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -650,20 +650,20 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_stpsv",11)==0) {
       cblas_rout = "cblas_stpsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stpsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_stpsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stpsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stpsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_stpsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stpsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_stpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -674,16 +674,16 @@ void F77_s2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stpsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_stpsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_stpsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_stpsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_stpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -696,7 +696,7 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_sger",10)==0) {
       cblas_rout = "cblas_sger";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sger)(INVALID, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_sger)(INVALID_LAYOUT, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_sger)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
@@ -731,10 +731,10 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_ssyr2",11)==0) {
       cblas_rout = "cblas_ssyr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_ssyr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_ssyr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ssyr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -749,7 +749,7 @@ void F77_s2chke(char *rout
       API_SUFFIX(cblas_ssyr2)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ssyr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_ssyr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ssyr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -766,10 +766,10 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_sskewsyr2",15)==0) {
       cblas_rout = "cblas_sskewsyr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsyr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_sskewsyr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsyr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_sskewsyr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_sskewsyr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -784,7 +784,7 @@ void F77_s2chke(char *rout
       API_SUFFIX(cblas_sskewsyr2)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sskewsyr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_sskewsyr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_sskewsyr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -801,10 +801,10 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_sspr2",11)==0) {
       cblas_rout = "cblas_sspr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_sspr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_sspr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_sspr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -816,7 +816,7 @@ void F77_s2chke(char *rout
       API_SUFFIX(cblas_sspr2)(CblasColMajor, CblasUpper, 0, ALPHA, X, 1, Y, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sspr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_sspr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_sspr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -830,10 +830,10 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_ssyr",10)==0) {
       cblas_rout = "cblas_ssyr";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyr)(INVALID, CblasUpper, 0, ALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_ssyr)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyr)(CblasColMajor, INVALID, 0, ALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_ssyr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ssyr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A, 1 );
@@ -845,7 +845,7 @@ void F77_s2chke(char *rout
       API_SUFFIX(cblas_ssyr)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ssyr)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_ssyr)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ssyr)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, A, 1 );
@@ -859,10 +859,10 @@ void F77_s2chke(char *rout
    } else if (strncmp( sf,"cblas_sspr",10)==0) {
       cblas_rout = "cblas_sspr";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr)(INVALID, CblasUpper, 0, ALPHA, X, 1, A );
+      API_SUFFIX(cblas_sspr)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr)(CblasColMajor, INVALID, 0, ALPHA, X, 1, A );
+      API_SUFFIX(cblas_sspr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_sspr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A );
@@ -871,7 +871,7 @@ void F77_s2chke(char *rout
       API_SUFFIX(cblas_sspr)(CblasColMajor, CblasUpper, 0, ALPHA, X, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr)(CblasColMajor, INVALID, 0, ALPHA, X, 1, A );
+      API_SUFFIX(cblas_sspr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_sspr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A );

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -65,63 +65,63 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_sgemmtr"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasUpper, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasUpper, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemmtr)( INVALID, CblasLower, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, CblasLower, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_sgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -294,35 +294,35 @@ void F77_s3chke(char *rout
    } else if (strncmp( sf,"cblas_sgemm"   ,11)==0) {
       cblas_rout = "cblas_sgemm"   ;
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemm)( INVALID,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemm)( INVALID,  CblasNoTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemm)( INVALID,  CblasTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( INVALID_LAYOUT,  CblasTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_sgemm)( INVALID,  CblasTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( INVALID_LAYOUT,  CblasTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemm)( CblasColMajor,  INVALID, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemm)( CblasColMajor,  INVALID, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemm)( CblasColMajor,  CblasNoTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( CblasColMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sgemm)( CblasColMajor,  CblasTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_sgemm)( CblasColMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -523,15 +523,15 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_ssymm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_ssymm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_ssymm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssymm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_ssymm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssymm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_ssymm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -700,15 +700,15 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_sskewsymm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_sskewsymm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_sskewsymm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsymm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_sskewsymm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsymm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_sskewsymm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -877,24 +877,24 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_strmm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_strmm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_strmm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strmm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_strmm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strmm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_strmm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_strmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1158,24 +1158,24 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_strsm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_strsm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_strsm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strsm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_strsm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strsm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_strsm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_strsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_strsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_strsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1439,15 +1439,15 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_ssyrk"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_ssyrk)( INVALID,  CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ssyrk)( INVALID_LAYOUT,  CblasUpper, CblasNoTrans,
                    0, 0, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyrk)( CblasColMajor,  INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ssyrk)( CblasColMajor,  INVALID_UPLO, CblasNoTrans,
                    0, 0, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyrk)( CblasColMajor,  CblasUpper, INVALID,
+      API_SUFFIX(cblas_ssyrk)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE,
                    0, 0, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -1551,15 +1551,15 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_ssyr2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_ssyr2k)( INVALID,  CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ssyr2k)( INVALID_LAYOUT,  CblasUpper, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyr2k)( CblasColMajor,  INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ssyr2k)( CblasColMajor,  INVALID_UPLO, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ssyr2k)( CblasColMajor,  CblasUpper, INVALID,
+      API_SUFFIX(cblas_ssyr2k)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -1694,15 +1694,15 @@ void F77_s3chke(char *rout
       cblas_rout = "cblas_sskewsyr2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_sskewsyr2k)( INVALID,  CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_sskewsyr2k)( INVALID_LAYOUT,  CblasUpper, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsyr2k)( CblasColMajor,  INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_sskewsyr2k)( CblasColMajor,  INVALID_UPLO, CblasNoTrans,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sskewsyr2k)( CblasColMajor,  CblasUpper, INVALID,
+      API_SUFFIX(cblas_sskewsyr2k)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE,
                     0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;

--- a/CBLAS/testing/c_sblas2.c
+++ b/CBLAS/testing/c_sblas2.c
@@ -35,7 +35,7 @@ void F77_sgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, floa
      API_SUFFIX(cblas_sgemv)( CblasColMajor, trans,
 		  *m, *n, *alpha, a, *lda, x, *incx, *beta, y, *incy );
   else
-     API_SUFFIX(cblas_sgemv)( UNDEFINED, trans,
+     API_SUFFIX(cblas_sgemv)( INVALID_LAYOUT, trans,
 		  *m, *n, *alpha, a, *lda, x, *incx, *beta, y, *incy );
 }
 
@@ -92,7 +92,7 @@ void F77_strmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_strmv)(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx);
   else {
-     API_SUFFIX(cblas_strmv)(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
+     API_SUFFIX(cblas_strmv)(INVALID_LAYOUT, uplo, trans, diag, *n, a, *lda, x, *incx);
   }
 }
 

--- a/CBLAS/testing/c_sblas3.c
+++ b/CBLAS/testing/c_sblas3.c
@@ -71,7 +71,7 @@ void F77_sgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
      API_SUFFIX(cblas_sgemm)( CblasColMajor, transa, transb, *m, *n, *k, *alpha, a, *lda,
                   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_sgemm)( UNDEFINED, transa, transb, *m, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_sgemm)( INVALID_LAYOUT, transa, transb, *m, *n, *k, *alpha, a, *lda,
                   b, *ldb, *beta, c, *ldc );
 }
 
@@ -144,7 +144,7 @@ void F77_sgemmtr(CBLAS_INT *layout, char *uplop, char *transpa, char *transpb, C
      API_SUFFIX(cblas_sgemmtr)( CblasColMajor, uplo, transa, transb, *n, *k, *alpha, a, *lda,
                   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_sgemmtr)( UNDEFINED, uplo, transa, transb, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_sgemmtr)( INVALID_LAYOUT, uplo, transa, transb, *n, *k, *alpha, a, *lda,
                   b, *ldb, *beta, c, *ldc );
 }
 
@@ -204,7 +204,7 @@ void F77_ssymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
      API_SUFFIX(cblas_ssymm)( CblasColMajor, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_ssymm)( UNDEFINED, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_ssymm)( INVALID_LAYOUT, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
 }
 
@@ -262,7 +262,7 @@ void F77_sskewsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBL
      API_SUFFIX(cblas_sskewsymm)( CblasColMajor, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_sskewsymm)( UNDEFINED, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_sskewsymm)( INVALID_LAYOUT, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
                   *beta, c, *ldc );
 }
 
@@ -314,7 +314,7 @@ void F77_ssyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
      API_SUFFIX(cblas_ssyrk)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
   else
-     API_SUFFIX(cblas_ssyrk)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+     API_SUFFIX(cblas_ssyrk)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
 }
 
@@ -374,7 +374,7 @@ void F77_ssyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_ssyr2k)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_ssyr2k)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_ssyr2k)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
 }
 void F77_sskewsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
@@ -433,7 +433,7 @@ void F77_sskewsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, 
      API_SUFFIX(cblas_sskewsyr2k)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_sskewsyr2k)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda,
+     API_SUFFIX(cblas_sskewsyr2k)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
 }
 void F77_strmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
@@ -487,7 +487,7 @@ void F77_strmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_strmm)(CblasColMajor, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_strmm)(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+     API_SUFFIX(cblas_strmm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
 }
 
@@ -542,6 +542,6 @@ void F77_strsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_strsm)(CblasColMajor, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_strsm)(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+     API_SUFFIX(cblas_strsm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, *alpha,
 		   a, *lda, b, *ldb);
 }

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -65,11 +65,11 @@ void F77_z2chke(char *rout
    if (strncmp( sf,"cblas_zgemv",11)==0) {
       cblas_rout = "cblas_zgemv";
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemv)(INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zgemv)(INVALID_LAYOUT, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_zgemv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -94,7 +94,7 @@ void F77_z2chke(char *rout
       chkxer();
 
       cblas_info = 2; RowMajorStrg = TRUE; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zgemv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_zgemv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -120,11 +120,11 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zgbmv",11)==0) {
       cblas_rout = "cblas_zgbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgbmv)(INVALID, CblasNoTrans, 0, 0, 0, 0,
+      API_SUFFIX(cblas_zgbmv)(INVALID_LAYOUT, CblasNoTrans, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgbmv)(CblasColMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_zgbmv)(CblasColMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -156,7 +156,7 @@ void F77_z2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zgbmv)(CblasRowMajor, INVALID, 0, 0, 0, 0,
+      API_SUFFIX(cblas_zgbmv)(CblasRowMajor, INVALID_TRANSPOSE, 0, 0, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -190,11 +190,11 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zhemv",11)==0) {
       cblas_rout = "cblas_zhemv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhemv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_zhemv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhemv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_zhemv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -214,7 +214,7 @@ void F77_z2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zhemv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_zhemv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -236,11 +236,11 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zhbmv",11)==0) {
       cblas_rout = "cblas_zhbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhbmv)(INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_zhbmv)(INVALID_LAYOUT, CblasUpper, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhbmv)(CblasColMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_zhbmv)(CblasColMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -264,7 +264,7 @@ void F77_z2chke(char *rout
                   ALPHA, A, 1, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zhbmv)(CblasRowMajor, INVALID, 0, 0,
+      API_SUFFIX(cblas_zhbmv)(CblasRowMajor, INVALID_UPLO, 0, 0,
                   ALPHA, A, 1, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -290,11 +290,11 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zhpmv",11)==0) {
       cblas_rout = "cblas_zhpmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpmv)(INVALID, CblasUpper, 0,
+      API_SUFFIX(cblas_zhpmv)(INVALID_LAYOUT, CblasUpper, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpmv)(CblasColMajor, INVALID, 0,
+      API_SUFFIX(cblas_zhpmv)(CblasColMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -310,7 +310,7 @@ void F77_z2chke(char *rout
                   ALPHA, A, X, 1, BETA, Y, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zhpmv)(CblasRowMajor, INVALID, 0,
+      API_SUFFIX(cblas_zhpmv)(CblasRowMajor, INVALID_UPLO, 0,
                   ALPHA, A, X, 1, BETA, Y, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
@@ -328,20 +328,20 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_ztrmv",11)==0) {
       cblas_rout = "cblas_ztrmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztrmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztrmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztrmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -356,16 +356,16 @@ void F77_z2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztrmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztrmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztrmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztrmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztrmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztrmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -382,20 +382,20 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_ztbmv",11)==0) {
       cblas_rout = "cblas_ztbmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztbmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztbmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztbmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztbmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztbmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztbmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztbmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -414,16 +414,16 @@ void F77_z2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztbmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztbmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztbmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztbmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztbmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -444,20 +444,20 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_ztpmv",11)==0) {
       cblas_rout = "cblas_ztpmv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztpmv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztpmv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztpmv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztpmv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztpmv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztpmv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztpmv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -468,16 +468,16 @@ void F77_z2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztpmv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztpmv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztpmv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztpmv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztpmv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -490,20 +490,20 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_ztrsv",11)==0) {
       cblas_rout = "cblas_ztrsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztrsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztrsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztrsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -518,16 +518,16 @@ void F77_z2chke(char *rout
                   CblasNonUnit, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztrsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztrsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztrsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztrsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztrsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztrsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -544,20 +544,20 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_ztbsv",11)==0) {
       cblas_rout = "cblas_ztbsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztbsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztbsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztbsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztbsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztbsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztbsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztbsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -576,16 +576,16 @@ void F77_z2chke(char *rout
                   CblasNonUnit, 0, 0, A, 1, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztbsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztbsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztbsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztbsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, 0, A, 1, X, 1 );
+                  INVALID_DIAG, 0, 0, A, 1, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztbsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -606,20 +606,20 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_ztpsv",11)==0) {
       cblas_rout = "cblas_ztpsv";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztpsv)(INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztpsv)(INVALID_LAYOUT, CblasUpper, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztpsv)(CblasColMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztpsv)(CblasColMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztpsv)(CblasColMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztpsv)(CblasColMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztpsv)(CblasColMajor, CblasUpper, CblasNoTrans,
@@ -630,16 +630,16 @@ void F77_z2chke(char *rout
                   CblasNonUnit, 0, A, X, 0 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztpsv)(CblasRowMajor, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztpsv)(CblasRowMajor, INVALID_UPLO, CblasNoTrans,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_ztpsv)(CblasRowMajor, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztpsv)(CblasRowMajor, CblasUpper, INVALID_TRANSPOSE,
                   CblasNonUnit, 0, A, X, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
-                  INVALID, 0, A, X, 1 );
+                  INVALID_DIAG, 0, A, X, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztpsv)(CblasRowMajor, CblasUpper, CblasNoTrans,
@@ -652,7 +652,7 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zgeru",10)==0) {
       cblas_rout = "cblas_zgeru";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgeru)(INVALID, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_zgeru)(INVALID_LAYOUT, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zgeru)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
@@ -687,7 +687,7 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zgerc",10)==0) {
       cblas_rout = "cblas_zgerc";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgerc)(INVALID, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_zgerc)(INVALID_LAYOUT, 0, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zgerc)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
@@ -722,10 +722,10 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zher2",11)==0) {
       cblas_rout = "cblas_zher2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zher2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_zher2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zher2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_zher2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zher2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -740,7 +740,7 @@ void F77_z2chke(char *rout
       API_SUFFIX(cblas_zher2)(CblasColMajor, CblasUpper, 2, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zher2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A, 1 );
+      API_SUFFIX(cblas_zher2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zher2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A, 1 );
@@ -757,10 +757,10 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zhpr2",11)==0) {
       cblas_rout = "cblas_zhpr2";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr2)(INVALID, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_zhpr2)(INVALID_LAYOUT, CblasUpper, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr2)(CblasColMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_zhpr2)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zhpr2)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -772,7 +772,7 @@ void F77_z2chke(char *rout
       API_SUFFIX(cblas_zhpr2)(CblasColMajor, CblasUpper, 0, ALPHA, X, 1, Y, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zhpr2)(CblasRowMajor, INVALID, 0, ALPHA, X, 1, Y, 1, A );
+      API_SUFFIX(cblas_zhpr2)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, Y, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zhpr2)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, Y, 1, A );
@@ -786,10 +786,10 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zher",10)==0) {
       cblas_rout = "cblas_zher";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zher)(INVALID, CblasUpper, 0, RALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_zher)(INVALID_LAYOUT, CblasUpper, 0, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zher)(CblasColMajor, INVALID, 0, RALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_zher)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zher)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A, 1 );
@@ -801,7 +801,7 @@ void F77_z2chke(char *rout
       API_SUFFIX(cblas_zher)(CblasColMajor, CblasUpper, 2, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zher)(CblasRowMajor, INVALID, 0, RALPHA, X, 1, A, 1 );
+      API_SUFFIX(cblas_zher)(CblasRowMajor, INVALID_UPLO, 0, RALPHA, X, 1, A, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zher)(CblasRowMajor, CblasUpper, INVALID, RALPHA, X, 1, A, 1 );
@@ -815,10 +815,10 @@ void F77_z2chke(char *rout
    } else if (strncmp( sf,"cblas_zhpr",10)==0) {
       cblas_rout = "cblas_zhpr";
       cblas_info = 1; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr)(INVALID, CblasUpper, 0, RALPHA, X, 1, A );
+      API_SUFFIX(cblas_zhpr)(INVALID_LAYOUT, CblasUpper, 0, RALPHA, X, 1, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr)(CblasColMajor, INVALID, 0, RALPHA, X, 1, A );
+      API_SUFFIX(cblas_zhpr)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zhpr)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A );
@@ -827,7 +827,7 @@ void F77_z2chke(char *rout
       API_SUFFIX(cblas_zhpr)(CblasColMajor, CblasUpper, 0, RALPHA, X, 0, A );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr)(CblasColMajor, INVALID, 0, RALPHA, X, 1, A );
+      API_SUFFIX(cblas_zhpr)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zhpr)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A );

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -66,63 +66,63 @@ void F77_z3chke(char *rout
       cblas_rout = "cblas_zgemmtr"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasUpper, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasUpper,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasUpper, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasUpper, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasLower, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasLower,CblasTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemmtr)( INVALID, CblasLower, CblasTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, CblasLower, CblasTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  INVALID, CblasNoTrans, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  CblasUpper, INVALID, CblasTrans, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( CblasColMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID, 0, 0,
+      API_SUFFIX(cblas_zgemmtr)( CblasColMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -296,35 +296,35 @@ void F77_z3chke(char *rout
       cblas_rout = "cblas_zgemm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemm)( INVALID,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemm)( INVALID,  CblasNoTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( INVALID_LAYOUT,  CblasNoTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemm)( INVALID,  CblasTrans, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( INVALID_LAYOUT,  CblasTrans, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 1;
-      API_SUFFIX(cblas_zgemm)( INVALID,  CblasTrans, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( INVALID_LAYOUT,  CblasTrans, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemm)( CblasColMajor,  INVALID, CblasNoTrans, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemm)( CblasColMajor,  INVALID, CblasTrans, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( CblasColMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemm)( CblasColMajor,  CblasNoTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( CblasColMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zgemm)( CblasColMajor,  CblasTrans, INVALID, 0, 0, 0,
+      API_SUFFIX(cblas_zgemm)( CblasColMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -524,15 +524,15 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_zhemm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zhemm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_zhemm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhemm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_zhemm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhemm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_zhemm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -700,15 +700,15 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_zsymm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zsymm)( INVALID,  CblasRight, CblasLower, 0, 0,
+      API_SUFFIX(cblas_zsymm)( INVALID_LAYOUT,  CblasRight, CblasLower, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zsymm)( CblasColMajor,  INVALID, CblasUpper, 0, 0,
+      API_SUFFIX(cblas_zsymm)( CblasColMajor,  INVALID_SIDE, CblasUpper, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zsymm)( CblasColMajor,  CblasLeft, INVALID, 0, 0,
+      API_SUFFIX(cblas_zsymm)( CblasColMajor,  CblasLeft, INVALID_UPLO, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
@@ -876,24 +876,24 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_ztrmm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_ztrmm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztrmm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrmm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztrmm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrmm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztrmm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztrmm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrmm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1156,24 +1156,24 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_ztrsm"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_ztrsm)( INVALID,  CblasLeft, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztrsm)( INVALID_LAYOUT,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrsm)( CblasColMajor,  INVALID, CblasUpper, CblasNoTrans,
+      API_SUFFIX(cblas_ztrsm)( CblasColMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrsm)( CblasColMajor,  CblasLeft, INVALID, CblasNoTrans,
+      API_SUFFIX(cblas_ztrsm)( CblasColMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_ztrsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID,
+      API_SUFFIX(cblas_ztrsm)( CblasColMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
                    CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
-                   INVALID, 0, 0, ALPHA, A, 1, B, 1 );
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrsm)( CblasColMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1436,11 +1436,11 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_zherk"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zherk)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zherk)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                   RALPHA, A, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zherk)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zherk)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                   RALPHA, A, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -1548,11 +1548,11 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_zsyrk"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zsyrk)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zsyrk)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zsyrk)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zsyrk)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                   ALPHA, A, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -1660,11 +1660,11 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_zher2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zher2k)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zher2k)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zher2k)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zher2k)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;
@@ -1804,11 +1804,11 @@ void F77_z3chke(char *rout
             cblas_rout = "cblas_zsyr2k"   ;
 
       cblas_info = 1;
-      API_SUFFIX(cblas_zsyr2k)(INVALID,  CblasUpper, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zsyr2k)(INVALID_LAYOUT,  CblasUpper, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zsyr2k)(CblasColMajor,  INVALID, CblasNoTrans, 0, 0,
+      API_SUFFIX(cblas_zsyr2k)(CblasColMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 3; RowMajorStrg = FALSE;

--- a/CBLAS/testing/c_zblas2.c
+++ b/CBLAS/testing/c_zblas2.c
@@ -38,7 +38,7 @@ void F77_zgemv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n,
      API_SUFFIX(cblas_zgemv)( CblasColMajor, trans,
                   *m, *n, alpha, a, *lda, x, *incx, beta, y, *incy );
   else
-     API_SUFFIX(cblas_zgemv)( UNDEFINED, trans,
+     API_SUFFIX(cblas_zgemv)( INVALID_LAYOUT, trans,
                   *m, *n, alpha, a, *lda, x, *incx, beta, y, *incy );
 }
 
@@ -89,7 +89,7 @@ void F77_zgbmv(CBLAS_INT *layout, char *transp, CBLAS_INT *m, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_zgbmv)( CblasColMajor, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
 		  *incx, beta, y, *incy );
   else
-     API_SUFFIX(cblas_zgbmv)( UNDEFINED, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
+     API_SUFFIX(cblas_zgbmv)( INVALID_LAYOUT, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
 		  *incx, beta, y, *incy );
 }
 
@@ -119,7 +119,7 @@ void F77_zgeru(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_zgeru)( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
   else
-     API_SUFFIX(cblas_zgeru)( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+     API_SUFFIX(cblas_zgeru)( INVALID_LAYOUT, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
 }
 
 void F77_zgerc(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
@@ -147,7 +147,7 @@ void F77_zgerc(CBLAS_INT *layout, CBLAS_INT *m, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_zgerc)( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
   else
-     API_SUFFIX(cblas_zgerc)( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+     API_SUFFIX(cblas_zgerc)( INVALID_LAYOUT, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
 }
 
 void F77_zhemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
@@ -180,7 +180,7 @@ void F77_zhemv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
      API_SUFFIX(cblas_zhemv)( CblasColMajor, uplo, *n, alpha, a, *lda, x, *incx,
 	   beta, y, *incy );
   else
-     API_SUFFIX(cblas_zhemv)( UNDEFINED, uplo, *n, alpha, a, *lda, x, *incx,
+     API_SUFFIX(cblas_zhemv)( INVALID_LAYOUT, uplo, *n, alpha, a, *lda, x, *incx,
 	   beta, y, *incy );
 }
 
@@ -202,7 +202,7 @@ CBLAS_INT i,irow,j,jcol,LDA;
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_zhbmv)(CblasRowMajor, UNDEFINED, *n, *k, alpha, a, *lda, x,
+        API_SUFFIX(cblas_zhbmv)(CblasRowMajor, INVALID_UPLO, *n, *k, alpha, a, *lda, x,
 		 *incx, beta, y, *incy );
      else {
         LDA = *k+2;
@@ -248,7 +248,7 @@ CBLAS_INT i,irow,j,jcol,LDA;
      API_SUFFIX(cblas_zhbmv)(CblasColMajor, uplo, *n, *k, alpha, a, *lda, x, *incx,
                  beta, y, *incy );
    else
-     API_SUFFIX(cblas_zhbmv)(UNDEFINED, uplo, *n, *k, alpha, a, *lda, x, *incx,
+     API_SUFFIX(cblas_zhbmv)(INVALID_LAYOUT, uplo, *n, *k, alpha, a, *lda, x, *incx,
                  beta, y, *incy );
 }
 
@@ -267,7 +267,7 @@ void F77_zhpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
   get_uplo_type(uplow,&uplo);
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_zhpmv)(CblasRowMajor, UNDEFINED, *n, alpha, ap, x, *incx,
+        API_SUFFIX(cblas_zhpmv)(CblasRowMajor, INVALID_UPLO, *n, alpha, ap, x, *incx,
 	         beta, y, *incy);
      else {
         LDA = *n;
@@ -308,7 +308,7 @@ void F77_zhpmv(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
      API_SUFFIX(cblas_zhpmv)( CblasColMajor, uplo, *n, alpha, ap, x, *incx, beta, y,
                   *incy );
   else
-     API_SUFFIX(cblas_zhpmv)( UNDEFINED, uplo, *n, alpha, ap, x, *incx, beta, y,
+     API_SUFFIX(cblas_zhpmv)( INVALID_LAYOUT, uplo, *n, alpha, ap, x, *incx, beta, y,
                   *incy );
 }
 
@@ -331,7 +331,7 @@ void F77_ztbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ztbmv)(CblasRowMajor, UNDEFINED, trans, diag, *n, *k, a, *lda,
+        API_SUFFIX(cblas_ztbmv)(CblasRowMajor, INVALID_UPLO, trans, diag, *n, *k, a, *lda,
 	x, *incx);
      else {
         LDA = *k+2;
@@ -376,7 +376,7 @@ void F77_ztbmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
    else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ztbmv)(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
    else
-     API_SUFFIX(cblas_ztbmv)(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+     API_SUFFIX(cblas_ztbmv)(INVALID_LAYOUT, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
 }
 
 void F77_ztbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -399,7 +399,7 @@ void F77_ztbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ztbsv)(CblasRowMajor, UNDEFINED, trans, diag, *n, *k, a, *lda, x,
+        API_SUFFIX(cblas_ztbsv)(CblasRowMajor, INVALID_UPLO, trans, diag, *n, *k, a, *lda, x,
 	         *incx);
      else {
         LDA = *k+2;
@@ -444,7 +444,7 @@ void F77_ztbsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ztbsv)(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
   else
-     API_SUFFIX(cblas_ztbsv)(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+     API_SUFFIX(cblas_ztbsv)(INVALID_LAYOUT, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
 }
 
 void F77_ztpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -465,7 +465,7 @@ void F77_ztpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ztpmv)( CblasRowMajor, UNDEFINED, trans, diag, *n, ap, x, *incx );
+        API_SUFFIX(cblas_ztpmv)( CblasRowMajor, INVALID_UPLO, trans, diag, *n, ap, x, *incx );
      else {
         LDA = *n;
         A=(CBLAS_TEST_ZOMPLEX*)malloc(LDA*LDA*sizeof(CBLAS_TEST_ZOMPLEX));
@@ -503,7 +503,7 @@ void F77_ztpmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ztpmv)( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
   else
-     API_SUFFIX(cblas_ztpmv)( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
+     API_SUFFIX(cblas_ztpmv)( INVALID_LAYOUT, uplo, trans, diag, *n, ap, x, *incx );
 }
 
 void F77_ztpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -524,7 +524,7 @@ void F77_ztpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_ztpsv)( CblasRowMajor, UNDEFINED, trans, diag, *n, ap, x, *incx );
+        API_SUFFIX(cblas_ztpsv)( CblasRowMajor, INVALID_UPLO, trans, diag, *n, ap, x, *incx );
      else {
         LDA = *n;
         A=(CBLAS_TEST_ZOMPLEX*)malloc(LDA*LDA*sizeof(CBLAS_TEST_ZOMPLEX));
@@ -562,7 +562,7 @@ void F77_ztpsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ztpsv)( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
   else
-     API_SUFFIX(cblas_ztpsv)( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
+     API_SUFFIX(cblas_ztpsv)( INVALID_LAYOUT, uplo, trans, diag, *n, ap, x, *incx );
 }
 
 void F77_ztrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
@@ -596,7 +596,7 @@ void F77_ztrmv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ztrmv)(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx);
   else
-     API_SUFFIX(cblas_ztrmv)(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
+     API_SUFFIX(cblas_ztrmv)(INVALID_LAYOUT, uplo, trans, diag, *n, a, *lda, x, *incx);
 }
 void F77_ztrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
        CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda, CBLAS_TEST_ZOMPLEX *x,
@@ -629,7 +629,7 @@ void F77_ztrsv(CBLAS_INT *layout, char *uplow, char *transp, char *diagn,
    else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_ztrsv)(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx );
    else
-     API_SUFFIX(cblas_ztrsv)(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx );
+     API_SUFFIX(cblas_ztrsv)(INVALID_LAYOUT, uplo, trans, diag, *n, a, *lda, x, *incx );
 }
 
 void F77_zhpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
@@ -646,7 +646,7 @@ void F77_zhpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_zhpr)(CblasRowMajor, UNDEFINED, *n, *alpha, x, *incx, ap );
+        API_SUFFIX(cblas_zhpr)(CblasRowMajor, INVALID_UPLO, *n, *alpha, x, *incx, ap );
      else {
         LDA = *n;
         A = (CBLAS_TEST_ZOMPLEX* )malloc(LDA*LDA*sizeof(CBLAS_TEST_ZOMPLEX ) );
@@ -708,7 +708,7 @@ void F77_zhpr(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_zhpr)(CblasColMajor, uplo, *n, *alpha, x, *incx, ap );
   else
-     API_SUFFIX(cblas_zhpr)(UNDEFINED, uplo, *n, *alpha, x, *incx, ap );
+     API_SUFFIX(cblas_zhpr)(INVALID_LAYOUT, uplo, *n, *alpha, x, *incx, ap );
 }
 
 void F77_zhpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
@@ -726,7 +726,7 @@ void F77_zhpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
 
   if (*layout == TEST_ROW_MJR) {
      if (uplo != CblasUpper && uplo != CblasLower )
-        API_SUFFIX(cblas_zhpr2)( CblasRowMajor, UNDEFINED, *n, alpha, x, *incx, y,
+        API_SUFFIX(cblas_zhpr2)( CblasRowMajor, INVALID_UPLO, *n, alpha, x, *incx, y,
 		     *incy, ap );
      else {
         LDA = *n;
@@ -789,7 +789,7 @@ void F77_zhpr2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_zhpr2)( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, ap );
   else
-     API_SUFFIX(cblas_zhpr2)( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, ap );
+     API_SUFFIX(cblas_zhpr2)( INVALID_LAYOUT, uplo, *n, alpha, x, *incx, y, *incy, ap );
 }
 
 void F77_zher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
@@ -825,7 +825,7 @@ void F77_zher(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, double *alpha,
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_zher)( CblasColMajor, uplo, *n, *alpha, x, *incx, a, *lda );
   else
-     API_SUFFIX(cblas_zher)( UNDEFINED, uplo, *n, *alpha, x, *incx, a, *lda );
+     API_SUFFIX(cblas_zher)( INVALID_LAYOUT, uplo, *n, *alpha, x, *incx, a, *lda );
 }
 
 void F77_zher2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX *alpha,
@@ -863,5 +863,5 @@ void F77_zher2(CBLAS_INT *layout, char *uplow, CBLAS_INT *n, CBLAS_TEST_ZOMPLEX 
   else if (*layout == TEST_COL_MJR)
      API_SUFFIX(cblas_zher2)( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
   else
-     API_SUFFIX(cblas_zher2)( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
+     API_SUFFIX(cblas_zher2)( INVALID_LAYOUT, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
 }

--- a/CBLAS/testing/c_zblas3.c
+++ b/CBLAS/testing/c_zblas3.c
@@ -10,7 +10,6 @@
 #include "cblas_test.h"
 #define  TEST_COL_MJR	0
 #define  TEST_ROW_MJR	1
-#define  UNDEFINED     -1
 
 void F77_zgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
      CBLAS_INT *k, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,
@@ -89,7 +88,7 @@ void F77_zgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CB
      API_SUFFIX(cblas_zgemm)( CblasColMajor, transa, transb, *m, *n, *k, alpha, a, *lda,
                   b, *ldb, beta, c, *ldc );
   else
-     API_SUFFIX(cblas_zgemm)( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+     API_SUFFIX(cblas_zgemm)( INVALID_LAYOUT, transa, transb, *m, *n, *k, alpha, a, *lda,
                   b, *ldb, beta, c, *ldc );
 }
 
@@ -169,7 +168,7 @@ void F77_zgemmtr(CBLAS_INT *layout, char *uplop, char *transpa, char *transpb, C
       API_SUFFIX(cblas_zgemmtr)( CblasColMajor, uplo, transa, transb, *n, *k, alpha, a, *lda,
               b, *ldb, beta, c, *ldc );
   else
-      API_SUFFIX(cblas_zgemmtr)( UNDEFINED, uplo, transa, transb, *n, *k, alpha, a, *lda,
+      API_SUFFIX(cblas_zgemmtr)( INVALID_LAYOUT, uplo, transa, transb, *n, *k, alpha, a, *lda,
               b, *ldb, beta, c, *ldc );
 }
 
@@ -239,7 +238,7 @@ void F77_zhemm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
      API_SUFFIX(cblas_zhemm)( CblasColMajor, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
   else
-     API_SUFFIX(cblas_zhemm)( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_zhemm)( INVALID_LAYOUT, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
 }
 void F77_zsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_INT *n,
@@ -297,7 +296,7 @@ void F77_zsymm(CBLAS_INT *layout, char *rtlf, char *uplow, CBLAS_INT *m, CBLAS_I
      API_SUFFIX(cblas_zsymm)( CblasColMajor, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
   else
-     API_SUFFIX(cblas_zsymm)( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+     API_SUFFIX(cblas_zsymm)( INVALID_LAYOUT, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
                   beta, c, *ldc );
 }
 
@@ -357,7 +356,7 @@ void F77_zherk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
      API_SUFFIX(cblas_zherk)(CblasColMajor, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
   else
-     API_SUFFIX(cblas_zherk)(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+     API_SUFFIX(cblas_zherk)(INVALID_LAYOUT, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
 	         c, *ldc );
 }
 
@@ -417,7 +416,7 @@ void F77_zsyrk(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS
      API_SUFFIX(cblas_zsyrk)(CblasColMajor, uplo, trans, *n, *k, alpha, a, *lda, beta,
 	         c, *ldc );
   else
-     API_SUFFIX(cblas_zsyrk)(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda, beta,
+     API_SUFFIX(cblas_zsyrk)(INVALID_LAYOUT, uplo, trans, *n, *k, alpha, a, *lda, beta,
 	         c, *ldc );
 }
 void F77_zher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
@@ -485,7 +484,7 @@ void F77_zher2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_zher2k)(CblasColMajor, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
   else
-     API_SUFFIX(cblas_zher2k)(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+     API_SUFFIX(cblas_zher2k)(INVALID_LAYOUT, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, *beta, c, *ldc );
 }
 void F77_zsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLAS_INT *k,
@@ -553,7 +552,7 @@ void F77_zsyr2k(CBLAS_INT *layout, char *uplow, char *transp, CBLAS_INT *n, CBLA
      API_SUFFIX(cblas_zsyr2k)(CblasColMajor, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, beta, c, *ldc );
   else
-     API_SUFFIX(cblas_zsyr2k)(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+     API_SUFFIX(cblas_zsyr2k)(INVALID_LAYOUT, uplo, trans, *n, *k, alpha, a, *lda,
 		   b, *ldb, beta, c, *ldc );
 }
 void F77_ztrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *diagn,
@@ -615,7 +614,7 @@ void F77_ztrmm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_ztrmm)(CblasColMajor, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_ztrmm)(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+     API_SUFFIX(cblas_ztrmm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
 }
 
@@ -678,6 +677,6 @@ void F77_ztrsm(CBLAS_INT *layout, char *rtlf, char *uplow, char *transp, char *d
      API_SUFFIX(cblas_ztrsm)(CblasColMajor, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
   else
-     API_SUFFIX(cblas_ztrsm)(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+     API_SUFFIX(cblas_ztrsm)(INVALID_LAYOUT, side, uplo, trans, diag, *m, *n, alpha,
 		   a, *lda, b, *ldb);
 }

--- a/CBLAS/testing/c_zblas3.c
+++ b/CBLAS/testing/c_zblas3.c
@@ -8,8 +8,6 @@
 #include <stdio.h>
 #include "cblas.h"
 #include "cblas_test.h"
-#define  TEST_COL_MJR	0
-#define  TEST_ROW_MJR	1
 
 void F77_zgemm(CBLAS_INT *layout, char *transpa, char *transpb, CBLAS_INT *m, CBLAS_INT *n,
      CBLAS_INT *k, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, CBLAS_INT *lda,


### PR DESCRIPTION
**Description**

Some compilers (e.g., nvc/nvfortran) emit warnings when using signed integers for enum values, as we did in the CBLAS error tests. This PR adds "typed" invalid values for each CBLAS enum, which fixes the warnings and makes the test code more readable.