### PR TITLE
TESTING: fix random IL/IU selection in the symmetric eigenvalue testers

### DIFF
--- a/TESTING/EIG/cchkst.f
+++ b/TESTING/EIG/cchkst.f
@@ -1353,8 +1353,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1617,8 +1617,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1677,8 +1677,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/cchkst.f
+++ b/TESTING/EIG/cchkst.f
@@ -1353,8 +1353,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1617,8 +1617,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1677,8 +1677,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/cchkst2stg.f
+++ b/TESTING/EIG/cchkst2stg.f
@@ -1444,8 +1444,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1707,8 +1707,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1766,8 +1766,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/cchkst2stg.f
+++ b/TESTING/EIG/cchkst2stg.f
@@ -1444,8 +1444,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1707,8 +1707,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1766,8 +1766,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/cdrvbd.f
+++ b/TESTING/EIG/cdrvbd.f
@@ -1140,8 +1140,8 @@
                   IL = 1
                   IU = MAX( 1, MNMIN )
                ELSE
-                  IL = 1 + INT( REAL( MNMIN-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( MNMIN-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( MNMIN )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( MNMIN )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/cdrvsg.f
+++ b/TESTING/EIG/cdrvsg.f
@@ -663,8 +663,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/cdrvsg2stg.f
+++ b/TESTING/EIG/cdrvsg2stg.f
@@ -671,8 +671,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/cdrvst.f
+++ b/TESTING/EIG/cdrvst.f
@@ -630,8 +630,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/cdrvst2stg.f
+++ b/TESTING/EIG/cdrvst2stg.f
@@ -632,8 +632,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/dchkbd.f
+++ b/TESTING/EIG/dchkbd.f
@@ -1261,8 +1261,8 @@
                IL = 1
                IU = MNMIN
             ELSE
-               IL = 1 + INT( ( MNMIN-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( MNMIN-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( MNMIN*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( MNMIN*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL

--- a/TESTING/EIG/dchkst.f
+++ b/TESTING/EIG/dchkst.f
@@ -1337,8 +1337,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1598,8 +1598,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1658,8 +1658,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/dchkst.f
+++ b/TESTING/EIG/dchkst.f
@@ -1337,8 +1337,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1598,8 +1598,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1658,8 +1658,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/dchkst2stg.f
+++ b/TESTING/EIG/dchkst2stg.f
@@ -1425,8 +1425,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1686,8 +1686,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1745,8 +1745,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/dchkst2stg.f
+++ b/TESTING/EIG/dchkst2stg.f
@@ -1425,8 +1425,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1686,8 +1686,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1745,8 +1745,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/ddrvbd.f
+++ b/TESTING/EIG/ddrvbd.f
@@ -1075,8 +1075,8 @@
                   IL = 1
                   IU = MAX( 1, MNMIN )
                ELSE
-                  IL = 1 + INT( ( MNMIN-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( MNMIN-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( MNMIN*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( MNMIN*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/ddrvsg.f
+++ b/TESTING/EIG/ddrvsg.f
@@ -645,8 +645,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/ddrvsg2stg.f
+++ b/TESTING/EIG/ddrvsg2stg.f
@@ -654,8 +654,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/ddrvst.f
+++ b/TESTING/EIG/ddrvst.f
@@ -759,8 +759,8 @@ c           LIWEDC = 12
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/ddrvst.f
+++ b/TESTING/EIG/ddrvst.f
@@ -759,8 +759,8 @@ c           LIWEDC = 12
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/ddrvst2stg.f
+++ b/TESTING/EIG/ddrvst2stg.f
@@ -761,8 +761,8 @@ c           LIWEDC = 12
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/schkbd.f
+++ b/TESTING/EIG/schkbd.f
@@ -1261,8 +1261,8 @@
                IL = 1
                IU = MNMIN
             ELSE
-               IL = 1 + INT( REAL( MNMIN-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( MNMIN-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( MNMIN )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( MNMIN )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL

--- a/TESTING/EIG/schkst.f
+++ b/TESTING/EIG/schkst.f
@@ -1337,8 +1337,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1598,8 +1598,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1658,8 +1658,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/schkst.f
+++ b/TESTING/EIG/schkst.f
@@ -1337,8 +1337,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1598,8 +1598,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1658,8 +1658,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/schkst2stg.f
+++ b/TESTING/EIG/schkst2stg.f
@@ -1426,8 +1426,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1688,8 +1688,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1747,8 +1747,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/schkst2stg.f
+++ b/TESTING/EIG/schkst2stg.f
@@ -1426,8 +1426,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1688,8 +1688,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1747,8 +1747,8 @@
 *
                IF( SRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/sdrvbd.f
+++ b/TESTING/EIG/sdrvbd.f
@@ -1075,8 +1075,8 @@
                   IL = 1
                   IU = MAX( 1, MNMIN )
                ELSE
-                  IL = 1 + INT( REAL( MNMIN-1 )*SLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( REAL( MNMIN-1 )*SLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( REAL( MNMIN )*SLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( REAL( MNMIN )*SLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/sdrvsg.f
+++ b/TESTING/EIG/sdrvsg.f
@@ -645,8 +645,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/sdrvsg2stg.f
+++ b/TESTING/EIG/sdrvsg2stg.f
@@ -654,8 +654,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/sdrvst.f
+++ b/TESTING/EIG/sdrvst.f
@@ -759,8 +759,8 @@ c           LIWEDC = 12
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/sdrvst2stg.f
+++ b/TESTING/EIG/sdrvst2stg.f
@@ -761,8 +761,8 @@ c           LIWEDC = 12
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
-               IU = 1 + INT( REAL( N-1 )*SLARND( 1, ISEED2 ) )
+               IL = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
+               IU = 1 + INT( REAL( N )*SLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/zchkst.f
+++ b/TESTING/EIG/zchkst.f
@@ -1353,8 +1353,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1616,8 +1616,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1676,8 +1676,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/zchkst.f
+++ b/TESTING/EIG/zchkst.f
@@ -1353,8 +1353,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1616,8 +1616,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1676,8 +1676,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/zchkst2stg.f
+++ b/TESTING/EIG/zchkst2stg.f
@@ -1443,8 +1443,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1706,8 +1706,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1765,8 +1765,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/zchkst2stg.f
+++ b/TESTING/EIG/zchkst2stg.f
@@ -1443,8 +1443,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-               IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                IF( IU.LT.IL ) THEN
                   ITEMP = IU
                   IU = IL
@@ -1706,8 +1706,8 @@
 *
                   RESULT( 27 ) = TEMP1 / TEMP2
 *
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL
@@ -1765,8 +1765,8 @@
 *
                IF( CRANGE ) THEN
                   NTEST = 29
-                  IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
-                  IU = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/zdrvbd.f
+++ b/TESTING/EIG/zdrvbd.f
@@ -1139,8 +1139,8 @@
                   IL = 1
                   IU = MAX( 1, MNMIN )
                ELSE
-                  IL = 1 + INT( ( MNMIN-1 )*DLARND( 1, ISEED2 ) )
-                  IU = 1 + INT( ( MNMIN-1 )*DLARND( 1, ISEED2 ) )
+                  IL = 1 + INT( MNMIN*DLARND( 1, ISEED2 ) )
+                  IU = 1 + INT( MNMIN*DLARND( 1, ISEED2 ) )
                   IF( IU.LT.IL ) THEN
                      ITEMP = IU
                      IU = IL

--- a/TESTING/EIG/zdrvsg.f
+++ b/TESTING/EIG/zdrvsg.f
@@ -663,8 +663,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/zdrvsg2stg.f
+++ b/TESTING/EIG/zdrvsg2stg.f
@@ -671,8 +671,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/zdrvst.f
+++ b/TESTING/EIG/zdrvst.f
@@ -630,8 +630,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU

--- a/TESTING/EIG/zdrvst2stg.f
+++ b/TESTING/EIG/zdrvst2stg.f
@@ -632,8 +632,8 @@
                IL = 1
                IU = N
             ELSE
-               IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
-               IU = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
+               IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
+               IU = 1 + INT( N*DLARND( 1, ISEED2 ) )
                IF( IL.GT.IU ) THEN
                   ITEMP = IL
                   IL = IU


### PR DESCRIPTION
## Description

`xCHKST`, `xCHKST2STG` and `DDRVST` never actually tested a partial eigenvalue range.  Their "choose random values for IL and IU" code applied `INT` to the `(0,1)` deviate instead of to the scaled value:

```fortran
IL = 1 + ( N-1 )*INT( DLARND( 1, ISEED2 ) )
```

`xLARND(1,·)` returns a value strictly inside `(0,1)`, so `INT(...)` is `0` on every call and the expression collapses to `IL = IU = 1`.  Every `RANGE='I'`/`RANGE='V'` test in those routines has been running on a single eigenvector.

Two commits: the fix, then a follow-up that widens the drawn range to the full `[1,N]`.

## 1. `TESTING: fix random IL and IU selection in xCHKST and DDRVST`

50 sites in 9 files, rewritten to the form already used by `xDRVBD`, `xDRVSG`, `xDRVST2STG` and the s/c/z `xDRVST` variants:

```fortran
IL = 1 + INT( ( N-1 )*DLARND( 1, ISEED2 ) )
```

## 2. `TESTING: draw IL and IU from the full [1,N] range`

`1 + INT( (N-1)*u )` with `u ∈ (0,1)` yields `[1, N-1]`, so `IU = N` can never be drawn.  The consumer in `ddrvst.f` explicitly guards for it:

```fortran
IF( IU.NE.N ) THEN
   VU = D1( IU ) + MAX( HALF*( D1( IU+1 )-D1( IU ) ), ... )
ELSE IF( N.GT.0 ) THEN
   VU = D1( N ) + MAX( HALF*( D1( N )-D1( 1 ) ), ... )
```

The `IU.NE.N` test exists only to keep `D1(IU+1)` in bounds, so the `ELSE` branch was written for a case the generator could not produce.  It has never executed.  This commit switches all 46 IL/IU draw pairs (92 lines, 30 files, covering `x{chk,drv}st`, `x{chk,drv}st2stg`, `xdrvsg`, `xdrvsg2stg`, `xchkbd`, `xdrvbd`) to:

```fortran
IL = 1 + INT( N*DLARND( 1, ISEED2 ) )
```

The `(N-1)` form predates the git history (2008 trunk import), so there is no recorded rationale.  It looks like the linear map of `[0,1]` onto `[1,N]`, which is correct with `NINT` but drops the top value under truncation.