### PR TITLE
Report BLAS test counts and summarize the BLAS tests in `lapack_testing.py`

### DIFF
--- a/BLAS/TESTING/CMakeLists.txt
+++ b/BLAS/TESTING/CMakeLists.txt
@@ -1,15 +1,22 @@
-function(_add_blas_test name src test_input)
+function(_add_blas_test name src test_input test_output)
   add_executable(${name} ${src})
   target_link_libraries(${name} ${BLASLIB})
   if(EXISTS "${test_input}")
+    # The Level 2 and 3 testers open their own summary file, whose name
+    # they read from the first line of the input file, so the harness
+    # must not also redirect stdout onto it.
     add_test(NAME BLAS-${name} COMMAND "${CMAKE_COMMAND}"
       -DTEST=$<TARGET_FILE:${name}>
       -DINPUT=${test_input}
       -DINTDIR=${CMAKE_CFG_INTDIR}
       -P "${LAPACK_SOURCE_DIR}/TESTING/runtest.cmake")
   else()
+    # The Level 1 testers read no input and write to stdout, so capture
+    # it here. This matches what BLAS/TESTING/Makefile's run target does
+    # (./xblat1s > sblat1.out) and is what lapack_testing.py reads.
     add_test(NAME BLAS-${name} COMMAND "${CMAKE_COMMAND}"
       -DTEST=$<TARGET_FILE:${name}>
+      -DOUTPUT=${test_output}
       -DINTDIR=${CMAKE_CFG_INTDIR}
       -P "${LAPACK_SOURCE_DIR}/TESTING/runtest.cmake")
   endif()
@@ -26,7 +33,8 @@ function(add_blas_test name source)
   set(test_input "${CMAKE_CURRENT_SOURCE_DIR}/${baseNAME}.in")
 
   if(BUILD_DEFAULT_API)
-    _add_blas_test(${name} ${source} "${test_input}")
+    _add_blas_test(${name} ${source} "${test_input}"
+      "${CMAKE_CURRENT_BINARY_DIR}/${baseNAME}.out")
   endif()
 
   if(BUILD_INDEX64_EXT_API)
@@ -43,7 +51,8 @@ function(add_blas_test name source)
       file(WRITE "${test_input_64}" "${test_input_content}")
     endif()
 
-    _add_blas_test(${name}_64 "${source_64}" "${test_input_64}")
+    _add_blas_test(${name}_64 "${source_64}" "${test_input_64}"
+      "${CMAKE_CURRENT_BINARY_DIR}/${baseNAME}_64.out")
     target_compile_options(${name}_64 PRIVATE ${FOPT_ILP64})
   endif()
 endfunction()

--- a/BLAS/TESTING/CMakeLists.txt
+++ b/BLAS/TESTING/CMakeLists.txt
@@ -2,18 +2,12 @@ function(_add_blas_test name src test_input test_output)
   add_executable(${name} ${src})
   target_link_libraries(${name} ${BLASLIB})
   if(EXISTS "${test_input}")
-    # The Level 2 and 3 testers open their own summary file, whose name
-    # they read from the first line of the input file, so the harness
-    # must not also redirect stdout onto it.
     add_test(NAME BLAS-${name} COMMAND "${CMAKE_COMMAND}"
       -DTEST=$<TARGET_FILE:${name}>
       -DINPUT=${test_input}
       -DINTDIR=${CMAKE_CFG_INTDIR}
       -P "${LAPACK_SOURCE_DIR}/TESTING/runtest.cmake")
   else()
-    # The Level 1 testers read no input and write to stdout, so capture
-    # it here. This matches what BLAS/TESTING/Makefile's run target does
-    # (./xblat1s > sblat1.out) and is what lapack_testing.py reads.
     add_test(NAME BLAS-${name} COMMAND "${CMAKE_COMMAND}"
       -DTEST=$<TARGET_FILE:${name}>
       -DOUTPUT=${test_output}

--- a/BLAS/TESTING/cblat1.f
+++ b/BLAS/TESTING/cblat1.f
@@ -46,6 +46,8 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -55,6 +57,8 @@
       EXTERNAL         CHECK1, CHECK2, HEADER
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             SFAC/9.765625E-4/
 *     .. Executable Statements ..
@@ -69,6 +73,8 @@
 *        these parameters.
 *
          PASS = .TRUE.
+         NTESTS = 0
+         NFAILS = 0
          INCX = 9999
          INCY = 9999
          MODE = 9999
@@ -79,11 +85,14 @@
          END IF
 *        -- Print
          IF (PASS) WRITE (NOUT,99998)
+         WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
       STOP
 *
 99999 FORMAT (' Complex BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
+99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
+     +        ' FAILED')
 *
 *     End of CBLAT1
 *
@@ -94,12 +103,14 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Arrays ..
       CHARACTER*6      L(11)
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             L(1)/'CDOTC '/
       DATA             L(2)/'CDOTU '/
@@ -114,6 +125,7 @@
       DATA             L(11)/'CAXPBY'/
 
 *     .. Executable Statements ..
+      SUBNAM = L(ICASE)
       WRITE (NOUT,99999) ICASE, L(ICASE)
       RETURN
 *
@@ -688,6 +700,7 @@
 *     .. Array Arguments ..
       REAL             SCOMP(LEN), SSIZE(LEN), STRUE(LEN)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -700,12 +713,15 @@
       INTRINSIC        ABS
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
 *
       DO 40 I = 1, LEN
+         NTESTS = NTESTS + 1
          SD = SCOMP(I) - STRUE(I)
          IF (ABS(SFAC*SD) .LE. ABS(SSIZE(I))*EPSILON(ZERO))
      +       GO TO 40
+         NFAILS = NFAILS + 1
 *
 *                             HERE    SCOMP(I) IS NOT CLOSE TO STRUE(I).
 *
@@ -820,14 +836,18 @@
 *     .. Scalar Arguments ..
       INTEGER           ICOMP, ITRUE
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER           ICASE, INCX, INCY, MODE, N
       LOGICAL           PASS
 *     .. Local Scalars ..
       INTEGER           ID
 *     .. Common blocks ..
       COMMON            /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
+      NTESTS = NTESTS + 1
       IF (ICOMP.EQ.ITRUE) GO TO 40
+      NFAILS = NFAILS + 1
 *
 *                            HERE ICOMP IS NOT EQUAL TO ITRUE.
 *
@@ -899,6 +919,10 @@
 *     .. Local Arrays ..
       COMPLEX           X(NMAX), Z(NMAX)
       REAL              VALUES(NV), WORK(NMAX)
+*     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+*     .. Common blocks ..
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
       VALUES(1) = ZERO
       VALUES(2) = TWO*SAFMIN
@@ -1040,7 +1064,9 @@
             ELSE
                TRAT = (ABS(SNRM-ZNRM) / ZNRM) / (TWO*REAL(N)*ULP)
             END IF
+            NTESTS = NTESTS + 1
             IF ((TRAT.NE.TRAT).OR.(TRAT.GE.THRESH)) THEN
+               NFAILS = NFAILS + 1
                IF (FIRST) THEN
                   FIRST = .FALSE.
                   WRITE(NOUT,99999)

--- a/BLAS/TESTING/cblat1.f
+++ b/BLAS/TESTING/cblat1.f
@@ -47,7 +47,7 @@
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
       INTEGER          NTESTS, NFAILS
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -103,7 +103,7 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Arrays ..

--- a/BLAS/TESTING/cblat2.f
+++ b/BLAS/TESTING/cblat2.f
@@ -469,6 +469,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, BETA, BLS, TRANSL
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IKU, IM, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, KL, KLS, KU, KUS, LAA, LDA,
      $                   LDAS, LX, LY, M, ML, MS, N, NARGS, NC, ND, NK,
@@ -505,6 +506,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -646,6 +649,8 @@
                               IF( .NOT.OK )THEN
                                  WRITE( NOUT, FMT = 9993 )
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -699,6 +704,8 @@
    40                         CONTINUE
                               IF( .NOT.SAME )THEN
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -711,6 +718,9 @@
      $                                       INCY, YT, G, YY, EPS, ERR,
      $                                       FATAL, NOUT, .TRUE. )
                                  ERRMAX = MAX( ERRMAX, ERR )
+                                 NTESTS = NTESTS + 1
+                                 IF( ERR.GE.THRESH )
+     $                              NFAILS = NFAILS + 1
 *                                If got really bad answer, report and
 *                                return.
                                  IF( FATAL )
@@ -762,6 +772,8 @@
       IF( .NOT.LCE( YS, YY, LY ) )THEN
          WRITE( NOUT, FMT = 9998 )NARGS - 1
          FATAL = .TRUE.
+         NTESTS = NTESTS + 1
+         NFAILS = NFAILS + 1
          GO TO 130
       END IF
 *
@@ -785,6 +797,7 @@
       END IF
 *
   140 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -803,6 +816,8 @@
      $      F4.1, '), Y,', I2, ')         .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK1
 *
@@ -843,6 +858,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, BETA, BLS, TRANSL
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IK, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, K, KS, LAA, LDA, LDAS, LX, LY,
      $                   N, NARGS, NC, NK, NS
@@ -881,6 +897,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1011,6 +1029,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9992 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1073,6 +1093,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1085,6 +1107,9 @@
      $                                    YY, EPS, ERR, FATAL, NOUT,
      $                                    .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1131,6 +1156,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1152,6 +1178,8 @@
      $      'Y,', I2, ')             .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK2
 *
@@ -1189,6 +1217,7 @@
 *     .. Local Scalars ..
       COMPLEX            TRANSL
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, ICD, ICT, ICU, IK, IN, INCX, INCXS, IX, K,
      $                   KS, LAA, LDA, LDAS, LX, N, NARGS, NC, NK, NS
       LOGICAL            BANDED, FULL, NULL, PACKED, RESET, SAME
@@ -1228,6 +1257,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero vector for CMVCH.
       DO 10 I = 1, NMAX
          Z( I ) = ZERO
@@ -1374,6 +1405,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1426,6 +1459,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1454,6 +1489,9 @@
      $                                    .FALSE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 120
@@ -1496,6 +1534,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1514,6 +1553,8 @@
      $      I3, ', X,', I2, ')                                   .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK3
 *
@@ -1554,6 +1595,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, TRANSL
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IM, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, LAA, LDA, LDAS, LX, LY, M, MS, N, NARGS,
      $                   NC, ND, NS
@@ -1581,6 +1623,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1681,6 +1725,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9993 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1711,6 +1757,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1740,6 +1788,9 @@
      $                                 AA( 1 + ( J - 1 )*LDA ), EPS,
      $                                 ERR, FATAL, NOUT, .TRUE. )
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 130
@@ -1776,6 +1827,7 @@
       WRITE( NOUT, FMT = 9994 )NC, SNAME, M, N, ALPHA, INCX, INCY, LDA
 *
   150 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1792,6 +1844,8 @@
      $      '      .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK4
 *
@@ -1832,6 +1886,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, TRANSL
       REAL               ERR, ERRMAX, RALPHA, RALS
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, IX, J, JA, JJ, LAA,
      $                   LDA, LDAS, LJ, LX, N, NARGS, NC, NS
       LOGICAL            FULL, NULL, PACKED, RESET, SAME, UPPER
@@ -1867,6 +1922,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1951,6 +2008,8 @@
                   IF( .NOT.OK )THEN
                      WRITE( NOUT, FMT = 9992 )
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -1981,6 +2040,8 @@
    30             CONTINUE
                   IF( .NOT.SAME )THEN
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -2021,6 +2082,9 @@
                            JA = JA + LJ
                         END IF
                         ERRMAX = MAX( ERRMAX, ERR )
+                        NTESTS = NTESTS + 1
+                        IF( ERR.GE.THRESH )
+     $                     NFAILS = NFAILS + 1
 *                       If got really bad answer, report and return.
                         IF( FATAL )
      $                     GO TO 110
@@ -2060,6 +2124,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -2077,6 +2142,8 @@
      $      I2, ', A,', I3, ')                                      .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK5
 *
@@ -2117,6 +2184,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, TRANSL
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, JA, JJ, LAA, LDA, LDAS, LJ, LX, LY, N,
      $                   NARGS, NC, NS
@@ -2153,6 +2221,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 140 IN = 1, NIDIM
          N = IDIM( IN )
@@ -2257,6 +2327,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9992 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2289,6 +2361,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2339,6 +2413,9 @@
                               JA = JA + LJ
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 150
@@ -2381,6 +2458,7 @@
       END IF
 *
   170 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -2400,6 +2478,8 @@
      $      '            .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK6
 *

--- a/BLAS/TESTING/cblat2.f
+++ b/BLAS/TESTING/cblat2.f
@@ -2501,6 +2501,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*6        SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Local Scalars ..
@@ -2514,6 +2515,7 @@
      $                   CTBSV, CTPMV, CTPSV, CTRMV, CTRSV
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2521,6 +2523,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
       GO TO ( 10, 20, 30, 40, 50, 60, 70, 80,
      $        90, 100, 110, 120, 130, 140, 150, 160,
      $        170 )ISNUM
@@ -2819,11 +2826,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A6, ' FAILED THE TESTS OF ERROR-EXITS *****',
      $      '**' )
