### PR TITLE
CI: BLAS, CBLAS, and LAPACKE coverage

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -251,6 +251,7 @@ jobs:
         -D BUILD_TESTING:BOOL=ON
         -D LAPACKE_WITH_TMG:BOOL=ON
         -D BUILD_SHARED_LIBS:BOOL=ON
+        -D BUILD_INDEX64_EXT_API:BOOL=OFF
 
     - name: Install
       # Since we use a single configuration generator, Ninja, there is no need to provide

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,8 +57,11 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
 
-    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
-    environment: codecov
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.  Nothing
+    # is being deployed here, so do not record a deployment for it.
+    environment:
+      name: codecov
+      deployment: false
 
     env:
       BUILD_TYPE: Release
@@ -175,8 +178,11 @@ jobs:
   test-extended-api-only:
     runs-on: ubuntu-latest
 
-    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
-    environment: codecov
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.  Nothing
+    # is being deployed here, so do not record a deployment for it.
+    environment:
+      name: codecov
+      deployment: false
 
     env:
       BUILD_TYPE: Release
@@ -263,8 +269,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
-    environment: codecov
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.  Nothing
+    # is being deployed here, so do not record a deployment for it.
+    environment:
+      name: codecov
+      deployment: false
 
     env:
       BUILD_TYPE: Coverage

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -138,9 +138,11 @@ jobs:
       # Like the artifact above, uploaded even when the tests failed: a failing
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # The uploader defaults to coverage; this is a test analytics report.
+        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true
@@ -228,9 +230,11 @@ jobs:
       # Like the artifact above, uploaded even when the tests failed: a failing
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # The uploader defaults to coverage; this is a test analytics report.
+        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -219,6 +219,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
+    environment: codecov
+
     env:
       BUILD_TYPE: Coverage
       FFLAGS: "-fopenmp"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,6 +57,9 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
 
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
+    environment: codecov
+
     env:
       BUILD_TYPE: Release
       FFLAGS: ${{ matrix.fflags }}
@@ -131,6 +134,23 @@ jobs:
         if-no-files-found: warn
         retention-days: 14
 
+    - name: Upload test results to Codecov
+      # Like the artifact above, uploaded even when the tests failed: a failing
+      # test is exactly what the test analytics report is for.
+      if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: build/lapack_testing_junit.xml
+        # The report is named above, so there is nothing to search the tree for.
+        disable_search: true
+        flags: tests-${{ matrix.os }}-${{ contains( matrix.fflags, 'openmp' ) && 'openmp' || 'no-openmp' }}
+        name: ${{ matrix.os }} ${{ contains( matrix.fflags, 'openmp' ) && 'openmp' || 'no-openmp' }}
+        # Pull requests from forks have no access to repository secrets, so they
+        # can only upload if the Codecov organization permits tokenless uploads.
+        # Do not turn that into a CI failure for the contributor.
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+
     - name: Write test summary
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
       env:
@@ -152,6 +172,9 @@ jobs:
 
   test-extended-api-only:
     runs-on: ubuntu-latest
+
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
+    environment: codecov
 
     env:
       BUILD_TYPE: Release
@@ -200,6 +223,23 @@ jobs:
           build/lapack_testing_junit.xml
         if-no-files-found: warn
         retention-days: 14
+
+    - name: Upload test results to Codecov
+      # Like the artifact above, uploaded even when the tests failed: a failing
+      # test is exactly what the test analytics report is for.
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: build/lapack_testing_junit.xml
+        # The report is named above, so there is nothing to search the tree for.
+        disable_search: true
+        flags: tests-extended-api-shared-${{ matrix.shared_libs }}
+        name: extended API only, shared ${{ matrix.shared_libs }}
+        # Pull requests from forks have no access to repository secrets, so they
+        # can only upload if the Codecov organization permits tokenless uploads.
+        # Do not turn that into a CI failure for the contributor.
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
     - name: Write test summary
       if: ${{ !cancelled() }}

