### PR TITLE
BLAS: Restore compact ROTMG flag output when no rescaling occurs

### DIFF
--- a/BLAS/SRC/drotmg.f
+++ b/BLAS/SRC/drotmg.f
@@ -193,48 +193,54 @@
             END IF
          END IF
 
-*     Normalize flag to -ONE so all H elements are explicit
-*
-           IF( DFLAG.EQ.ZERO ) THEN
-              DH11 = ONE
-              DH22 = ONE
-              DFLAG = -ONE
-           ELSE IF( DFLAG.EQ.ONE ) THEN
-              DH21 = -ONE
-              DH12 = ONE
-              DFLAG = -ONE
-           END IF
-*
 *     PROCEDURE..SCALE-CHECK
-          IF (DD1.NE.ZERO) THEN
-             DO WHILE ((DD1.LE.RGAMSQ) .OR. (DD1.GE.GAMSQ))
-                 IF (DD1.LE.RGAMSQ) THEN
-                    DD1 = DD1*GAM**2
-                    DX1 = DX1/GAM
-                    DH11 = DH11/GAM
-                    DH12 = DH12/GAM
-                 ELSE
-                    DD1 = DD1/GAM**2
-                    DX1 = DX1*GAM
-                    DH11 = DH11*GAM
-                    DH12 = DH12*GAM
-                 END IF
-              ENDDO
-           END IF
+         IF (DD1.NE.ZERO) THEN
+            DO WHILE ((DD1.LE.RGAMSQ) .OR. (DD1.GE.GAMSQ))
+               IF (DFLAG.EQ.ZERO) THEN
+                  DH11 = ONE
+                  DH22 = ONE
+                  DFLAG = -ONE
+               ELSE IF (DFLAG.EQ.ONE) THEN
+                  DH21 = -ONE
+                  DH12 = ONE
+                  DFLAG = -ONE
+               END IF
+               IF (DD1.LE.RGAMSQ) THEN
+                  DD1 = DD1*GAM**2
+                  DX1 = DX1/GAM
+                  DH11 = DH11/GAM
+                  DH12 = DH12/GAM
+               ELSE
+                  DD1 = DD1/GAM**2
+                  DX1 = DX1*GAM
+                  DH11 = DH11*GAM
+                  DH12 = DH12*GAM
+               END IF
+            ENDDO
+         END IF
 
-          IF (DD2.NE.ZERO) THEN
-             DO WHILE ((DABS(DD2).LE.RGAMSQ) .OR. (DABS(DD2).GE.GAMSQ))
-                IF (DABS(DD2).LE.RGAMSQ) THEN
-                   DD2 = DD2*GAM**2
-                   DH21 = DH21/GAM
-                   DH22 = DH22/GAM
-                ELSE
-                   DD2 = DD2/GAM**2
-                   DH21 = DH21*GAM
-                   DH22 = DH22*GAM
-                END IF
-             END DO
-          END IF
+         IF (DD2.NE.ZERO) THEN
+            DO WHILE ( (DABS(DD2).LE.RGAMSQ) .OR. (DABS(DD2).GE.GAMSQ) )
+               IF (DFLAG.EQ.ZERO) THEN
+                  DH11 = ONE
+                  DH22 = ONE
+                  DFLAG = -ONE
+               ELSE IF (DFLAG.EQ.ONE) THEN
+                  DH21 = -ONE
+                  DH12 = ONE
+                  DFLAG = -ONE
+               END IF
+               IF (DABS(DD2).LE.RGAMSQ) THEN
+                  DD2 = DD2*GAM**2
+                  DH21 = DH21/GAM
+                  DH22 = DH22/GAM
+               ELSE
+                  DD2 = DD2/GAM**2
+                  DH21 = DH21*GAM
+                  DH22 = DH22*GAM
+               END IF
+            END DO
+         END IF
 
       END IF
 

--- a/BLAS/SRC/srotmg.f
+++ b/BLAS/SRC/srotmg.f
@@ -193,48 +193,54 @@
             END IF
          END IF
 
-*     Normalize flag to -ONE so all H elements are explicit
-*
-           IF( SFLAG.EQ.ZERO ) THEN
-              SH11 = ONE
-              SH22 = ONE
-              SFLAG = -ONE
-           ELSE IF( SFLAG.EQ.ONE ) THEN
-              SH21 = -ONE
-              SH12 = ONE
-              SFLAG = -ONE
-           END IF
-*
 *     PROCEDURE..SCALE-CHECK