+ 9979 FORMAT( ' ', A6, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHKE
 *
@@ -3331,11 +3341,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*6        SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3401,11 +3420,13 @@
       INTEGER            INFO
       CHARACTER*6        SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*6        SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Executable Statements ..
       LERR = .TRUE.
@@ -3416,10 +3437,12 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       IF( SRNAME.NE.SRNAMT )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/cblat3.f
+++ b/BLAS/TESTING/cblat3.f
@@ -2074,6 +2074,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*7        SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Parameters ..
@@ -2089,6 +2090,7 @@
      $                   CSYR2K, CSYRK, CTRMM, CTRSM, CGEMMTR
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2096,6 +2098,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
 *
 *     Initialize ALPHA, BETA, RALPHA, and RBETA.
 *
@@ -3180,11 +3187,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A7, ' FAILED THE TESTS OF ERROR-EXITS *****',
      $      '**' )
+ 9979 FORMAT( ' ', A7, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHKE
 *
@@ -3688,11 +3698,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*7        SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3725,11 +3744,13 @@
       INTEGER            INFO
       CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*7        SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Locals ..
       INTEGER            SRLEN
@@ -3742,11 +3763,13 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
       IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/cblat3.f
+++ b/BLAS/TESTING/cblat3.f
@@ -443,6 +443,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, BETA, BLS
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IM, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS, M,
      $                   MA, MB, MS, N, NA, NARGS, NB, NC, NS
@@ -471,6 +472,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IM = 1, NIDIM
          M = IDIM( IM )
@@ -592,6 +595,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -627,6 +632,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -639,6 +646,9 @@
      $                                    C, NMAX, CT, G, CC, LDC, EPS,
      $                                    ERR, FATAL, NOUT, .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -674,6 +684,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -689,6 +700,8 @@
      $      ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK1
 *
@@ -728,6 +741,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, BETA, BLS
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICS, ICU, IM, IN, LAA, LBB, LCC,
      $                   LDA, LDAS, LDB, LDBS, LDC, LDCS, M, MS, N, NA,
      $                   NARGS, NC, NS
@@ -757,6 +771,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IM = 1, NIDIM
          M = IDIM( IM )
@@ -867,6 +883,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9994 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -901,6 +919,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -920,6 +940,9 @@
      $                                    FATAL, NOUT, .TRUE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and
 *                          return.
                            IF( FATAL )
@@ -953,6 +976,7 @@
      $   LDB, BETA, LDC
 *
   120 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -968,6 +992,8 @@
      $      ',', F4.1, '), C,', I3, ')    .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK2
 *
@@ -1006,6 +1032,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, ICD, ICS, ICT, ICU, IM, IN, J, LAA, LBB,
      $                   LDA, LDAS, LDB, LDBS, M, MS, N, NA, NARGS, NC,
      $                   NS
@@ -1036,6 +1063,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero matrix for CMMCH.
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
@@ -1145,6 +1174,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1178,6 +1209,8 @@
    50                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1228,6 +1261,9 @@
                                  END IF
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1263,6 +1299,7 @@
      $   N, ALPHA, LDA, LDB
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1278,6 +1315,8 @@
      $      '      .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK3
 *
@@ -1317,6 +1356,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, BETA, BETS
       REAL               ERR, ERRMAX, RALPHA, RALS, RBETA, RBETS
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, K, KS,
      $                   LAA, LCC, LDA, LDAS, LDC, LDCS, LJ, MA, N, NA,
      $                   NARGS, NC, NS
@@ -1346,6 +1386,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1466,6 +1508,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1506,6 +1550,8 @@
    30                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1548,6 +1594,9 @@
                                  JC = JC + LDC + 1
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1591,6 +1640,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1610,6 +1660,8 @@
      $      '), C,', I3, ')          .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK4
 *
@@ -1649,6 +1701,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, BETA, BETS
       REAL               ERR, ERRMAX, RBETA, RBETS
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, JJAB,
      $                   K, KS, LAA, LBB, LCC, LDA, LDAS, LDB, LDBS,
      $                   LDC, LDCS, LJ, MA, N, NA, NARGS, NC, NS
@@ -1678,6 +1731,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 130 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1811,6 +1866,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1849,6 +1906,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1921,6 +1980,9 @@
      $                              JJAB = JJAB + 2*NMAX
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1964,6 +2026,7 @@
       END IF
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1983,6 +2046,8 @@
      $      ',', F4.1, '), C,', I3, ')    .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK5
 *
@@ -3731,6 +3796,7 @@
 *     .. Local Scalars ..
       COMPLEX            ALPHA, ALS, BETA, BLS
       REAL               ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS,
      $                   MA, MB,  N, NA, NARGS, NB, NC, NS, IS
@@ -3762,6 +3828,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -3884,6 +3952,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3919,6 +3989,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3931,6 +4003,9 @@
      $                                    BETA, C, NMAX, CT, G, CC, LDC,
      $                                    EPS, ERR, FATAL, NOUT, .TRUE.)
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -3966,6 +4041,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -3981,6 +4057,8 @@
      $      ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of CCHK6
 *

--- a/BLAS/TESTING/dblat1.f
+++ b/BLAS/TESTING/dblat1.f
@@ -47,7 +47,7 @@
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
       INTEGER          NTESTS, NFAILS
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -108,7 +108,7 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Arrays ..

--- a/BLAS/TESTING/dblat1.f
+++ b/BLAS/TESTING/dblat1.f
@@ -46,6 +46,8 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -55,6 +57,8 @@
       EXTERNAL         CHECK0, CHECK1, CHECK2, CHECK3, HEADER
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             SFAC/9.765625D-4/
 *     .. Executable Statements ..
@@ -69,6 +73,8 @@
 *        .. these parameters ..
 *
          PASS = .TRUE.
+         NTESTS = 0
+         NFAILS = 0
          INCX = 9999
          INCY = 9999
          IF (ICASE.EQ.3 .OR. ICASE.EQ.11) THEN
@@ -85,11 +91,14 @@
          END IF
 *        -- Print
          IF (PASS) WRITE (NOUT,99998)
+         WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
       STOP
 *
 99999 FORMAT (' Real BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
+99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
+     +        ' FAILED')
 *
 *     End of DBLAT1
 *
@@ -99,12 +108,14 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Arrays ..
       CHARACTER*6      L(14)
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             L(1)/' DDOT '/
       DATA             L(2)/'DAXPY '/
@@ -122,6 +133,7 @@
       DATA             L(14)/'DAXPBY'/
 
 *     .. Executable Statements ..
+      SUBNAM = L(ICASE)
       WRITE (NOUT,99999) ICASE, L(ICASE)
       RETURN
 *
@@ -1004,6 +1016,7 @@
 *     .. Array Arguments ..
       DOUBLE PRECISION SCOMP(LEN), SSIZE(LEN), STRUE(LEN)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -1016,12 +1029,15 @@
       INTRINSIC        ABS
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
 *
       DO 40 I = 1, LEN
+         NTESTS = NTESTS + 1
          SD = SCOMP(I) - STRUE(I)
          IF (ABS(SFAC*SD) .LE. ABS(SSIZE(I))*EPSILON(ZERO))
      +       GO TO 40
+         NFAILS = NFAILS + 1
 *
 *                             HERE    SCOMP(I) IS NOT CLOSE TO STRUE(I).
 *
@@ -1061,6 +1077,7 @@
 *     .. Scalar Arguments ..
       REAL             SFAC, SCOMP, SSIZE, STRUE
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -1069,11 +1086,13 @@
       INTRINSIC        ABS
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
 *
          SD = SCOMP - STRUE
          IF (ABS(SFAC*SD) .LE. ABS(SSIZE) * EPSILON(ZERO))
      +       GO TO 40
+         NFAILS = NFAILS + 1
 *
 *                             HERE    SCOMP(I) IS NOT CLOSE TO STRUE(I).
 *
@@ -1153,15 +1172,19 @@
 *     .. Scalar Arguments ..
       INTEGER           ICOMP, ITRUE
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER           ICASE, INCX, INCY, N
       LOGICAL           PASS
 *     .. Local Scalars ..
       INTEGER           ID
 *     .. Common blocks ..
       COMMON            /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
 *
+      NTESTS = NTESTS + 1
       IF (ICOMP.EQ.ITRUE) GO TO 40
+      NFAILS = NFAILS + 1
 *
 *                            HERE ICOMP IS NOT EQUAL TO ITRUE.
 *
@@ -1231,6 +1254,10 @@
       LOGICAL           FIRST
 *     .. Local Arrays ..
       DOUBLE PRECISION  VALUES(NV), WORK(NMAX), X(NMAX), Z(NMAX)
+*     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+*     .. Common blocks ..
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
       VALUES(1) = ZERO
       VALUES(2) = TWO*SAFMIN
@@ -1357,7 +1384,9 @@
             ELSE
                TRAT = (ABS(SNRM-ZNRM) / ZNRM) / (DBLE(N)*ULP)
             END IF
+            NTESTS = NTESTS + 1
             IF ((TRAT.NE.TRAT).OR.(TRAT.GE.THRESH)) THEN
+               NFAILS = NFAILS + 1
                IF (FIRST) THEN
                   FIRST = .FALSE.
                   WRITE(NOUT,99999)

--- a/BLAS/TESTING/dblat2.f
+++ b/BLAS/TESTING/dblat2.f
@@ -2494,6 +2494,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*10       SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Local Scalars ..
@@ -2506,6 +2507,7 @@
      $                   DTPSV, DTRMV, DTRSV
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2513,6 +2515,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
       GO TO ( 10, 20, 30, 40, 50, 60, 70, 80,
      $        90, 100, 110, 120, 130, 140, 150,
      $        160, 170, 180 )ISNUM
@@ -2827,11 +2834,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A10, ' FAILED THE TESTS OF ERROR-EXITS ****',
      $      '***' )
+ 9979 FORMAT( ' ', A10, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHKE
 *
@@ -3313,11 +3323,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*10       SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3383,11 +3402,13 @@
       INTEGER            INFO
       CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*10       SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Locals ..
       INTEGER            SRLEN
@@ -3400,11 +3421,13 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
       IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/dblat2.f
+++ b/BLAS/TESTING/dblat2.f
@@ -465,6 +465,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC ), KB( NKB )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, BETA, BLS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IKU, IM, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, KL, KLS, KU, KUS, LAA, LDA,
      $                   LDAS, LX, LY, M, ML, MS, N, NARGS, NC, ND, NK,
@@ -501,6 +502,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -642,6 +645,8 @@
                               IF( .NOT.OK )THEN
                                  WRITE( NOUT, FMT = 9993 )
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -695,6 +700,8 @@
    40                         CONTINUE
                               IF( .NOT.SAME )THEN
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -707,6 +714,9 @@
      $                                       INCY, YT, G, YY, EPS, ERR,
      $                                       FATAL, NOUT, .TRUE. )
                                  ERRMAX = MAX( ERRMAX, ERR )
+                                 NTESTS = NTESTS + 1
+                                 IF( ERR.GE.THRESH )
+     $                              NFAILS = NFAILS + 1
 *                                If got really bad answer, report and
 *                                return.
                                  IF( FATAL )
@@ -758,6 +768,8 @@
       IF( .NOT.LDE( YS, YY, LY ) )THEN
          WRITE( NOUT, FMT = 9998 )NARGS - 1
          FATAL = .TRUE.
+         NTESTS = NTESTS + 1
+         NFAILS = NFAILS + 1
          GO TO 130
       END IF
 *
@@ -781,6 +793,7 @@
       END IF
 *
   140 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -798,6 +811,8 @@
      $      ')         .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK1
 *
@@ -835,6 +850,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC ), KB( NKB )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, BETA, BLS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IK, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, K, KS, LAA, LDA, LDAS, LX, LY,
      $                   N, NARGS, NC, NK, NS
@@ -875,6 +891,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1013,6 +1031,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9992 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1075,6 +1095,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1087,6 +1109,9 @@
      $                                    YY, EPS, ERR, FATAL, NOUT,
      $                                    .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1133,6 +1158,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1153,6 +1179,8 @@
      $      ')             .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK2
 *
@@ -1186,6 +1214,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC ), KB( NKB )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, ICD, ICT, ICU, IK, IN, INCX, INCXS, IX, K,
      $                   KS, LAA, LDA, LDAS, LX, N, NARGS, NC, NK, NS
       LOGICAL            BANDED, FULL, NULL, PACKED, RESET, SAME
@@ -1225,6 +1254,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero vector for DMVCH.
       DO 10 I = 1, NMAX
          Z( I ) = ZERO
@@ -1371,6 +1402,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1423,6 +1456,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1451,6 +1486,9 @@
      $                                    .FALSE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 120
@@ -1493,6 +1531,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1511,6 +1550,8 @@
      $      I3, ', X,', I2, ')                     .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK3
 *
@@ -1546,6 +1587,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IM, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, LAA, LDA, LDAS, LX, LY, M, MS, N, NARGS,
      $                   NC, ND, NS
@@ -1572,6 +1614,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1665,6 +1709,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9993 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1695,6 +1741,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1722,6 +1770,9 @@
      $                                 AA( 1 + ( J - 1 )*LDA ), EPS,
      $                                 ERR, FATAL, NOUT, .TRUE. )
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 130
@@ -1758,6 +1809,7 @@
       WRITE( NOUT, FMT = 9994 )NC, SNAME, M, N, ALPHA, INCX, INCY, LDA
 *
   150 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1773,6 +1825,8 @@
      $      ', Y,', I2, ', A,', I3, ')                  .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK4
 *
