### PR TITLE
CBLAS: unify the XERBLA name/INFO logic between the library and the test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # ignore objects and archives, anywhere in the tree.
 *.[oa]
+*.so
+*.dll
+*.dylib
+*.pdb
 
 # test in INSTALL
 INSTALL/test*

--- a/CBLAS/.clang-format
+++ b/CBLAS/.clang-format
@@ -1,0 +1,334 @@
+# Options we simply inherit from the LLVM base style are commented out, so the
+# uncommented lines are exactly what this style changes:
+#
+#     IndentWidth / ContinuationIndentWidth  3
+#     BreakBeforeBraces                      Linux
+#     AllowShortFunctionsOnASingleLine       None
+#     AllowShortIfStatementsOnASingleLine    AllIfsAndElse
+#     BreakAfterReturnType                    Automatic
+#     IncludeCategories                      system headers, then project
+#
+# Generated against clang-format 22; a run of --dump-config there reproduces
+# this file's settings. Older releases will not recognise every
+# uncommented key (BreakAfterReturnType and the SortIncludes struct are 19+),
+# but commented lines are inert, so they cost nothing.
+
+BasedOnStyle: LLVM
+
+Language: Cpp
+# AlignAfterOpenBracket: true
+# AccessModifierOffset: -2
+# AlignArrayOfStructures: None
+# AlignConsecutiveAssignments:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionDeclarations: false
+#   AlignFunctionPointers: false
+#   PadOperators: true
+# AlignConsecutiveBitFields:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionDeclarations: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveDeclarations:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionDeclarations: true
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveMacros:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionDeclarations: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveShortCaseStatements:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCaseArrows: false
+#   AlignCaseColons: false
+# AlignConsecutiveTableGenBreakingDAGArgColons:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionDeclarations: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveTableGenCondOperatorColons:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionDeclarations: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveTableGenDefinitionColons:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionDeclarations: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignEscapedNewlines: Right
+# AlignOperands: Align
+# AlignTrailingComments:
+#   AlignPPAndNotPP: true
+#   Kind: Always
+#   OverEmptyLines: 0
+# AllowAllArgumentsOnNextLine: true
+# AllowAllParametersOfDeclarationOnNextLine: true
+# AllowBreakBeforeNoexceptSpecifier: Never
+# AllowBreakBeforeQtProperty: false
+# AllowShortBlocksOnASingleLine: Never
+# AllowShortCaseExpressionOnASingleLine: true
+# AllowShortCaseLabelsOnASingleLine: false
+# AllowShortCompoundRequirementOnASingleLine: true
+# AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+# AllowShortLambdasOnASingleLine: All
+# AllowShortLoopsOnASingleLine: false
+# AllowShortNamespacesOnASingleLine: false
+# AlwaysBreakAfterDefinitionReturnType: None
+# AlwaysBreakBeforeMultilineStrings: false
+# AttributeMacros:
+#   - __capability
+# BinPackArguments: true
+# BinPackLongBracedList: true
+# BinPackParameters: BinPack
+# BitFieldColonSpacing: Both
+# BracedInitializerIndentWidth: -1
+# BraceWrapping:
+#   AfterCaseLabel: true
+#   AfterClass: true
+#   AfterControlStatement: Always
+#   AfterEnum: true
+#   AfterExternBlock: true
+#   AfterFunction: true
+#   AfterNamespace: true
+#   AfterObjCDeclaration: true
+#   AfterStruct: true
+#   AfterUnion: true
+#   BeforeCatch: true
+#   BeforeElse: true
+#   BeforeLambdaBody: true
+#   BeforeWhile: false
+#   IndentBraces: false
+#   SplitEmptyFunction: true
+#   SplitEmptyRecord: true
+#   SplitEmptyNamespace: true
+# BreakAdjacentStringLiterals: true
+# BreakAfterAttributes: Leave
+# BreakAfterJavaFieldAnnotations: false
+# BreakAfterOpenBracketBracedList: false
+# BreakAfterOpenBracketFunction: false
+# BreakAfterOpenBracketIf: false
+# BreakAfterOpenBracketLoop: false
+# BreakAfterOpenBracketSwitch: false
+# Definitions carry the return type on its own line:
+#     static inline size_t
+#     cblas_xerbla_trimmed_length(const char *name, size_t name_len)
+# Spelled AlwaysBreakAfterReturnType before clang-format 19.
+BreakAfterReturnType: Automatic
+# BreakArrays: true
+# BreakBeforeBinaryOperators: None
+# BreakBeforeCloseBracketBracedList: false
+# BreakBeforeCloseBracketFunction: false
+# BreakBeforeCloseBracketIf: false
+# BreakBeforeCloseBracketLoop: false
+# BreakBeforeCloseBracketSwitch: false
+# BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Linux
+# BreakBeforeInlineASMColon: OnlyMultiline
+# BreakBeforeTemplateCloser: false
+# BreakBeforeTernaryOperators: true
+# BreakBinaryOperations: Never
+# BreakConstructorInitializers: BeforeColon
+# BreakFunctionDefinitionParameters: false
+# BreakInheritanceList: BeforeColon
+# BreakStringLiterals: true
+# BreakTemplateDeclarations: MultiLine
+# ColumnLimit: 80
+# CommentPragmas: '^ IWYU pragma:'
+# CompactNamespaces: false
+# ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 3
+# Cpp11BracedListStyle: AlignFirstComment
+# DerivePointerAlignment: false
+# DisableFormat: false
+# EmptyLineAfterAccessModifier: Never
+# EmptyLineBeforeAccessModifier: LogicalBlock
+# EnumTrailingComma: Leave
+# ExperimentalAutoDetectBinPacking: false
+# FixNamespaceComments: true
+# ForEachMacros:
+#   - foreach
+#   - Q_FOREACH
+#   - BOOST_FOREACH
+# IfMacros:
+#   - KJ_IF_MAYBE
+IncludeCategories:
+  - Regex: '^<'
+    Priority: 1
+  - Regex: 'cblas.*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+# IncludeIsMainRegex: '(Test)?$'
+# IncludeIsMainSourceRegex: ''
+# IndentAccessModifiers: false
+# IndentCaseBlocks: false
+# IndentCaseLabels: false
+# IndentExportBlock: true
+# IndentExternBlock: AfterExternBlock
+# IndentGotoLabels: true
+# IndentPPDirectives: None
+# IndentRequiresClause: true
+IndentWidth: 3
+# IndentWrappedFunctionNames: false
+# InsertBraces: true
+# InsertNewlineAtEOF: false
+# InsertTrailingCommas: None
+# IntegerLiteralSeparator:
+#   Binary: 0
+#   BinaryMinDigitsInsert: 0
+#   BinaryMaxDigitsRemove: 0
+#   Decimal: 0
+#   DecimalMinDigitsInsert: 0
+#   DecimalMaxDigitsRemove: 0
+#   Hex: 0
+#   HexMinDigitsInsert: 0
+#   HexMaxDigitsRemove: 0
+#   BinaryMinDigits: 0
+#   DecimalMinDigits: 0
+#   HexMinDigits: 0
+# JavaScriptQuotes: Leave
+# JavaScriptWrapImports: true
+# KeepEmptyLines:
+#   AtEndOfFile: false
+#   AtStartOfBlock: true
+#   AtStartOfFile: true
+# KeepFormFeed: false
+# LambdaBodyIndentation: Signature
+# LineEnding: DeriveLF
+# MacroBlockBegin: ''
+# MacroBlockEnd: ''
+# MainIncludeChar: Quote
+# MaxEmptyLinesToKeep: 1
+# NamespaceIndentation: None
+# NumericLiteralCase:
+#   ExponentLetter: Leave
+#   HexDigit: Leave
+#   Prefix: Leave
+#   Suffix: Leave
+# ObjCBinPackProtocolList: Auto
+# ObjCBlockIndentWidth: 2
+# ObjCBreakBeforeNestedBlockParam: true
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: true
+# OneLineFormatOffRegex: ''
+# PackConstructorInitializers: BinPack
+# PenaltyBreakAssignment: 2
+# PenaltyBreakBeforeFirstCallParameter: 19
+# PenaltyBreakBeforeMemberAccess: 150
+# PenaltyBreakComment: 300
+# PenaltyBreakFirstLessLess: 120
+# PenaltyBreakOpenParenthesis: 0
+# PenaltyBreakScopeResolution: 500
+# PenaltyBreakString: 1000
+# PenaltyBreakTemplateDeclaration: 10
+# PenaltyExcessCharacter: 1000000
+# PenaltyIndentedWhitespace: 0
+# PenaltyReturnTypeOnItsOwnLine: 60
+# PointerAlignment: Right
+# PPIndentWidth: -1
+# QualifierAlignment: Leave
+# ReferenceAlignment: Pointer
+# ReflowComments: Always
+# RemoveBracesLLVM: false
+# RemoveEmptyLinesInUnwrappedLines: false
+# RemoveParentheses: Leave
+# RemoveSemicolon: false
+# RequiresClausePosition: OwnLine
+# RequiresExpressionIndentation: OuterScope
+# SeparateDefinitionBlocks: Leave
+# ShortNamespaceLines: 1
+# SkipMacroDefinitionBody: false
+# Sorting is LLVM's default and is deliberately left on; the grouping it
+# produces comes from the IncludeCategories priorities above.
+# SortIncludes:
+#   Enabled: true
+#   IgnoreCase: false
+#   IgnoreExtension: false
+# SortJavaStaticImport: Before
+# SortUsingDeclarations: LexicographicNumeric
+# SpaceAfterCStyleCast: false
+# SpaceAfterLogicalNot: false
+# SpaceAfterOperatorKeyword: false
+# SpaceAfterTemplateKeyword: true
+# SpaceAroundPointerQualifiers: Default
+# SpaceBeforeAssignmentOperators: true
+# SpaceBeforeCaseColon: false
+# SpaceBeforeCpp11BracedList: false
+# SpaceBeforeCtorInitializerColon: true
+# SpaceBeforeInheritanceColon: true
+# SpaceBeforeJsonColon: false
+# SpaceBeforeParens: ControlStatements
+# SpaceBeforeParensOptions:
+#   AfterControlStatements: true
+#   AfterForeachMacros: true
+#   AfterFunctionDefinitionName: false
+#   AfterFunctionDeclarationName: false
+#   AfterIfMacros: true
+#   AfterNot: false
+#   AfterOverloadedOperator: false
+#   AfterPlacementOperator: true
+#   AfterRequiresInClause: false
+#   AfterRequiresInExpression: false
+#   BeforeNonEmptyParentheses: false
+# SpaceBeforeRangeBasedForLoopColon: true
+# SpaceBeforeSquareBrackets: false
+# SpaceInEmptyBraces: Never
+# SpacesBeforeTrailingComments: 1
+# SpacesInAngles: Never
+# SpacesInContainerLiterals: true
+# SpacesInLineCommentPrefix:
+#   Minimum: 1
+#   Maximum: -1
+# SpacesInParens: Never
+# SpacesInParensOptions:
+#   ExceptDoubleParentheses: false
+#   InCStyleCasts: false
+#   InConditionalStatements: false
+#   InEmptyParentheses: false
+#   Other: false
+# SpacesInSquareBrackets: false
+# Standard: Latest
+# StatementAttributeLikeMacros:
+#   - Q_EMIT
+# StatementMacros:
+#   - Q_UNUSED
+#   - QT_REQUIRE_VERSION
+# TableGenBreakInsideDAGArg: DontBreak
+# TabWidth: 8
+# UseTab: Never
+# VerilogBreakBetweenInstancePorts: true
+# WhitespaceSensitiveMacros:
+#   - BOOST_PP_STRINGIZE
+#   - CF_SWIFT_NAME
+#   - NS_SWIFT_NAME
+#   - PP_STRINGIZE
+#   - STRINGIZE
+# WrapNamespaceBodyWithEmptyLines: Leave

