### PR TITLE
TESTING: raise SEP threshold to account for xSTEIN's orthogonality guarantee

### DIFF
--- a/TESTING/se2.in
+++ b/TESTING/se2.in
@@ -5,7 +5,7 @@ SE2:  Data file for testing Symmetric Eigenvalue Problem routines
 1 3  3  3 10                      Values of NB (blocksize)
 2 2  2  2  2                      Values of NBMIN (minimum blocksize)
 1 0  5  9  1                      Values of NX (crossover point)
-500.0                             Threshold value
+60.0                              Threshold value (theoretical limit ~500, empirically reached limit ~170, increase if necessary)
 T                                 Put T to test the LAPACK routines
 T                                 Put T to test the driver routines
 T                                 Put T to test the error exits

--- a/TESTING/se2.in
+++ b/TESTING/se2.in
@@ -5,7 +5,7 @@ SE2:  Data file for testing Symmetric Eigenvalue Problem routines
 1 3  3  3 10                      Values of NB (blocksize)
 2 2  2  2  2                      Values of NBMIN (minimum blocksize)
 1 0  5  9  1                      Values of NX (crossover point)
-50.0                              Threshold value
+500.0                             Threshold value
 T                                 Put T to test the LAPACK routines
 T                                 Put T to test the driver routines
 T                                 Put T to test the error exits

--- a/TESTING/sep.in
+++ b/TESTING/sep.in
@@ -5,7 +5,7 @@ SEP:  Data file for testing Symmetric Eigenvalue Problem routines
 1 3  3  3 10                      Values of NB (blocksize)
 2 2  2  2  2                      Values of NBMIN (minimum blocksize)
 1 0  5  9  1                      Values of NX (crossover point)
-50.0                              Threshold value
+500.0                             Threshold value
 T                                 Put T to test the LAPACK routines
 T                                 Put T to test the driver routines
 T                                 Put T to test the error exits

--- a/TESTING/sep.in
+++ b/TESTING/sep.in
@@ -5,7 +5,7 @@ SEP:  Data file for testing Symmetric Eigenvalue Problem routines
 1 3  3  3 10                      Values of NB (blocksize)
 2 2  2  2  2                      Values of NBMIN (minimum blocksize)
 1 0  5  9  1                      Values of NX (crossover point)
-500.0                             Threshold value
+60.0                              Threshold value (theoretical limit ~500, empirically reached limit ~170, increase if necessary)
 T                                 Put T to test the LAPACK routines
 T                                 Put T to test the driver routines
 T                                 Put T to test the error exits


### PR DESCRIPTION
## Problem

The SEP test suites report a single deterministic numerical failure (observed for example with
ifx on Windows, both the 32-bit and 64-bit integer APIs):

```
Testing COMPLEX 'Symmetric Eigenvalue Problem' (csep.out / csep_64.out)
Testing COMPLEX 'Symmetric Eigenvalue Problem 2-stage' (cse2.out / cse2_64.out)
 Matrix order=    5, type=21, seed= 240,1205,2853,1453, result  21 is   53.72
 CST:    1 out of  4440 tests failed to pass the threshold
```

## Root cause

**DISCLAIMER: The following derivation of the theoretical worst-case was done by Claude Fable 5 ... so could contain mistakes, take it for what it is.**

`xSTEIN` reorthogonalizes (modified Gram-Schmidt) only eigenvectors whose
eigenvalues lie within `ORTOL = 1e-3 * ||T||_1` of each other.  A pair of
eigenvalues with a gap *just above* `ORTOL` is deliberately not reorthogonalized,
and inverse iteration then only guarantees

```
|z_i^H z_j|  <=  (||r_i|| + ||r_j||) / |lambda_i - lambda_j|  =  O(ulp * ||T|| / gap)
```

For the failing matrix (5x5 Hermitian tridiagonal, matrix type 21: diagonally
dominant with geometrically spaced eigenvalues) the eigenvalues `1.222e-4` and
`2.362e-3` have gap `2.24e-3 ~= 2.1 * ORTOL`, so their eigenvectors are skipped by
the reorthogonalization and retain an inner product of ~211 ulp, giving the ratio
53.72.  This is expected, documented behavior of inverse iteration; the test's
`n * ulp` scaling simply does not model the gap-just-above-ORTOL regime.

## Worst-case analysis

Theoretical bound: with converged residuals `||r|| <= C * ulp * ||T||_1` and gaps
between different Gram-Schmidt groups exceeding `k * ORTOL` (k = number of group
boundaries crossed), the 1-norm accumulates harmonically over a ladder of
singleton groups:

```
RESULT(21)  <=  2000 * C * (2 * H(n-1)) / n      (H = harmonic number)
```

Empirical calibration of `C`: staged adversarial scans (~2.6 million generated
symmetric tridiagonals run through the exact `SSTEBZ('A','B')` + `CSTEIN` +
`CSTT21` pipeline, with Monte-Carlo perturbation of the last bits) never produced
a per-pair contamination above `~450 * ulp / (gap/ORTOL)`, i.e. `C ~= 0.22-0.25`.
With `C = 0.25` the bound evaluates to ~500 at n = 3 (its supremum over n), ~417
at n = 5 and ~177 at n = 20.  Notes:

* the worst reachable shape is a norm-carrying eigenvalue at `||T||` weakly
  coupled to a cluster of eigenvalues near 0 spaced just above `ORTOL`;
  the largest ratio actually observed in the scans is **169.7** (n = 4);
* n = 2 is structurally immune: a 2x2 tridiagonal has gap >= 2|e|, so any
  coupling strong enough to contaminate forces the gap far above `ORTOL`;
* the ratio is precision-independent (everything scales with ulp), so the same
  threshold serves all four precisions.

## Change

Raise the threshold in `TESTING/sep.in` and `TESTING/se2.in` from 50 to **60** and
document the legitimate ceiling in the input files themselves:

```
60.0    Threshold value (theoretical limit ~500, empirically reached limit ~170, increase if necessary)
```

60 clears the known deterministic failure (53.72) with margin while keeping the
suite tight for genuine regressions, which produce ratios orders of magnitude
larger (`ULPINV ~ 1.7e7` in single precision).  Should another seed/compiler
combination legitimately exceed 60, the in-file comment records how far the ratio
can go before a real bug should be suspected.