@@ -1808,6 +1862,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, IX, J, JA, JJ, LAA,
      $                   LDA, LDAS, LJ, LX, N, NARGS, NC, NS
       LOGICAL            FULL, NULL, PACKED, RESET, SAME, UPPER
@@ -1843,6 +1898,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1926,6 +1983,8 @@
                   IF( .NOT.OK )THEN
                      WRITE( NOUT, FMT = 9992 )
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -1956,6 +2015,8 @@
    30             CONTINUE
                   IF( .NOT.SAME )THEN
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -1996,6 +2057,9 @@
                            JA = JA + LJ
                         END IF
                         ERRMAX = MAX( ERRMAX, ERR )
+                        NTESTS = NTESTS + 1
+                        IF( ERR.GE.THRESH )
+     $                     NFAILS = NFAILS + 1
 *                       If got really bad answer, report and return.
                         IF( FATAL )
      $                     GO TO 110
@@ -2035,6 +2099,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -2052,6 +2117,8 @@
      $       ', X,', I2, ', A,', I3, ')                        .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK5
 *
@@ -2087,6 +2154,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, JA, JJ, LAA, LDA, LDAS, LJ, LX, LY, N,
      $                   NARGS, NC, NS
@@ -2125,6 +2193,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 140 IN = 1, NIDIM
          N = IDIM( IN )
@@ -2237,6 +2307,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9992 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2269,6 +2341,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2333,6 +2407,9 @@
                               JA = JA + LJ
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 150
@@ -2375,6 +2452,7 @@
       END IF
 *
   170 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -2393,6 +2471,8 @@
      $       ')                  .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK6
 *

--- a/BLAS/TESTING/dblat3.f
+++ b/BLAS/TESTING/dblat3.f
@@ -435,6 +435,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, BETA, BLS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IM, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS, M,
      $                   MA, MB, MS, N, NA, NARGS, NB, NC, NS
@@ -463,6 +464,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IM = 1, NIDIM
          M = IDIM( IM )
@@ -584,6 +587,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -619,6 +624,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -631,6 +638,9 @@
      $                                    C, NMAX, CT, G, CC, LDC, EPS,
      $                                    ERR, FATAL, NOUT, .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -666,6 +676,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -681,6 +692,8 @@
      $      'C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK1
 *
@@ -717,6 +730,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, BETA, BLS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICS, ICU, IM, IN, LAA, LBB, LCC,
      $                   LDA, LDAS, LDB, LDBS, LDC, LDCS, M, MS, N, NA,
      $                   NARGS, NC, NS
@@ -746,6 +760,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IM = 1, NIDIM
          M = IDIM( IM )
@@ -862,6 +878,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9994 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -896,6 +914,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -915,6 +935,9 @@
      $                                    FATAL, NOUT, .TRUE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and
 *                          return.
                            IF( FATAL )
@@ -948,6 +971,7 @@
      $   LDB, BETA, LDC
 *
   120 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -963,6 +987,8 @@
      $       ', C,', I3, ')   ', ' .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK2
 *
@@ -998,6 +1024,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, ICD, ICS, ICT, ICU, IM, IN, J, LAA, LBB,
      $                   LDA, LDAS, LDB, LDBS, M, MS, N, NA, NARGS, NC,
      $                   NS
@@ -1028,6 +1055,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero matrix for DMMCH.
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
@@ -1137,6 +1166,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1170,6 +1201,8 @@
    50                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1220,6 +1253,9 @@
                                  END IF
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1255,6 +1291,7 @@
      $   N, ALPHA, LDA, LDB
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1269,6 +1306,8 @@
      $       2( I3, ',' ), F4.1, ', A,', I3, ', B,', I3, ')        .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK3
 *
@@ -1305,6 +1344,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, BETA, BETS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, K, KS,
      $                   LAA, LCC, LDA, LDAS, LDC, LDCS, LJ, MA, N, NA,
      $                   NARGS, NC, NS
@@ -1334,6 +1374,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1423,6 +1465,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9993 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1455,6 +1499,8 @@
    30                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1492,6 +1538,9 @@
                                  JC = JC + LDC + 1
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1530,6 +1579,7 @@
      $   LDA, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1546,6 +1596,8 @@
      $       ')           .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK4
 *
@@ -1582,6 +1634,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, BETA, BETS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, JJAB,
      $                   K, KS, LAA, LBB, LCC, LDA, LDAS, LDB, LDBS,
      $                   LDC, LDCS, LJ, MA, N, NA, NARGS, NC, NS
@@ -1612,6 +1665,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 130 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1733,6 +1788,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9993 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1772,6 +1829,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1846,6 +1905,9 @@
      $                              JJAB = JJAB + 2*NMAX
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1884,6 +1946,7 @@
      $   LDA, LDB, BETA, LDC
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1900,6 +1963,8 @@
      $       ', C,', I3, ')   ', ' .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK5
 *
@@ -3204,6 +3269,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       DOUBLE PRECISION   ALPHA, ALS, BETA, BLS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS,
      $                   MA, MB, N, NA, NARGS, NB, NC, NS, IS
@@ -3234,6 +3300,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -3357,6 +3425,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3392,6 +3462,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3405,6 +3477,9 @@
      $                                 C, NMAX, CT, G, CC, LDC, EPS,
      $                                 ERR, FATAL, NOUT, .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -3441,6 +3516,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -3456,6 +3532,8 @@
      $       F4.1, ', ', 'C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK6
 *

--- a/BLAS/TESTING/dblat3.f
+++ b/BLAS/TESTING/dblat3.f
@@ -1991,6 +1991,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*11       SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Parameters ..
@@ -2005,6 +2006,7 @@
      $                   DTRSM, DGEMMTR
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2012,6 +2014,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
 *
 *     Initialize ALPHA and BETA.
 *
@@ -2729,11 +2736,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A11, ' FAILED THE TESTS OF ERROR-EXITS ****',
      $      '***' )
+ 9979 FORMAT( ' ', A11, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHKE
 *
@@ -3166,11 +3176,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*11       SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3204,11 +3223,13 @@
       INTEGER            INFO
       CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*11       SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Locals ..
       INTEGER            SRLEN
@@ -3221,11 +3242,13 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
       IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/sblat1.f
+++ b/BLAS/TESTING/sblat1.f
@@ -47,7 +47,7 @@
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
       INTEGER          NTESTS, NFAILS
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -108,7 +108,7 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Arrays ..

--- a/BLAS/TESTING/sblat1.f
+++ b/BLAS/TESTING/sblat1.f
@@ -46,6 +46,8 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -55,6 +57,8 @@
       EXTERNAL         CHECK0, CHECK1, CHECK2, CHECK3, HEADER
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             SFAC/9.765625E-4/
 *     .. Executable Statements ..
@@ -69,6 +73,8 @@
 *        .. these parameters ..
 *
          PASS = .TRUE.
+         NTESTS = 0
+         NFAILS = 0
          INCX = 9999
          INCY = 9999
          IF (ICASE.EQ.3 .OR. ICASE.EQ.11) THEN
@@ -85,11 +91,14 @@
          END IF
 *        -- Print
          IF (PASS) WRITE (NOUT,99998)
+         WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
       STOP
 *
 99999 FORMAT (' Real BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
+99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
+     +        ' FAILED')
 *
 *     End of SBLAT1
 *
@@ -99,12 +108,14 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Arrays ..
       CHARACTER*6      L(14)
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             L(1)/' SDOT '/
       DATA             L(2)/'SAXPY '/
@@ -122,6 +133,7 @@
       DATA             L(14)/'SAXPBY'/
 
 *     .. Executable Statements ..
+      SUBNAM = L(ICASE)
       WRITE (NOUT,99999) ICASE, L(ICASE)
       RETURN
 *
@@ -1001,6 +1013,7 @@
 *     .. Array Arguments ..
       REAL             SCOMP(LEN), SSIZE(LEN), STRUE(LEN)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -1013,12 +1026,15 @@
       INTRINSIC        ABS
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
 *
       DO 40 I = 1, LEN
+         NTESTS = NTESTS + 1
          SD = SCOMP(I) - STRUE(I)
          IF (ABS(SFAC*SD) .LE. ABS(SSIZE(I))*EPSILON(ZERO))
      +       GO TO 40
+         NFAILS = NFAILS + 1
 *
 *                             HERE    SCOMP(I) IS NOT CLOSE TO STRUE(I).
 *
@@ -1095,15 +1111,19 @@
 *     .. Scalar Arguments ..
       INTEGER           ICOMP, ITRUE
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER           ICASE, INCX, INCY, N
       LOGICAL           PASS
 *     .. Local Scalars ..
       INTEGER           ID
 *     .. Common blocks ..
       COMMON            /COMBLA/ICASE, N, INCX, INCY, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
 *
+      NTESTS = NTESTS + 1
       IF (ICOMP.EQ.ITRUE) GO TO 40
+      NFAILS = NFAILS + 1
 *
 *                            HERE ICOMP IS NOT EQUAL TO ITRUE.
 *
@@ -1173,6 +1193,10 @@
       LOGICAL           FIRST
 *     .. Local Arrays ..
       REAL              VALUES(NV), WORK(NMAX), X(NMAX), Z(NMAX)
+*     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+*     .. Common blocks ..
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
       VALUES(1) = ZERO
       VALUES(2) = TWO*SAFMIN
@@ -1299,7 +1323,9 @@
             ELSE
                TRAT = (ABS(SNRM-ZNRM) / ZNRM) / (REAL(N)*ULP)
             END IF
+            NTESTS = NTESTS + 1
             IF ((TRAT.NE.TRAT).OR.(TRAT.GE.THRESH)) THEN
+               NFAILS = NFAILS + 1
                IF (FIRST) THEN
                   FIRST = .FALSE.
                   WRITE(NOUT,99999)

--- a/BLAS/TESTING/sblat2.f
+++ b/BLAS/TESTING/sblat2.f
@@ -466,6 +466,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC ), KB( NKB )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, BETA, BLS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IKU, IM, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, KL, KLS, KU, KUS, LAA, LDA,
      $                   LDAS, LX, LY, M, ML, MS, N, NARGS, NC, ND, NK,
@@ -502,6 +503,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -643,6 +646,8 @@
                               IF( .NOT.OK )THEN
                                  WRITE( NOUT, FMT = 9993 )
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -696,6 +701,8 @@
    40                         CONTINUE
                               IF( .NOT.SAME )THEN
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -708,6 +715,9 @@
      $                                       INCY, YT, G, YY, EPS, ERR,
      $                                       FATAL, NOUT, .TRUE. )
                                  ERRMAX = MAX( ERRMAX, ERR )
+                                 NTESTS = NTESTS + 1
+                                 IF( ERR.GE.THRESH )
+     $                              NFAILS = NFAILS + 1
 *                                If got really bad answer, report and
 *                                return.
                                  IF( FATAL )
@@ -759,6 +769,8 @@
       IF( .NOT.LSE( YS, YY, LY ) )THEN
          WRITE( NOUT, FMT = 9998 )NARGS - 1
          FATAL = .TRUE.
+         NTESTS = NTESTS + 1
+         NFAILS = NFAILS + 1
          GO TO 130
       END IF
 *
@@ -782,6 +794,7 @@
       END IF
 *
   140 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -799,6 +812,8 @@
      $      ')         .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK1
 *
@@ -836,6 +851,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC ), KB( NKB )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, BETA, BLS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IK, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, K, KS, LAA, LDA, LDAS, LX, LY,
      $                   N, NARGS, NC, NK, NS
@@ -876,6 +892,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1014,6 +1032,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9992 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1076,6 +1096,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1088,6 +1110,9 @@
      $                                    YY, EPS, ERR, FATAL, NOUT,
      $                                    .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1134,6 +1159,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1154,6 +1180,8 @@
      $       '  .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK2
 *
@@ -1187,6 +1215,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC ), KB( NKB )
 *     .. Local Scalars ..
       REAL               ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, ICD, ICT, ICU, IK, IN, INCX, INCXS, IX, K,
      $                   KS, LAA, LDA, LDAS, LX, N, NARGS, NC, NK, NS
       LOGICAL            BANDED, FULL, NULL, PACKED, RESET, SAME
@@ -1226,6 +1255,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero vector for SMVCH.
       DO 10 I = 1, NMAX
          Z( I ) = ZERO
@@ -1372,6 +1403,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1424,6 +1457,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1452,6 +1487,9 @@
      $                                    .FALSE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 120
@@ -1494,6 +1532,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1512,6 +1551,8 @@
      $      I3, ', X,', I2, ')                     .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK3
 *
@@ -1547,6 +1588,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IM, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, LAA, LDA, LDAS, LX, LY, M, MS, N, NARGS,
      $                   NC, ND, NS
@@ -1573,6 +1615,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1666,6 +1710,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9993 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1696,6 +1742,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1723,6 +1771,9 @@
      $                                 AA( 1 + ( J - 1 )*LDA ), EPS,
      $                                 ERR, FATAL, NOUT, .TRUE. )
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 130
@@ -1759,6 +1810,7 @@
       WRITE( NOUT, FMT = 9994 )NC, SNAME, M, N, ALPHA, INCX, INCY, LDA
 *
   150 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1774,6 +1826,8 @@
      $      ', Y,', I2, ', A,', I3, ')                  .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK4
 *
@@ -1809,6 +1863,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, IX, J, JA, JJ, LAA,
      $                   LDA, LDAS, LJ, LX, N, NARGS, NC, NS
       LOGICAL            FULL, NULL, PACKED, RESET, SAME, UPPER