--- a/CBLAS/examples/cblas_example1_64.c
+++ b/CBLAS/examples/cblas_example1_64.c
@@ -61,7 +61,7 @@ int main ( )
                 y, incy );
    /* Print y */
    for( i = 0; i < n; i++ )
-      printf(" y%d = %f\n", (int) i, y[i]);
+      printf(" y%" PRId64 " = %f\n", i, y[i]);
    free(a);
    free(x);
    free(y);

--- a/CBLAS/include/cblas.h
+++ b/CBLAS/include/cblas.h
@@ -45,6 +45,21 @@ typedef enum CBLAS_SIDE {CblasLeft=141, CblasRight=142} CBLAS_SIDE;
 #define CBLAS_ORDER CBLAS_LAYOUT /* this for backward compatibility with CBLAS_ORDER */
 
 /*
+ * Weak symbol support for cblas_xerbla() and F77_xerbla()
+ *
+ * Must precede the cblas_64.h include below: that header declares
+ * cblas_xerbla_64() with CBLAS_WEAK_SYMBOL, and its own include of cblas.h is
+ * a no-op while we are still inside this header's include guard.
+ */
+#ifndef CBLAS_WEAK_SYMBOL
+#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
+   #define CBLAS_WEAK_SYMBOL __attribute__((weak))
+#else
+   #define CBLAS_WEAK_SYMBOL
+#endif
+#endif
+
+/*
  * Integer specific API
  */
 #ifndef API_SUFFIX
@@ -684,11 +699,8 @@ void cblas_zher2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                   const void *B, const CBLAS_INT ldb, const double beta,
                   void *C, const CBLAS_INT ldc);
 
-void
-#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
-__attribute__((weak))
-#endif
-cblas_xerbla(CBLAS_INT p, const char *rout, const char *form, ...);
+void CBLAS_WEAK_SYMBOL cblas_xerbla(CBLAS_INT p, const char *rout,
+                                    const char *form, ...);
 
 #ifdef __cplusplus
 }

--- a/CBLAS/include/cblas_64.h
+++ b/CBLAS/include/cblas_64.h
@@ -639,11 +639,8 @@ void cblas_zher2k_64(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                   const void *B, const int64_t ldb, const double beta,
                   void *C, const int64_t ldc);
 
-void
-#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
-__attribute__((weak))
-#endif
-cblas_xerbla_64(int64_t p, const char *rout, const char *form, ...);
+void CBLAS_WEAK_SYMBOL cblas_xerbla_64(int64_t p, const char *rout,
+                                       const char *form, ...);
 
 #ifdef __cplusplus
 }

--- a/CBLAS/include/cblas_f77.h
+++ b/CBLAS/include/cblas_f77.h
@@ -59,6 +59,17 @@
 #endif
 #endif
 
