### PR TITLE
CBLAS: fix & enhance error handling for row-major layout

### DIFF
--- a/CBLAS/src/cblas_cgemm.c
+++ b/CBLAS/src/cblas_cgemm.c
@@ -89,7 +89,7 @@ void API_SUFFIX(cblas_cgemm)(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE Tr
       else if ( TransB == CblasNoTrans )   TA='N';
       else
       {
-         API_SUFFIX(cblas_xerbla)(2, "cblas_cgemm", "Illegal TransB setting, %d\n", TransB);
+         API_SUFFIX(cblas_xerbla)(3, "cblas_cgemm", "Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_cher2k.c
+++ b/CBLAS/src/cblas_cher2k.c
@@ -85,8 +85,7 @@ void API_SUFFIX(cblas_cher2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          RowMajorStrg = 0;
          return;
       }
-      if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
+      if( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='C';
       else
       {

--- a/CBLAS/src/cblas_cherk.c
+++ b/CBLAS/src/cblas_cherk.c
@@ -74,7 +74,7 @@ void API_SUFFIX(cblas_cherk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_cherk", "Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_cherk", "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_cherk.c
+++ b/CBLAS/src/cblas_cherk.c
@@ -79,8 +79,7 @@ void API_SUFFIX(cblas_cherk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          RowMajorStrg = 0;
          return;
       }
-      if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
+      if( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='C';
       else
       {

--- a/CBLAS/src/cblas_csyr2k.c
+++ b/CBLAS/src/cblas_csyr2k.c
@@ -78,7 +78,7 @@ void API_SUFFIX(cblas_csyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_csyr2k", "Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_csyr2k", "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_csyr2k.c
+++ b/CBLAS/src/cblas_csyr2k.c
@@ -84,7 +84,6 @@ void API_SUFFIX(cblas_csyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          return;
       }
       if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='T';
       else
       {

--- a/CBLAS/src/cblas_csyrk.c
+++ b/CBLAS/src/cblas_csyrk.c
@@ -76,7 +76,7 @@ void API_SUFFIX(cblas_csyrk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_csyrk", "Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_csyrk", "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_csyrk.c
+++ b/CBLAS/src/cblas_csyrk.c
@@ -82,7 +82,6 @@ void API_SUFFIX(cblas_csyrk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          return;
       }
       if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='T';
       else
       {

--- a/CBLAS/src/cblas_ctbmv.c
+++ b/CBLAS/src/cblas_ctbmv.c
@@ -124,7 +124,7 @@ void API_SUFFIX(cblas_ctbmv)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if (Diag == CblasNonUnit) DI = 'N';
       else
       {
-         API_SUFFIX(cblas_xerbla)(4, "cblas_ctbmv","Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(4, "cblas_ctbmv","Illegal Diag setting, %d\n", Diag);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_dskewsyr2k.c
+++ b/CBLAS/src/cblas_dskewsyr2k.c
@@ -79,7 +79,7 @@ void API_SUFFIX(cblas_dskewsyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Up
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_dskewsyr2k","Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_dskewsyr2k","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_dsyr2k.c
+++ b/CBLAS/src/cblas_dsyr2k.c
@@ -78,7 +78,7 @@ void API_SUFFIX(cblas_dsyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_dsyr2k","Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_dsyr2k","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_dsyrk.c
+++ b/CBLAS/src/cblas_dsyrk.c
@@ -76,7 +76,7 @@ void API_SUFFIX(cblas_dsyrk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_dsyrk","Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_dsyrk","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_dtbmv.c
+++ b/CBLAS/src/cblas_dtbmv.c
@@ -101,7 +101,7 @@ void API_SUFFIX(cblas_dtbmv)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if (Diag == CblasNonUnit) DI = 'N';
       else
       {
-         API_SUFFIX(cblas_xerbla)(4, "cblas_dtbmv","Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(4, "cblas_dtbmv","Illegal Diag setting, %d\n", Diag);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_sskewsyr2k.c
+++ b/CBLAS/src/cblas_sskewsyr2k.c
@@ -80,7 +80,7 @@ void API_SUFFIX(cblas_sskewsyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Up
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_sskewsyr2k",
+         API_SUFFIX(cblas_xerbla)(2, "cblas_sskewsyr2k",
                        "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;

--- a/CBLAS/src/cblas_ssyr2k.c
+++ b/CBLAS/src/cblas_ssyr2k.c
@@ -79,7 +79,7 @@ void API_SUFFIX(cblas_ssyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_ssyr2k",
+         API_SUFFIX(cblas_xerbla)(2, "cblas_ssyr2k",
                        "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;

--- a/CBLAS/src/cblas_ssyrk.c
+++ b/CBLAS/src/cblas_ssyrk.c
@@ -77,7 +77,7 @@ void API_SUFFIX(cblas_ssyrk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_ssyrk",
+         API_SUFFIX(cblas_xerbla)(2, "cblas_ssyrk",
                        "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;

--- a/CBLAS/src/cblas_stbmv.c
+++ b/CBLAS/src/cblas_stbmv.c
@@ -101,7 +101,7 @@ void API_SUFFIX(cblas_stbmv)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if (Diag == CblasNonUnit) DI = 'N';
       else
       {
-         API_SUFFIX(cblas_xerbla)(4, "cblas_stbmv","Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(4, "cblas_stbmv","Illegal Diag setting, %d\n", Diag);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_zher2k.c
+++ b/CBLAS/src/cblas_zher2k.c
@@ -85,8 +85,7 @@ void API_SUFFIX(cblas_zher2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          RowMajorStrg = 0;
          return;
       }
-      if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
+      if( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='C';
       else
       {

--- a/CBLAS/src/cblas_zherk.c
+++ b/CBLAS/src/cblas_zherk.c
@@ -79,8 +79,7 @@ void API_SUFFIX(cblas_zherk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          RowMajorStrg = 0;
          return;
       }
-      if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
+      if( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='C';
       else
       {

--- a/CBLAS/src/cblas_zherk.c
+++ b/CBLAS/src/cblas_zherk.c
@@ -74,7 +74,7 @@ void API_SUFFIX(cblas_zherk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_zherk", "Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_zherk", "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_zsyr2k.c
+++ b/CBLAS/src/cblas_zsyr2k.c
@@ -78,7 +78,7 @@ void API_SUFFIX(cblas_zsyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_zsyr2k", "Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_zsyr2k", "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_zsyr2k.c
+++ b/CBLAS/src/cblas_zsyr2k.c
@@ -84,7 +84,6 @@ void API_SUFFIX(cblas_zsyr2k)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          return;
       }
       if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='T';
       else
       {

--- a/CBLAS/src/cblas_zsyrk.c
+++ b/CBLAS/src/cblas_zsyrk.c
@@ -82,7 +82,6 @@ void API_SUFFIX(cblas_zsyrk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
          return;
       }
       if( Trans == CblasTrans) TR ='N';
-      else if ( Trans == CblasConjTrans ) TR='N';
       else if ( Trans == CblasNoTrans )   TR='T';
       else
       {

--- a/CBLAS/src/cblas_zsyrk.c
+++ b/CBLAS/src/cblas_zsyrk.c
@@ -76,7 +76,7 @@ void API_SUFFIX(cblas_zsyrk)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if ( Uplo == CblasLower ) UL='U';
       else
       {
-         API_SUFFIX(cblas_xerbla)(3, "cblas_zsyrk", "Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(2, "cblas_zsyrk", "Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/src/cblas_ztbmv.c
+++ b/CBLAS/src/cblas_ztbmv.c
@@ -124,7 +124,7 @@ void API_SUFFIX(cblas_ztbmv)(const CBLAS_LAYOUT layout, const CBLAS_UPLO Uplo,
       else if (Diag == CblasNonUnit) DI = 'N';
       else
       {
-         API_SUFFIX(cblas_xerbla)(4, "cblas_ztbmv","Illegal Uplo setting, %d\n", Uplo);
+         API_SUFFIX(cblas_xerbla)(4, "cblas_ztbmv","Illegal Diag setting, %d\n", Diag);
          CBLAS_CallFromC = 0;
          RowMajorStrg = 0;
          return;

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -825,14 +825,14 @@ void F77_c2chke(char *rout
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_chpr)(CblasColMajor, CblasUpper, 0, RALPHA, X, 0, A );
       chkxer();
-      cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_chpr)(CblasRowMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
       chkxer();
-      cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A );
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_chpr)(CblasRowMajor, CblasUpper, INVALID, RALPHA, X, 1, A );
       chkxer();
-      cblas_info = 6; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_chpr)(CblasColMajor, CblasUpper, 0, RALPHA, X, 0, A );
+      cblas_info = 6; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_chpr)(CblasRowMajor, CblasUpper, 0, RALPHA, X, 0, A );
       chkxer();
    }
    if (cblas_ok == TRUE)

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -211,6 +211,33 @@ void  F77_c3chke(char *  rout
       chkxer();
 
       /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -263,15 +290,19 @@ void  F77_c3chke(char *  rout
       chkxer();
 
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 0, 2,
-                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 2 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasNoTrans, 0, 2,
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 2, B, 1, BETA, C, 2 );
+      chkxer();
+      cblas_info = 11; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasTrans, 0, 2,
                    ALPHA, A, 2, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_cgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasTrans, 2, 0,
+      API_SUFFIX(cblas_cgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasTrans, 0, 2,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -421,6 +452,23 @@ void  F77_c3chke(char *  rout
       chkxer();
       cblas_info = 14; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_cgemm)( CblasColMajor,  CblasTrans, CblasTrans, 2, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemm)( CblasRowMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cgemm)( CblasRowMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
@@ -614,6 +662,15 @@ void  F77_c3chke(char *  rout
       API_SUFFIX(cblas_chemm)( CblasColMajor,  CblasRight, CblasLower, 2, 0,
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_chemm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_chemm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_chemm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -789,6 +846,15 @@ void  F77_c3chke(char *  rout
       cblas_info = 13; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_csymm)( CblasColMajor,  CblasRight, CblasLower, 2, 0,
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csymm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csymm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_csymm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
@@ -1021,6 +1087,23 @@ void  F77_c3chke(char *  rout
       cblas_info = 12; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ctrmm)( CblasColMajor,  CblasRight, CblasLower, CblasTrans,
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrmm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrmm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrmm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctrmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1302,6 +1385,23 @@ void  F77_c3chke(char *  rout
       API_SUFFIX(cblas_ctrsm)( CblasColMajor,  CblasRight, CblasLower, CblasTrans,
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrsm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrsm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrsm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ctrsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ctrsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, INVALID, 0, ALPHA, A, 1, B, 1 );
@@ -1478,6 +1578,47 @@ void  F77_c3chke(char *  rout
       API_SUFFIX(cblas_cherk)(CblasColMajor,  CblasLower, CblasConjTrans, 0, INVALID,
                   RALPHA, A, 1, RBETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasUpper, CblasTrans, 0, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasUpper, CblasConjTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasLower, CblasConjTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasLower, CblasConjTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_cherk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, 2,
                   RALPHA, A, 1, RBETA, C, 2 );
@@ -1590,6 +1731,47 @@ void  F77_c3chke(char *  rout
       API_SUFFIX(cblas_csyrk)(CblasColMajor,  CblasLower, CblasTrans, 0, INVALID,
                   ALPHA, A, 1, BETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasUpper, CblasTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasLower, CblasTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasUpper, CblasTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasLower, CblasTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_csyrk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, 2,
                   ALPHA, A, 1, BETA, C, 2 );
@@ -1700,6 +1882,47 @@ void  F77_c3chke(char *  rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_cher2k)(CblasColMajor,  CblasLower, CblasConjTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasUpper, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasUpper, CblasConjTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasLower, CblasConjTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_cher2k)(CblasRowMajor,  CblasLower, CblasConjTrans, 0, INVALID,
                    ALPHA, A, 1, B, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
@@ -1844,6 +2067,47 @@ void  F77_c3chke(char *  rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_csyr2k)(CblasColMajor,  CblasLower, CblasTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasUpper, CblasTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasLower, CblasTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasUpper, CblasTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_csyr2k)(CblasRowMajor,  CblasLower, CblasTrans, 0, INVALID,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -870,14 +870,14 @@ void F77_d2chke(char *rout
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dspr)(CblasColMajor, CblasUpper, 0, ALPHA, X, 0, A );
       chkxer();
-      cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dspr)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
       chkxer();
-      cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A );
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dspr)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, A );
       chkxer();
-      cblas_info = 6; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_dspr)(CblasColMajor, CblasUpper, 0, ALPHA, X, 0, A );
+      cblas_info = 6; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dspr)(CblasRowMajor, CblasUpper, 0, ALPHA, X, 0, A );
       chkxer();
    }
    if (cblas_ok == TRUE)

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -209,6 +209,33 @@ void F77_d3chke(char *rout
       chkxer();
 
       /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -261,15 +288,19 @@ void F77_d3chke(char *rout
       chkxer();
 
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 0, 2,
-                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 2 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasNoTrans, 0, 2,
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 2, B, 1, BETA, C, 2 );
+      chkxer();
+      cblas_info = 11; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasTrans, 0, 2,
                    ALPHA, A, 2, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_dgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasTrans, 2, 0,
+      API_SUFFIX(cblas_dgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasTrans, 0, 2,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -419,6 +450,23 @@ void F77_d3chke(char *rout
       chkxer();
       cblas_info = 14; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dgemm)( CblasColMajor,  CblasTrans, CblasTrans, 2, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemm)( CblasRowMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dgemm)( CblasRowMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
@@ -613,6 +661,15 @@ void F77_d3chke(char *rout
       API_SUFFIX(cblas_dsymm)( CblasColMajor,  CblasRight, CblasLower, 2, 0,
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsymm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsymm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dsymm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -788,6 +845,15 @@ void F77_d3chke(char *rout
       cblas_info = 13; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dskewsymm)( CblasColMajor,  CblasRight, CblasLower, 2, 0,
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsymm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsymm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dskewsymm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
@@ -1020,6 +1086,23 @@ void F77_d3chke(char *rout
       cblas_info = 12; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dtrmm)( CblasColMajor,  CblasRight, CblasLower, CblasTrans,
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrmm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrmm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrmm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtrmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1302,6 +1385,23 @@ void F77_d3chke(char *rout
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
       chkxer();
 
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrsm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrsm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrsm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dtrsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dtrsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, INVALID, 0, ALPHA, A, 1, B, 1 );
@@ -1478,6 +1578,47 @@ void F77_d3chke(char *rout
       API_SUFFIX(cblas_dsyrk)( CblasColMajor,  CblasLower, CblasTrans,
                    0, INVALID, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans,
+                   0, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE,
+                   0, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasUpper, CblasTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasLower, CblasTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasUpper, CblasTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasLower, CblasTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_dsyrk)( CblasRowMajor,  CblasUpper, CblasNoTrans,
                    0, 2, ALPHA, A, 1, BETA, C, 2 );
@@ -1588,6 +1729,47 @@ void F77_d3chke(char *rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dsyr2k)( CblasColMajor,  CblasLower, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dsyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
                     0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
@@ -1731,6 +1913,47 @@ void F77_d3chke(char *rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_dskewsyr2k)( CblasColMajor,  CblasLower, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_dskewsyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
                     0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -870,14 +870,14 @@ void F77_s2chke(char *rout
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_sspr)(CblasColMajor, CblasUpper, 0, ALPHA, X, 0, A );
       chkxer();
-      cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr)(CblasColMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sspr)(CblasRowMajor, INVALID_UPLO, 0, ALPHA, X, 1, A );
       chkxer();
-      cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr)(CblasColMajor, CblasUpper, INVALID, ALPHA, X, 1, A );
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sspr)(CblasRowMajor, CblasUpper, INVALID, ALPHA, X, 1, A );
       chkxer();
-      cblas_info = 6; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_sspr)(CblasColMajor, CblasUpper, 0, ALPHA, X, 0, A );
+      cblas_info = 6; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sspr)(CblasRowMajor, CblasUpper, 0, ALPHA, X, 0, A );
       chkxer();
    }
    if (cblas_ok == TRUE)

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -210,6 +210,33 @@ void F77_s3chke(char *rout
       chkxer();
 
       /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -262,15 +289,19 @@ void F77_s3chke(char *rout
       chkxer();
 
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 0, 2,
-                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 2 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasNoTrans, 0, 2,
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 2, B, 1, BETA, C, 2 );
+      chkxer();
+      cblas_info = 11; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasTrans, 0, 2,
                    ALPHA, A, 2, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_sgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasTrans, 2, 0,
+      API_SUFFIX(cblas_sgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasTrans, 0, 2,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -422,6 +453,23 @@ void F77_s3chke(char *rout
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemm)( CblasRowMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sgemm)( CblasRowMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_sgemm)( CblasRowMajor,  CblasNoTrans, CblasNoTrans, INVALID, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -615,6 +663,15 @@ void F77_s3chke(char *rout
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
       chkxer();
 
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssymm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssymm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ssymm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -792,6 +849,15 @@ void F77_s3chke(char *rout
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
       chkxer();
 
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsymm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsymm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_sskewsymm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -1025,6 +1091,23 @@ void F77_s3chke(char *rout
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
       chkxer();
 
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strmm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strmm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strmm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_strmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, INVALID, 0, ALPHA, A, 1, B, 1 );
@@ -1306,6 +1389,23 @@ void F77_s3chke(char *rout
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
       chkxer();
 
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strsm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strsm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strsm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_strsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_strsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, INVALID, 0, ALPHA, A, 1, B, 1 );
@@ -1482,6 +1582,48 @@ void F77_s3chke(char *rout
       API_SUFFIX(cblas_ssyrk)( CblasColMajor,  CblasLower, CblasTrans,
                    0, INVALID, ALPHA, A, 1, BETA, C, 1 );
       chkxer();
+
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans,
+                   0, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE,
+                   0, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasUpper, CblasTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasLower, CblasTrans,
+                   INVALID, 0, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasUpper, CblasTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasLower, CblasTrans,
+                   0, INVALID, ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ssyrk)( CblasRowMajor,  CblasUpper, CblasNoTrans,
                    0, 2, ALPHA, A, 1, BETA, C, 2 );
@@ -1592,6 +1734,48 @@ void F77_s3chke(char *rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ssyr2k)( CblasColMajor,  CblasLower, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ssyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
                     0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
@@ -1735,6 +1919,48 @@ void F77_s3chke(char *rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_sskewsyr2k)( CblasColMajor,  CblasLower, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE,
+                    0, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
+                    INVALID, 0, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasUpper, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasUpper, CblasTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasLower, CblasNoTrans,
+                    0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_sskewsyr2k)( CblasRowMajor,  CblasLower, CblasTrans,
                     0, INVALID, ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -826,14 +826,14 @@ void F77_z2chke(char *rout
       cblas_info = 6; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zhpr)(CblasColMajor, CblasUpper, 0, RALPHA, X, 0, A );
       chkxer();
-      cblas_info = 2; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr)(CblasColMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zhpr)(CblasRowMajor, INVALID_UPLO, 0, RALPHA, X, 1, A );
       chkxer();
-      cblas_info = 3; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr)(CblasColMajor, CblasUpper, INVALID, RALPHA, X, 1, A );
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zhpr)(CblasRowMajor, CblasUpper, INVALID, RALPHA, X, 1, A );
       chkxer();
-      cblas_info = 6; RowMajorStrg = FALSE;
-      API_SUFFIX(cblas_zhpr)(CblasColMajor, CblasUpper, 0, RALPHA, X, 0, A );
+      cblas_info = 6; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zhpr)(CblasRowMajor, CblasUpper, 0, RALPHA, X, 0, A );
       chkxer();
    }
    if (cblas_ok == TRUE)

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -211,6 +211,33 @@ void F77_z3chke(char *rout
       chkxer();
 
       /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  INVALID_UPLO, CblasNoTrans, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  CblasUpper, INVALID_TRANSPOSE, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor, CblasUpper,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor, CblasUpper, CblasTrans, INVALID_TRANSPOSE, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+
       cblas_info = 5; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -263,15 +290,19 @@ void F77_z3chke(char *rout
       chkxer();
 
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 0, 2,
-                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 2 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasNoTrans, 0, 2,
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasNoTrans, 2, 0,
+                   ALPHA, A, 2, B, 1, BETA, C, 2 );
+      chkxer();
+      cblas_info = 11; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  CblasUpper, CblasNoTrans, CblasTrans, 0, 2,
                    ALPHA, A, 2, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 11; RowMajorStrg = TRUE;
-      API_SUFFIX(cblas_zgemmtr)( CblasColMajor,  CblasUpper, CblasTrans, CblasTrans, 2, 0,
+      API_SUFFIX(cblas_zgemmtr)( CblasRowMajor,  CblasUpper, CblasTrans, CblasTrans, 0, 2,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
 
@@ -421,6 +452,23 @@ void F77_z3chke(char *rout
       chkxer();
       cblas_info = 14; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zgemm)( CblasColMajor,  CblasTrans, CblasTrans, 2, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasNoTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemm)( CblasRowMajor,  INVALID_TRANSPOSE, CblasTrans, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemm)( CblasRowMajor,  CblasNoTrans, INVALID_TRANSPOSE, 0, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zgemm)( CblasRowMajor,  CblasTrans, INVALID_TRANSPOSE, 0, 0, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
@@ -615,6 +663,15 @@ void F77_z3chke(char *rout
       API_SUFFIX(cblas_zhemm)( CblasColMajor,  CblasRight, CblasLower, 2, 0,
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zhemm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zhemm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zhemm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
@@ -790,6 +847,15 @@ void F77_z3chke(char *rout
       cblas_info = 13; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zsymm)( CblasColMajor,  CblasRight, CblasLower, 2, 0,
                    ALPHA, A, 1, B, 2, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsymm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsymm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 4; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zsymm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID, 0,
@@ -1022,6 +1088,23 @@ void F77_z3chke(char *rout
       cblas_info = 12; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_ztrmm)( CblasColMajor,  CblasRight, CblasLower, CblasTrans,
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrmm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrmm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrmm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
       chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztrmm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
@@ -1303,6 +1386,23 @@ void F77_z3chke(char *rout
       API_SUFFIX(cblas_ztrsm)( CblasColMajor,  CblasRight, CblasLower, CblasTrans,
                    CblasNonUnit, 2, 0, ALPHA, A, 1, B, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrsm)( CblasRowMajor,  INVALID_SIDE, CblasUpper, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrsm)( CblasRowMajor,  CblasLeft, INVALID_UPLO, CblasNoTrans,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrsm)( CblasRowMajor,  CblasLeft, CblasUpper, INVALID_TRANSPOSE,
+                   CblasNonUnit, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_ztrsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
+                   INVALID_DIAG, 0, 0, ALPHA, A, 1, B, 1 );
+      chkxer();
       cblas_info = 6; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_ztrsm)( CblasRowMajor,  CblasLeft, CblasUpper, CblasNoTrans,
                    CblasNonUnit, INVALID, 0, ALPHA, A, 1, B, 1 );
@@ -1479,6 +1579,47 @@ void F77_z3chke(char *rout
       API_SUFFIX(cblas_zherk)(CblasColMajor,  CblasLower, CblasConjTrans, 0, INVALID,
                   RALPHA, A, 1, RBETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasUpper, CblasTrans, 0, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasUpper, CblasConjTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasLower, CblasConjTrans, INVALID, 0,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasLower, CblasConjTrans, 0, INVALID,
+                  RALPHA, A, 1, RBETA, C, 1 );
+      chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zherk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, 2,
                   RALPHA, A, 1, RBETA, C, 2 );
@@ -1591,6 +1732,47 @@ void F77_z3chke(char *rout
       API_SUFFIX(cblas_zsyrk)(CblasColMajor,  CblasLower, CblasTrans, 0, INVALID,
                   ALPHA, A, 1, BETA, C, 1 );
       chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasUpper, CblasTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasLower, CblasTrans, INVALID, 0,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasUpper, CblasTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasLower, CblasTrans, 0, INVALID,
+                  ALPHA, A, 1, BETA, C, 1 );
+      chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
       API_SUFFIX(cblas_zsyrk)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, 2,
                   ALPHA, A, 1, BETA, C, 2 );
@@ -1701,6 +1883,47 @@ void F77_z3chke(char *rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zher2k)(CblasColMajor,  CblasLower, CblasConjTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasUpper, CblasTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasUpper, CblasConjTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasLower, CblasConjTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, RBETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zher2k)(CblasRowMajor,  CblasLower, CblasConjTrans, 0, INVALID,
                    ALPHA, A, 1, B, 1, RBETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;
@@ -1845,6 +2068,47 @@ void F77_z3chke(char *rout
       chkxer();
       cblas_info = 5; RowMajorStrg = FALSE;
       API_SUFFIX(cblas_zsyr2k)(CblasColMajor,  CblasLower, CblasTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      /* Row Major */
+      cblas_info = 2; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  INVALID_UPLO, CblasNoTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 3; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasUpper, CblasConjTrans, 0, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasUpper, CblasTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasLower, CblasNoTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 4; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasLower, CblasTrans, INVALID, 0,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasUpper, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasUpper, CblasTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasLower, CblasNoTrans, 0, INVALID,
+                   ALPHA, A, 1, B, 1, BETA, C, 1 );
+      chkxer();
+      cblas_info = 5; RowMajorStrg = TRUE;
+      API_SUFFIX(cblas_zsyr2k)(CblasRowMajor,  CblasLower, CblasTrans, 0, INVALID,
                    ALPHA, A, 1, B, 1, BETA, C, 1 );
       chkxer();
       cblas_info = 8; RowMajorStrg = TRUE;


### PR DESCRIPTION
## Description


The CBLAS error-exit testers never exercised the option arguments (`Side`, `Uplo`, `Trans`, `Diag`) of the level-3 routines with `CblasRowMajor`, so the diagnostics in the row-major branches were untested. This PR:

- **Adds row-major error-exit tests**: every column-major option-argument test now has a `CblasRowMajor` twin; the syrk/herk/syr2k/her2k/skewsyr2k families gain the missing row-major `N`/`K` tests; the gemmtr ldb "row major" tests now actually use `CblasRowMajor`; and the spr/hpr sections' accidentally duplicated column-major blocks become the intended row-major tests.
- **Fixes wrong diagnostics the new tests flag**: `cblas_cgemm` reported an illegal `TransB` as parameter 2 instead of 3, and the syrk/syr2k/herk/skewsyr2k families reported an illegal `Uplo` as parameter 3 instead of 2 (row-major branches only). The tbmv routines also printed "Illegal Uplo setting" for an illegal `Diag`.
- **Fixes silently accepted invalid `Trans` values**: the row-major branches of `{c,z}herk`/`{c,z}her2k` mapped the invalid `CblasTrans`, and `{c,z}syrk`/`{c,z}syr2k` the invalid `CblasConjTrans`, onto `'N'` and computed the wrong operation without any error. They now reach the existing error exit (parameter 3), matching the column-major
  behavior, where the Fortran routine rejects the forwarded value.