--- a/BLAS/SRC/CMakeLists.txt
+++ b/BLAS/SRC/CMakeLists.txt
@@ -119,6 +119,7 @@ list(REMOVE_DUPLICATES SOURCES)
 
 if(BUILD_DEFAULT_API)
   add_library(${BLASLIB}_obj OBJECT ${SOURCES})
+  lapack_add_coverage(${BLASLIB}_obj)
 endif()
 
 if(BUILD_INDEX64_EXT_API)
@@ -144,6 +145,7 @@ set_target_properties(
   VERSION ${LAPACK_VERSION}
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
+lapack_add_coverage(${BLASLIB})
 lapack_install_library(${BLASLIB})
 
 add_library(BLAS::BLAS ALIAS ${BLASLIB})

--- a/CBLAS/src/CMakeLists.txt
+++ b/CBLAS/src/CMakeLists.txt
@@ -144,6 +144,7 @@ if(BUILD_DEFAULT_API)
 else()
   add_library(${CBLASLIB}_obj OBJECT ${COMMON_SOURCES})
 endif()
+lapack_add_coverage(${CBLASLIB}_obj)
 
 if(BUILD_INDEX64_EXT_API)
   include(ExtendedAPIHelpers)
@@ -175,4 +176,6 @@ target_include_directories(${CBLASLIB} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(${CBLASLIB} PUBLIC ${BLAS_LIBRARIES})
+
+lapack_add_coverage(${CBLASLIB})
 lapack_install_library(${CBLASLIB})

--- a/CMAKE/FindGcov.cmake
+++ b/CMAKE/FindGcov.cmake
@@ -107,33 +107,31 @@ function (add_gcov_target TNAME)
 
   # We don't have to check, if the target has support for coverage, thus this
   # will be checked by add_coverage_target in Findcoverage.cmake. Instead we
-  # have to determine which gcov binary to use.
+  # have to determine which gcov binary to use. A target may mix languages
+  # built by different compilers, so this is decided per source file.
   get_target_property(TSOURCES ${TNAME} SOURCES)
-  set(SOURCES "")
-  set(TCOMPILER "")
-  foreach (FILE ${TSOURCES})
-    codecov_path_of_source(${FILE} FILE)
-    if(NOT "${FILE}" STREQUAL "")
-      codecov_lang_of_source(${FILE} LANG)
-      if(NOT "${LANG}" STREQUAL "")
-        list(APPEND SOURCES "${FILE}")
-        set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
-      endif()
-    endif()
-  endforeach()
-
-  # If no gcov binary was found, coverage data can't be evaluated.
-  if(NOT GCOV_${TCOMPILER}_BIN)
-    message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
-    return()
-  endif()
-
-  set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
-  set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
-
-
   set(BUFFER "")
-  foreach(FILE ${SOURCES})
+  foreach(FILE IN LISTS TSOURCES)
+    codecov_path_of_source("${FILE}" FILE)
+    if(FILE STREQUAL "")
+      continue()
+    endif()
+
+    codecov_lang_of_source("${FILE}" LANG)
+    if(LANG STREQUAL "")
+      continue()
+    endif()
+
+    # If no gcov binary was found, coverage data can't be evaluated.
+    set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
+    if(NOT GCOV_${TCOMPILER}_BIN)
+      message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
+      return()
+    endif()
+
+    set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
+    set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
+
     get_filename_component(FILE_PATH "${TDIR}/${FILE}" PATH)
 
     # call gcov
@@ -146,6 +144,11 @@ function (add_gcov_target TNAME)
     list(APPEND BUFFER ${TDIR}/${FILE}.gcov)
   endforeach()
 
+  # Targets assembled purely from $<TARGET_OBJECTS:...> compile nothing of
+  # their own; their coverage data is evaluated with the object libraries.
+  if(NOT BUFFER)
+    return()
+  endif()
 
   # add target for gcov evaluation of <TNAME>
   add_custom_target(${TNAME}-gcov DEPENDS ${BUFFER})

--- a/CMAKE/Findcodecov.cmake
+++ b/CMAKE/Findcodecov.cmake
@@ -10,6 +10,10 @@
 # Written by Alexander Haase, alexander.haase@rwth-aachen.de
 # Updated by Guillaume Jacquenot, guillaume.jacquenot@gmail.com
 
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+include(CheckFortranCompilerFlag)
+
 set(COVERAGE_FLAG_CANDIDATES
   # gcc and clang
   "-O0 -g -fprofile-arcs -ftest-coverage"
@@ -18,90 +22,81 @@ set(COVERAGE_FLAG_CANDIDATES
   "-O0 -g --coverage"
 )
 
-
-# To avoid error messages about CMP0051, this policy will be set to new. There
-# will be no problem, as TARGET_OBJECTS generator expressions will be filtered
-# with a regular expression from the sources.
-if(POLICY CMP0051)
-  cmake_policy(SET CMP0051 NEW)
-endif()
+# The languages this module knows how to probe for coverage flags.
+set(COVERAGE_LANGUAGES C CXX Fortran)
 
 
-# Add coverage support for target ${TNAME} and register target for coverage
-# evaluation.
-function(add_coverage TNAME)
-  foreach (TNAME ${ARGV})
-    add_coverage_target(${TNAME})
+# Find the coverage flags for language ${LANG} and cache them in
+# COVERAGE_<compiler id>_FLAGS. Coverage flags are not dependent on the
+# language, but on the compiler, so languages sharing a compiler are probed
+# only once. A language may be enabled after this module has been found, so
+# this is called again from add_coverage_target() rather than only here.
+function(codecov_find_flags LANG)
+  set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+  if(NOT COMPILER OR DEFINED CACHE{COVERAGE_${COMPILER}_FLAGS})
+    return()
+  endif()
+
+  set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
+
+  foreach(FLAG IN LISTS COVERAGE_FLAG_CANDIDATES)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try ${COMPILER} code coverage flag = [${FLAG}]")
+    endif()
+
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(COVERAGE_FLAG_DETECTED CACHE)
+
+    if(LANG STREQUAL "C")
+      check_c_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+    elseif(LANG STREQUAL "CXX")
+      check_cxx_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+    elseif(LANG STREQUAL "Fortran")
+      check_fortran_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+    endif()
+
+    if(COVERAGE_FLAG_DETECTED)
+      # Cache the flags as a list, so they can be handed to
+      # target_compile_options() and target_link_options() unmodified.
+      string(REPLACE " " ";" FLAG_LIST "${FLAG}")
+      set(COVERAGE_${COMPILER}_FLAGS "${FLAG_LIST}"
+        CACHE STRING "${COMPILER} flags for code coverage.")
+      mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
+      return()
+    endif()
   endforeach()
+
+  # Remember that this compiler has no usable coverage flags, so that it is not
+  # probed again for every target.
+  set(COVERAGE_${COMPILER}_FLAGS "COVERAGE_${COMPILER}_FLAGS-NOTFOUND"
+    CACHE STRING "${COMPILER} flags for code coverage.")
+  mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
 endfunction()
 
 
-# Find the required flags foreach language.
-set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
-set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
-
+# Probe the languages that are already enabled, so that the check appears in
+# the configure output next to the other compiler checks.
 get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
-foreach (LANG ${ENABLED_LANGUAGES})
-  # Coverage flags are not dependent on language, but the used compiler. So
-  # instead of searching flags foreach language, search flags foreach compiler
-  # used.
-  set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
-  if(NOT COVERAGE_${COMPILER}_FLAGS)
-    foreach (FLAG ${COVERAGE_FLAG_CANDIDATES})
-      if(NOT CMAKE_REQUIRED_QUIET)
-        message(STATUS "Try ${COMPILER} code coverage flag = [${FLAG}]")
-      endif()
-
-      set(CMAKE_REQUIRED_FLAGS "${FLAG}")
-      unset(COVERAGE_FLAG_DETECTED CACHE)
-
-      if(${LANG} STREQUAL "C")
-        include(CheckCCompilerFlag)
-        check_c_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
-
-      elseif(${LANG} STREQUAL "CXX")
-        include(CheckCXXCompilerFlag)
-        check_cxx_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
-
-      elseif(${LANG} STREQUAL "Fortran")
-        # CheckFortranCompilerFlag was introduced in CMake 3.x. To be
-        # compatible with older Cmake versions, we will check if this
-        # module is present before we use it. Otherwise we will define
-        # Fortran coverage support as not available.
-        include(CheckFortranCompilerFlag OPTIONAL
-          RESULT_VARIABLE INCLUDED)
-        if(INCLUDED)
-          check_fortran_compiler_flag("${FLAG}"
-            COVERAGE_FLAG_DETECTED)
-        elseif(NOT CMAKE_REQUIRED_QUIET)
-          message("-- Performing Test COVERAGE_FLAG_DETECTED")
-          message("-- Performing Test COVERAGE_FLAG_DETECTED - Failed"
-            " (Check not supported)")
-        endif()
-      endif()
-
-      if(COVERAGE_FLAG_DETECTED)
-        set(COVERAGE_${COMPILER}_FLAGS "${FLAG}"
-          CACHE STRING "${COMPILER} flags for code coverage.")
-        mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
-        break()
-      endif()
-    endforeach()
+foreach(LANG IN LISTS ENABLED_LANGUAGES)
+  if(LANG IN_LIST COVERAGE_LANGUAGES)
+    codecov_find_flags(${LANG})
   endif()
 endforeach()
 
-set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
 
 # Helper function to get the language of a source file.
-function (codecov_lang_of_source FILE RETURN_VAR)
+function(codecov_lang_of_source FILE RETURN_VAR)
   get_filename_component(FILE_EXT "${FILE}" EXT)
   string(TOLOWER "${FILE_EXT}" FILE_EXT)
+  if(FILE_EXT STREQUAL "")
+    set(${RETURN_VAR} "" PARENT_SCOPE)
+    return()
+  endif()
   string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
 
   get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
-  foreach (LANG ${ENABLED_LANGUAGES})
-    list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
-    if(NOT ${TEMP} EQUAL -1)
+  foreach(LANG IN LISTS ENABLED_LANGUAGES)
+    if(FILE_EXT IN_LIST CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS)
       set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
       return()
     endif()
@@ -110,17 +105,19 @@ function (codecov_lang_of_source FILE RETURN_VAR)
   set(${RETURN_VAR} "" PARENT_SCOPE)
 endfunction()
 
+
 # Helper function to get the relative path of the source file destination path.
 # This path is needed by FindGcov and FindLcov cmake files to locate the
 # captured data.
-function (codecov_path_of_source FILE RETURN_VAR)
-  string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _source ${FILE})
-
-  # If expression was found, SOURCEFILE is a generator-expression for an
-  # object library. Currently we found no way to call this function automatic
-  # for the referenced target, so it must be called in the directory of the
-  # object library definition.
-  if(NOT "${_source}" STREQUAL "")
+function(codecov_path_of_source FILE RETURN_VAR)
+  # Generator expressions cannot be resolved to a path here, so they have no
+  # coverage data of their own. In particular a $<TARGET_OBJECTS:...> source
+  # belongs to an object library and is evaluated together with that library.
+  # Note that a conditional such as
+  #   $<$<BOOL:${COND}>: $<TARGET_OBJECTS:foo>>
+  # reaches us split at the whitespace, so only one of its fragments mentions
+  # TARGET_OBJECTS; skip anything that looks like a generator expression.
+  if(FILE MATCHES "\\$<")
     set(${RETURN_VAR} "" PARENT_SCOPE)
     return()
   endif()
@@ -139,63 +136,64 @@ endfunction()
 # Add coverage support for target ${TNAME} and register target for coverage
 # evaluation.
 function(add_coverage_target TNAME)
-  # Check if all sources for target use the same compiler. If a target uses
-  # e.g. C and Fortran mixed and uses different compilers (e.g. clang and
-  # gfortran) this can trigger huge problems, because different compilers may
-  # use different implementations for code coverage.
-  get_target_property(TSOURCES ${TNAME} SOURCES)
-  set(TARGET_COMPILER "")
-  set(ADDITIONAL_FILES "")
-  foreach (FILE ${TSOURCES})
-    # If expression was found, FILE is a generator-expression for an object
-    # library. Object libraries will be ignored.
-    string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
-    if("${_file}" STREQUAL "")
-      codecov_lang_of_source(${FILE} LANG)
-      if(LANG)
-        list(APPEND TARGET_COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+  # A target may mix languages that are built by different compilers, which may
+  # use incompatible coverage implementations. Guard each compiler's flags with
+  # the language they were detected for, so that every source is compiled with
+  # the flags of the compiler that actually builds it.
+  set(COMPILE_OPTIONS "")
+  set(LINK_OPTIONS "")
+  foreach(LANG IN LISTS COVERAGE_LANGUAGES)
+    codecov_find_flags(${LANG})
 
-        list(APPEND ADDITIONAL_FILES "${FILE}.gcno")
-        list(APPEND ADDITIONAL_FILES "${FILE}.gcda")
-      endif()
+    set(FLAGS "${COVERAGE_${CMAKE_${LANG}_COMPILER_ID}_FLAGS}")
+    if(FLAGS)
+      list(APPEND COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:${LANG}>:${FLAGS}>")
+      list(APPEND LINK_OPTIONS "$<$<LINK_LANGUAGE:${LANG}>:${FLAGS}>")
     endif()
-  endforeach ()
+  endforeach()
 
-  list(REMOVE_DUPLICATES TARGET_COMPILER)
-  list(LENGTH TARGET_COMPILER NUM_COMPILERS)
-
-  if(NUM_COMPILERS GREATER 1)
-    message(AUTHOR_WARNING "Coverage disabled for target ${TNAME} because "
-      "it will be compiled by different compilers.")
-    return()
-
-  elseif((NUM_COMPILERS EQUAL 0) OR
-    (NOT DEFINED "COVERAGE_${TARGET_COMPILER}_FLAGS"))
-    message(AUTHOR_WARNING "Coverage disabled for target ${TNAME} "
-      "because there is no sanitizer available for target sources.")
+  if(NOT COMPILE_OPTIONS)
+    message(AUTHOR_WARNING "Coverage disabled for target ${TNAME} because no "
+      "coverage flags are available for any enabled language.")
     return()
   endif()
 
-
   # enable coverage for target
-  set_property(TARGET ${TNAME} APPEND_STRING
-    PROPERTY COMPILE_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
-  set_property(TARGET ${TNAME} APPEND_STRING
-    PROPERTY LINK_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
+  target_compile_options(${TNAME} PRIVATE ${COMPILE_OPTIONS})
+  target_link_options(${TNAME} PRIVATE ${LINK_OPTIONS})
 
 
   # Add gcov files generated by compiler to clean target.
+  get_target_property(TSOURCES ${TNAME} SOURCES)
   set(CLEAN_FILES "")
-  foreach (FILE ${ADDITIONAL_FILES})
-    codecov_path_of_source(${FILE} FILE)
-    list(APPEND CLEAN_FILES "CMakeFiles/${TNAME}.dir/${FILE}")
+  foreach(FILE IN LISTS TSOURCES)
+    codecov_path_of_source("${FILE}" FILE)
+    if(FILE STREQUAL "")
+      continue()
+    endif()
+
+    codecov_lang_of_source("${FILE}" LANG)
+    if(LANG)
+      list(APPEND CLEAN_FILES
+        "CMakeFiles/${TNAME}.dir/${FILE}.gcno"
+        "CMakeFiles/${TNAME}.dir/${FILE}.gcda")
+    endif()
   endforeach()
 
-  set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
-    "${CLEAN_FILES}")
+  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES ${CLEAN_FILES})
 
   add_gcov_target(${TNAME})
 endfunction()
+
+
+# Add coverage support for target ${TNAME} and register target for coverage
+# evaluation.
+function(add_coverage TNAME)
+  foreach(T IN LISTS ARGV)
+    add_coverage_target(${T})
+  endforeach()
+endfunction()
+
 
 # Include modules for parsing the collected data and output it in a readable
 # format (like gcov).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,18 @@ if(_is_coverage_build)
   find_package(codecov)
 endif()
 
+# Instrument the library ${lib} for coverage.
+function(lapack_add_coverage lib)
+  if(NOT _is_coverage_build)
+    return()
+  endif()
+  if(NOT TARGET ${lib})
+    message(FATAL_ERROR "lapack_add_coverage: no such target '${lib}'")
+  endif()
+  add_coverage(${lib})
+  target_link_libraries(${lib} PRIVATE gcov)
+endfunction()
+
 # Use valgrind if it is found
 option( LAPACK_TESTING_USE_PYTHON "Use Python for testing. Disable it on memory checks." ON )
 find_program( MEMORYCHECK_COMMAND valgrind )

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -87,6 +87,7 @@ if(BUILD_DEFAULT_API)
 else()
   add_library(${LAPACKELIB}_obj OBJECT ${COMMON_SOURCES} ${COMMON_UTILS})
 endif()
+lapack_add_coverage(${LAPACKELIB}_obj)
 
 if(BUILD_INDEX64_EXT_API)
   add_library(${LAPACKELIB}_64_obj OBJECT ${SOURCES})
@@ -114,6 +115,7 @@ if(LAPACKE_WITH_TMG)
 endif()
 target_link_libraries(${LAPACKELIB} PRIVATE ${LAPACK_LIBRARIES})
 
+lapack_add_coverage(${LAPACKELIB})
 lapack_install_library(${LAPACKELIB})
 
 if(BUILD_TESTING)

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -528,14 +528,17 @@ list(REMOVE_DUPLICATES SOURCES)
 # any other files that depend on them
 add_library(const_mod_file OBJECT ${CONSTMOD})
 set_target_properties(const_mod_file PROPERTIES Fortran_PREPROCESS ON)
+lapack_add_coverage(const_mod_file)
 
 add_library(mod_files OBJECT ${NANMOD} $<TARGET_OBJECTS:const_mod_file>)
 set_target_properties(mod_files PROPERTIES Fortran_PREPROCESS ON)
+lapack_add_coverage(mod_files)
 
 if(BUILD_DEFAULT_API)
   add_library(${LAPACKLIB}_obj OBJECT ${SOURCES} ${XSOURCES})
-  target_link_libraries(${LAPACKLIB}_obj mod_files)
+  target_link_libraries(${LAPACKLIB}_obj PUBLIC mod_files)
   set_target_properties(${LAPACKLIB}_obj PROPERTIES Fortran_PREPROCESS ON)
+  lapack_add_coverage(${LAPACKLIB}_obj)
 endif()
 
 if(BUILD_INDEX64_EXT_API)
@@ -543,7 +546,7 @@ if(BUILD_INDEX64_EXT_API)
   generate_64bit_suffixed_sources(${LAPACKLIB} SOURCES SOURCES_64)
 
   add_library(${LAPACKLIB}_64_obj OBJECT ${SOURCES_64})
-  target_link_libraries(${LAPACKLIB}_64_obj mod_files)
+  target_link_libraries(${LAPACKLIB}_64_obj PUBLIC mod_files)
   target_compile_options(${LAPACKLIB}_64_obj PRIVATE ${FOPT_ILP64})
   set_target_properties(${LAPACKLIB}_64_obj PROPERTIES Fortran_PREPROCESS ON)
 endif()
@@ -575,9 +578,5 @@ if(USE_XBLAS)
 endif()
 target_link_libraries(${LAPACKLIB} PRIVATE ${BLAS_LIBRARIES})
 
-if(_is_coverage_build)
-  target_link_libraries(${LAPACKLIB} PRIVATE gcov)
-  add_coverage(${LAPACKLIB}_obj)
-endif()
-
+lapack_add_coverage(${LAPACKLIB})
 lapack_install_library(${LAPACKLIB})


### PR DESCRIPTION
**Description**

Enable coverage for BLAS, CBLAS & LAPACKE. Also update the coverage cmake modules for more modern CMake and fix some latent bugs.

Reopened as a new PR, becasue the other was cluttered with deployment objects.