+/*
+ * Weak symbol support for cblas_xerbla() and F77_xerbla()
+ */
+#ifndef CBLAS_WEAK_SYMBOL
+#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
+   #define CBLAS_WEAK_SYMBOL __attribute__((weak))
+#else
+   #define CBLAS_WEAK_SYMBOL
+#endif
+#endif
+
 #define F77_GLOBAL_SUFFIX(a,b) F77_GLOBAL_SUFFIX_(API_SUFFIX(a),API_SUFFIX(b))
 #define F77_GLOBAL_SUFFIX_(a,b) F77_GLOBAL(a,b)
 
@@ -613,11 +624,7 @@ extern "C" {
 #else
    #define F77_xerbla(...) F77_xerbla_base(__VA_ARGS__)
 #endif
-void
-#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
-__attribute__((weak))
-#endif
-F77_xerbla_base(FCHAR, void *
+void CBLAS_WEAK_SYMBOL F77_xerbla_base(FCHAR, void *
 #ifdef BLAS_FORTRAN_STRLEN_END
    , FORTRAN_STRLEN
 #endif

--- a/CBLAS/include/cblas_test.h
+++ b/CBLAS/include/cblas_test.h
@@ -22,6 +22,20 @@
   #define FORTRAN_STRLEN size_t
 #endif
 
+#ifndef F77_INT
+#ifdef WeirdNEC
+  #define F77_INT int64_t
+#else
+  #define F77_INT int32_t
+#endif
+#endif
+
+#ifdef  F77_CHAR
+  #define FCHAR F77_CHAR
+#else
+  #define FCHAR char *
+#endif
+
 #define TRUE         1
 #define PASSED       1
 #define TEST_ROW_MJR 1

--- a/CBLAS/include/cblas_xerbla_internal.h
+++ b/CBLAS/include/cblas_xerbla_internal.h
@@ -1,0 +1,203 @@
+#ifndef CBLAS_XERBLA_INTERNAL_H
+#define CBLAS_XERBLA_INTERNAL_H
+
+#include <ctype.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "cblas.h"
+
+// Keep a bit of headroom for possible future CBLAS routines
+#define CBLAS_XERBLA_MAX_ROUTINE_NAME 32u
+#define CBLAS_XERBLA_ROUT_BUFFER_SIZE                                          \
+   (sizeof("cblas_") - 1 + CBLAS_XERBLA_MAX_ROUTINE_NAME + 1)
+
+/**
+ * \brief Length of a Fortran-style name with trailing blanks removed.
+ *
+ * \param[in] name      Character data, not necessarily NUL terminated.
+ * \param[in] name_len  Number of characters available in \p name.
+ *
+ * \return Length up to the first NUL, excluding trailing blanks, or 0 if
+ *         \p name is NULL.
+ */
+static inline size_t cblas_xerbla_trimmed_length(const char *name,
+                                                 size_t name_len)
+{
+   if (name == NULL) return 0;
+
+   size_t actual_len = 0;
+   while (actual_len < name_len && name[actual_len] != '\0') {
+      actual_len++;
+   }
+   while (actual_len > 0 && name[actual_len - 1] == ' ') {
+      actual_len--;
+   }
+
+   return actual_len;
+}
+
+/**
+ * \brief Build the "cblas_"-prefixed routine name used in error messages.
+ *
+ * Lowercases \p name and drops trailing blanks and, in 64-bit API builds, a
+ * trailing "_64". The result is always NUL terminated, and is truncated
+ * rather than allowed to overflow \p rout.
+ *
+ * \param[out] rout       Destination buffer, normally of size
+ *                        CBLAS_XERBLA_ROUT_BUFFER_SIZE.
+ * \param[in]  rout_size  Size of \p rout in bytes.
+ * \param[in]  name       Fortran routine name, not necessarily NUL
+ *                        terminated.
+ * \param[in]  name_len   Number of characters available in \p name.
+ */
+static inline void cblas_xerbla_make_rout(char *rout, size_t rout_size,
+                                          const char *name, size_t name_len)
+{
+
+   if (rout_size == 0) return;
+
+   name_len = cblas_xerbla_trimmed_length(name, name_len);
+
+#ifdef CBLAS_API64
+   if (name_len >= 3 && name[name_len - 3] == '_' &&
+       name[name_len - 2] == '6' && name[name_len - 1] == '4')
+      name_len -= 3;
+#endif
+
+   if (name_len > CBLAS_XERBLA_MAX_ROUTINE_NAME) {
+      name_len = CBLAS_XERBLA_MAX_ROUTINE_NAME;
+   }
+
+   static const char prefix[] = "cblas_";
+   size_t prefix_len = sizeof(prefix) - 1;
+   size_t rout_len = 0;
+   for (size_t i = 0; i < prefix_len && rout_len + 1 < rout_size; i++) {
+      rout[rout_len++] = prefix[i];
+   }
+   for (size_t i = 0; i < name_len && rout_len + 1 < rout_size; i++) {
+      rout[rout_len++] = (char)tolower((unsigned char)name[i]);
+   }
+
+   rout[rout_len] = '\0';
+}
+
+/**
+ * \brief Reduce a routine name to its bare operation.
+ *
+ * Skips the "cblas_" prefix and the precision character, so that
+ * "cblas_dgemm" yields "gemm".
+ *
+ * \param[in] rout  CBLAS routine name, or NULL.
+ *
+ * \return Pointer into \p rout past the prefix and precision character, or
+ *         NULL if \p rout is NULL.
+ */
+static inline const char *cblas_xerbla_operation(const char *rout)
+{
+   if (rout == NULL) return NULL;
+
+   if (strncmp(rout, "cblas_", sizeof("cblas_") - 1) == 0) {
+      rout += sizeof("cblas_") - 1;
+   }
+   if ((rout[0] == 's' || rout[0] == 'd' || rout[0] == 'c' || rout[0] == 'z') &&
+       rout[1] != '\0') {
+      rout++;
+   }
+
+   return rout;
+}
+
+/**
+ * \brief Test an operation name for equality.
+ *
+ * The comparison is exact, so "gemm" does not also match "gemmtr".
+ *
+ * \param[in] operation  Result of cblas_xerbla_operation(), or NULL.
+ * \param[in] expected   Operation name to match.
+ *
+ * \return Nonzero when \p operation equals \p expected.
+ */
+static inline int cblas_xerbla_operation_is(const char *operation,
+                                            const char *expected)
+{
+   return operation != NULL && strcmp(operation, expected) == 0;
+}
+
+/**
+ * \brief Map a Fortran argument number onto its CBLAS position.
+ *
+ * Row-major calls reach the Fortran BLAS with arguments swapped or
+ * transposed, so the number XERBLA reports is not that of the CBLAS
+ * argument actually at fault. Column-major calls, and operations needing no
+ * adjustment, return \p info unchanged.
+ *
+ * \param[in] info       Argument number reported by the Fortran BLAS.
+ * \param[in] rout       CBLAS routine name, e.g. "cblas_dgemm".
+ * \param[in] row_major  Nonzero if the call used CblasRowMajor.
+ *
+ * \return The corresponding CBLAS argument number.
+ */
+static inline CBLAS_INT cblas_xerbla_map_info(CBLAS_INT info, const char *rout,
+                                              int row_major)
+{
+   if (!row_major) return info;
+
+   const char *operation = cblas_xerbla_operation(rout);
+   if (cblas_xerbla_operation_is(operation, "gemmtr")) {
+
+      if (info == 11) info = 9;
+      else if (info == 9) info = 11;
+
+   } else if (cblas_xerbla_operation_is(operation, "gemm")) {
+
+      if (info == 5) info = 4;
+      else if (info == 4) info = 5;
+      else if (info == 11) info = 9;
+      else if (info == 9) info = 11;
+
+   } else if (cblas_xerbla_operation_is(operation, "symm") ||
+              cblas_xerbla_operation_is(operation, "hemm") ||
+              cblas_xerbla_operation_is(operation, "skewsymm")) {
+
+      if (info == 5) info = 4;
+      else if (info == 4) info = 5;
+
+   } else if (cblas_xerbla_operation_is(operation, "trmm") ||
+              cblas_xerbla_operation_is(operation, "trsm")) {
+
+      if (info == 7) info = 6;
+      else if (info == 6) info = 7;
+
+   } else if (cblas_xerbla_operation_is(operation, "gemv")) {
+
+      if (info == 4) info = 3;
+      else if (info == 3) info = 4;
+
+   } else if (cblas_xerbla_operation_is(operation, "gbmv")) {
+
+      if (info == 4) info = 3;
+      else if (info == 3) info = 4;
+      else if (info == 6) info = 5;
+      else if (info == 5) info = 6;
+
+   } else if (cblas_xerbla_operation_is(operation, "ger") ||
+              cblas_xerbla_operation_is(operation, "geru") ||
+              cblas_xerbla_operation_is(operation, "gerc")) {
+
+      if (info == 3) info = 2;
+      else if (info == 2) info = 3;
+      else if (info == 8) info = 6;
+      else if (info == 6) info = 8;
+
+   } else if (cblas_xerbla_operation_is(operation, "her2") ||
+              cblas_xerbla_operation_is(operation, "hpr2")) {
+
+      if (info == 8) info = 6;
+      else if (info == 6) info = 8;
+   }
+
+   return info;
+}
+
+#endif // CBLAS_XERBLA_INTERNAL_H

--- a/CBLAS/include/cblas_xerbla_internal.h
+++ b/CBLAS/include/cblas_xerbla_internal.h
@@ -9,6 +9,7 @@
 
 // Keep a bit of headroom for possible future CBLAS routines
 #define CBLAS_XERBLA_MAX_ROUTINE_NAME 32u
+#define CBLAS_XERBLA_API_PREFIX "cblas_"
 #define CBLAS_XERBLA_API64_SUFFIX "_64"
 #ifdef CBLAS_API64
 #define CBLAS_XERBLA_API_SUFFIX CBLAS_XERBLA_API64_SUFFIX
@@ -17,7 +18,7 @@
 #endif
 
 #define CBLAS_XERBLA_ROUT_BUFFER_SIZE                                          \
-   ((sizeof("cblas_") - 1) + CBLAS_XERBLA_MAX_ROUTINE_NAME +                   \
+   ((sizeof(CBLAS_XERBLA_API_PREFIX) - 1) + CBLAS_XERBLA_MAX_ROUTINE_NAME +    \
     (sizeof(CBLAS_XERBLA_API_SUFFIX) - 1) + 1)
 
 /**
@@ -30,7 +31,7 @@
  *         \p name is NULL.
  */
 static inline size_t cblas_xerbla_trimmed_length(const char *name,
-                                                 size_t name_len)
+                                                 const size_t name_len)
 {
    if (name == NULL) return 0;
 
@@ -59,7 +60,7 @@ static inline size_t cblas_xerbla_trimmed_length(const char *name,
  *                        terminated.
  * \param[in]  name_len   Number of characters available in \p name.
  */
-static inline void cblas_xerbla_make_rout(char *rout, size_t rout_size,
+static inline void cblas_xerbla_make_rout(char *rout, const size_t rout_size,
                                           const char *name, size_t name_len)
 {
    if (rout_size == 0) return;
@@ -67,7 +68,7 @@ static inline void cblas_xerbla_make_rout(char *rout, size_t rout_size,
    name_len = cblas_xerbla_trimmed_length(name, name_len);
 
    static const char suffix[] = CBLAS_XERBLA_API_SUFFIX;
-   size_t suffix_len = sizeof(suffix) - 1;
+   const size_t suffix_len = sizeof(suffix) - 1;
    if (suffix_len > 0 && name_len >= suffix_len &&
        strncmp(name + name_len - suffix_len, suffix, suffix_len) == 0) {
       name_len -= suffix_len;
@@ -77,8 +78,8 @@ static inline void cblas_xerbla_make_rout(char *rout, size_t rout_size,
       name_len = CBLAS_XERBLA_MAX_ROUTINE_NAME;
    }
 
-   static const char prefix[] = "cblas_";
-   size_t prefix_len = sizeof(prefix) - 1;
+   static const char prefix[] = CBLAS_XERBLA_API_PREFIX;
+   const size_t prefix_len = sizeof(prefix) - 1;
    size_t rout_len = 0;
    for (size_t i = 0; i < prefix_len && rout_len + 1 < rout_size; i++) {
       rout[rout_len++] = prefix[i];
@@ -104,7 +105,8 @@ static inline void cblas_xerbla_make_rout(char *rout, size_t rout_size,
  * \param[in]  rout_size  Size of \p rout in bytes.
  * \param[in]  name       Routine name, e.g. "cblas_dgemm", or NULL.
  */
-static inline void cblas_xerbla_apply_api_suffix(char *rout, size_t rout_size,
+static inline void cblas_xerbla_apply_api_suffix(char *rout,
+                                                 const size_t rout_size,
                                                  const char *name)
 {
    if (rout_size == 0) return;
@@ -116,7 +118,7 @@ static inline void cblas_xerbla_apply_api_suffix(char *rout, size_t rout_size,
 
    static const char suffix[] = CBLAS_XERBLA_API_SUFFIX;
    size_t suffix_len = sizeof(suffix) - 1;
-   size_t name_len = strlen(name);
+   const size_t name_len = strlen(name);
    if (suffix_len > 0 && name_len >= suffix_len &&
        strcmp(name + name_len - suffix_len, suffix) == 0) {
       suffix_len = 0;
@@ -148,8 +150,10 @@ static inline const char *cblas_xerbla_operation(const char *rout)
 {
    if (rout == NULL) return NULL;
 
-   if (strncmp(rout, "cblas_", sizeof("cblas_") - 1) == 0) {
-      rout += sizeof("cblas_") - 1;
+   static const char prefix[] = CBLAS_XERBLA_API_PREFIX;
+   const size_t prefix_len = sizeof(prefix) - 1;
+   if (strncmp(rout, prefix, prefix_len) == 0) {
+      rout += prefix_len;
    }
    if ((rout[0] == 's' || rout[0] == 'd' || rout[0] == 'c' || rout[0] == 'z') &&
        rout[1] != '\0') {
@@ -177,7 +181,7 @@ static inline int cblas_xerbla_operation_is(const char *operation,
 {
    if (operation == NULL) return 0;
 
-   size_t expected_len = strlen(expected);
+   const size_t expected_len = strlen(expected);
    if (strncmp(operation, expected, expected_len) != 0) return 0;
 
    return operation[expected_len] == '\0' ||
@@ -199,11 +203,11 @@ static inline int cblas_xerbla_operation_is(const char *operation,
  * \return The corresponding CBLAS argument number.
  */
 static inline CBLAS_INT cblas_xerbla_map_info(CBLAS_INT info, const char *rout,
-                                              int row_major)
+                                              const int row_major)
 {
    if (!row_major) return info;
 
-   const char *operation = cblas_xerbla_operation(rout);
+   const char *const operation = cblas_xerbla_operation(rout);
    if (cblas_xerbla_operation_is(operation, "gemmtr")) {
 
       if (info == 11) info = 9;

--- a/CBLAS/include/cblas_xerbla_internal.h
+++ b/CBLAS/include/cblas_xerbla_internal.h
@@ -9,8 +9,16 @@
 
 // Keep a bit of headroom for possible future CBLAS routines
 #define CBLAS_XERBLA_MAX_ROUTINE_NAME 32u
+#define CBLAS_XERBLA_API64_SUFFIX "_64"
+#ifdef CBLAS_API64
+#define CBLAS_XERBLA_API_SUFFIX CBLAS_XERBLA_API64_SUFFIX
+#else
+#define CBLAS_XERBLA_API_SUFFIX ""
+#endif
+
 #define CBLAS_XERBLA_ROUT_BUFFER_SIZE                                          \
-   (sizeof("cblas_") - 1 + CBLAS_XERBLA_MAX_ROUTINE_NAME + 1)
+   ((sizeof("cblas_") - 1) + CBLAS_XERBLA_MAX_ROUTINE_NAME +                   \
+    (sizeof(CBLAS_XERBLA_API_SUFFIX) - 1) + 1)
 
 /**
  * \brief Length of a Fortran-style name with trailing blanks removed.
@@ -54,16 +62,16 @@ static inline size_t cblas_xerbla_trimmed_length(const char *name,
 static inline void cblas_xerbla_make_rout(char *rout, size_t rout_size,
                                           const char *name, size_t name_len)
 {
-
    if (rout_size == 0) return;
 
    name_len = cblas_xerbla_trimmed_length(name, name_len);
 
-#ifdef CBLAS_API64
-   if (name_len >= 3 && name[name_len - 3] == '_' &&
-       name[name_len - 2] == '6' && name[name_len - 1] == '4')
-      name_len -= 3;
-#endif
+   static const char suffix[] = CBLAS_XERBLA_API_SUFFIX;
+   size_t suffix_len = sizeof(suffix) - 1;
+   if (suffix_len > 0 && name_len >= suffix_len &&
+       strncmp(name + name_len - suffix_len, suffix, suffix_len) == 0) {
+      name_len -= suffix_len;
+   }
 
    if (name_len > CBLAS_XERBLA_MAX_ROUTINE_NAME) {
       name_len = CBLAS_XERBLA_MAX_ROUTINE_NAME;
@@ -77,6 +85,49 @@ static inline void cblas_xerbla_make_rout(char *rout, size_t rout_size,
    }
    for (size_t i = 0; i < name_len && rout_len + 1 < rout_size; i++) {
       rout[rout_len++] = (char)tolower((unsigned char)name[i]);
+   }
+
+   rout[rout_len] = '\0';
+}
+
+/**
+ * \brief Copy a routine name as it should be reported to the user.
+ *
+ * Appends the extended API suffix, so that a 64-bit build names
+ * cblas_dgemm_64() rather than cblas_dgemm() in its diagnostics. A name that
+ * already carries the suffix is copied unchanged, which keeps the call
+ * idempotent whatever the caller passes. The result is always NUL terminated
+ * and is truncated rather than allowed to overflow \p rout.
+ *
+ * \param[out] rout       Destination buffer, normally of size
+ *                        CBLAS_XERBLA_ROUT_BUFFER_SIZE.
+ * \param[in]  rout_size  Size of \p rout in bytes.
+ * \param[in]  name       Routine name, e.g. "cblas_dgemm", or NULL.
+ */
+static inline void cblas_xerbla_apply_api_suffix(char *rout, size_t rout_size,
+                                                 const char *name)
+{
+   if (rout_size == 0) return;
+
+   if (name == NULL) {
+      rout[0] = '\0';
+      return;
+   }
+
+   static const char suffix[] = CBLAS_XERBLA_API_SUFFIX;
+   size_t suffix_len = sizeof(suffix) - 1;
+   size_t name_len = strlen(name);
+   if (suffix_len > 0 && name_len >= suffix_len &&
+       strcmp(name + name_len - suffix_len, suffix) == 0) {
+      suffix_len = 0;
+   }
+
+   size_t rout_len = 0;
+   for (size_t i = 0; i < name_len && rout_len + 1 < rout_size; i++) {
+      rout[rout_len++] = name[i];
+   }
+   for (size_t i = 0; i < suffix_len && rout_len + 1 < rout_size; i++) {
+      rout[rout_len++] = suffix[i];
    }
 
    rout[rout_len] = '\0';
@@ -111,17 +162,26 @@ static inline const char *cblas_xerbla_operation(const char *rout)
 /**
  * \brief Test an operation name for equality.
  *
- * The comparison is exact, so "gemm" does not also match "gemmtr".
+ * The comparison is exact, so "gemm" does not also match "gemmtr". A trailing
+ * extended API suffix is tolerated, so that a name arriving already suffixed
+ * still selects the right remapping rather than silently selecting none.
  *
  * \param[in] operation  Result of cblas_xerbla_operation(), or NULL.
  * \param[in] expected   Operation name to match.
  *
- * \return Nonzero when \p operation equals \p expected.
+ * \return Nonzero when \p operation equals \p expected, ignoring any trailing
+ *         extended API suffix.
  */
 static inline int cblas_xerbla_operation_is(const char *operation,
                                             const char *expected)
 {
-   return operation != NULL && strcmp(operation, expected) == 0;
+   if (operation == NULL) return 0;
+
+   size_t expected_len = strlen(expected);
+   if (strncmp(operation, expected, expected_len) != 0) return 0;
+
+   return operation[expected_len] == '\0' ||
+          strcmp(operation + expected_len, CBLAS_XERBLA_API64_SUFFIX) == 0;
 }
 
 /**

--- a/CBLAS/src/cblas_xerbla.c
+++ b/CBLAS/src/cblas_xerbla.c
@@ -26,8 +26,11 @@ void CBLAS_WEAK_SYMBOL API_SUFFIX(cblas_xerbla)(CBLAS_INT info,
 
    info = cblas_xerbla_map_info(info, rout, RowMajorStrg);
    if (info) {
+      char reported[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
+      cblas_xerbla_apply_api_suffix(reported, sizeof(reported), rout);
+
       fprintf(stderr, "Parameter %" CBLAS_IFMT " to routine %s was incorrect\n",
-              info, rout);
+              info, reported);
    }
 
    va_list argptr;

--- a/CBLAS/src/cblas_xerbla.c
+++ b/CBLAS/src/cblas_xerbla.c
@@ -1,72 +1,42 @@
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
+#include "cblas_xerbla_internal.h"
 
-void
-#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
-__attribute__((weak))
-#endif
-API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout, const char *form, ...)
+/**
+ * \brief CBLAS error handler: report an invalid argument and terminate.
+ *
+ * Remaps \p info to the CBLAS argument position for row-major calls, writes
+ * the diagnostic to stderr and exits; it does not return to its caller.
+ *
+ * \param[in] info  CBLAS argument number, or 0 to report only \p form.
+ * \param[in] rout  Routine name, e.g. "cblas_dgemm".
+ * \param[in] form  printf-style format for further detail, followed by the
+ *                  values it refers to.
+ */
+void CBLAS_WEAK_SYMBOL API_SUFFIX(cblas_xerbla)(CBLAS_INT info,
+                                                const char *rout,
+                                                const char *form, ...)
 {
    extern int RowMajorStrg;
    char empty[1] = "";
-   va_list argptr;
 
-   va_start(argptr, form);
-
-   if (RowMajorStrg)
-   {
-      if (strstr(rout,"gemm") != 0)
-      {
-         if      (info == 5 ) info =  4;
-         else if (info == 4 ) info =  5;
-         else if (info == 11) info =  9;
-         else if (info == 9 ) info = 11;
-      }
-      else if (strstr(rout,"symm") != 0 || strstr(rout,"hemm") != 0)
-      {
-         if      (info == 5 ) info =  4;
-         else if (info == 4 ) info =  5;
-      }
-      else if (strstr(rout,"trmm") != 0 || strstr(rout,"trsm") != 0)
-      {
-         if      (info == 7 ) info =  6;
-         else if (info == 6 ) info =  7;
-      }
-      else if (strstr(rout,"gemv") != 0)
-      {
-         if      (info == 4)  info = 3;
-         else if (info == 3)  info = 4;
-      }
-      else if (strstr(rout,"gbmv") != 0)
-      {
-         if      (info == 4)  info = 3;
-         else if (info == 3)  info = 4;
-         else if (info == 6)  info = 5;
-         else if (info == 5)  info = 6;
-      }
-      else if (strstr(rout,"ger") != 0)
-      {
-         if      (info == 3) info = 2;
-         else if (info == 2) info = 3;
-         else if (info == 8) info = 6;
-         else if (info == 6) info = 8;
-      }
-      else if ( (strstr(rout,"her2") != 0 || strstr(rout,"hpr2") != 0)
-                 && strstr(rout,"her2k") == 0 )
-      {
-         if      (info == 8) info = 6;
-         else if (info == 6) info = 8;
-      }
+   info = cblas_xerbla_map_info(info, rout, RowMajorStrg);
+   if (info) {
+      fprintf(stderr, "Parameter %" CBLAS_IFMT " to routine %s was incorrect\n",
+              info, rout);
    }
-   if (info)
-      fprintf(stderr, "Parameter %" CBLAS_IFMT " to routine %s was incorrect\n", info, rout);
+
+   va_list argptr;
+   va_start(argptr, form);
    vfprintf(stderr, form, argptr);
    va_end(argptr);
-   if (info && !info)
+
+   if (info && !info) {
       F77_xerbla(empty, &info); /* Force link of our F77 error handler */
+   }
    exit(-1);
 }

--- a/CBLAS/src/xerbla.c
+++ b/CBLAS/src/xerbla.c
@@ -28,29 +28,28 @@ void CBLAS_WEAK_SYMBOL F77_xerbla_base(FCHAR F77_srname, void *vinfo
 {
    extern int CBLAS_CallFromC;
 
-   size_t srname_len;
 #ifdef BLAS_FORTRAN_STRLEN_END
-   srname_len = len > 0 ? (size_t)len : 0;
+   const size_t srname_len = len > 0 ? (size_t)len : 0;
 #else
-   srname_len = 6;
+   const size_t srname_len = 6;
 #endif
 
-   char *srname;
 #ifdef F77_CHAR
-   srname = F2C_STR(F77_srname, srname_len);
+   const char *srname = F2C_STR(F77_srname, srname_len);
 #else
-   srname = F77_srname;
+   const char *srname = F77_srname;
 #endif
 
-   F77_INT *info = (F77_INT *)vinfo;
-   CBLAS_INT cblas_info = (CBLAS_INT)*info;
+   const F77_INT *info = (const F77_INT *)vinfo;
+   const CBLAS_INT cblas_info = (CBLAS_INT)*info;
 
    if (CBLAS_CallFromC) {
       char rout[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
       cblas_xerbla_make_rout(rout, sizeof(rout), srname, srname_len);
       API_SUFFIX(cblas_xerbla)(cblas_info + 1, rout, "");
    } else {
-      size_t display_len = cblas_xerbla_trimmed_length(srname, srname_len);
+      const size_t display_len =
+         cblas_xerbla_trimmed_length(srname, srname_len);
 
       fprintf(stderr, "Parameter %" CBLAS_IFMT " to routine ", cblas_info);
       if (display_len > 0) {

--- a/CBLAS/src/xerbla.c
+++ b/CBLAS/src/xerbla.c
@@ -1,50 +1,61 @@
 #include <stdio.h>
-#include <ctype.h>
+
 #include "cblas.h"
 #include "cblas_f77.h"
+#include "cblas_xerbla_internal.h"
 
-#define XerblaStrLen 6
-#define XerblaStrLen1 7
-
-void
-#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT
-__attribute__((weak))
-#endif
-F77_xerbla_base
-#ifdef F77_CHAR
-(F77_CHAR F77_srname, void *vinfo
-#else
-(char *srname, void *vinfo
-#endif
+/**
+ * \brief XERBLA implementation linked in together with the CBLAS library.
+ *
+ * An error raised beneath a CBLAS wrapper is forwarded to cblas_xerbla()
+ * under the CBLAS spelling of the routine name, with the argument number
+ * shifted by one to account for the extra layout argument. Errors from
+ * direct Fortran calls are reported under the Fortran name instead.
+ *
+ * \param[in] F77_srname  Routine name reported by the Fortran BLAS, blank
+ *                        padded and not NUL terminated.
+ * \param[in] vinfo       Pointer to the Fortran argument number.
+ * \param[in] len         Hidden Fortran length of \p F77_srname, on
+ *                        compilers that pass string lengths at the end of
+ *                        the argument list.
+ */
+void CBLAS_WEAK_SYMBOL F77_xerbla_base(FCHAR F77_srname, void *vinfo
 #ifdef BLAS_FORTRAN_STRLEN_END
-, FORTRAN_STRLEN len
+   ,
+   FORTRAN_STRLEN len
 #endif
 )
 {
-#ifdef F77_CHAR
-   char *srname;
-#endif
-
-   char rout[] = {'c','b','l','a','s','_','\0','\0','\0','\0','\0','\0','\0'};
-
-   int *info=vinfo;
-   int i;
-
    extern int CBLAS_CallFromC;
 
-#ifdef F77_CHAR
-   srname = F2C_STR(F77_srname, XerblaStrLen);
+   size_t srname_len;
+#ifdef BLAS_FORTRAN_STRLEN_END
+   srname_len = len > 0 ? (size_t)len : 0;
+#else
+   srname_len = 6;
 #endif
 
-   if (CBLAS_CallFromC)
-   {
-      for(i=0; i != XerblaStrLen; i++) rout[i+6] = tolower(srname[i]);
-      rout[XerblaStrLen+6] = '\0';
-      API_SUFFIX(cblas_xerbla)(*info+1,rout,"");
-   }
-   else
-   {
-      fprintf(stderr, "Parameter %d to routine %s was incorrect\n",
-              *info, srname);
+   char *srname;
+#ifdef F77_CHAR
+   srname = F2C_STR(F77_srname, srname_len);
+#else
+   srname = F77_srname;
+#endif
+
+   F77_INT *info = (F77_INT *)vinfo;
+   CBLAS_INT cblas_info = (CBLAS_INT)*info;
+
+   if (CBLAS_CallFromC) {
+      char rout[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
+      cblas_xerbla_make_rout(rout, sizeof(rout), srname, srname_len);
+      API_SUFFIX(cblas_xerbla)(cblas_info + 1, rout, "");
+   } else {
+      size_t display_len = cblas_xerbla_trimmed_length(srname, srname_len);
+
+      fprintf(stderr, "Parameter %" CBLAS_IFMT " to routine ", cblas_info);
+      if (display_len > 0) {
+         fwrite(srname, 1, display_len, stderr);
+      }
+      fputs(" was incorrect\n", stderr);
    }
 }

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -34,10 +34,16 @@ void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout,
     */
    if (link_xerbla) return;
 
-   if (cblas_rout != NULL && strcmp(cblas_rout, rout) != 0) {
+   /* The name is checked and reported as the user would see it, suffix and
+    * all, while the remapping below keys off the unsuffixed \p rout.
+    */
+   char reported[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
+   cblas_xerbla_apply_api_suffix(reported, sizeof(reported), rout);
+
+   if (cblas_rout != NULL && strcmp(cblas_rout, reported) != 0) {
       printf(
          "***** XERBLA WAS CALLED WITH SRNAME = <%s> INSTEAD OF <%s> *******\n",
-         rout, cblas_rout);
+         reported, cblas_rout);
       cblas_ok = FALSE;
    }
 
@@ -46,7 +52,7 @@ void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout,
    if (info != cblas_info) {
       printf("***** XERBLA WAS CALLED WITH INFO = %" CBLAS_IFMT
              " INSTEAD OF %" CBLAS_IFMT " in %s *******\n",
-             info, cblas_info, rout);
+             info, cblas_info, reported);
       cblas_lerr = PASSED;
       cblas_ok = FALSE;
    } else {
@@ -65,8 +71,8 @@ void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout,
  */
 void F77_xerbla(FCHAR F77_srname, void *vinfo
 #ifdef BLAS_FORTRAN_STRLEN_END
-   ,
-   FORTRAN_STRLEN len
+                ,
+                FORTRAN_STRLEN len
 #endif
 )
 {

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -83,22 +83,20 @@ void F77_xerbla(FCHAR F77_srname, void *vinfo
       return;
    }
 
-   size_t srname_len;
 #ifdef BLAS_FORTRAN_STRLEN_END
-   srname_len = len > 0 ? (size_t)len : 0;
+   const size_t srname_len = len > 0 ? (size_t)len : 0;
 #else
-   srname_len = 6;
+   const size_t srname_len = 6;
 #endif
 
-   char *srname;
 #ifdef F77_CHAR
-   srname = F2C_STR(F77_srname, srname_len);
+   const char *srname = F2C_STR(F77_srname, srname_len);
 #else
-   srname = F77_srname;
+   const char *srname = F77_srname;
 #endif
 
-   F77_INT *info = (F77_INT *)vinfo;
-   CBLAS_INT cblas_info = (CBLAS_INT)*info;
+   const F77_INT *info = (const F77_INT *)vinfo;
+   const CBLAS_INT cblas_info = (CBLAS_INT)*info;
 
    char rout[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
    cblas_xerbla_make_rout(rout, sizeof(rout), srname, srname_len);

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -45,8 +45,8 @@ void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout,
 
    if (info != cblas_info) {
       printf("***** XERBLA WAS CALLED WITH INFO = %" CBLAS_IFMT
-             " INSTEAD OF %d in %s *******\n",
-             info, (int)cblas_info, rout);
+             " INSTEAD OF %" CBLAS_IFMT " in %s *******\n",
+             info, cblas_info, rout);
       cblas_lerr = PASSED;
       cblas_ok = FALSE;
    } else {

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -1,15 +1,31 @@
-#include <stdio.h>
 #include <ctype.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <string.h>
+
 #include "cblas.h"
 #include "cblas_test.h"
+#include "cblas_xerbla_internal.h"
 
-void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout, const char *form, ...)
+/**
+ * \brief Test-harness stand-in for the CBLAS error handler.
+ *
+ * Rather than terminating, checks the reported routine name and argument
+ * number against the values the calling tester put in cblas_rout and
+ * cblas_info, and records the outcome in cblas_ok and cblas_lerr.
+ *
+ * \param[in] info  CBLAS argument number reported by the caller.
+ * \param[in] rout  Routine name, e.g. "cblas_dgemm".
+ * \param[in] form  Unused; kept so the signature matches the library's.
+ */
+void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout,
+                              const char *form, ...)
 {
    extern CBLAS_INT cblas_lerr, cblas_info, cblas_ok;
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
+
+   (void)form;
 
    /* Initially, c__3chke may call this routine with
     * global variable link_xerbla=1, and F77_xerbla will set link_xerbla=0.
@@ -18,120 +34,71 @@ void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout, const char *form
     */
    if (link_xerbla) return;
 
-   if (cblas_rout != NULL && strcmp(cblas_rout, rout) != 0){
-      printf("***** XERBLA WAS CALLED WITH SRNAME = <%s> INSTEAD OF <%s> *******\n", rout, cblas_rout);
+   if (cblas_rout != NULL && strcmp(cblas_rout, rout) != 0) {
+      printf(
+         "***** XERBLA WAS CALLED WITH SRNAME = <%s> INSTEAD OF <%s> *******\n",
+         rout, cblas_rout);
       cblas_ok = FALSE;
    }
 
-   if (RowMajorStrg)
-   {
-      /* To properly check leading dimension problems in cblas__gemm, we
-       * need to do the following trick. When cblas__gemm is called with
-       * CblasRowMajor, the arguments A and B switch places in the call to
-       * f77__gemm. Thus when we test for bad leading dimension problems
-       * for A and B, lda is in position 11 instead of 9, and ldb is in
-       * position 9 instead of 11.
-       */
-      if (strstr(rout,"gemm") != 0 && strstr(rout, "gemmtr") == 0)
-      {
-         if      (info == 5 ) info =  4;
-         else if (info == 4 ) info =  5;
-         else if (info == 11) info =  9;
-         else if (info == 9 ) info = 11;
-      } else if (strstr(rout, "gemmtr") != 0)
-      {
-         if (info == 11) info =  9;
-         else if (info == 9 ) info = 11;
-      }
+   info = cblas_xerbla_map_info(info, rout, RowMajorStrg);
 
-      else if (strstr(rout,"symm") != 0 || strstr(rout,"skewsymm") != 0 || strstr(rout,"hemm") != 0)
-      {
-         if      (info == 5 ) info =  4;
-         else if (info == 4 ) info =  5;
-      }
-      else if (strstr(rout,"trmm") != 0 || strstr(rout,"trsm") != 0)
-      {
-         if      (info == 7 ) info =  6;
-         else if (info == 6 ) info =  7;
-      }
-      else if (strstr(rout,"gemv") != 0)
-      {
-         if      (info == 4)  info = 3;
-         else if (info == 3)  info = 4;
-      }
-      else if (strstr(rout,"gbmv") != 0)
-      {
-         if      (info == 4)  info = 3;
-         else if (info == 3)  info = 4;
-         else if (info == 6)  info = 5;
-         else if (info == 5)  info = 6;
-      }
-      else if (strstr(rout,"ger") != 0)
-      {
-         if      (info == 3) info = 2;
-         else if (info == 2) info = 3;
-         else if (info == 8) info = 6;
-         else if (info == 6) info = 8;
-      }
-      else if ( ( strstr(rout,"her2") != 0 || strstr(rout,"hpr2") != 0 )
-               && strstr(rout,"her2k") == 0 )
-      {
-         if      (info == 8) info = 6;
-         else if (info == 6) info = 8;
-      }
-   }
-
-   if (info != cblas_info){
-      printf("***** XERBLA WAS CALLED WITH INFO = %" CBLAS_IFMT " INSTEAD OF %d in %s *******\n",info, (int) cblas_info, rout);
+   if (info != cblas_info) {
+      printf("***** XERBLA WAS CALLED WITH INFO = %" CBLAS_IFMT
+             " INSTEAD OF %d in %s *******\n",
+             info, (int)cblas_info, rout);
       cblas_lerr = PASSED;
       cblas_ok = FALSE;
-   } else cblas_lerr = FAILED;
+   } else {
+      cblas_lerr = FAILED;
+   }
 }
 
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo
-#else
-void F77_xerbla(char *srname, void *vinfo
-#endif
+/**
+ * \brief Test-harness XERBLA that redirects Fortran errors to cblas_xerbla().
+ *
+ * \param[in] F77_srname  Routine name reported by the Fortran BLAS, blank
+ *                        padded and not NUL terminated.
+ * \param[in] vinfo       Pointer to the Fortran argument number.
+ * \param[in] len         Hidden Fortran length of \p F77_srname, on
+ *                        compilers that pass string lengths at the end.
+ */
+void F77_xerbla(FCHAR F77_srname, void *vinfo
 #ifdef BLAS_FORTRAN_STRLEN_END
-, FORTRAN_STRLEN srname_len
+   ,
+   FORTRAN_STRLEN len
 #endif
 )
 {
-#ifdef F77_Char
-   char *srname;
-#endif
-
-   char rout[] = {'c','b','l','a','s','_','\0','\0','\0','\0','\0','\0','\0', '\0', '\0', '\0', '\0', '\0'};
-
-#ifdef F77_Integer
-   F77_Integer *info=vinfo;
-   F77_Integer i;
-   extern F77_Integer link_xerbla;
-#else
-   CBLAS_INT *info=vinfo;
-   CBLAS_INT i;
-   extern CBLAS_INT link_xerbla;
-#endif
-#ifdef F77_Char
-   srname = F2C_STR(F77_srname, XerblaStrLen);
-#endif
-
    /* See the comment in API_SUFFIX(cblas_xerbla)() above */
-   if (link_xerbla)
-   {
+   extern CBLAS_INT link_xerbla;
+   if (link_xerbla) {
       link_xerbla = 0;
       return;
    }
-#ifndef BLAS_FORTRAN_STRLEN_END
-   const int srname_len = 6;
+
+   size_t srname_len;
+#ifdef BLAS_FORTRAN_STRLEN_END
+   srname_len = len > 0 ? (size_t)len : 0;
+#else
+   srname_len = 6;
 #endif
 
-   for(i=0;  i  < srname_len; i++) rout[i+6] = tolower(srname[i]);
-   for(i=16; i >= 9; i--) if (rout[i] == ' ') rout[i] = '\0';
+   char *srname;
+#ifdef F77_CHAR
+   srname = F2C_STR(F77_srname, srname_len);
+#else
+   srname = F77_srname;
+#endif
+
+   F77_INT *info = (F77_INT *)vinfo;
+   CBLAS_INT cblas_info = (CBLAS_INT)*info;
+
+   char rout[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
+   cblas_xerbla_make_rout(rout, sizeof(rout), srname, srname_len);
 
    /* We increment *info by 1 since the CBLAS interface adds one more
     * argument to all level 2 and 3 routines.
     */
-   API_SUFFIX(cblas_xerbla)(*info+1,rout,"");
+   API_SUFFIX(cblas_xerbla)(cblas_info + 1, rout, "");
 }

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -22,7 +22,7 @@ void chkxer(void) {
    extern CBLAS_INT link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", (int) cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %" CBLAS_IFMT " NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;


### PR DESCRIPTION
## Motivation

CBLAS carries three near-identical copies of the same two pieces of logic — building the `cblas_`-prefixed routine name, and remapping the Fortran argument number to the CBLAS argument position for row-major calls: `CBLAS/src/cblas_xerbla.c`, `CBLAS/src/xerbla.c` and `CBLAS/testing/c_xerbla.c`. They have drifted apart, and the `strstr()`-based matching they use is wrong for some routine names.

This PR extracts the logic into a single header, `CBLAS/include/cblas_xerbla_internal.h`, and makes all three sites use it. No public API or ABI change.

## Bugs fixed

* **`gemmtr` got the `gemm` remapping.** `strstr(rout, "gemm")` also matches
  `cblas_?gemmtr`, so row-major `gemmtr` errors swapped arguments 4 and 5 and reported
  the wrong parameter number. Matching is now exact (with the test harness's existing
  `gemmtr` special case folded in).
* **Routine names longer than six characters were truncated.** `src/xerbla.c` copied a
  fixed six characters into a fixed-size buffer, so e.g. `cblas_dskewsymm` was reported
  as `cblas_dskewsy`. The name is now trimmed from the real Fortran string length into a
  correctly sized buffer (with a bit of headroom for potential new routines).
* **Extended (64-bit) API builds reported the wrong name.** `Generate64BitSuffixedSource`
  rewrites the XERBLA literals, so the Fortran layer passes `DGEMM_64`. The suffix is now
  stripped when rebuilding the name and re-applied when reporting, so a 64-bit build names
  `cblas_dgemm_64()` and the test harness's name comparison matches.
* **`INFO` was read as the wrong integer type.** Both `xerbla.c` files dereferenced the
  Fortran-supplied `void *info` as `int`/`CBLAS_INT`; it is now read as `F77_INT`.
* **`skewsymm` was only handled by substring accident** (`strstr(rout, "symm")`); it is now
  matched explicitly.
* **Unbounded write into a fixed-size buffer in the test harness.** `F77_xerbla()` copied
  the name with `for (i = 0; i < srname_len; i++) rout[i+6] = ...`, where `srname_len` is
  the hidden Fortran string length, so nothing bounds the write by the size of `rout`.
  GCC 16 on macOS flags this:

  ```
  CBLAS/testing/c_xerbla.c:130:46: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  ```

  `cblas_xerbla_make_rout()` takes the destination size and bounds every write by it, so
  the warning goes away.

## Other changes

* `CBLAS_WEAK_SYMBOL` replaces the repeated `#ifdef HAS_ATTRIBUTE_WEAK_SUPPORT` /
  `__attribute__((weak))` blocks in `cblas.h`, `cblas_64.h` and `cblas_f77.h`.
* `cblas_test.h` now provides `F77_INT` and `FCHAR`, so the harness no longer rolls its own
  `F77_Integer`/`F77_Char` variants (which were invalid).
* `(int)` casts on `CBLAS_INT` values in the test printfs are replaced by `CBLAS_IFMT`,
  which was already the convention elsewhere; same for `PRId64` in `cblas_example1_64.c`.
* A `CBLAS/.clang-format` matching the existing CBLAS style, and `.gitignore` entries for
  shared libraries and debug info.

I tried to keep the .clang-format stye as close to the existing CBLAS formatting. This could enable us to actually format the entire CBLAS codebase without too many changes. Could be discussed in the future.