### PR TITLE
Fix SGEBAL test failure

### DIFF
--- a/TESTING/EIG/dchkbl.f
+++ b/TESTING/EIG/dchkbl.f
@@ -133,7 +133,7 @@
 *
       DO 50 I = 1, N
          DO 40 J = 1, N
-            TEMP = MAX( A( I, J ), AIN( I, J ) )
+            TEMP = MAX( ABS( A( I, J ) ), ABS( AIN( I, J ) ) )
             TEMP = MAX( TEMP, SFMIN )
             VMAX = MAX( VMAX, ABS( A( I, J )-AIN( I, J ) ) / TEMP )
    40    CONTINUE

--- a/TESTING/EIG/schkbl.f
+++ b/TESTING/EIG/schkbl.f
@@ -133,7 +133,7 @@
 *
       DO 50 I = 1, N
          DO 40 J = 1, N
-            TEMP = MAX( A( I, J ), AIN( I, J ) )
+            TEMP = MAX( ABS( A( I, J ) ), ABS( AIN( I, J ) ) )
             TEMP = MAX( TEMP, SFMIN )
             VMAX = MAX( VMAX, ABS( A( I, J )-AIN( I, J ) ) / TEMP )
    40    CONTINUE


### PR DESCRIPTION
## Summary

`SCHKBL`/`DCHKBL` measure the relative error between the balanced matrix and the stored
reference with

```fortran
TEMP = MAX( A( I, J ), AIN( I, J ) )
TEMP = MAX( TEMP, SFMIN )
VMAX = MAX( VMAX, ABS( A( I, J )-AIN( I, J ) ) / TEMP )
```

The denominator is missing `ABS`. For an entry where both `A(I,J)` and `AIN(I,J)` are
negative, `MAX` returns a negative value, the clamp on the next line replaces it with
`SFMIN`, and the (non-negative) numerator is then divided by the smallest normalized
number.

In single precision, that overflows. `xeigtsts < sbal.in` on master reports:

```
 .. test output of SGEBAL ..
 value of largest test error            =     Infinity
 example number where info is not zero  =    0
 example number where ILO or IHI wrong  =    0
 example number having largest error    =   11
 number of examples where info is not 0 =    0
 total number of examples tested        =   13

Warning: Floating overflow occurred
```

The complex checkers already get this right — `CCHKBL`/`ZCHKBL` apply `CABS1` to both
arguments of the `MAX` (`TESTING/EIG/cchkbl.f:142`).

## Fix

Take absolute values before the `MAX`, matching the complex checkers:

```fortran
TEMP = MAX( ABS( A( I, J ) ), ABS( AIN( I, J ) ) )
```

Applied to `TESTING/EIG/schkbl.f` and `TESTING/EIG/dchkbl.f`.

## Effect

| test | before | after |
| --- | --- | --- |
| `SGEBAL` (`sbal.in`) | `Infinity` at example 11, floating overflow | `0.100E+01` at example 5 |
| `DGEBAL` (`dbal.in`) | `0.100D+01` at example 5 | `0.100D+01` at example 5 (unchanged) |
| `CGEBAL` (`cbal.in`) | `0.100E+01` at example 5 | untouched |
| `ZGEBAL` (`zbal.in`) | `0.100D+01` at example 5 | untouched |

All four precisions now report the same finite largest error at the same example.

`DCHKBL`'s reported value does not change on the current data — in double precision the
entries hitting the negative-denominator path happen to be exactly equal, so the numerator
is zero and `0/SFMIN` is harmless. The metric was equally wrong there, though, and would
misreport for any input where those entries differ, so it is fixed alongside the single
precision one.

## Notes

- The `SCALE` comparison loop just below uses `MAX( SCALE( I ), SCALIN( I ) )` with no
  `ABS`. Left as is deliberately: `?GEBAL` returns scaling factors that are positive powers
  of the radix, so `ABS` would be a no-op. The complex checkers do the same.
- Test-only change. Nothing under `SRC/` or `BLAS/` is touched, so no library behavior
  changes — this only fixes the error metric used to report `?GEBAL` accuracy.