@@ -1844,6 +1899,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1927,6 +1984,8 @@
                   IF( .NOT.OK )THEN
                      WRITE( NOUT, FMT = 9992 )
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -1957,6 +2016,8 @@
    30             CONTINUE
                   IF( .NOT.SAME )THEN
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -1997,6 +2058,9 @@
                            JA = JA + LJ
                         END IF
                         ERRMAX = MAX( ERRMAX, ERR )
+                        NTESTS = NTESTS + 1
+                        IF( ERR.GE.THRESH )
+     $                     NFAILS = NFAILS + 1
 *                       If got really bad answer, report and return.
                         IF( FATAL )
      $                     GO TO 110
@@ -2036,6 +2100,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -2053,6 +2118,8 @@
      $      ',', I2, ', A,', I3, ')                        .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK5
 *
@@ -2088,6 +2155,7 @@
       INTEGER            IDIM( NIDIM ), INC( NINC )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, ERR, ERRMAX, TRANSL
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, JA, JJ, LAA, LDA, LDAS, LJ, LX, LY, N,
      $                   NARGS, NC, NS
@@ -2126,6 +2194,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 140 IN = 1, NIDIM
          N = IDIM( IN )
@@ -2238,6 +2308,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9992 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2270,6 +2342,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2334,6 +2408,9 @@
                               JA = JA + LJ
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 150
@@ -2376,6 +2453,7 @@
       END IF
 *
   170 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -2393,6 +2471,8 @@
      $      ',', I2, ', Y,', I2, ', A,', I3, ')                  .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A10, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK6
 *

--- a/BLAS/TESTING/sblat2.f
+++ b/BLAS/TESTING/sblat2.f
@@ -2494,6 +2494,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*10       SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Local Scalars ..
@@ -2506,6 +2507,7 @@
      $                   STPSV, STRMV, STRSV
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2513,6 +2515,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
       GO TO ( 10, 20, 30, 40, 50, 60, 70, 80,
      $        90, 100, 110, 120, 130, 140, 150,
      $        160, 170, 180 )ISNUM
@@ -2827,11 +2834,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A10, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A10, ' FAILED THE TESTS OF ERROR-EXITS ****',
      $      '***' )
+ 9979 FORMAT( ' ', A10, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHKE
 *
@@ -3313,11 +3323,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*10       SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3383,11 +3402,13 @@
       INTEGER            INFO
       CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*10       SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Locals ..
       INTEGER            SRLEN
@@ -3400,11 +3421,13 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
       IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/sblat3.f
+++ b/BLAS/TESTING/sblat3.f
@@ -436,6 +436,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, BETA, BLS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IM, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS, M,
      $                   MA, MB, MS, N, NA, NARGS, NB, NC, NS
@@ -464,6 +465,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IM = 1, NIDIM
          M = IDIM( IM )
@@ -585,6 +588,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -620,6 +625,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -632,6 +639,9 @@
      $                                    C, NMAX, CT, G, CC, LDC, EPS,
      $                                    ERR, FATAL, NOUT, .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -667,6 +677,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -682,6 +693,8 @@
      $      'C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK1
 *
@@ -718,6 +731,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, BETA, BLS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICS, ICU, IM, IN, LAA, LBB, LCC,
      $                   LDA, LDAS, LDB, LDBS, LDC, LDCS, M, MS, N, NA,
      $                   NARGS, NC, NS
@@ -747,6 +761,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IM = 1, NIDIM
          M = IDIM( IM )
@@ -863,6 +879,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9994 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -897,6 +915,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -916,6 +936,9 @@
      $                                    FATAL, NOUT, .TRUE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and
 *                          return.
                            IF( FATAL )
@@ -949,6 +972,7 @@
      $   LDB, BETA, LDC
 *
   120 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -964,6 +988,8 @@
      $      ', C,', I3, ')    .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK2
 *
@@ -999,6 +1025,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, ICD, ICS, ICT, ICU, IM, IN, J, LAA, LBB,
      $                   LDA, LDAS, LDB, LDBS, M, MS, N, NA, NARGS, NC,
      $                   NS
@@ -1029,6 +1056,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero matrix for SMMCH.
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
@@ -1138,6 +1167,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1171,6 +1202,8 @@
    50                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1221,6 +1254,9 @@
                                  END IF
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1256,6 +1292,7 @@
      $   N, ALPHA, LDA, LDB
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1270,6 +1307,8 @@
      $      2( I3, ',' ), F4.1, ', A,', I3, ', B,', I3, ')        .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK3
 *
@@ -1306,6 +1345,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, BETA, BETS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, K, KS,
      $                   LAA, LCC, LDA, LDAS, LDC, LDCS, LJ, MA, N, NA,
      $                   NARGS, NC, NS
@@ -1335,6 +1375,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1424,6 +1466,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9993 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1456,6 +1500,8 @@
    30                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1493,6 +1539,9 @@
                                  JC = JC + LDC + 1
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1531,6 +1580,7 @@
      $   LDA, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1547,6 +1597,8 @@
      $      ')           .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK4
 *
@@ -1583,6 +1635,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, BETA, BETS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, JJAB,
      $                   K, KS, LAA, LBB, LCC, LDA, LDAS, LDB, LDBS,
      $                   LDC, LDCS, LJ, MA, N, NA, NARGS, NC, NS
@@ -1613,6 +1666,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 130 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1734,6 +1789,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9993 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1773,6 +1830,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1847,6 +1906,9 @@
      $                              JJAB = JJAB + 2*NMAX
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1885,6 +1947,7 @@
      $   LDA, LDB, BETA, LDC
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -1901,6 +1964,8 @@
      $      ', C,', I3, ')    .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHK5
 *
@@ -3206,6 +3271,7 @@
       INTEGER            IDIM( NIDIM )
 *     .. Local Scalars ..
       REAL               ALPHA, ALS, BETA, BLS, ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS,
      $                   MA, MB, N, NA, NARGS, NB, NC, NS, IS
@@ -3236,6 +3302,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = ZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -3359,6 +3427,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3394,6 +3464,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3407,6 +3479,9 @@
      $                                 C, NMAX, CT, G, CC, LDC, EPS,
      $                                 ERR, FATAL, NOUT, .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -3443,6 +3518,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CAL',
@@ -3458,6 +3534,8 @@
      $       F4.1, ', ', 'C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A11, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of DCHK6
 *

--- a/BLAS/TESTING/sblat3.f
+++ b/BLAS/TESTING/sblat3.f
@@ -1992,6 +1992,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*11       SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Parameters ..
@@ -2006,6 +2007,7 @@
      $                   STRSM, SGEMMTR
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2013,6 +2015,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
 *
 *     Initialize ALPHA and BETA.
 *
@@ -2730,11 +2737,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A11, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A11, ' FAILED THE TESTS OF ERROR-EXITS ****',
      $      '***' )
+ 9979 FORMAT( ' ', A11, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of SCHKE
 *
@@ -3167,11 +3177,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*11       SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3205,11 +3224,13 @@
       INTEGER            INFO
       CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*11       SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Locals ..
       INTEGER            SRLEN
@@ -3222,11 +3243,13 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
       IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/zblat1.f
+++ b/BLAS/TESTING/zblat1.f
@@ -47,7 +47,7 @@
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
       INTEGER          NTESTS, NFAILS
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -102,7 +102,7 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
-      CHARACTER*6     SUBNAM
+      CHARACTER*6      SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Arrays ..

--- a/BLAS/TESTING/zblat1.f
+++ b/BLAS/TESTING/zblat1.f
@@ -46,6 +46,8 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -55,6 +57,8 @@
       EXTERNAL         CHECK1, CHECK2, HEADER
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             SFAC/9.765625D-4/
 *     .. Executable Statements ..
@@ -69,6 +73,8 @@
 *        these parameters.
 *
          PASS = .TRUE.
+         NTESTS = 0
+         NFAILS = 0
          INCX = 9999
          INCY = 9999
          MODE = 9999
@@ -79,11 +85,14 @@
          END IF
 *        -- Print
          IF (PASS) WRITE (NOUT,99998)
+         WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
       STOP
 *
 99999 FORMAT (' Complex BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
+99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
+     +        ' FAILED')
 *
 *     End of ZBLAT1
 *
@@ -93,12 +102,14 @@
       INTEGER          NOUT
       PARAMETER        (NOUT=6)
 *     .. Scalars in Common ..
+      CHARACTER*6     SUBNAM
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Arrays ..
       CHARACTER*6      L(11)
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /NAMBLA/SUBNAM
 *     .. Data statements ..
       DATA             L(1)/'ZDOTC '/
       DATA             L(2)/'ZDOTU '/
@@ -113,6 +124,7 @@
       DATA             L(11)/'ZAXPBY'/
 
 *     .. Executable Statements ..
+      SUBNAM = L(ICASE)
       WRITE (NOUT,99999) ICASE, L(ICASE)
       RETURN
 *
@@ -688,6 +700,7 @@
 *     .. Array Arguments ..
       DOUBLE PRECISION SCOMP(LEN), SSIZE(LEN), STRUE(LEN)
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
@@ -700,12 +713,15 @@
       INTRINSIC        ABS
 *     .. Common blocks ..
       COMMON           /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
 *
       DO 40 I = 1, LEN
+         NTESTS = NTESTS + 1
          SD = SCOMP(I) - STRUE(I)
          IF (ABS(SFAC*SD) .LE. ABS(SSIZE(I))*EPSILON(ZERO))
      +       GO TO 40
+         NFAILS = NFAILS + 1
 *
 *                             HERE    SCOMP(I) IS NOT CLOSE TO STRUE(I).
 *
@@ -820,14 +836,18 @@
 *     .. Scalar Arguments ..
       INTEGER           ICOMP, ITRUE
 *     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
       INTEGER           ICASE, INCX, INCY, MODE, N
       LOGICAL           PASS
 *     .. Local Scalars ..
       INTEGER           ID
 *     .. Common blocks ..
       COMMON            /COMBLA/ICASE, N, INCX, INCY, MODE, PASS
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
+      NTESTS = NTESTS + 1
       IF (ICOMP.EQ.ITRUE) GO TO 40
+      NFAILS = NFAILS + 1
 *
 *                            HERE ICOMP IS NOT EQUAL TO ITRUE.
 *
@@ -899,6 +919,10 @@
 *     .. Local Arrays ..
       COMPLEX*16        X(NMAX), Z(NMAX)
       DOUBLE PRECISION  VALUES(NV), WORK(NMAX)
+*     .. Scalars in Common ..
+      INTEGER          NTESTS, NFAILS
+*     .. Common blocks ..
+      COMMON           /CNTBLA/NTESTS, NFAILS
 *     .. Executable Statements ..
       VALUES(1) = ZERO
       VALUES(2) = TWO*SAFMIN
@@ -1040,7 +1064,9 @@
             ELSE
                TRAT = (ABS(SNRM-ZNRM) / ZNRM) / (TWO*DBLE(N)*ULP)
             END IF
+            NTESTS = NTESTS + 1
             IF ((TRAT.NE.TRAT).OR.(TRAT.GE.THRESH)) THEN
+               NFAILS = NFAILS + 1
                IF (FIRST) THEN
                   FIRST = .FALSE.
                   WRITE(NOUT,99999)

--- a/BLAS/TESTING/zblat2.f
+++ b/BLAS/TESTING/zblat2.f
@@ -470,6 +470,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, BETA, BLS, TRANSL
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IKU, IM, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, KL, KLS, KU, KUS, LAA, LDA,
      $                   LDAS, LX, LY, M, ML, MS, N, NARGS, NC, ND, NK,
@@ -506,6 +507,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -647,6 +650,8 @@
                               IF( .NOT.OK )THEN
                                  WRITE( NOUT, FMT = 9993 )
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -700,6 +705,8 @@
    40                         CONTINUE
                               IF( .NOT.SAME )THEN
                                  FATAL = .TRUE.
+                                 NTESTS = NTESTS + 1
+                                 NFAILS = NFAILS + 1
                                  GO TO 130
                               END IF
 *
@@ -712,6 +719,9 @@
      $                                       INCY, YT, G, YY, EPS, ERR,
      $                                       FATAL, NOUT, .TRUE. )
                                  ERRMAX = MAX( ERRMAX, ERR )
+                                 NTESTS = NTESTS + 1
+                                 IF( ERR.GE.THRESH )
+     $                              NFAILS = NFAILS + 1
 *                                If got really bad answer, report and
 *                                return.
                                  IF( FATAL )
@@ -763,6 +773,8 @@
       IF( .NOT.LZE( YS, YY, LY ) )THEN
          WRITE( NOUT, FMT = 9998 )NARGS - 1
          FATAL = .TRUE.
+         NTESTS = NTESTS + 1
+         NFAILS = NFAILS + 1
          GO TO 130
       END IF
 *
@@ -786,6 +798,7 @@
       END IF
 *
   140 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -804,6 +817,8 @@
      $      F4.1, '), Y,', I2, ')         .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK1
 *
@@ -845,6 +860,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, BETA, BLS, TRANSL
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, IC, IK, IN, INCX, INCXS, INCY,
      $                   INCYS, IX, IY, K, KS, LAA, LDA, LDAS, LX, LY,
      $                   N, NARGS, NC, NK, NS
@@ -883,6 +899,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1013,6 +1031,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9992 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1075,6 +1095,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -1087,6 +1109,9 @@
      $                                    YY, EPS, ERR, FATAL, NOUT,
      $                                    .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1133,6 +1158,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1154,6 +1180,8 @@
      $      'Y,', I2, ')             .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK2
 *
