### PR TITLE
TESTING: Accept the documented `xGEES` reordering exit codes `N+1` and `N+2`

### DIFF
--- a/TESTING/EIG/ddrves.f
+++ b/TESTING/EIG/ddrves.f
@@ -734,7 +734,14 @@
                   CALL DLACPY( 'F', N, N, A, LDA, H, LDA )
                   CALL DGEES( 'V', SORT, DSLECT, N, H, LDA, SDIM, WR,
      $                        WI, VS, LDVS, WORK, NNWORK, BWORK, IINFO )
-                  IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+                  IF( IINFO.EQ.N+1 ) THEN
+                     WRITE( NOUNIT, FMT = 9991 )'DGEES1', IINFO, N,
+     $                  JTYPE, IOLDSD
+                     GO TO 220
+                  ELSE IF( IINFO.EQ.N+2 ) THEN
+                     WRITE( NOUNIT, FMT = 9990 )'DGEES1', IINFO, N,
+     $                  JTYPE, IOLDSD
+                  ELSE IF( IINFO.NE.0 ) THEN
                      RESULT( 1+RSUB ) = ULPINV
                      WRITE( NOUNIT, FMT = 9992 )'DGEES1', IINFO, N,
      $                  JTYPE, IOLDSD
@@ -809,7 +816,14 @@
                   CALL DGEES( 'N', SORT, DSLECT, N, HT, LDA, SDIM, WRT,
      $                        WIT, VS, LDVS, WORK, NNWORK, BWORK,
      $                        IINFO )
-                  IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+                  IF( IINFO.EQ.N+1 ) THEN
+                     WRITE( NOUNIT, FMT = 9991 )'DGEES2', IINFO, N,
+     $                  JTYPE, IOLDSD
+                     GO TO 220
+                  ELSE IF( IINFO.EQ.N+2 ) THEN
+                     WRITE( NOUNIT, FMT = 9990 )'DGEES2', IINFO, N,
+     $                  JTYPE, IOLDSD
+                  ELSE IF( IINFO.NE.0 ) THEN
                      RESULT( 5+RSUB ) = ULPINV
                      WRITE( NOUNIT, FMT = 9992 )'DGEES2', IINFO, N,
      $                  JTYPE, IOLDSD
