### PR TITLE
Fix extended API xerbla tests

### DIFF
--- a/BLAS/TESTING/cblat2.f
+++ b/BLAS/TESTING/cblat2.f
@@ -3451,7 +3451,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A6, ' INSTE',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INSTE',
      $      'AD OF ', A6, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/BLAS/TESTING/cblat2.f
+++ b/BLAS/TESTING/cblat2.f
@@ -3418,7 +3418,7 @@
 *
 *     .. Scalar Arguments ..
       INTEGER            INFO
-      CHARACTER*6        SRNAME
+      CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
       INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
@@ -3428,6 +3428,8 @@
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
       COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
+*     .. Locals ..
+      INTEGER            SRLEN
 *     .. Executable Statements ..
       LERR = .TRUE.
       IF( INFO.NE.INFOT )THEN
@@ -3439,7 +3441,8 @@
          OK = .FALSE.
          NXBAD = 1
       END IF
-      IF( SRNAME.NE.SRNAMT )THEN
+      SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
+      IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
          NXBAD = 1

--- a/BLAS/TESTING/cblat3.f
+++ b/BLAS/TESTING/cblat3.f
@@ -3775,7 +3775,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A7, ' INSTE',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INSTE',
      $      'AD OF ', A7, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/BLAS/TESTING/dblat2.f
+++ b/BLAS/TESTING/dblat2.f
@@ -3433,7 +3433,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A10, ' INST',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INST',
      $      'EAD OF ', A10, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/BLAS/TESTING/dblat3.f
+++ b/BLAS/TESTING/dblat3.f
@@ -3254,7 +3254,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A11, ' INST',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INST',
      $      'EAD OF ', A11, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/BLAS/TESTING/sblat2.f
+++ b/BLAS/TESTING/sblat2.f
@@ -3433,7 +3433,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A10, ' INST',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INST',
      $      'EAD OF ', A10, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/BLAS/TESTING/sblat3.f
+++ b/BLAS/TESTING/sblat3.f
@@ -3255,7 +3255,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A11, ' INST',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INST',
      $      'EAD OF ', A11, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/BLAS/TESTING/zblat2.f
+++ b/BLAS/TESTING/zblat2.f
@@ -3425,7 +3425,7 @@
 *
 *     .. Scalar Arguments ..
       INTEGER            INFO
-      CHARACTER*6        SRNAME
+      CHARACTER*(*)      SRNAME
 *     .. Scalars in Common ..
       INTEGER            NXRUN, NXFAIL, NXBAD
       INTEGER            INFOT, NOUT
@@ -3435,6 +3435,8 @@
       COMMON             /INFOC/INFOT, NOUT, OK, LERR
       COMMON             /XERCNT/NXRUN, NXFAIL, NXBAD
       COMMON             /SRNAMC/SRNAMT
+*     .. Locals ..
+      INTEGER            SRLEN
 *     .. Executable Statements ..
       LERR = .TRUE.
       IF( INFO.NE.INFOT )THEN
@@ -3446,7 +3448,8 @@
          OK = .FALSE.
          NXBAD = 1
       END IF
-      IF( SRNAME.NE.SRNAMT )THEN
+      SRLEN = MIN(LEN_TRIM(SRNAME), LEN_TRIM(SRNAMT))
+      IF( SRNAME(1:SRLEN).NE.SRNAMT(1:SRLEN) )THEN
          WRITE( NOUT, FMT = 9998 )SRNAME, SRNAMT
          OK = .FALSE.
          NXBAD = 1

--- a/BLAS/TESTING/zblat2.f
+++ b/BLAS/TESTING/zblat2.f
@@ -3458,7 +3458,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A6, ' INSTE',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INSTE',
      $      'AD OF ', A6, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/BLAS/TESTING/zblat3.f
+++ b/BLAS/TESTING/zblat3.f
@@ -3786,7 +3786,7 @@
 *
  9999 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6, ' INSTEAD',
      $      ' OF ', I2, ' *******' )
- 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A7, ' INSTE',
+ 9998 FORMAT( ' ******* XERBLA WAS CALLED WITH SRNAME = ', A, ' INSTE',
      $      'AD OF ', A7, ' *******' )
  9997 FORMAT( ' ******* XERBLA WAS CALLED WITH INFO = ', I6,
      $      ' *******' )

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -36,15 +36,20 @@ void API_SUFFIX(cblas_xerbla)(CBLAS_INT info, const char *rout,
    if (link_xerbla) return;
 
    /* The name is checked and reported as the user would see it, suffix and
-    * all, while the remapping below keys off the unsuffixed \p rout.
+    * all, while the remapping below keys off the unsuffixed \p rout. The
+    * expected name goes through the same normalisation, since the testers
+    * spell it without the extended API suffix.
     */
    char reported[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
    cblas_xerbla_apply_api_suffix(reported, sizeof(reported), rout);
 
-   if (cblas_rout != NULL && strcmp(cblas_rout, reported) != 0) {
+   char expected[CBLAS_XERBLA_ROUT_BUFFER_SIZE];
+   cblas_xerbla_apply_api_suffix(expected, sizeof(expected), cblas_rout);
+
+   if (cblas_rout != NULL && strcmp(expected, reported) != 0) {
       printf(
          "***** XERBLA WAS CALLED WITH SRNAME = <%s> INSTEAD OF <%s> *******\n",
-         reported, cblas_rout);
+         reported, expected);
       cblas_ok = FALSE;
       cblas_xbad = 1;
    }


### PR DESCRIPTION
**Description**

Fixes the xerbla error-exit tests in extended API (`_64`) builds, where the library reports a suffixed routine name (`CGEMV_64`, `cblas_cgemv_64`) that the testers were not prepared for.

1. **`cblat2.f`, `zblat2.f`** — their private `XERBLA` still declared `CHARACTER*6 SRNAME` and compared it exactly, so `'CGEMV_64 '` truncated to `'CGEMV_'` and never matched. They now use the assumed-length dummy and `LEN_TRIM` prefix compare that the other six testers already got in 4c637b832 and a0e44d743 — those two were simply missed, since no complex Level 2 name exceeds 6 characters.

2. **All eight Level 2/3 testers** — the mismatch diagnostic printed the reported name through a fixed-width `A6`/`A7`/`A10`/`A11` descriptor, which truncates it. Only that one descriptor becomes `A`; the expected name keeps its width, which already matches its declaration exactly. 

3. **`c_xerbla.c`** — the CBLAS testers spell `cblas_rout` without the suffix, so every `_64` error-exit test reported a name mismatch. The expected name now goes through the same normalisation as the reported one.