@@ -1192,6 +1220,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         TRANSL
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, ICD, ICT, ICU, IK, IN, INCX, INCXS, IX, K,
      $                   KS, LAA, LDA, LDAS, LX, N, NARGS, NC, NK, NS
       LOGICAL            BANDED, FULL, NULL, PACKED, RESET, SAME
@@ -1231,6 +1260,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero vector for ZMVCH.
       DO 10 I = 1, NMAX
          Z( I ) = ZERO
@@ -1377,6 +1408,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1429,6 +1462,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1457,6 +1492,9 @@
      $                                    .FALSE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 120
@@ -1499,6 +1537,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1517,6 +1556,8 @@
      $      I3, ', X,', I2, ')                                   .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK3
 *
@@ -1558,6 +1599,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, TRANSL
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IM, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, LAA, LDA, LDAS, LX, LY, M, MS, N, NARGS,
      $                   NC, ND, NS
@@ -1585,6 +1627,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 120 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1685,6 +1729,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9993 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1715,6 +1761,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 140
                      END IF
 *
@@ -1744,6 +1792,9 @@
      $                                 AA( 1 + ( J - 1 )*LDA ), EPS,
      $                                 ERR, FATAL, NOUT, .TRUE. )
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 130
@@ -1780,6 +1831,7 @@
       WRITE( NOUT, FMT = 9994 )NC, SNAME, M, N, ALPHA, INCX, INCY, LDA
 *
   150 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1796,6 +1848,8 @@
      $      '      .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK4
 *
@@ -1837,6 +1891,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, TRANSL
       DOUBLE PRECISION   ERR, ERRMAX, RALPHA, RALS
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, IX, J, JA, JJ, LAA,
      $                   LDA, LDAS, LJ, LX, N, NARGS, NC, NS
       LOGICAL            FULL, NULL, PACKED, RESET, SAME, UPPER
@@ -1872,6 +1927,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1956,6 +2013,8 @@
                   IF( .NOT.OK )THEN
                      WRITE( NOUT, FMT = 9992 )
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -1986,6 +2045,8 @@
    30             CONTINUE
                   IF( .NOT.SAME )THEN
                      FATAL = .TRUE.
+                     NTESTS = NTESTS + 1
+                     NFAILS = NFAILS + 1
                      GO TO 120
                   END IF
 *
@@ -2026,6 +2087,9 @@
                            JA = JA + LJ
                         END IF
                         ERRMAX = MAX( ERRMAX, ERR )
+                        NTESTS = NTESTS + 1
+                        IF( ERR.GE.THRESH )
+     $                     NFAILS = NFAILS + 1
 *                       If got really bad answer, report and return.
                         IF( FATAL )
      $                     GO TO 110
@@ -2065,6 +2129,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -2082,6 +2147,8 @@
      $      I2, ', A,', I3, ')                                      .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK5
 *
@@ -2123,6 +2190,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, TRANSL
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IC, IN, INCX, INCXS, INCY, INCYS, IX,
      $                   IY, J, JA, JJ, LAA, LDA, LDAS, LJ, LX, LY, N,
      $                   NARGS, NC, NS
@@ -2159,6 +2227,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 140 IN = 1, NIDIM
          N = IDIM( IN )
@@ -2263,6 +2333,8 @@
                      IF( .NOT.OK )THEN
                         WRITE( NOUT, FMT = 9992 )
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2295,6 +2367,8 @@
    40                CONTINUE
                      IF( .NOT.SAME )THEN
                         FATAL = .TRUE.
+                        NTESTS = NTESTS + 1
+                        NFAILS = NFAILS + 1
                         GO TO 160
                      END IF
 *
@@ -2345,6 +2419,9 @@
                               JA = JA + LJ
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and return.
                            IF( FATAL )
      $                        GO TO 150
@@ -2387,6 +2464,7 @@
       END IF
 *
   170 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -2406,6 +2484,8 @@
      $      '            .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A6, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK6
 *

--- a/BLAS/TESTING/zblat2.f
+++ b/BLAS/TESTING/zblat2.f
@@ -2507,6 +2507,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*6        SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Local Scalars ..
@@ -2520,6 +2521,7 @@
      $                   ZTBSV, ZTPMV, ZTPSV, ZTRMV, ZTRSV
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2527,6 +2529,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
       GO TO ( 10, 20, 30, 40, 50, 60, 70, 80,
      $        90, 100, 110, 120, 130, 140, 150, 160,
      $        170 )ISNUM
@@ -2825,11 +2832,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A6, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A6, ' FAILED THE TESTS OF ERROR-EXITS *****',
      $      '**' )
+ 9979 FORMAT( ' ', A6, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHKE
 *
@@ -3338,11 +3348,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*6        SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3408,11 +3427,13 @@
       INTEGER            INFO
       CHARACTER*6        SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*6        SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Executable Statements ..
       LERR = .TRUE.
@@ -3423,10 +3444,12 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       IF( SRNAME.NE.SRNAMT )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/zblat3.f
+++ b/BLAS/TESTING/zblat3.f
@@ -2080,6 +2080,7 @@
       INTEGER            ISNUM, NOUT
       CHARACTER*7        SRNAMT
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUTC
       LOGICAL            LERR, OK
 *     .. Parameters ..
@@ -2097,6 +2098,7 @@
       INTRINSIC          DCMPLX
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
@@ -2104,6 +2106,11 @@
 *     LERR is set to .TRUE. by the special version of XERBLA each time
 *     it is called, and is then tested and re-set by CHKXER.
       LERR = .FALSE.
+*     NXRUN and NXFAIL count the error-exit tests of this routine;
+*     NXBAD is set by XERBLA when it is called wrongly.
+      NXRUN = 0
+      NXFAIL = 0
+      NXBAD = 0
 *
 *     Initialize ALPHA, BETA, RALPHA, and RBETA.
 *
@@ -3188,11 +3195,14 @@
       ELSE
          WRITE( NOUT, FMT = 9998 )SRNAMT
       END IF
+      WRITE( NOUT, FMT = 9979 )SRNAMT, NXRUN, NXFAIL
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE TESTS OF ERROR-EXITS' )
  9998 FORMAT( ' ******* ', A7, ' FAILED THE TESTS OF ERROR-EXITS *****',
      $      '**' )
+ 9979 FORMAT( ' ', A7, ' ERROR-EXIT TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHKE
 *
@@ -3699,11 +3709,20 @@
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*7        SRNAMT
+*     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
+*     .. Common blocks ..
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
 *     .. Executable Statements ..
+      NXRUN = NXRUN + 1
       IF( .NOT.LERR )THEN
          WRITE( NOUT, FMT = 9999 )INFOT, SRNAMT
          OK = .FALSE.
+         NXFAIL = NXFAIL + 1
+      ELSE IF( NXBAD.NE.0 )THEN
+         NXFAIL = NXFAIL + 1
       END IF
+      NXBAD = 0
       LERR = .FALSE.
       RETURN
 *
@@ -3736,11 +3755,13 @@
       INTEGER            INFO
       CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
+      INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
       LOGICAL            LERR, OK
       CHARACTER*7        SRNAMT
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
+      COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
 *     .. Locals ..
       INTEGER            SRLEN
@@ -3753,11 +3774,13 @@
             WRITE( NOUT, FMT = 9997 )INFO
          END IF
          OK = .FALSE.
+         NXBAD = 1
       END IF
       SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
       IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
+         NXBAD = 1
       END IF
       RETURN
 *

--- a/BLAS/TESTING/zblat3.f
+++ b/BLAS/TESTING/zblat3.f
@@ -446,6 +446,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, BETA, BLS
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IM, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS, M,
      $                   MA, MB, MS, N, NA, NARGS, NB, NC, NS
@@ -474,6 +475,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 110 IM = 1, NIDIM
          M = IDIM( IM )
@@ -595,6 +598,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -630,6 +635,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -642,6 +649,9 @@
      $                                    C, NMAX, CT, G, CC, LDC, EPS,
      $                                    ERR, FATAL, NOUT, .TRUE. )
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -677,6 +687,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -692,6 +703,8 @@
      $      ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK1
 *
@@ -731,6 +744,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, BETA, BLS
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICS, ICU, IM, IN, LAA, LBB, LCC,
      $                   LDA, LDAS, LDB, LDBS, LDC, LDCS, M, MS, N, NA,
      $                   NARGS, NC, NS
@@ -760,6 +774,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IM = 1, NIDIM
          M = IDIM( IM )
@@ -870,6 +886,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9994 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -904,6 +922,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 110
                         END IF
 *
@@ -923,6 +943,9 @@
      $                                    FATAL, NOUT, .TRUE. )
                            END IF
                            ERRMAX = MAX( ERRMAX, ERR )
+                           NTESTS = NTESTS + 1
+                           IF( ERR.GE.THRESH )
+     $                        NFAILS = NFAILS + 1
 *                          If got really bad answer, report and
 *                          return.
                            IF( FATAL )
@@ -956,6 +979,7 @@
      $   LDB, BETA, LDC
 *
   120 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -971,6 +995,8 @@
      $      ',', F4.1, '), C,', I3, ')    .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK2
 *
@@ -1010,6 +1036,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, ICD, ICS, ICT, ICU, IM, IN, J, LAA, LBB,
      $                   LDA, LDAS, LDB, LDBS, M, MS, N, NA, NARGS, NC,
      $                   NS
@@ -1040,6 +1067,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *     Set up zero matrix for ZMMCH.
       DO 20 J = 1, NMAX
          DO 10 I = 1, NMAX
@@ -1149,6 +1178,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1182,6 +1213,8 @@
    50                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 150
                            END IF
 *
@@ -1232,6 +1265,9 @@
                                  END IF
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1267,6 +1303,7 @@
      $   N, ALPHA, LDA, LDB
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1282,6 +1319,8 @@
      $      '      .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK3
 *
@@ -1321,6 +1360,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, BETA, BETS
       DOUBLE PRECISION   ERR, ERRMAX, RALPHA, RALS, RBETA, RBETS
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, K, KS,
      $                   LAA, LCC, LDA, LDAS, LDC, LDCS, LJ, MA, N, NA,
      $                   NARGS, NC, NS
@@ -1350,6 +1390,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1470,6 +1512,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1510,6 +1554,8 @@
    30                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 120
                         END IF
 *
@@ -1552,6 +1598,9 @@
                                  JC = JC + LDC + 1
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1595,6 +1644,7 @@
       END IF
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1614,6 +1664,8 @@
      $      '), C,', I3, ')          .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK4
 *
@@ -1654,6 +1706,7 @@
 *     .. Local Scalars ..
       COMPLEX*16         ALPHA, ALS, BETA, BETS
       DOUBLE PRECISION   ERR, ERRMAX, RBETA, RBETS
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICT, ICU, IK, IN, J, JC, JJ, JJAB,
      $                   K, KS, LAA, LBB, LCC, LDA, LDAS, LDB, LDBS,
      $                   LDC, LDCS, LJ, MA, N, NA, NARGS, NC, NS
@@ -1683,6 +1736,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 130 IN = 1, NIDIM
          N = IDIM( IN )
@@ -1816,6 +1871,8 @@
                         IF( .NOT.OK )THEN
                            WRITE( NOUT, FMT = 9992 )
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1854,6 +1911,8 @@
    40                   CONTINUE
                         IF( .NOT.SAME )THEN
                            FATAL = .TRUE.
+                           NTESTS = NTESTS + 1
+                           NFAILS = NFAILS + 1
                            GO TO 150
                         END IF
 *
@@ -1926,6 +1985,9 @@
      $                              JJAB = JJAB + 2*NMAX
                               END IF
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -1969,6 +2031,7 @@
       END IF
 *
   160 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -1988,6 +2051,8 @@
      $      ',', F4.1, '), C,', I3, ')    .' )
  9992 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK5
 *
@@ -3744,6 +3809,7 @@
 *     .. Local Scalars ..
       COMPLEX*16            ALPHA, ALS, BETA, BLS
       DOUBLE PRECISION   ERR, ERRMAX
+      INTEGER            NTESTS, NFAILS
       INTEGER            I, IA, IB, ICA, ICB, IK, IN, K, KS, LAA,
      $                   LBB, LCC, LDA, LDAS, LDB, LDBS, LDC, LDCS,
      $                   MA, MB,  N, NA, NARGS, NB, NC, NS, IS
@@ -3775,6 +3841,8 @@
       NC = 0
       RESET = .TRUE.
       ERRMAX = RZERO
+      NTESTS = 0
+      NFAILS = 0
 *
       DO 100 IN = 1, NIDIM
          N = IDIM( IN )
@@ -3897,6 +3965,8 @@
                            IF( .NOT.OK )THEN
                               WRITE( NOUT, FMT = 9994 )
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3932,6 +4002,8 @@
    40                      CONTINUE
                            IF( .NOT.SAME )THEN
                               FATAL = .TRUE.
+                              NTESTS = NTESTS + 1
+                              NFAILS = NFAILS + 1
                               GO TO 120
                            END IF
 *
@@ -3944,6 +4016,9 @@
      $                                    BETA, C, NMAX, CT, G, CC, LDC,
      $                                    EPS, ERR, FATAL, NOUT, .TRUE.)
                               ERRMAX = MAX( ERRMAX, ERR )