@@ -950,6 +964,14 @@
      $      ' type ', I2, ', test(', I2, ')=', G10.3 )
  9992 FORMAT( ' DDRVES: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
      $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9991 FORMAT( ' DDRVES: ', A, ' returned the known code N+1 =', I6,
+     $      ': eigenvalues too close', / 9X, 'to reorder; ill-',
+     $      'conditioned matrix, accepted as no error.', / 9X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9990 FORMAT( ' DDRVES: ', A, ' returned the known code N+2 =', I6,
+     $      ': roundoff undid the sort', / 9X, 'order; ill-conditioned',
+     $      ' matrix, accepted as no error.', / 9X, 'N=', I6,
+     $      ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
 *
       RETURN
 *

--- a/TESTING/EIG/dget24.f
+++ b/TESTING/EIG/dget24.f
@@ -458,7 +458,24 @@
          CALL DGEESX( 'V', SORT, DSLECT, 'N', N, H, LDA, SDIM, WR, WI,
      $                VS, LDVS, RCONDE, RCONDV, WORK, LWORK, IWORK,
      $                LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX1', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX1', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            RETURN
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX1', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX1', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 1+RSUB ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'DGEESX1', IINFO, N, JTYPE,
@@ -567,7 +584,24 @@
          CALL DGEESX( 'N', SORT, DSLECT, 'N', N, HT, LDA, SDIM, WRT,
      $                WIT, VS, LDVS, RCONDE, RCONDV, WORK, LWORK, IWORK,
      $                LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX2', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX2', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX2', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX2', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 5+RSUB ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'DGEESX2', IINFO, N, JTYPE,
@@ -633,7 +667,24 @@
          CALL DGEESX( 'V', SORT, DSLECT, 'B', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCONDE, RCONDV, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX3', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX3', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX3', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX3', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
@@ -668,7 +719,24 @@
          CALL DGEESX( 'N', SORT, DSLECT, 'B', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX4', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX4', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX4', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX4', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
@@ -710,7 +778,24 @@
          CALL DGEESX( 'V', SORT, DSLECT, 'E', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX5', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX5', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX5', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX5', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'DGEESX5', IINFO, N, JTYPE,
@@ -749,7 +834,24 @@
          CALL DGEESX( 'N', SORT, DSLECT, 'E', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX6', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX6', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX6', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX6', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'DGEESX6', IINFO, N, JTYPE,
@@ -788,7 +890,24 @@
          CALL DGEESX( 'V', SORT, DSLECT, 'V', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX7', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX7', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX7', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX7', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'DGEESX7', IINFO, N, JTYPE,
@@ -827,7 +946,24 @@
          CALL DGEESX( 'N', SORT, DSLECT, 'V', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'DGEESX8', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'DGEESX8', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'DGEESX8', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'DGEESX8', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'DGEESX8', IINFO, N, JTYPE,
@@ -911,7 +1047,12 @@
          CALL DGEESX( 'N', 'S', DSLECT, 'B', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCONDE, RCONDV, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            WRITE( NOUNIT, FMT = 9997 )'DGEESX9', IINFO, N, ISEED( 1 )
+            GO TO 300
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            WRITE( NOUNIT, FMT = 9995 )'DGEESX9', IINFO, N, ISEED( 1 )
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 16 ) = ULPINV
             RESULT( 17 ) = ULPINV
             WRITE( NOUNIT, FMT = 9999 )'DGEESX9', IINFO, N, ISEED( 1 )
@@ -985,6 +1126,22 @@
      $      I6, ', INPUT EXAMPLE NUMBER = ', I4 )
  9998 FORMAT( ' DGET24: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
      $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9997 FORMAT( ' DGET24: ', A, ' returned the known code N+1 =', I6,
+     $      ': eigenvalues too close', / 9X, 'to reorder; ill-',
+     $      'conditioned matrix, accepted as no error.', / 9X, 'N=',
+     $      I6, ', INPUT EXAMPLE NUMBER = ', I4 )
+ 9996 FORMAT( ' DGET24: ', A, ' returned the known code N+1 =', I6,
+     $      ': eigenvalues too close', / 9X, 'to reorder; ill-',
+     $      'conditioned matrix, accepted as no error.', / 9X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9995 FORMAT( ' DGET24: ', A, ' returned the known code N+2 =', I6,
+     $      ': roundoff undid the sort', / 9X, 'order; ill-conditioned',
+     $      ' matrix, accepted as no error.', / 9X, 'N=', I6,
+     $      ', INPUT EXAMPLE NUMBER = ', I4 )
+ 9994 FORMAT( ' DGET24: ', A, ' returned the known code N+2 =', I6,
+     $      ': roundoff undid the sort', / 9X, 'order; ill-conditioned',
+     $      ' matrix, accepted as no error.', / 9X, 'N=', I6,
+     $      ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
 *
       RETURN
 *

--- a/TESTING/EIG/sdrves.f
+++ b/TESTING/EIG/sdrves.f
@@ -734,7 +734,14 @@
                   CALL SLACPY( 'F', N, N, A, LDA, H, LDA )
                   CALL SGEES( 'V', SORT, SSLECT, N, H, LDA, SDIM, WR,
      $                        WI, VS, LDVS, WORK, NNWORK, BWORK, IINFO )
-                  IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+                  IF( IINFO.EQ.N+1 ) THEN
+                     WRITE( NOUNIT, FMT = 9991 )'SGEES1', IINFO, N,
+     $                  JTYPE, IOLDSD
+                     GO TO 220
+                  ELSE IF( IINFO.EQ.N+2 ) THEN
+                     WRITE( NOUNIT, FMT = 9990 )'SGEES1', IINFO, N,
+     $                  JTYPE, IOLDSD
+                  ELSE IF( IINFO.NE.0 ) THEN
                      RESULT( 1+RSUB ) = ULPINV
                      WRITE( NOUNIT, FMT = 9992 )'SGEES1', IINFO, N,
      $                  JTYPE, IOLDSD
@@ -809,7 +816,14 @@
                   CALL SGEES( 'N', SORT, SSLECT, N, HT, LDA, SDIM, WRT,
      $                        WIT, VS, LDVS, WORK, NNWORK, BWORK,
      $                        IINFO )
-                  IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+                  IF( IINFO.EQ.N+1 ) THEN
+                     WRITE( NOUNIT, FMT = 9991 )'SGEES2', IINFO, N,
+     $                  JTYPE, IOLDSD
+                     GO TO 220
+                  ELSE IF( IINFO.EQ.N+2 ) THEN
+                     WRITE( NOUNIT, FMT = 9990 )'SGEES2', IINFO, N,
+     $                  JTYPE, IOLDSD
+                  ELSE IF( IINFO.NE.0 ) THEN
                      RESULT( 5+RSUB ) = ULPINV
                      WRITE( NOUNIT, FMT = 9992 )'SGEES2', IINFO, N,
      $                  JTYPE, IOLDSD
@@ -950,6 +964,14 @@
      $      ' type ', I2, ', test(', I2, ')=', G10.3 )
  9992 FORMAT( ' SDRVES: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
      $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9991 FORMAT( ' SDRVES: ', A, ' returned the known code N+1 =', I6,
+     $      ': eigenvalues too close', / 9X, 'to reorder; ill-',
+     $      'conditioned matrix, accepted as no error.', / 9X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9990 FORMAT( ' SDRVES: ', A, ' returned the known code N+2 =', I6,
+     $      ': roundoff undid the sort', / 9X, 'order; ill-conditioned',
+     $      ' matrix, accepted as no error.', / 9X, 'N=', I6,
+     $      ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
 *
       RETURN
 *

--- a/TESTING/EIG/sget24.f
+++ b/TESTING/EIG/sget24.f
@@ -458,7 +458,24 @@
          CALL SGEESX( 'V', SORT, SSLECT, 'N', N, H, LDA, SDIM, WR, WI,
      $                VS, LDVS, RCONDE, RCONDV, WORK, LWORK, IWORK,
      $                LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX1', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX1', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            RETURN
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX1', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX1', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 1+RSUB ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'SGEESX1', IINFO, N, JTYPE,
@@ -568,7 +585,24 @@
          CALL SGEESX( 'N', SORT, SSLECT, 'N', N, HT, LDA, SDIM, WRT,
      $                WIT, VS, LDVS, RCONDE, RCONDV, WORK, LWORK, IWORK,
      $                LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX2', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX2', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX2', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX2', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 5+RSUB ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'SGEESX2', IINFO, N, JTYPE,
@@ -634,7 +668,24 @@
          CALL SGEESX( 'V', SORT, SSLECT, 'B', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCONDE, RCONDV, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX3', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX3', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX3', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX3', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
@@ -669,7 +720,24 @@
          CALL SGEESX( 'N', SORT, SSLECT, 'B', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX4', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX4', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX4', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX4', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
@@ -711,7 +779,24 @@
          CALL SGEESX( 'V', SORT, SSLECT, 'E', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX5', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX5', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX5', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX5', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'SGEESX5', IINFO, N, JTYPE,
@@ -750,7 +835,24 @@
          CALL SGEESX( 'N', SORT, SSLECT, 'E', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX6', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX6', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX6', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX6', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 14 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'SGEESX6', IINFO, N, JTYPE,
@@ -789,7 +891,24 @@
          CALL SGEESX( 'V', SORT, SSLECT, 'V', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX7', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX7', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX7', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX7', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'SGEESX7', IINFO, N, JTYPE,
@@ -828,7 +947,24 @@
          CALL SGEESX( 'N', SORT, SSLECT, 'V', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCNDE1, RCNDV1, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9996 )'SGEESX8', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9997 )'SGEESX8', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+            GO TO 250
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            IF( JTYPE.NE.22 ) THEN
+               WRITE( NOUNIT, FMT = 9994 )'SGEESX8', IINFO, N, JTYPE,
+     $            ISEED
+            ELSE
+               WRITE( NOUNIT, FMT = 9995 )'SGEESX8', IINFO, N,
+     $            ISEED( 1 )
+            END IF
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 15 ) = ULPINV
             IF( JTYPE.NE.22 ) THEN
                WRITE( NOUNIT, FMT = 9998 )'SGEESX8', IINFO, N, JTYPE,
@@ -912,7 +1048,12 @@
          CALL SGEESX( 'N', 'S', SSLECT, 'B', N, HT, LDA, SDIM1, WRT,
      $                WIT, VS1, LDVS, RCONDE, RCONDV, WORK, LWORK,
      $                IWORK, LIWORK, BWORK, IINFO )
-         IF( IINFO.NE.0 .AND. IINFO.NE.N+2 ) THEN
+         IF( IINFO.EQ.N+1 ) THEN
+            WRITE( NOUNIT, FMT = 9997 )'SGEESX9', IINFO, N, ISEED( 1 )
+            GO TO 300
+         ELSE IF( IINFO.EQ.N+2 ) THEN
+            WRITE( NOUNIT, FMT = 9995 )'SGEESX9', IINFO, N, ISEED( 1 )
+         ELSE IF( IINFO.NE.0 ) THEN
             RESULT( 16 ) = ULPINV
             RESULT( 17 ) = ULPINV
             WRITE( NOUNIT, FMT = 9999 )'SGEESX9', IINFO, N, ISEED( 1 )
@@ -986,6 +1127,22 @@
      $      I6, ', INPUT EXAMPLE NUMBER = ', I4 )
  9998 FORMAT( ' SGET24: ', A, ' returned INFO=', I6, '.', / 9X, 'N=',
      $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9997 FORMAT( ' SGET24: ', A, ' returned the known code N+1 =', I6,
+     $      ': eigenvalues too close', / 9X, 'to reorder; ill-',
+     $      'conditioned matrix, accepted as no error.', / 9X, 'N=',
+     $      I6, ', INPUT EXAMPLE NUMBER = ', I4 )
+ 9996 FORMAT( ' SGET24: ', A, ' returned the known code N+1 =', I6,
+     $      ': eigenvalues too close', / 9X, 'to reorder; ill-',
+     $      'conditioned matrix, accepted as no error.', / 9X, 'N=',
+     $      I6, ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
+ 9995 FORMAT( ' SGET24: ', A, ' returned the known code N+2 =', I6,
+     $      ': roundoff undid the sort', / 9X, 'order; ill-conditioned',
+     $      ' matrix, accepted as no error.', / 9X, 'N=', I6,
+     $      ', INPUT EXAMPLE NUMBER = ', I4 )
+ 9994 FORMAT( ' SGET24: ', A, ' returned the known code N+2 =', I6,
+     $      ': roundoff undid the sort', / 9X, 'order; ill-conditioned',
+     $      ' matrix, accepted as no error.', / 9X, 'N=', I6,
+     $      ', JTYPE=', I6, ', ISEED=(', 3( I5, ',' ), I5, ')' )
 *
       RETURN
 *


### PR DESCRIPTION
## Problem

`ded.out` (the `xeigtstd < ded.in` output collected by `lapack_testing.py`) reports four failures on macOS and on arm64 Linux:

```
Testing DOUBLE PRECISION 'Nonsymmetric Eigenvalue' (ded.out) - passed: 14678
-->  DDRVES: DGEES1 returned INFO=     6.
-->  DDRVES: DGEES1 returned INFO=     6.
-->  DES:    2 out of  3810 tests failed to pass the threshold
-->  DGET24: DGEESX1 returned INFO=     6.
-->  DGET24: DGEESX1 returned INFO=     6.
-->  DSX:    2 out of  3494 tests failed to pass the threshold
failing to pass the threshold: 4
Info Error: 4
```

## Root cause

The chain is `DGEES` → `DTRSEN` → `DTREXC` → `DLAEXC`. Instrumenting `DLAEXC` shows exactly one rejected swap:

```
J1=2  N1=2  N2=2                     (swap rows 2:3 past rows 4:5)
DNORM  = 1.7182987758677357E+138
THRESH = 3.8153897283071631E+123     (= 10*eps*DNORM)
resid  = 8.0344355986676333E+126     (2105 x THRESH)
DLASY2: SCALE=1.0  XNORM=1.5519803771084378E+07  IERR=1
```

`DLAEXC` is doing its job. The Sylvester solution has norm `1.6e7`, so the direct 2×2/2×2 swap cannot be performed backward-stably and the Bai–Demmel acceptance test correctly refuses it. `DTRSEN` reports `INFO = 1`, and `dgees.f` maps that to `INFO = N+1`, documented as *"the eigenvalues could not be reordered because some eigenvalues were too close to separate (the problem is very ill-conditioned)"*.

## Fix

Nothing in `SRC/` needs to change. Tests 1–6 (unsorted: `‖A − VS·T·VSᵀ‖`, orthogonality) pass for this matrix, so the Schur decomposition is backward stable; `DLAEXC` correctly refuses an unstable swap; `INFO = N+1` is exactly what `dgees.f` documents.

`{s,d}drves.f` and `{s,d}get24.f` already tolerate `INFO = N+2` but score the equally documented `N+1` as a numerical failure. Both are now accepted and reported:

```fortran
                  IF( IINFO.EQ.N+1 ) THEN
                     WRITE( NOUNIT, FMT = 9991 )'DGEES1', IINFO, N,
     $                  JTYPE, IOLDSD
                     GO TO 220
                  ELSE IF( IINFO.EQ.N+2 ) THEN
                     WRITE( NOUNIT, FMT = 9990 )'DGEES1', IINFO, N,
     $                  JTYPE, IOLDSD
                  ELSE IF( IINFO.NE.0 ) THEN
                     RESULT( 1+RSUB ) = ULPINV
                     ...
```

* `N+1` — the tests that need the sorted Schur form are left unrun
  (`RESULT = -1`) instead of set to `1/ulp`, and `INFO` is not set. The
  accepted branch uses the same exit statement the failure path used at that
  site (`RETURN` at `xGEESX1`, `GO TO 250` at `xGEESX2`–`8`, `GO TO 300` at
  `xGEESX9`, `GO TO 220` in the drivers).
* `N+2` — unchanged behaviour, it just gains a message. It was previously
  tolerated with no trace in the output.

`cdrves.f`, `zdrves.f`, `cget24.f` and `zget24.f` need no change: complex Schur
forms consist only of 1×1 blocks, so `CTREXC` never rejects a swap and `N+1`
cannot occur.