-          IF (SD1.NE.ZERO) THEN
-             DO WHILE ((SD1.LE.RGAMSQ) .OR. (SD1.GE.GAMSQ))
-                 IF (SD1.LE.RGAMSQ) THEN
-                    SD1 = SD1*GAM**2
-                    SX1 = SX1/GAM
-                    SH11 = SH11/GAM
-                    SH12 = SH12/GAM
-                 ELSE
-                    SD1 = SD1/GAM**2
-                    SX1 = SX1*GAM
-                    SH11 = SH11*GAM
-                    SH12 = SH12*GAM
-                 END IF
-              ENDDO
-           END IF
+         IF (SD1.NE.ZERO) THEN
+            DO WHILE ((SD1.LE.RGAMSQ) .OR. (SD1.GE.GAMSQ))
+               IF (SFLAG.EQ.ZERO) THEN
+                  SH11 = ONE
+                  SH22 = ONE
+                  SFLAG = -ONE
+               ELSE IF (SFLAG.EQ.ONE) THEN
+                  SH21 = -ONE
+                  SH12 = ONE
+                  SFLAG = -ONE
+               END IF
+               IF (SD1.LE.RGAMSQ) THEN
+                  SD1 = SD1*GAM**2
+                  SX1 = SX1/GAM
+                  SH11 = SH11/GAM
+                  SH12 = SH12/GAM
+               ELSE
+                  SD1 = SD1/GAM**2
+                  SX1 = SX1*GAM
+                  SH11 = SH11*GAM
+                  SH12 = SH12*GAM
+               END IF
+            ENDDO
+         END IF
 
-           IF (SD2.NE.ZERO) THEN
-              DO WHILE ( (ABS(SD2).LE.RGAMSQ) .OR. (ABS(SD2).GE.GAMSQ) )
-                 IF (ABS(SD2).LE.RGAMSQ) THEN
-                    SD2 = SD2*GAM**2
-                    SH21 = SH21/GAM
-                    SH22 = SH22/GAM
-                 ELSE
-                    SD2 = SD2/GAM**2
-                    SH21 = SH21*GAM
-                    SH22 = SH22*GAM
-                 END IF
-              END DO
-           END IF
+         IF (SD2.NE.ZERO) THEN
+            DO WHILE ( (ABS(SD2).LE.RGAMSQ) .OR. (ABS(SD2).GE.GAMSQ) )
+               IF (SFLAG.EQ.ZERO) THEN
+                  SH11 = ONE
+                  SH22 = ONE
+                  SFLAG = -ONE
+               ELSE IF (SFLAG.EQ.ONE) THEN
+                  SH21 = -ONE
+                  SH12 = ONE
+                  SFLAG = -ONE
+               END IF
+               IF (ABS(SD2).LE.RGAMSQ) THEN
+                  SD2 = SD2*GAM**2
+                  SH21 = SH21/GAM
+                  SH22 = SH22/GAM
+               ELSE
+                  SD2 = SD2/GAM**2
+                  SH21 = SH21*GAM
+                  SH22 = SH22*GAM
+               END IF
+            END DO
+         END IF
 
       END IF
 


### PR DESCRIPTION
**Description**

Since 6dc1a78 (#1284, the fix for #244), `SROTMG`/`DROTMG` normalize
`DFLAG` 0/1 to -1 for *every* regular result, not just rescaled ones. That
contradicts the documented compact `DPARAM` forms (implied values "ARE NOT
STORED"), diverges from other implementations (OpenBLAS, MKL, Gonum), costs
`xROTM` its cheaper flag-0/1 paths, and fails `xblat1`'s ROTMG points 1–2,
whose expected results still encode the compact forms:

```
SROTMG COMPUTATIONAL TESTS:       81 RUN,        6 FAILED
DROTMG COMPUTATIONAL TESTS:       81 RUN,        6 FAILED
```

The commit message of 6dc1a78 describes a minimal fix — change the scaling
loops' `ELSE` to `ELSE IF (DFLAG.EQ.ONE)` so the implied-element
initialization can't clobber an already-scaled `DH12`/`DH21` — but the code
instead hoisted the normalization out of the loops and made it
unconditional. This PR implements what the message described: normalization
back inside both loops, with the guard.