+                              NTESTS = NTESTS + 1
+                              IF( ERR.GE.THRESH )
+     $                           NFAILS = NFAILS + 1
 *                             If got really bad answer, report and
 *                             return.
                               IF( FATAL )
@@ -3979,6 +4054,7 @@
      $   ALPHA, LDA, LDB, BETA, LDC
 *
   130 CONTINUE
+      WRITE( NOUT, FMT = 9979 )SNAME, NTESTS, NFAILS
       RETURN
 *
  9999 FORMAT( ' ', A7, ' PASSED THE COMPUTATIONAL TESTS (', I6, ' CALL',
@@ -3994,6 +4070,8 @@
      $      ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
+ 9979 FORMAT( ' ', A7, ' COMPUTATIONAL TESTS:', I9, ' RUN,', I9,
+     $      ' FAILED' )
 *
 *     End of ZCHK6
 *

--- a/lapack_testing.py
+++ b/lapack_testing.py
@@ -7,6 +7,9 @@ summary table of the number of tests run and the number of failures per
 precision (s/d/c/z).  With ``--run`` it executes the testing drivers
 first and then analyzes their output.
 
+Results are reported per library, each in its own summary section, so
+that more than one test suite can be summarized side by side.
+
 When index-64 extended API outputs (``*_64.out``, produced by CMake
 builds with ``BUILD_INDEX64_EXT_API=ON``) are present, they are analyzed
 as well and reported in a separate "extended API" section so that the
@@ -92,8 +95,21 @@ LIN_SETS: "Tuple[Tuple[str, str, str, str], ...]" = (
     ("rfp", "test_rfp", "xlintstrf", "RFP linear equation routines"),
 )
 
+# Libraries, in reporting order.  Each has its own testing directory and
+# its own section in the summary table.
+LIBRARY_LAPACK = "LAPACK"
+LIBRARIES: "Tuple[str, ...]" = (LIBRARY_LAPACK,)
+
+# LAPACK test families, in reporting order per precision.
+LAPACK_FAMILIES: "Tuple[str, ...]" = ("eig",) + tuple(s[0] for s in LIN_SETS) + ("dmd",)
+
 # All test families, in reporting order per precision.
-ALL_FAMILIES: "Tuple[str, ...]" = ("eig",) + tuple(s[0] for s in LIN_SETS) + ("dmd",)
+ALL_FAMILIES: "Tuple[str, ...]" = LAPACK_FAMILIES
+
+# Which library each family belongs to.
+FAMILY_LIBRARY: "Dict[str, str]" = {
+    family: LIBRARY_LAPACK for family in LAPACK_FAMILIES
+}
 
 # API suffixes that may exist: default API and index-64 extended API.
 KNOWN_SUFFIXES: "Tuple[str, ...]" = ("", "_64")
@@ -180,7 +196,7 @@ class FileReport:
 
 @dataclass(frozen=True)
 class TestCase:
-    """One LAPACK test driver invocation and its expected output file."""
+    """One test driver invocation and its expected output file."""
 
     precision: str
     family: str
@@ -189,6 +205,7 @@ class TestCase:
     output_name: str
     executable: str
     parser: str
+    library: str = LIBRARY_LAPACK
 
     def suffixed_output(self, suffix: str) -> str:
         """Return the output file name for an API suffix.
@@ -410,8 +427,8 @@ def parse_lines(parser: str, lines: "Sequence[str]") -> FileReport:
     """Parse test output lines with the parser kind of a test case.
 
     Args:
-        parser: One of ``PARSER_STANDARD``, ``PARSER_BALANCE`` and
-            ``PARSER_DMD``.
+        parser: One of ``PARSER_STANDARD``, ``PARSER_BALANCE``,
+            and ``PARSER_DMD``.
         lines: The lines of the output file.
 
     Returns:
@@ -424,37 +441,49 @@ def parse_lines(parser: str, lines: "Sequence[str]") -> FileReport:
     return parse_standard(lines)
 
 
-def find_unrecognized_outputs(test_dir: Path) -> "List[str]":
-    """Find ``.out`` files in the test directory this script cannot analyze.
+def find_unrecognized_outputs(directories: "Dict[str, Path]") -> "List[str]":
+    """Find ``.out`` files in the test directories this script cannot analyze.
 
-    A file is unrecognized if its name matches no known test case in any
-    precision, family or API variant — typically a test that was added to
-    the harness without extending this script's test tables, or a renamed
-    output such as those of ``make variants_testing``.  The current
-    ``-p``/``-t`` selection is deliberately ignored: a deselected file is
-    not an unrecognized one.
+    A file is unrecognized if its name matches no known test case of the
+    library that owns its directory, in any precision, family or API
+    variant — typically a test that was added to the harness without
+    extending this script's test tables, or a renamed output such as
+    those of ``make variants_testing``.  The current ``-p``/``-t``
+    selection is deliberately ignored: a deselected file is not an
+    unrecognized one.
 
     Args:
-        test_dir: The directory containing the ``.out`` files.
+        directories: The existing testing directory of each library.
 
     Returns:
-        The unrecognized file names, sorted alphabetically.
+        The unrecognized file names, prefixed by their directory when
+        more than one directory was scanned, sorted alphabetically.
     """
     all_cases = build_test_cases("sdcz", ALL_FAMILIES)
-    known = {
-        case.suffixed_output(suffix) for case in all_cases for suffix in KNOWN_SUFFIXES
-    }
-    return sorted(
-        path.name for path in test_dir.glob("*.out") if path.name not in known
-    )
+    unrecognized: "List[str]" = []
+    for library, directory in directories.items():
+        known = {
+            case.suffixed_output(suffix)
+            for case in all_cases
+            if case.library == library
+            for suffix in KNOWN_SUFFIXES
+        }
+        known.add(RESULTS_FILENAME)
+        for path in directory.glob("*.out"):
+            if path.name in known:
+                continue
+            unrecognized.append(
+                path.name if len(directories) == 1 else str(directory / path.name)
+            )
+    return sorted(unrecognized)
 
 
-def discover_suffixes(test_dir: Path, cases: "Sequence[TestCase]") -> "List[str]":
-    """Detect which API variants have output files in the test directory.
+def discover_suffixes(cases: "Sequence[TestCase]", directory: Path) -> "List[str]":
+    """Detect which API variants have output files in a testing directory.
 
     Args:
-        test_dir: The directory containing the ``.out`` files.
-        cases: The selected test cases.
+        cases: The selected test cases of one library.
+        directory: That library's testing directory.
 
     Returns:
         The suffixes (out of ``""`` and ``"_64"``) for which at least one
@@ -463,7 +492,7 @@ def discover_suffixes(test_dir: Path, cases: "Sequence[TestCase]") -> "List[str]
     suffixes = [
         suffix
         for suffix in KNOWN_SUFFIXES
-        if any((test_dir / case.suffixed_output(suffix)).is_file() for case in cases)
+        if any((directory / case.suffixed_output(suffix)).is_file() for case in cases)
     ]
     return suffixes or [""]
 
@@ -618,18 +647,20 @@ def format_summary_row(label: str, counts: Counts) -> str:
     )
 
 
-def section_title(suffix: str) -> str:
-    """Return the human-readable name of an API section.
+def section_title(library: str, suffix: str) -> str:
+    """Return the human-readable name of a library/API section.
 
     Args:
+        library: The library name, e.g. ``"BLAS"``.
         suffix: The API suffix, either ``""`` or ``"_64"``.
 
     Returns:
-        The section name used in headings and messages.
+        The section name used in headings and messages, e.g.
+        ``"BLAS: Extended API (_64)"``.
     """
     if suffix:
-        return "Extended API ({})".format(suffix)
-    return "Default API"
+        return "{}: Extended API ({})".format(library, suffix)
+    return "{}: Default API".format(library)
 
 
 def section_heading(title: str) -> str:
@@ -690,8 +721,9 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
         description="Analyze the .out files produced by the LAPACK test "
         "suite and print a summary of the test results.",
         epilog="By default all precisions and all test families are "
-        "analyzed, and both the default API and extended API (_64) "
-        "outputs are summarized when present.",
+        "analyzed, each library is reported in its own section, and both "
+        "the default API and extended API (_64) outputs are summarized "
+        "when present.",
     )
     parser.add_argument(
         "-d",
@@ -746,11 +778,12 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
     parser.add_argument(
         "-t",
         "--test",
-        choices=list(ALL_FAMILIES) + ["all"],
+        choices=list(ALL_FAMILIES) + ["lapack", "all"],
         default="all",
         help="test family to analyze: lin=linear equations, "
         "eig=eigenproblems (including balancing), mixed=mixed precision, "
-        "rfp=RFP format, dmd=dynamic mode decomposition, all (default)",
+        "rfp=RFP format, dmd=dynamic mode decomposition, "
+        "lapack=all LAPACK families, all (default)",
     )
     parser.add_argument(
         "--suffix",
@@ -766,7 +799,7 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
         action="store_true",
         help="exit with a nonzero status if any test failure or error was "
         "found, a test driver could not be run, or unrecognized .out files "
-        "were present in the testing directory",
+        "were present in a testing directory",
     )
     parser.add_argument(
         "--fail-if-empty",
@@ -777,7 +810,7 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
         "--fail-on-unrecognized",
         action="store_true",
         help="exit with a nonzero status if .out files not known to this "
-        "script were present in the testing directory",
+        "script were present in a testing directory",
     )
     return parser.parse_args(argv)
 
@@ -805,6 +838,10 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
         )
         return 2
 
+    # One testing directory per library; more are added as further test
+    # suites are taught to this script.
+    directories: "Dict[str, Path]" = {LIBRARY_LAPACK: test_dir}
+
     letters = "sdcz" if args.prec == "x" else args.prec
     if args.test == "mixed":
         # The mixed-precision drivers exist only for d (ds) and z (zc);
@@ -816,7 +853,14 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
                 file=sys.stderr,
             )
         letters = "dz"
-    families = list(ALL_FAMILIES) if args.test == "all" else [args.test]
+    if args.test == "all":
+        families = list(ALL_FAMILIES)
+    elif args.test == "lapack":
+        families = list(LAPACK_FAMILIES)
+    else:
+        families = [args.test]
+    # Drop the families of libraries that were not built.
+    families = [family for family in families if FAMILY_LIBRARY[family] in directories]
     cases = build_test_cases(letters, families)
     if not cases:
         print(
@@ -827,16 +871,27 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
         )
         return 2
 
+    forced_suffixes: "Optional[List[str]]" = None
     if args.suffix is not None:
-        suffixes: "List[str]" = []
+        forced_suffixes = []
         for choice in args.suffix:
             suffix = "" if choice == "none" else "_64"
-            if suffix not in suffixes:
-                suffixes.append(suffix)
+            if suffix not in forced_suffixes:
+                forced_suffixes.append(suffix)
     elif args.run:
-        suffixes = [""]
-    else:
-        suffixes = discover_suffixes(test_dir, cases)
+        forced_suffixes = [""]
+
+    # One (library, API) pair per summary section, in reporting order.
+    sections: "List[Tuple[str, str]]" = []
+    for library in LIBRARIES:
+        library_cases = [case for case in cases if case.library == library]
+        if not library_cases:
+            continue
+        suffixes = forced_suffixes
+        if suffixes is None:
+            suffixes = discover_suffixes(library_cases, directories[library])
+        for suffix in suffixes:
+            sections.append((library, suffix))
 
     results_path = test_dir / RESULTS_FILENAME
     try:
@@ -867,18 +922,24 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
     missing_files = 0
     run_failures = 0
 
-    for suffix in suffixes:
-        if len(suffixes) > 1 or suffix:
-            summary += "\n" + section_heading(section_title(suffix)) + "\n"
+    for library, suffix in sections:
+        directory = directories[library]
+        title = section_title(library, suffix)
+        if len(sections) > 1 or suffix:
+            summary += "\n" + section_heading(title) + "\n"
             if not short_summary:
                 print(" ")
-                print(section_heading(section_title(suffix)))
+                print(section_heading(title))
         summary += SUMMARY_HEADER + "\n"
         summary += SUMMARY_RULE + "\n"
         section_total = Counts()
 
         for letter, precision_name in PRECISIONS:
-            precision_cases = [case for case in cases if case.precision == letter]
+            precision_cases = [
+                case
+                for case in cases
+                if case.precision == letter and case.library == library
+            ]
             if not precision_cases:
                 continue
             precision_total = Counts()
@@ -893,7 +954,7 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
                         end=" ",
                     )
                 if args.run:
-                    error_message = run_test_case(case, suffix, test_dir, args.bin)
+                    error_message = run_test_case(case, suffix, directory, args.bin)
                     if error_message is not None:
                         run_failures += 1
                         print(
@@ -901,20 +962,27 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
                                 case.suffixed_executable(suffix), error_message
                             )
                         )
-                lines = read_output_file(test_dir / output_name)
+                lines = read_output_file(directory / output_name)
                 if lines is None:
                     missing_files += 1
                     if not short_summary:
                         print(
-                            "---- WARNING: please check that you have the LAPACK "
-                            "output {}!".format(output_name)
+                            "---- WARNING: please check that you have the {} "
+                            "output {}!".format(library, output_name)
                         )
                         print(
                             "---- WARNING: with the option -r, we can run the "
-                            "LAPACK testing for you"
+                            "testing for you"
                         )
                     continue
-                log.record(output_name, lines)
+                log.record(
+                    (
+                        output_name
+                        if library == LIBRARY_LAPACK
+                        else str(directory / output_name)
+                    ),
+                    lines,
+                )
                 report = parse_lines(case.parser, lines)
                 precision_total.add(report.counts)
 
@@ -975,12 +1043,15 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
             file=sys.stderr,
         )
 
-    unrecognized = find_unrecognized_outputs(test_dir)
+    unrecognized = find_unrecognized_outputs(directories)
     if unrecognized:
         print(
             "lapack_testing.py: {} .out file(s) in {} are not known to this "
             "script and were NOT analyzed (new tests must be added to the "
-            "test tables in this script):".format(len(unrecognized), test_dir),
+            "test tables in this script):".format(
+                len(unrecognized),
+                ", ".join(str(directory) for directory in directories.values()),
+            ),
             file=sys.stderr,
         )
         for name in unrecognized:

--- a/lapack_testing.py
+++ b/lapack_testing.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Summarize (and optionally run) the LAPACK Fortran test suite.
+"""Summarize (and optionally run) the LAPACK and BLAS test suites.
 
 This script analyzes the ``.out`` files written by the LAPACK testing
 drivers (``xlintst*``, ``xeigtst*`` and ``xdmdeigtst*``) and prints a
@@ -7,8 +7,16 @@ summary table of the number of tests run and the number of failures per
 precision (s/d/c/z).  With ``--run`` it executes the testing drivers
 first and then analyzes their output.
 
-Results are reported per library, each in its own summary section, so
-that more than one test suite can be summarized side by side.
+The BLAS (``xblat[123]?``) test drivers are analyzed too, from their own
+testing directory, and are reported in their own summary section.  Those
+drivers report their test counts in lines of the form::
+
+     SGEMV      COMPUTATIONAL TESTS:     3456 RUN,        0 FAILED
+     SGEMV      ERROR-EXIT TESTS:           6 RUN,        0 FAILED
+
+Computational failures are counted as numerical errors and error-exit
+failures as other errors.  Output produced by a build whose drivers do
+not report counts is still summarized, by counting one test per verdict.
 
 When index-64 extended API outputs (``*_64.out``, produced by CMake
 builds with ``BUILD_INDEX64_EXT_API=ON``) are present, they are analyzed
@@ -25,6 +33,9 @@ Examples:
     ./lapack_testing.py -n -p s -t eig
         Print the numbers of failures in REAL precision by analyzing only
         the eigenproblem test output.
+
+    ./lapack_testing.py -t blas
+        Summarize only the BLAS test output.
 """
 
 from __future__ import annotations
@@ -32,6 +43,7 @@ from __future__ import annotations
 import argparse
 import io
 import math
+import os
 import re
 import subprocess
 import sys
@@ -95,21 +107,30 @@ LIN_SETS: "Tuple[Tuple[str, str, str, str], ...]" = (
     ("rfp", "test_rfp", "xlintstrf", "RFP linear equation routines"),
 )
 
+# BLAS test sets, one per BLAS level: (level, description).  The Level 1
+# drivers read no input file and write to standard output.
+BLAS_LEVELS: "Tuple[Tuple[int, str], ...]" = (
+    (1, "Level 1 BLAS routines"),
+    (2, "Level 2 BLAS routines"),
+    (3, "Level 3 BLAS routines"),
+)
+
 # Libraries, in reporting order.  Each has its own testing directory and
 # its own section in the summary table.
 LIBRARY_LAPACK = "LAPACK"
-LIBRARIES: "Tuple[str, ...]" = (LIBRARY_LAPACK,)
+LIBRARY_BLAS = "BLAS"
+LIBRARIES: "Tuple[str, ...]" = (LIBRARY_LAPACK, LIBRARY_BLAS)
 
 # LAPACK test families, in reporting order per precision.
 LAPACK_FAMILIES: "Tuple[str, ...]" = ("eig",) + tuple(s[0] for s in LIN_SETS) + ("dmd",)
 
 # All test families, in reporting order per precision.
-ALL_FAMILIES: "Tuple[str, ...]" = LAPACK_FAMILIES
+ALL_FAMILIES: "Tuple[str, ...]" = LAPACK_FAMILIES + ("blas",)
 
 # Which library each family belongs to.
-FAMILY_LIBRARY: "Dict[str, str]" = {
-    family: LIBRARY_LAPACK for family in LAPACK_FAMILIES
-}
+FAMILY_LIBRARY: "Dict[str, str]" = dict(
+    [(family, LIBRARY_LAPACK) for family in LAPACK_FAMILIES] + [("blas", LIBRARY_BLAS)]
+)
 
 # API suffixes that may exist: default API and index-64 extended API.
 KNOWN_SUFFIXES: "Tuple[str, ...]" = ("", "_64")
@@ -141,10 +162,66 @@ RE_LARGEST_ERROR = re.compile(r"(?:value|ratio) of largest test error\s*=\s*(\S+
 # aggregate lines such as "SGEDMD :: ALL TESTS PASSED." from matching.
 RE_DMD_VERDICT = re.compile(r"\btest\s+(PASSED|FAILED)\b", re.IGNORECASE)
 
+# Test counts reported by the BLAS drivers, e.g.
+#   " SGEMV      COMPUTATIONAL TESTS:     3456 RUN,        0 FAILED"
+# The routine name field width differs per driver, so never match on
+# column positions.
+RE_BLAS_COUNTS = re.compile(
+    r"^\s*\S+\s+(COMPUTATIONAL|ERROR-EXIT) TESTS:" r"\s*(\d+) RUN,\s*(\d+) FAILED\s*$"
+)
+
+# Per-routine verdicts.  These are only counted when the driver did not
+# report counts (output from a build without the counting instrumentation).
+RE_BLAS_PASSED = re.compile(
+    r"^\s*\S+\s+PASSED THE (?:COMPUTATIONAL TESTS|TESTS OF ERROR-EXITS)\b"
+)
+RE_BLAS_SUSPECT = re.compile(r"\bCOMPLETED THE COMPUTATIONAL TESTS\b")
+RE_BLAS_FAILED_COMPUTATIONAL = re.compile(r"\bFAILED ON CALL NUMBER:")
+RE_BLAS_FAILED_ERROR_EXIT = re.compile(r"\bFAILED THE TESTS OF ERROR-EXITS\b")
+
+# Driver-level breakage that the per-routine counts cannot express: the
+# run was abandoned, misconfigured, or never reached its footer.
+RE_BLAS_ABANDONED = re.compile(r"\*{5,7} (?:FATAL ERROR - )?TESTS ABANDONED \*{5,7}")
+RE_BLAS_NOT_RECOGNIZED = re.compile(r"^\s*SUBPROGRAM NAME .* NOT RECOGNIZED")
+RE_BLAS_DOT_PRODUCTS = re.compile(r"^\s*ERROR IN [SDCZ]M[VM]T?CH\b")
+RE_BLAS_INTERNAL = re.compile(r"Shouldn't be here in CHECK")
+RE_BLAS_INPUT_ERROR = re.compile(
+    r"^\s*(?:NUMBER OF VALUES OF |VALUE OF [NK] IS LESS THAN"
+    r"|ABSOLUTE VALUE OF INCX OR INCY )"
+)
+
+# Detail lines that sit behind a verdict which is already counted.  They
+# are worth showing but must not be counted: the ``cblat2_64.out`` fixture
+# has 91 of them behind just 17 failing routines.
+RE_BLAS_DETAIL = re.compile(
+    r"XERBLA WAS CALLED WITH"
+    r"|ILLEGAL VALUE OF PARAMETER NUMBER"
+    r"|FATAL ERROR - COMPUTED RESULT IS LESS THAN HALF ACCURATE"
+    r"|FATAL ERROR - PARAMETER NUMBER"
+    r"|FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL"
+    r"|BUT WITH MAXIMUM TEST RATIO"
+    r"|WARNING: Skipping xerbla tests"
+)
+RE_BLAS_NOT_TESTED = re.compile(r"^\s*\S+\s+WAS NOT TESTED\s*$")
+
+# Level 2/3 footer.  Note this is printed even when routines failed, so
+# it means "not truncated", not "passed"; its absence means the driver
+# died part way through.
+RE_BLAS_END_OF_TESTS = re.compile(r"^\s*END OF TESTS\s*$")
+
+# Level 1 drivers have no counts of their own in an uninstrumented build
+# and no footer at all; one "Test of subprogram number" block is one
+# subprogram, followed by either a PASS line or FAIL detail.
+RE_BLAS_L1_CASE = re.compile(r"^\s*Test of subprogram number\s*\d+")
+RE_BLAS_L1_PASS = re.compile(r"^\s*-{5} PASS -{5}\s*$")
+RE_BLAS_L1_FAIL = re.compile(r"^\s*FAIL\s*$")
+
 # Parser kinds, used by TestCase.parser.
 PARSER_STANDARD = "standard"
 PARSER_BALANCE = "balance"
 PARSER_DMD = "dmd"
+PARSER_BLAS1 = "blas1"
+PARSER_BLAS23 = "blas23"
 
 
 @dataclass
@@ -201,11 +278,19 @@ class TestCase:
     precision: str
     family: str
     description: str
-    input_name: str
+    input_name: "Optional[str]"
     output_name: str
     executable: str
     parser: str
     library: str = LIBRARY_LAPACK
+    # True when the API suffix also applies to the input file name.  The
+    # BLAS Level 2/3 inputs name the output file on their first line, so
+    # the _64 run needs the generated _64 input; every other driver takes
+    # the same input for both APIs.
+    input_suffixed: bool = False
+    # False when the driver opens its own output file, so the harness must
+    # not also redirect standard output onto it.
+    redirect_stdout: bool = True
 
     def suffixed_output(self, suffix: str) -> str:
         """Return the output file name for an API suffix.
@@ -219,6 +304,21 @@ class TestCase:
         """
         stem = self.output_name[: -len(".out")]
         return "{}{}.out".format(stem, suffix)
+
+    def suffixed_input(self, suffix: str) -> "Optional[str]":
+        """Return the input file name for an API suffix.
+
+        Args:
+            suffix: The API suffix, either ``""`` or ``"_64"``.
+
+        Returns:
+            The input file name, or None for the drivers that read no
+            input at all.
+        """
+        if self.input_name is None or not self.input_suffixed or not suffix:
+            return self.input_name
+        stem, _, extension = self.input_name.rpartition(".")
+        return "{}{}.{}".format(stem, suffix, extension)
 
     def suffixed_executable(self, suffix: str) -> str:
         """Return the test driver name for an API suffix.
@@ -305,6 +405,27 @@ def build_test_cases(letters: str, families: "Sequence[str]") -> "List[TestCase]
                     parser=PARSER_DMD,
                 )
             )
+        if "blas" in families:
+            for level, description in BLAS_LEVELS:
+                # Level 1 reads no input; Level 2/3 read e.g. sblat2.in,
+                # whose first line names the output file, so the _64 run
+                # needs the generated sblat2_64.in.
+                cases.append(
+                    TestCase(
+                        precision=letter,
+                        family="blas",
+                        description=description,
+                        input_name=(
+                            None if level == 1 else "{}blat{}.in".format(letter, level)
+                        ),
+                        output_name="{}blat{}.out".format(letter, level),
+                        executable="xblat{}{}".format(level, letter),
+                        parser=PARSER_BLAS1 if level == 1 else PARSER_BLAS23,
+                        library=LIBRARY_BLAS,
+                        input_suffixed=level != 1,
+                        redirect_stdout=level == 1,
+                    )
+                )
     return cases
 
 
@@ -423,12 +544,121 @@ def parse_dmd(lines: "Sequence[str]") -> FileReport:
     return report
 
 
+def parse_blas(lines: "Sequence[str]", level_one: bool) -> FileReport:
+    """Parse a BLAS test output file.
+
+    Test counts come from the ``... TESTS: n RUN, m FAILED`` lines the
+    drivers report per routine: computational failures are numerical
+    errors, error-exit failures are other errors.  Output from a build
+    whose drivers do not report counts is still summarized, by falling
+    back to one test per verdict.
+
+    The drivers exit with status 0 even when they abandon the run, and
+    print ``END OF TESTS`` even when routines failed, so breakage is
+    detected from the text: an abandoned or misconfigured run, and a
+    Level 2/3 file that never reached its footer, each count as one other
+    error.
+
+    Args:
+        lines: The lines of the output file.
+        level_one: True for the Level 1 drivers, which have no footer.
+
+    Returns:
+        The counts and the notable (error) lines of the file.
+    """
+    report = FileReport()
+    reported_counts = False
+    saw_footer = False
+    abandoned = False
+    # Verdict tallies, used only if the driver reported no counts.
+    verdicts = Counts()
+    cases = 0
+    case_failed = False
+
+    for line in lines:
+        match = RE_BLAS_COUNTS.match(line)
+        if match:
+            reported_counts = True
+            report.counts.runs += int(match.group(2))
+            failures = int(match.group(3))
+            if match.group(1) == "COMPUTATIONAL":
+                report.counts.numerical += failures
+            else:
+                report.counts.illegal += failures
+            continue
+
+        if RE_BLAS_END_OF_TESTS.match(line):
+            saw_footer = True
+            continue
+
+        # Driver-level breakage, which no per-routine count can express.
+        if (
+            RE_BLAS_ABANDONED.search(line)
+            or RE_BLAS_NOT_RECOGNIZED.match(line)
+            or RE_BLAS_DOT_PRODUCTS.match(line)
+            or RE_BLAS_INTERNAL.search(line)
+            or RE_BLAS_INPUT_ERROR.match(line)
+        ):
+            abandoned = True
+            report.counts.info += 1
+            report.notable_lines.append(line)
+            continue
+
+        if RE_BLAS_FAILED_ERROR_EXIT.search(line):
+            verdicts.runs += 1
+            verdicts.illegal += 1
+            report.notable_lines.append(line)
+            continue
+        if RE_BLAS_FAILED_COMPUTATIONAL.search(line):
+            verdicts.runs += 1
+            verdicts.numerical += 1
+            report.notable_lines.append(line)
+            continue
+        if RE_BLAS_SUSPECT.search(line):
+            verdicts.runs += 1
+            verdicts.numerical += 1
+            report.notable_lines.append(line)
+            continue
+        if RE_BLAS_PASSED.match(line):
+            verdicts.runs += 1
+            continue
+
+        if RE_BLAS_DETAIL.search(line) or RE_BLAS_NOT_TESTED.match(line):
+            report.notable_lines.append(line)
+            continue
+
+        if level_one:
+            if RE_BLAS_L1_CASE.match(line):
+                cases += 1
+                case_failed = False
+                continue
+            # A NRM2 stress failure prints FAIL without clearing PASS, so
+            # a case can report both; treat any FAIL as a failure.
+            if RE_BLAS_L1_FAIL.match(line) and not case_failed:
+                case_failed = True
+                verdicts.numerical += 1
+                report.notable_lines.append(line)
+
+    if not reported_counts:
+        if level_one:
+            verdicts.runs += cases
+        report.counts.add(verdicts)
+
+    # A run that reported why it stopped has already been counted.
+    if not level_one and not saw_footer and not abandoned:
+        report.counts.info += 1
+        report.notable_lines.append(
+            "output ends without 'END OF TESTS': the driver did not finish\n"
+        )
+    return report
+
+
 def parse_lines(parser: str, lines: "Sequence[str]") -> FileReport:
     """Parse test output lines with the parser kind of a test case.
 
     Args:
         parser: One of ``PARSER_STANDARD``, ``PARSER_BALANCE``,
-            and ``PARSER_DMD``.
+            ``PARSER_DMD``, ``PARSER_BLAS1`` and ``PARSER_BLAS23``.
         lines: The lines of the output file.
 
     Returns:
@@ -438,6 +668,8 @@ def parse_lines(parser: str, lines: "Sequence[str]") -> FileReport:
         return parse_balance(lines)
     if parser == PARSER_DMD:
         return parse_dmd(lines)
+    if parser in (PARSER_BLAS1, PARSER_BLAS23):
+        return parse_blas(lines, level_one=parser == PARSER_BLAS1)
     return parse_standard(lines)
 
 
@@ -519,6 +751,7 @@ def find_executable(name: str, bin_dir: "Optional[str]") -> "Optional[Path]":
             Path("bin") / "Debug",
             Path("TESTING") / "LIN",
             Path("TESTING") / "EIG",
+            Path("BLAS") / "TESTING",
         ]
     for directory in directories:
         for filename in (name, name + ".exe"):
@@ -528,10 +761,16 @@ def find_executable(name: str, bin_dir: "Optional[str]") -> "Optional[Path]":
     return None
 
 
+SOURCE_INPUT_DIRS: "Dict[str, str]" = {
+    LIBRARY_LAPACK: "TESTING",
+    LIBRARY_BLAS: "BLAS/TESTING",
+}
+
+
 def run_test_case(
     case: TestCase, suffix: str, test_dir: Path, bin_dir: "Optional[str]"
 ) -> "Optional[str]":
-    """Run one test driver, redirecting its output to the ``.out`` file.
+    """Run one test driver, capturing its output in the ``.out`` file.
 
     Args:
         case: The test case to run.
@@ -549,22 +788,46 @@ def run_test_case(
     executable = find_executable(executable_name, bin_dir)
     if executable is None:
         return "executable {} not found".format(executable_name)
-    input_path = test_dir / case.input_name
-    if not input_path.is_file():
-        # CMake build trees hold only the .out files; the .in files
-        # live next to this script in the source tree.
-        source_input = Path(__file__).resolve().parent / "TESTING" / case.input_name
-        if source_input.is_file():
-            input_path = source_input
-        else:
-            return "input file {} not found".format(input_path)
+
+    input_name = case.suffixed_input(suffix)
+    input_path: "Optional[Path]" = None
+    if input_name is not None:
+        input_path = test_dir / input_name
+        if not input_path.is_file():
+            # CMake build trees hold only the .out files; the .in files
+            # live in the source tree next to this script.  The _64 input
+            # of a BLAS Level 2/3 driver is generated into the build tree
+            # and has no source-tree counterpart.
+            source_input = (
+                Path(__file__).resolve().parent
+                / SOURCE_INPUT_DIRS[case.library]
+                / input_name
+            )
+            if source_input.is_file():
+                input_path = source_input
+            elif case.input_suffixed and suffix:
+                # Falling back to the default-API input would make the
+                # driver overwrite the default-API output file.
+                return (
+                    "input file {} not found (needed to keep the {} output "
+                    "separate)".format(input_path, suffix)
+                )
+            else:
+                return "input file {} not found".format(input_path)
+
     output_path = test_dir / case.suffixed_output(suffix)
     # Write to a temporary file first so that a driver that cannot even
-    # start does not clobber the results of an earlier run.
+    # start does not clobber the results of an earlier run.  Drivers that
+    # open their own output file (the BLAS Level 2/3 testers, which take
+    # its name from the first line of their input) write it directly.
     temporary_path = output_path.with_name(output_path.name + ".tmp")
     try:
-        with open(str(input_path), "rb") as stdin, open(
-            str(temporary_path), "wb"
+        with (
+            open(str(input_path), "rb")
+            if input_path is not None
+            else open(os.devnull, "rb")
+        ) as stdin, open(
+            str(temporary_path) if case.redirect_stdout else os.devnull, "wb"
         ) as stdout:
             process = subprocess.run(
                 [str(executable)],
@@ -574,12 +837,14 @@ def run_test_case(
                 cwd=str(test_dir),
             )
     except OSError as error:
-        try:
-            temporary_path.unlink()
-        except OSError:
-            pass
+        if case.redirect_stdout:
+            try:
+                temporary_path.unlink()
+            except OSError:
+                pass
         return "{} could not be run: {}".format(executable_name, error)
-    temporary_path.replace(output_path)
+    if case.redirect_stdout:
+        temporary_path.replace(output_path)
     if process.returncode != 0:
         return "{} exited with status {}".format(executable_name, process.returncode)
     return None
@@ -718,8 +983,8 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
         The parsed arguments.
     """
     parser = argparse.ArgumentParser(
-        description="Analyze the .out files produced by the LAPACK test "
-        "suite and print a summary of the test results.",
+        description="Analyze the .out files produced by the LAPACK and "
+        "BLAS test suites and print a summary of the test results.",
         epilog="By default all precisions and all test families are "
         "analyzed, each library is reported in its own section, and both "
         "the default API and extended API (_64) outputs are summarized "
@@ -733,12 +998,18 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
         "(default: %(default)s)",
     )
     parser.add_argument(
+        "--blas-dir",
+        default=str(Path("BLAS") / "TESTING"),
+        help="directory containing the BLAS testing output (.out) files; "
+        "skipped without warning if it does not exist (default: %(default)s)",
+    )
+    parser.add_argument(
         "-b",
         "--bin",
         default=None,
-        help="directory containing the LAPACK test drivers for --run; by "
-        "default bin, bin/Release, bin/Debug, TESTING/LIN and TESTING/EIG "
-        "are probed",
+        help="directory containing the test drivers for --run; by default "
+        "bin, bin/Release, bin/Debug, TESTING/LIN, TESTING/EIG and "
+        "BLAS/TESTING are probed",
     )
     parser.add_argument(
         "-r",
@@ -782,7 +1053,7 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
         default="all",
         help="test family to analyze: lin=linear equations, "
         "eig=eigenproblems (including balancing), mixed=mixed precision, "
-        "rfp=RFP format, dmd=dynamic mode decomposition, "
+        "rfp=RFP format, dmd=dynamic mode decomposition, blas=BLAS, "
         "lapack=all LAPACK families, all (default)",
     )
     parser.add_argument(
@@ -816,7 +1087,7 @@ def parse_args(argv: "Optional[Sequence[str]]" = None) -> argparse.Namespace:
 
 
 def main(argv: "Optional[Sequence[str]]" = None) -> int:
-    """Run the LAPACK test summary tool.
+    """Run the LAPACK and BLAS test summary tool.
 
     Args:
         argv: The command line arguments, or None to use ``sys.argv``.
@@ -838,9 +1109,23 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
         )
         return 2
 
-    # One testing directory per library; more are added as further test
-    # suites are taught to this script.
+    # The BLAS tests are absent from builds that use an optimized BLAS, so
+    # a missing directory is normal and is skipped silently.  An
+    # explicitly selected library that has no directory is a usage error,
+    # though.
     directories: "Dict[str, Path]" = {LIBRARY_LAPACK: test_dir}
+    for library, option in ((LIBRARY_BLAS, args.blas_dir),):
+        directory = Path(option)
+        if directory.is_dir():
+            directories[library] = directory
+        elif FAMILY_LIBRARY.get(args.test) == library:
+            print(
+                "lapack_testing.py: {} testing directory {} not found".format(
+                    library, directory
+                ),
+                file=sys.stderr,
+            )
+            return 2
 
     letters = "sdcz" if args.prec == "x" else args.prec
     if args.test == "mixed":


### PR DESCRIPTION
## Summary

`lapack_testing.py` summarizes only the LAPACK Fortran drivers. The BLAS tests run under both build systems — `ctest` and `make blas_testing` — but nothing reports on them, so a BLAS regression is invisible unless someone reads the `.out` files by hand.

Two things had to be fixed before the script could report anything meaningful.

**The drivers do not report test counts.** They print a per-routine verdict and a
cumulative count of BLAS calls. That call count is not a test count, and it is not
printed at all on the hard-failure path, so it shrinks exactly when something breaks.
Each `?CHKn` already computes a test ratio per accuracy check and compares the worst of
them against the threshold; it just discards the rest. The drivers now keep and report
those counts, in the same spirit as `alasum` for LAPACK:

```
 SGEMV      ERROR-EXIT TESTS:        6 RUN,        0 FAILED
 SGEMV      COMPUTATIONAL TESTS:     3456 RUN,        0 FAILED
```

**BLAS Level 1 output is discarded in CMake builds.** `xblat1s` was registered with
neither `-DINPUT` nor `-DOUTPUT`, so its stdout reached only the ctest log and no
`.out` file was produced. The Makefile path already redirected it.

### Notes on the driver changes

- **Every existing output line is unchanged.** The report lines are purely additive, so
  anything that parses the current output keeps working.
- **A hard failure can never report `0 FAILED`.** A corrupted argument or a spurious
  error exit is not a threshold failure, so the paths that set `FATAL` bump the counters
  too.
- **Error-exit tests fail in two ways**, and only one was detectable from `CHKXER`:
  either the routine never called XERBLA (`LERR`), or XERBLA was called with the wrong
  `INFO` or the wrong name, which clears `OK` without `CHKXER` noticing. The second is
  not hypothetical — it is what the `_64` drivers hit, reporting `CGEMV_` against an
  expected `CGEMV`. `NXBAD` carries it across, so the counts agree with the verdict
  instead of showing `0 FAILED` beside a `FAILED` line.
- **Only Level 1 gets `-DOUTPUT`.** The Level 2 and 3 drivers `OPEN` their own summary
  file on unit 6; redirecting stdout onto the same path would put two writers on one
  file.

### Notes on the script changes

- `--blas-dir` defaults to `BLAS/TESTING`, which is the correct relative path from a
  CMake build root *and* from the source tree, so **no existing invocation changes** —
  the CTest summary test, `CTestCustom.cmake` and `make lapack_testing` all pick the
  BLAS section up as they are.
- A missing directory is skipped silently: builds against an optimized BLAS have none.

## Result

```
 ----------------------------- BLAS: Default API ------------------------------

  SUMMARY                nb test run      numerical error          other error
  ==================   =============   ==================   ==================
  REAL                         81216           6   (0.0%)           0   (0.0%)
  DOUBLE PRECISION             81200           6   (0.0%)           0   (0.0%)
  COMPLEX                      76728           0   (0.0%)           0   (0.0%)
  COMPLEX16                    76728           0   (0.0%)           0   (0.0%)

  --> ALL PRECISIONS          315872          12   (0.0%)           0   (0.0%)
```

## Pre-existing failures this makes visible

Both predate this branch — confirmed by running the unmodified drivers — and both are
reported by drivers that still exit 0, which is the argument for having the summary.
Fixing them is separate work.

- **`SROTMG`/`DROTMG` fail 6 Level 1 comparisons each** (the 12 numerical errors above).
  The `FAIL` block was already printed; nothing ever surfaced it, and in CMake builds
  the output was discarded entirely.
- **The `_64` complex Level 2 error-exit tests fail** (182 other errors), because the
  BLAS reports `SRNAME` as `CGEMV_` while the checker expects `CGEMV`.

These will be fixed in a follow-up PR.

## Note for review

This changes the output of the reference BLAS test programs. Existing lines are byte-identical and the new ones are strictly additive, so old parsers keep working, but the files do gain lines.