### PR TITLE
CI: Report coverage and test results per library on Codecov

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -144,7 +144,7 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         # The uploader defaults to coverage; this is a test analytics report.
@@ -238,7 +238,7 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         # The uploader defaults to coverage; this is a test analytics report.
@@ -396,7 +396,7 @@ jobs:
     - name: Upload BLAS coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/BLAS
@@ -411,7 +411,7 @@ jobs:
     - name: Upload CBLAS coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/CBLAS
@@ -424,7 +424,7 @@ jobs:
     - name: Upload LAPACK coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/SRC
@@ -437,7 +437,7 @@ jobs:
     - name: Upload LAPACK testing coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/TESTING
@@ -450,7 +450,7 @@ jobs:
     - name: Upload LAPACKE coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/LAPACKE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -144,7 +144,7 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         # The uploader defaults to coverage; this is a test analytics report.
@@ -238,7 +238,7 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         # The uploader defaults to coverage; this is a test analytics report.
@@ -396,7 +396,7 @@ jobs:
     - name: Upload BLAS coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/BLAS
@@ -411,7 +411,7 @@ jobs:
     - name: Upload CBLAS coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/CBLAS
@@ -424,7 +424,7 @@ jobs:
     - name: Upload LAPACK coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/SRC
@@ -437,7 +437,7 @@ jobs:
     - name: Upload LAPACK testing coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/TESTING
@@ -450,7 +450,7 @@ jobs:
     - name: Upload LAPACKE coverage report to Codecov
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: build/LAPACKE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -144,11 +144,9 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        # The uploader defaults to coverage; this is a test analytics report.
-        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true
@@ -238,11 +236,9 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        # The uploader defaults to coverage; this is a test analytics report.
-        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -70,7 +70,7 @@ jobs:
       FFLAGS: ${{ matrix.fflags }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest ]
         fflags: [
@@ -143,6 +143,7 @@ jobs:
       # Like the artifact above, uploaded even when the tests failed: a failing
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
+      continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -153,10 +154,8 @@ jobs:
         disable_search: true
         flags: tests-${{ matrix.os }}-${{ contains( matrix.fflags, 'openmp' ) && 'openmp' || 'no-openmp' }}
         name: ${{ matrix.os }} ${{ contains( matrix.fflags, 'openmp' ) && 'openmp' || 'no-openmp' }}
-        # Pull requests from forks have no access to repository secrets, so they
-        # can only upload if the Codecov organization permits tokenless uploads.
-        # Do not turn that into a CI failure for the contributor.
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+        fail_ci_if_error: true
+        verbose: true
 
     - name: Write test summary
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
@@ -191,7 +190,7 @@ jobs:
       FFLAGS: "-Wall -Wno-unused-dummy-argument -Wno-unused-variable -Wno-unused-label -Werror=conversion -fimplicit-none -frecursive -fcheck=all"
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         shared_libs: [ OFF, ON ]
 
@@ -238,6 +237,7 @@ jobs:
       # Like the artifact above, uploaded even when the tests failed: a failing
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() }}
+      continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -248,10 +248,8 @@ jobs:
         disable_search: true
         flags: tests-extended-api-shared-${{ matrix.shared_libs }}
         name: extended API only, shared ${{ matrix.shared_libs }}
-        # Pull requests from forks have no access to repository secrets, so they
-        # can only upload if the Codecov organization permits tokenless uploads.
-        # Do not turn that into a CI failure for the contributor.
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+        fail_ci_if_error: true
+        verbose: true
 
     - name: Write test summary
       if: ${{ !cancelled() }}
@@ -382,6 +380,7 @@ jobs:
     # declared in codecov.yml.
     - name: Upload BLAS coverage report to Codecov
       if: ${{ !cancelled() }}
+      continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -391,14 +390,12 @@ jobs:
         # The .gcov files already exist, so there is no need for the uploader
         # to run gcov a second time itself.
         plugins: noop
+        fail_ci_if_error: true
         verbose: true
-        # Pull requests from forks have no access to repository secrets, so
-        # they can only upload if the Codecov organization permits tokenless
-        # uploads.  Do not turn that into a CI failure for the contributor.
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
     - name: Upload CBLAS coverage report to Codecov
       if: ${{ !cancelled() }}
+      continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -406,11 +403,12 @@ jobs:
         flags: cblas
         name: CBLAS
         plugins: noop
+        fail_ci_if_error: true
         verbose: true
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
     - name: Upload LAPACK coverage report to Codecov
       if: ${{ !cancelled() }}
+      continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -418,11 +416,12 @@ jobs:
         flags: lapack
         name: LAPACK
         plugins: noop
+        fail_ci_if_error: true
         verbose: true
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
     - name: Upload LAPACKE coverage report to Codecov
       if: ${{ !cancelled() }}
+      continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -430,8 +429,8 @@ jobs:
         flags: lapacke
         name: LAPACKE
         plugins: noop
+        fail_ci_if_error: true
         verbose: true
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
   test-install-cblas-lapacke-without-fortran-compiler:
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -251,6 +251,7 @@ jobs:
         -D BUILD_TESTING:BOOL=ON
         -D LAPACKE_WITH_TMG:BOOL=ON
         -D BUILD_SHARED_LIBS:BOOL=ON
+        -D BUILD_INDEX64_EXT_API:BOOL=OFF
 
     - name: Install
       # Since we use a single configuration generator, Ninja, there is no need to provide

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -342,7 +342,8 @@ jobs:
         # gcov writes its report next to the object it belongs to, so the
         # reports of a component are those below its own build directory.
         # These are the directories the uploads below use as well.
-        for component in BLAS:build/BLAS CBLAS:build/CBLAS LAPACK:build/SRC LAPACKE:build/LAPACKE; do
+        for component in BLAS:build/BLAS CBLAS:build/CBLAS LAPACK:build/SRC \
+                         LAPACKE:build/LAPACKE TESTING:build/TESTING; do
           name=${component%%:*}
           dir=${component#*:}
           if [ ! -d "${dir}" ]; then
@@ -429,6 +430,19 @@ jobs:
         directory: build/SRC
         flags: lapack
         name: LAPACK
+        plugins: noop
+        fail_ci_if_error: true
+        verbose: true
+
+    - name: Upload LAPACK testing coverage report to Codecov
+      if: ${{ !cancelled() }}
+      continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: build/TESTING
+        flags: lapack
+        name: LAPACK testing
         plugins: noop
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -144,9 +144,11 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # The uploader defaults to coverage; this is a test analytics report.
+        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true
@@ -236,9 +238,11 @@ jobs:
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() }}
       continue-on-error: ${{ secrets.CODECOV_TOKEN == '' }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # The uploader defaults to coverage; this is a test analytics report.
+        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,8 +57,11 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
 
-    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
-    environment: codecov
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.  Nothing
+    # is being deployed here, so do not record a deployment for it.
+    environment:
+      name: codecov
+      deployment: false
 
     env:
       BUILD_TYPE: Release
@@ -175,8 +178,11 @@ jobs:
   test-extended-api-only:
     runs-on: ubuntu-latest
 
-    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
-    environment: codecov
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.  Nothing
+    # is being deployed here, so do not record a deployment for it.
+    environment:
+      name: codecov
+      deployment: false
 
     env:
       BUILD_TYPE: Release
@@ -263,8 +269,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
-    environment: codecov
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.  Nothing
+    # is being deployed here, so do not record a deployment for it.
+    environment:
+      name: codecov
+      deployment: false
 
     env:
       BUILD_TYPE: Coverage

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -138,9 +138,11 @@ jobs:
       # Like the artifact above, uploaded even when the tests failed: a failing
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # The uploader defaults to coverage; this is a test analytics report.
+        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true
@@ -228,9 +230,11 @@ jobs:
       # Like the artifact above, uploaded even when the tests failed: a failing
       # test is exactly what the test analytics report is for.
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # The uploader defaults to coverage; this is a test analytics report.
+        report_type: test_results
         files: build/lapack_testing_junit.xml
         # The report is named above, so there is nothing to search the tree for.
         disable_search: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -349,13 +349,20 @@ jobs:
           files=$(find "${dir}" -name '*.gcov' | wc -l)
           # In a gcov report an executed line is prefixed with its execution
           # count and an unexecuted one with '#####' or '====='; everything
-          # else ('-') is not executable.
+          # else ('-') is not executable.  gcov -b additionally emits one
+          # 'branch N ...' record per branch outcome, taken either a number
+          # of times or never; a branch outcome counts as covered when it was
+          # taken at least once.
           set -- $(find "${dir}" -name '*.gcov' -exec cat {} + | awk '
-            /^ *[0-9]+[*]?:/     { hit++; next }
-            /^ *(#####|=====):/  { miss++ }
-            END { printf "%d %d\n", hit + 0, hit + miss + 0 }')
+            /^ *[0-9]+[*]?:/         { hit++; next }
+            /^ *(#####|=====):/      { miss++; next }
+            /^branch +[0-9]+ taken/  { btotal++; if ($4 + 0 > 0) bhit++; next }
+            /^branch +[0-9]+ never/  { btotal++ }
+            END { printf "%d %d %d %d\n", hit + 0, hit + miss + 0, bhit + 0, btotal + 0 }')
           hit=$1
           total=$2
+          bhit=$3
+          btotal=$4
           if [ "${hit}" -eq 0 ]; then
             echo "::error::${name}: not a single line was executed; its Codecov flag would be empty."
             status=1
@@ -363,10 +370,17 @@ jobs:
           else
             percent=$(awk -v h="${hit}" -v t="${total}" 'BEGIN { printf "%.2f%%", 100 * h / t }')
           fi
-          echo "${name}: ${hit} of ${total} lines executed (${percent}) across ${files} files"
-          summary="${summary}| ${name} | ${percent} | ${hit} | ${total} | ${files} |"$'\n'
+          # A component with no branches at all is possible in principle, so
+          # report n/a rather than dividing by zero.
+          if [ "${btotal}" -eq 0 ]; then
+            bpercent="n/a"
+          else
+            bpercent=$(awk -v h="${bhit}" -v t="${btotal}" 'BEGIN { printf "%.2f%%", 100 * h / t }')
+          fi
+          echo "${name}: ${hit} of ${total} lines executed (${percent}), ${bhit} of ${btotal} branches taken (${bpercent}) across ${files} files"
+          summary="${summary}| ${name} | ${percent} | ${hit} | ${total} | ${bpercent} | ${bhit} | ${btotal} | ${files} |"$'\n'
         done
-        printf '## Coverage\n\n| Component | Coverage | Lines executed | Lines executable | Files |\n| --- | --: | --: | --: | --: |\n%s' \
+        printf '## Coverage\n\n| Component | Lines | Executed | Executable | Branches | Taken | Total | Files |\n| --- | --: | --: | --: | --: | --: | --: | --: |\n%s' \
           "${summary}" >> "$GITHUB_STEP_SUMMARY"
         exit ${status}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,6 +7,7 @@ on:
     - try-github-actions-for-windows
     paths:
     - .github/workflows/cmake.yml
+    - codecov.yml
     - lapack_testing.py
     - '**CMakeLists.txt'
     - 'BLAS/**'
@@ -22,6 +23,7 @@ on:
   pull_request:
     paths:
     - .github/workflows/cmake.yml
+    - codecov.yml
     - lapack_testing.py
     - '**CMakeLists.txt'
     - 'BLAS/**'
@@ -324,7 +326,9 @@ jobs:
     - name: Summarize coverage
       # The coverage target discards gcov's output, so an entirely empty report
       # is indistinguishable from a good one unless we look at the numbers.
-      # Print them, and fail if nothing was measured at all.
+      # Print them, per component, and fail if any component measured nothing:
+      # each is uploaded under its own Codecov flag, and a flag without data
+      # would quietly disappear from the report.
       if: ${{ !cancelled() }}
       run: |
         gcda=$(find build -name '*.gcda' | wc -l)
@@ -335,29 +339,55 @@ jobs:
           echo "::error::No coverage data was recorded; the report would be empty."
           exit 1
         fi
-        # In a gcov report an executed line is prefixed with its execution
-        # count and an unexecuted one with '#####' or '====='; everything else
-        # ('-') is not executable.
-        set -- $(find build -name '*.gcov' -exec cat {} + | awk '
-          /^ *[0-9]+[*]?:/     { hit++; next }
-          /^ *(#####|=====):/  { miss++ }
-          END { printf "%d %d\n", hit + 0, hit + miss + 0 }')
-        hit=$1
-        total=$2
-        if [ "${hit}" -eq 0 ]; then
-          echo "::error::Coverage report is empty: not a single line was executed."
-          exit 1
-        fi
-        percent=$(awk -v h="${hit}" -v t="${total}" 'BEGIN { printf "%.2f", 100 * h / t }')
-        echo "lines executed: ${hit} of ${total} (${percent}%)"
-        printf '## Coverage\n\n%s%% of lines executed (%s of %s) across %s files.\n' \
-          "${percent}" "${hit}" "${total}" "${reports}" >> "$GITHUB_STEP_SUMMARY"
+        status=0
+        summary=""
+        # gcov writes its report next to the object it belongs to, so the
+        # reports of a component are those below its own build directory.
+        # These are the directories the uploads below use as well.
+        for component in BLAS:build/BLAS CBLAS:build/CBLAS LAPACK:build/SRC LAPACKE:build/LAPACKE; do
+          name=${component%%:*}
+          dir=${component#*:}
+          if [ ! -d "${dir}" ]; then
+            echo "::error::${name}: ${dir} does not exist; its Codecov flag would be empty."
+            status=1
+            continue
+          fi
+          files=$(find "${dir}" -name '*.gcov' | wc -l)
+          # In a gcov report an executed line is prefixed with its execution
+          # count and an unexecuted one with '#####' or '====='; everything
+          # else ('-') is not executable.
+          set -- $(find "${dir}" -name '*.gcov' -exec cat {} + | awk '
+            /^ *[0-9]+[*]?:/     { hit++; next }
+            /^ *(#####|=====):/  { miss++ }
+            END { printf "%d %d\n", hit + 0, hit + miss + 0 }')
+          hit=$1
+          total=$2
+          if [ "${hit}" -eq 0 ]; then
+            echo "::error::${name}: not a single line was executed; its Codecov flag would be empty."
+            status=1
+            percent="n/a"
+          else
+            percent=$(awk -v h="${hit}" -v t="${total}" 'BEGIN { printf "%.2f%%", 100 * h / t }')
+          fi
+          echo "${name}: ${hit} of ${total} lines executed (${percent}) across ${files} files"
+          summary="${summary}| ${name} | ${percent} | ${hit} | ${total} | ${files} |"$'\n'
+        done
+        printf '## Coverage\n\n| Component | Coverage | Lines executed | Lines executable | Files |\n| --- | --: | --: | --: | --: |\n%s' \
+          "${summary}" >> "$GITHUB_STEP_SUMMARY"
+        exit ${status}
 
-    - name: Upload coverage report to Codecov
+    # Each component is uploaded on its own, so that Codecov reports the
+    # coverage of BLAS, CBLAS, LAPACK and LAPACKE under a flag of its own
+    # rather than as a single number for the whole library.  The flags are
+    # declared in codecov.yml.
+    - name: Upload BLAS coverage report to Codecov
       if: ${{ !cancelled() }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        directory: build/BLAS
+        flags: blas
+        name: BLAS
         # The .gcov files already exist, so there is no need for the uploader
         # to run gcov a second time itself.
         plugins: noop
@@ -365,6 +395,42 @@ jobs:
         # Pull requests from forks have no access to repository secrets, so
         # they can only upload if the Codecov organization permits tokenless
         # uploads.  Do not turn that into a CI failure for the contributor.
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+
+    - name: Upload CBLAS coverage report to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: build/CBLAS
+        flags: cblas
+        name: CBLAS
+        plugins: noop
+        verbose: true
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+
+    - name: Upload LAPACK coverage report to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: build/SRC
+        flags: lapack
+        name: LAPACK
+        plugins: noop
+        verbose: true
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+
+    - name: Upload LAPACKE coverage report to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: build/LAPACKE
+        flags: lapacke
+        name: LAPACKE
+        plugins: noop
+        verbose: true
         fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
   test-install-cblas-lapacke-without-fortran-compiler:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -219,6 +219,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
+    environment: codecov
+
     env:
       BUILD_TYPE: Coverage
       FFLAGS: "-fopenmp"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,6 +57,9 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
 
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
+    environment: codecov
+
     env:
       BUILD_TYPE: Release
       FFLAGS: ${{ matrix.fflags }}
@@ -131,6 +134,23 @@ jobs:
         if-no-files-found: warn
         retention-days: 14
 
+    - name: Upload test results to Codecov
+      # Like the artifact above, uploaded even when the tests failed: a failing
+      # test is exactly what the test analytics report is for.
+      if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: build/lapack_testing_junit.xml
+        # The report is named above, so there is nothing to search the tree for.
+        disable_search: true
+        flags: tests-${{ matrix.os }}-${{ contains( matrix.fflags, 'openmp' ) && 'openmp' || 'no-openmp' }}
+        name: ${{ matrix.os }} ${{ contains( matrix.fflags, 'openmp' ) && 'openmp' || 'no-openmp' }}
+        # Pull requests from forks have no access to repository secrets, so they
+        # can only upload if the Codecov organization permits tokenless uploads.
+        # Do not turn that into a CI failure for the contributor.
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+
     - name: Write test summary
       if: ${{ !cancelled() && matrix.os != 'windows-latest' }}
       env:
@@ -152,6 +172,9 @@ jobs:
 
   test-extended-api-only:
     runs-on: ubuntu-latest
+
+    # CODECOV_TOKEN is stored as a secret of the 'codecov' environment.
+    environment: codecov
 
     env:
       BUILD_TYPE: Release
@@ -200,6 +223,23 @@ jobs:
           build/lapack_testing_junit.xml
         if-no-files-found: warn
         retention-days: 14
+
+    - name: Upload test results to Codecov
+      # Like the artifact above, uploaded even when the tests failed: a failing
+      # test is exactly what the test analytics report is for.
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: build/lapack_testing_junit.xml
+        # The report is named above, so there is nothing to search the tree for.
+        disable_search: true
+        flags: tests-extended-api-shared-${{ matrix.shared_libs }}
+        name: extended API only, shared ${{ matrix.shared_libs }}
+        # Pull requests from forks have no access to repository secrets, so they
+        # can only upload if the Codecov organization permits tokenless uploads.
+        # Do not turn that into a CI failure for the contributor.
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
     - name: Write test summary
       if: ${{ !cancelled() }}

--- a/BLAS/SRC/CMakeLists.txt
+++ b/BLAS/SRC/CMakeLists.txt
@@ -119,6 +119,7 @@ list(REMOVE_DUPLICATES SOURCES)
 
 if(BUILD_DEFAULT_API)
   add_library(${BLASLIB}_obj OBJECT ${SOURCES})
+  lapack_add_coverage(${BLASLIB}_obj)
 endif()
 
 if(BUILD_INDEX64_EXT_API)
@@ -144,6 +145,7 @@ set_target_properties(
   VERSION ${LAPACK_VERSION}
   SOVERSION ${LAPACK_MAJOR_VERSION}
   )
+lapack_add_coverage(${BLASLIB})
 lapack_install_library(${BLASLIB})
 
 add_library(BLAS::BLAS ALIAS ${BLASLIB})

--- a/BLAS/TESTING/CMakeLists.txt
+++ b/BLAS/TESTING/CMakeLists.txt
@@ -1,6 +1,7 @@
 function(_add_blas_test name src test_input test_output)
   add_executable(${name} ${src})
-  target_link_libraries(${name} ${BLASLIB})
+  target_link_libraries(${name} PRIVATE ${BLASLIB})
+  lapack_add_coverage(${name})
   if(EXISTS "${test_input}")
     add_test(NAME BLAS-${name} COMMAND "${CMAKE_COMMAND}"
       -DTEST=$<TARGET_FILE:${name}>

--- a/BLAS/TESTING/cblat1.f
+++ b/BLAS/TESTING/cblat1.f
@@ -51,6 +51,7 @@
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      REAL             S1, S2
       REAL             SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -62,6 +63,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625E-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 11
          ICASE = IC
@@ -87,12 +89,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Complex BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
 *
 *     End of CBLAT1
 *

--- a/BLAS/TESTING/cblat2.f
+++ b/BLAS/TESTING/cblat2.f
@@ -123,6 +123,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NOUT, NTRA
@@ -165,6 +166,7 @@
      $                   'CGERU ', 'CHER  ', 'CHPR  ', 'CHER2 ',
      $                   'CHPR2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -394,6 +396,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -429,6 +433,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of CBLAT2
 *

--- a/BLAS/TESTING/cblat3.f
+++ b/BLAS/TESTING/cblat3.f
@@ -105,6 +105,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NOUT, NTRA
       LOGICAL            FATAL, LTESTT, REWI, SAME, SFATAL, TRACE,
@@ -144,6 +145,7 @@
      $                   'CTRSM ', 'CHERK ', 'CSYRK ', 'CHER2K',
      $                   'CSYR2K', 'CGEMMTR'/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -373,6 +375,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -404,6 +408,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of CBLAT3
 *

--- a/BLAS/TESTING/dblat1.f
+++ b/BLAS/TESTING/dblat1.f
@@ -51,6 +51,7 @@
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      DOUBLE PRECISION S1, S2
       DOUBLE PRECISION SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -62,6 +63,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625D-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 14
          ICASE = IC
@@ -93,12 +95,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Real BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
 *
 *     End of DBLAT1
 *

--- a/BLAS/TESTING/dblat2.f
+++ b/BLAS/TESTING/dblat2.f
@@ -122,6 +122,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NOUT, NTRA
@@ -167,6 +168,7 @@
      $                   'DSYR2     ', 'DSPR2     ',
      $                   'DSKEWSYMV ', 'DSKEWSYR2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -395,6 +397,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -428,6 +432,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of DBLAT2
 *

--- a/BLAS/TESTING/dblat3.f
+++ b/BLAS/TESTING/dblat3.f
@@ -102,6 +102,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NOUT, NTRA
       LOGICAL            FATAL, LTESTT, REWI, SAME, SFATAL, TRACE,
@@ -142,6 +143,7 @@
      $                   'DGEMMTR    ',
      $                   'DSKEWSYMM  ', 'DSKEWSYR2K '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -370,6 +372,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -399,6 +403,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of DBLAT3
 *

--- a/BLAS/TESTING/sblat1.f
+++ b/BLAS/TESTING/sblat1.f
@@ -51,6 +51,7 @@
       INTEGER          ICASE, INCX, INCY, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      REAL             S1, S2
       REAL             SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -62,6 +63,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625E-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 14
          ICASE = IC
@@ -93,12 +95,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Real BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
 *
 *     End of SBLAT1
 *

--- a/BLAS/TESTING/sblat2.f
+++ b/BLAS/TESTING/sblat2.f
@@ -122,6 +122,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NOUT, NTRA
@@ -167,6 +168,7 @@
      $                   'SSYR2     ', 'SSPR2     ',
      $                   'SSKEWSYMV ', 'SSKEWSYR2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -396,6 +398,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -429,6 +433,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of SBLAT2
 *

--- a/BLAS/TESTING/sblat3.f
+++ b/BLAS/TESTING/sblat3.f
@@ -102,6 +102,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NOUT, NTRA
       LOGICAL            FATAL, LTESTT, REWI, SAME, SFATAL, TRACE,
@@ -142,6 +143,7 @@
      $                   'SGEMMTR    ',
      $                   'SSKEWSYMM  ', 'SSKEWSYR2K '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -371,6 +373,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -400,6 +404,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of SBLAT3
 *

--- a/BLAS/TESTING/zblat1.f
+++ b/BLAS/TESTING/zblat1.f
@@ -51,6 +51,7 @@
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      DOUBLE PRECISION S1, S2
       DOUBLE PRECISION SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -62,6 +63,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625D-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 11
          ICASE = IC
@@ -87,12 +89,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Complex BLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A6,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
 *
 *     End of ZBLAT1
 *

--- a/BLAS/TESTING/zblat2.f
+++ b/BLAS/TESTING/zblat2.f
@@ -124,6 +124,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NOUT, NTRA
@@ -166,6 +167,7 @@
      $                   'ZGERU ', 'ZHER  ', 'ZHPR  ', 'ZHER2 ',
      $                   'ZHPR2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -394,6 +396,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -429,6 +433,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of ZBLAT2
 *

--- a/BLAS/TESTING/zblat3.f
+++ b/BLAS/TESTING/zblat3.f
@@ -107,6 +107,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NOUT, NTRA
       LOGICAL            FATAL, LTESTT, REWI, SAME, SFATAL, TRACE,
@@ -146,6 +147,7 @@
      $                   'ZTRSM ', 'ZHERK ', 'ZSYRK ', 'ZHER2K',
      $                   'ZSYR2K', 'ZGEMMTR'/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -376,6 +378,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -407,6 +411,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of ZBLAT3
 *

--- a/CBLAS/src/CMakeLists.txt
+++ b/CBLAS/src/CMakeLists.txt
@@ -144,6 +144,7 @@ if(BUILD_DEFAULT_API)
 else()
   add_library(${CBLASLIB}_obj OBJECT ${COMMON_SOURCES})
 endif()
+lapack_add_coverage(${CBLASLIB}_obj)
 
 if(BUILD_INDEX64_EXT_API)
   include(ExtendedAPIHelpers)
@@ -175,4 +176,6 @@ target_include_directories(${CBLASLIB} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(${CBLASLIB} PUBLIC ${BLAS_LIBRARIES})
+
+lapack_add_coverage(${CBLASLIB})
 lapack_install_library(${CBLASLIB})

--- a/CBLAS/testing/CMakeLists.txt
+++ b/CBLAS/testing/CMakeLists.txt
@@ -28,6 +28,7 @@ endfunction()
 
 function(add_cblas_test_target target)
   add_executable(${target} ${ARGN})
+  lapack_add_coverage(${target})
 
   if(HAS_ATTRIBUTE_WEAK_SUPPORT)
     target_compile_definitions(${target} PRIVATE HAS_ATTRIBUTE_WEAK_SUPPORT)

--- a/CBLAS/testing/c_cblat1.f
+++ b/CBLAS/testing/c_cblat1.f
@@ -13,6 +13,7 @@
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      REAL             S1, S2
       REAL             SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -24,6 +25,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625E-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 11
          ICASE = IC
@@ -49,12 +51,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Complex CBLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A15,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
       END
 
 *  =====================================================================

--- a/CBLAS/testing/c_cblat2.f
+++ b/CBLAS/testing/c_cblat2.f
@@ -80,6 +80,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NTRA, LAYOUT
@@ -123,6 +124,7 @@
      $                   'cblas_cgerc ','cblas_cgeru ','cblas_cher  ',
      $                   'cblas_chpr  ','cblas_cher2 ','cblas_chpr2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
       NOUTC = NOUT
 *
@@ -420,6 +422,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -458,6 +462,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of CBLAT2.
 *

--- a/CBLAS/testing/c_cblat3.f
+++ b/CBLAS/testing/c_cblat3.f
@@ -62,6 +62,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NTRA,
      $                   LAYOUT
@@ -103,6 +104,7 @@
      $                   'cblas_cherk ', 'cblas_csyrk ', 'cblas_cher2k',
      $                   'cblas_csyr2k', 'cblas_cgemmtr' /
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
       NOUTC = NOUT
 *
@@ -404,6 +406,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -438,6 +442,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of CBLAT3.
 *

--- a/CBLAS/testing/c_dblat1.f
+++ b/CBLAS/testing/c_dblat1.f
@@ -13,6 +13,7 @@
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      DOUBLE PRECISION S1, S2
       DOUBLE PRECISION SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -24,6 +25,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625D-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 11
          ICASE = IC
@@ -55,12 +57,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Real CBLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A15,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
       END
 
 *  =====================================================================

--- a/CBLAS/testing/c_dblat2.f
+++ b/CBLAS/testing/c_dblat2.f
@@ -79,6 +79,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NTRA, LAYOUT
@@ -133,6 +134,7 @@
      $                   'cblas_dskewsymv ',
      $                   'cblas_dskewsyr2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
       NOUTC = NOUT
 *
@@ -429,6 +431,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -465,6 +469,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of DBLAT2.
 *

--- a/CBLAS/testing/c_dblat3.f
+++ b/CBLAS/testing/c_dblat3.f
@@ -59,6 +59,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NTRA,
      $                    LAYOUT
@@ -104,6 +105,7 @@
      $                   'cblas_dskewsymm  ',
      $                   'cblas_dskewsyr2k '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
 *     Read name and unit number for summary output file and open file.
 *
@@ -404,6 +406,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -436,6 +440,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of DBLAT3.
 *

--- a/CBLAS/testing/c_sblat1.f
+++ b/CBLAS/testing/c_sblat1.f
@@ -13,6 +13,7 @@
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      REAL             S1, S2
       REAL             SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -24,6 +25,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625E-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 11
          ICASE = IC
@@ -55,12 +57,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Real CBLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A15,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
       END
 
 *  =====================================================================

--- a/CBLAS/testing/c_sblat2.f
+++ b/CBLAS/testing/c_sblat2.f
@@ -79,6 +79,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NTRA, LAYOUT
@@ -133,6 +134,7 @@
      $                   'cblas_sskewsymv ',
      $                   'cblas_sskewsyr2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
       NOUTC = NOUT
 *
@@ -430,6 +432,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -466,6 +470,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of SBLAT2.
 *

--- a/CBLAS/testing/c_sblat3.f
+++ b/CBLAS/testing/c_sblat3.f
@@ -59,6 +59,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      REAL               S1, S2
       REAL               EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NTRA,
      $                   LAYOUT
@@ -104,6 +105,7 @@
      $                   'cblas_sskewsymm  ',
      $                   'cblas_sskewsyr2k '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
       NOUTC = NOUT
 *     Read name and unit number for summary output file and open file.
@@ -404,6 +406,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -436,6 +440,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of SBLAT3.
 *

--- a/CBLAS/testing/c_zblat1.f
+++ b/CBLAS/testing/c_zblat1.f
@@ -13,6 +13,7 @@
       INTEGER          ICASE, INCX, INCY, MODE, N
       LOGICAL          PASS
 *     .. Local Scalars ..
+      DOUBLE PRECISION S1, S2
       DOUBLE PRECISION SFAC
       INTEGER          IC
 *     .. External Subroutines ..
@@ -24,6 +25,7 @@
 *     .. Data statements ..
       DATA             SFAC/9.765625D-4/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
       WRITE (NOUT,99999)
       DO 20 IC = 1, 11
          ICASE = IC
@@ -49,12 +51,15 @@
          IF (PASS) WRITE (NOUT,99998)
          WRITE (NOUT,99997) SUBNAM, NTESTS, NFAILS
    20 CONTINUE
+      CALL CPU_TIME( S2 )
+      WRITE (NOUT,99996) S2 - S1
       STOP
 *
 99999 FORMAT (' Complex CBLAS Test Program Results',/1X)
 99998 FORMAT ('                                    ----- PASS -----')
 99997 FORMAT (1X,A15,' COMPUTATIONAL TESTS:',I9,' RUN,',I9,
      +        ' FAILED')
+99996 FORMAT (' Total time used = ',F12.2,' seconds',/)
       END
 
 *  =====================================================================

--- a/CBLAS/testing/c_zblat2.f
+++ b/CBLAS/testing/c_zblat2.f
@@ -81,6 +81,7 @@
       PARAMETER          ( NINMAX = 7, NIDMAX = 9, NKBMAX = 7,
      $                   NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NINC, NKB,
      $                   NTRA, LAYOUT
@@ -124,6 +125,7 @@
      $                   'cblas_zgerc ','cblas_zgeru ','cblas_zher  ',
      $                   'cblas_zhpr  ','cblas_zher2 ','cblas_zhpr2 '/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
       NOUTC = NOUT
 *
@@ -419,6 +421,8 @@
   240 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9979 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -457,6 +461,7 @@
  9982 FORMAT( /' END OF TESTS' )
  9981 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9980 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9979 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of ZBLAT2.
 *

--- a/CBLAS/testing/c_zblat3.f
+++ b/CBLAS/testing/c_zblat3.f
@@ -63,6 +63,7 @@
       INTEGER            NIDMAX, NALMAX, NBEMAX
       PARAMETER          ( NIDMAX = 9, NALMAX = 7, NBEMAX = 7 )
 *     .. Local Scalars ..
+      DOUBLE PRECISION   S1, S2
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NTRA,
      $                   LAYOUT
@@ -104,6 +105,7 @@
      $                   'cblas_zherk ', 'cblas_zsyrk ', 'cblas_zher2k',
      $                   'cblas_zsyr2k', 'cblas_zgemmtr'/
 *     .. Executable Statements ..
+      CALL CPU_TIME( S1 )
 *
       NOUTC = NOUT
 *
@@ -403,6 +405,8 @@
   230 CONTINUE
       IF( TRACE )
      $   CLOSE ( NTRA )
+      CALL CPU_TIME( S2 )
+      WRITE( NOUT, FMT = 9983 )S2 - S1
       CLOSE ( NOUT )
       STOP
 *
@@ -437,6 +441,7 @@
  9986 FORMAT( /' END OF TESTS' )
  9985 FORMAT( /' ******* FATAL ERROR - TESTS ABANDONED *******' )
  9984 FORMAT( ' ERROR-EXITS WILL NOT BE TESTED' )
+ 9983 FORMAT( ' Total time used = ', F12.2, ' seconds', / )
 *
 *     End of ZBLAT3.
 *

--- a/CMAKE/FindGcov.cmake
+++ b/CMAKE/FindGcov.cmake
@@ -135,8 +135,12 @@ function (add_gcov_target TNAME)
     get_filename_component(FILE_PATH "${TDIR}/${FILE}" PATH)
 
     # call gcov
+    #
+    # -b records branch frequencies, -c reports them as counts rather than
+    # percentages. Without -b the report carries line counts only, and both
+    # the summary below and Codecov have no branch coverage to work with.
     add_custom_command(OUTPUT ${TDIR}/${FILE}.gcov
-      COMMAND ${GCOV_ENV} ${GCOV_BIN} ${TDIR}/${FILE}.gcno > /dev/null
+      COMMAND ${GCOV_ENV} ${GCOV_BIN} -b -c ${TDIR}/${FILE}.gcno > /dev/null
       DEPENDS ${TNAME} ${TDIR}/${FILE}.gcno
       WORKING_DIRECTORY ${FILE_PATH}
     )

--- a/CMAKE/FindGcov.cmake
+++ b/CMAKE/FindGcov.cmake
@@ -107,33 +107,31 @@ function (add_gcov_target TNAME)
 
   # We don't have to check, if the target has support for coverage, thus this
   # will be checked by add_coverage_target in Findcoverage.cmake. Instead we
-  # have to determine which gcov binary to use.
+  # have to determine which gcov binary to use. A target may mix languages
+  # built by different compilers, so this is decided per source file.
   get_target_property(TSOURCES ${TNAME} SOURCES)
-  set(SOURCES "")
-  set(TCOMPILER "")
-  foreach (FILE ${TSOURCES})
-    codecov_path_of_source(${FILE} FILE)
-    if(NOT "${FILE}" STREQUAL "")
-      codecov_lang_of_source(${FILE} LANG)
-      if(NOT "${LANG}" STREQUAL "")
-        list(APPEND SOURCES "${FILE}")
-        set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
-      endif()
-    endif()
-  endforeach()
-
-  # If no gcov binary was found, coverage data can't be evaluated.
-  if(NOT GCOV_${TCOMPILER}_BIN)
-    message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
-    return()
-  endif()
-
-  set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
-  set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
-
-
   set(BUFFER "")
-  foreach(FILE ${SOURCES})
+  foreach(FILE IN LISTS TSOURCES)
+    codecov_path_of_source("${FILE}" FILE)
+    if(FILE STREQUAL "")
+      continue()
+    endif()
+
+    codecov_lang_of_source("${FILE}" LANG)
+    if(LANG STREQUAL "")
+      continue()
+    endif()
+
+    # If no gcov binary was found, coverage data can't be evaluated.
+    set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
+    if(NOT GCOV_${TCOMPILER}_BIN)
+      message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
+      return()
+    endif()
+
+    set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
+    set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
+
     get_filename_component(FILE_PATH "${TDIR}/${FILE}" PATH)
 
     # call gcov
@@ -146,6 +144,11 @@ function (add_gcov_target TNAME)
     list(APPEND BUFFER ${TDIR}/${FILE}.gcov)
   endforeach()
 
+  # Targets assembled purely from $<TARGET_OBJECTS:...> compile nothing of
+  # their own; their coverage data is evaluated with the object libraries.
+  if(NOT BUFFER)
+    return()
+  endif()
 
   # add target for gcov evaluation of <TNAME>
   add_custom_target(${TNAME}-gcov DEPENDS ${BUFFER})

--- a/CMAKE/Findcodecov.cmake
+++ b/CMAKE/Findcodecov.cmake
@@ -10,6 +10,10 @@
 # Written by Alexander Haase, alexander.haase@rwth-aachen.de
 # Updated by Guillaume Jacquenot, guillaume.jacquenot@gmail.com
 
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+include(CheckFortranCompilerFlag)
+
 set(COVERAGE_FLAG_CANDIDATES
   # gcc and clang
   "-O0 -g -fprofile-arcs -ftest-coverage"
@@ -18,90 +22,81 @@ set(COVERAGE_FLAG_CANDIDATES
   "-O0 -g --coverage"
 )
 
-
-# To avoid error messages about CMP0051, this policy will be set to new. There
-# will be no problem, as TARGET_OBJECTS generator expressions will be filtered
-# with a regular expression from the sources.
-if(POLICY CMP0051)
-  cmake_policy(SET CMP0051 NEW)
-endif()
+# The languages this module knows how to probe for coverage flags.
+set(COVERAGE_LANGUAGES C CXX Fortran)
 
 
-# Add coverage support for target ${TNAME} and register target for coverage
-# evaluation.
-function(add_coverage TNAME)
-  foreach (TNAME ${ARGV})
-    add_coverage_target(${TNAME})
+# Find the coverage flags for language ${LANG} and cache them in
+# COVERAGE_<compiler id>_FLAGS. Coverage flags are not dependent on the
+# language, but on the compiler, so languages sharing a compiler are probed
+# only once. A language may be enabled after this module has been found, so
+# this is called again from add_coverage_target() rather than only here.
+function(codecov_find_flags LANG)
+  set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+  if(NOT COMPILER OR DEFINED CACHE{COVERAGE_${COMPILER}_FLAGS})
+    return()
+  endif()
+
+  set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
+
+  foreach(FLAG IN LISTS COVERAGE_FLAG_CANDIDATES)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try ${COMPILER} code coverage flag = [${FLAG}]")
+    endif()
+
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(COVERAGE_FLAG_DETECTED CACHE)
+
+    if(LANG STREQUAL "C")
+      check_c_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+    elseif(LANG STREQUAL "CXX")
+      check_cxx_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+    elseif(LANG STREQUAL "Fortran")
+      check_fortran_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+    endif()
+
+    if(COVERAGE_FLAG_DETECTED)
+      # Cache the flags as a list, so they can be handed to
+      # target_compile_options() and target_link_options() unmodified.
+      string(REPLACE " " ";" FLAG_LIST "${FLAG}")
+      set(COVERAGE_${COMPILER}_FLAGS "${FLAG_LIST}"
+        CACHE STRING "${COMPILER} flags for code coverage.")
+      mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
+      return()
+    endif()
   endforeach()
+
+  # Remember that this compiler has no usable coverage flags, so that it is not
+  # probed again for every target.
+  set(COVERAGE_${COMPILER}_FLAGS "COVERAGE_${COMPILER}_FLAGS-NOTFOUND"
+    CACHE STRING "${COMPILER} flags for code coverage.")
+  mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
 endfunction()
 
 
-# Find the required flags foreach language.
-set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
-set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
-
+# Probe the languages that are already enabled, so that the check appears in
+# the configure output next to the other compiler checks.
 get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
-foreach (LANG ${ENABLED_LANGUAGES})
-  # Coverage flags are not dependent on language, but the used compiler. So
-  # instead of searching flags foreach language, search flags foreach compiler
-  # used.
-  set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
-  if(NOT COVERAGE_${COMPILER}_FLAGS)
-    foreach (FLAG ${COVERAGE_FLAG_CANDIDATES})
-      if(NOT CMAKE_REQUIRED_QUIET)
-        message(STATUS "Try ${COMPILER} code coverage flag = [${FLAG}]")
-      endif()
-
-      set(CMAKE_REQUIRED_FLAGS "${FLAG}")
-      unset(COVERAGE_FLAG_DETECTED CACHE)
-
-      if(${LANG} STREQUAL "C")
-        include(CheckCCompilerFlag)
-        check_c_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
-
-      elseif(${LANG} STREQUAL "CXX")
-        include(CheckCXXCompilerFlag)
-        check_cxx_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
-
-      elseif(${LANG} STREQUAL "Fortran")
-        # CheckFortranCompilerFlag was introduced in CMake 3.x. To be
-        # compatible with older Cmake versions, we will check if this
-        # module is present before we use it. Otherwise we will define
-        # Fortran coverage support as not available.
-        include(CheckFortranCompilerFlag OPTIONAL
-          RESULT_VARIABLE INCLUDED)
-        if(INCLUDED)
-          check_fortran_compiler_flag("${FLAG}"
-            COVERAGE_FLAG_DETECTED)
-        elseif(NOT CMAKE_REQUIRED_QUIET)
-          message("-- Performing Test COVERAGE_FLAG_DETECTED")
-          message("-- Performing Test COVERAGE_FLAG_DETECTED - Failed"
-            " (Check not supported)")
-        endif()
-      endif()
-
-      if(COVERAGE_FLAG_DETECTED)
-        set(COVERAGE_${COMPILER}_FLAGS "${FLAG}"
-          CACHE STRING "${COMPILER} flags for code coverage.")
-        mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
-        break()
-      endif()
-    endforeach()
+foreach(LANG IN LISTS ENABLED_LANGUAGES)
+  if(LANG IN_LIST COVERAGE_LANGUAGES)
+    codecov_find_flags(${LANG})
   endif()
 endforeach()
 
-set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
 
 # Helper function to get the language of a source file.
-function (codecov_lang_of_source FILE RETURN_VAR)
+function(codecov_lang_of_source FILE RETURN_VAR)
   get_filename_component(FILE_EXT "${FILE}" EXT)
   string(TOLOWER "${FILE_EXT}" FILE_EXT)
+  if(FILE_EXT STREQUAL "")
+    set(${RETURN_VAR} "" PARENT_SCOPE)
+    return()
+  endif()
   string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
 
   get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
-  foreach (LANG ${ENABLED_LANGUAGES})
-    list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
-    if(NOT ${TEMP} EQUAL -1)
+  foreach(LANG IN LISTS ENABLED_LANGUAGES)
+    if(FILE_EXT IN_LIST CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS)
       set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
       return()
     endif()
@@ -110,17 +105,19 @@ function (codecov_lang_of_source FILE RETURN_VAR)
   set(${RETURN_VAR} "" PARENT_SCOPE)
 endfunction()
 
+
 # Helper function to get the relative path of the source file destination path.
 # This path is needed by FindGcov and FindLcov cmake files to locate the
 # captured data.
-function (codecov_path_of_source FILE RETURN_VAR)
-  string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _source ${FILE})
-
-  # If expression was found, SOURCEFILE is a generator-expression for an
-  # object library. Currently we found no way to call this function automatic
-  # for the referenced target, so it must be called in the directory of the
-  # object library definition.
-  if(NOT "${_source}" STREQUAL "")
+function(codecov_path_of_source FILE RETURN_VAR)
+  # Generator expressions cannot be resolved to a path here, so they have no
+  # coverage data of their own. In particular a $<TARGET_OBJECTS:...> source
+  # belongs to an object library and is evaluated together with that library.
+  # Note that a conditional such as
+  #   $<$<BOOL:${COND}>: $<TARGET_OBJECTS:foo>>
+  # reaches us split at the whitespace, so only one of its fragments mentions
+  # TARGET_OBJECTS; skip anything that looks like a generator expression.
+  if(FILE MATCHES "\\$<")
     set(${RETURN_VAR} "" PARENT_SCOPE)
     return()
   endif()
@@ -139,63 +136,64 @@ endfunction()
 # Add coverage support for target ${TNAME} and register target for coverage
 # evaluation.
 function(add_coverage_target TNAME)
-  # Check if all sources for target use the same compiler. If a target uses
-  # e.g. C and Fortran mixed and uses different compilers (e.g. clang and
-  # gfortran) this can trigger huge problems, because different compilers may
-  # use different implementations for code coverage.
-  get_target_property(TSOURCES ${TNAME} SOURCES)
-  set(TARGET_COMPILER "")
-  set(ADDITIONAL_FILES "")
-  foreach (FILE ${TSOURCES})
-    # If expression was found, FILE is a generator-expression for an object
-    # library. Object libraries will be ignored.
-    string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
-    if("${_file}" STREQUAL "")
-      codecov_lang_of_source(${FILE} LANG)
-      if(LANG)
-        list(APPEND TARGET_COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+  # A target may mix languages that are built by different compilers, which may
+  # use incompatible coverage implementations. Guard each compiler's flags with
+  # the language they were detected for, so that every source is compiled with
+  # the flags of the compiler that actually builds it.
+  set(COMPILE_OPTIONS "")
+  set(LINK_OPTIONS "")
+  foreach(LANG IN LISTS COVERAGE_LANGUAGES)
+    codecov_find_flags(${LANG})
 
-        list(APPEND ADDITIONAL_FILES "${FILE}.gcno")
-        list(APPEND ADDITIONAL_FILES "${FILE}.gcda")
-      endif()
+    set(FLAGS "${COVERAGE_${CMAKE_${LANG}_COMPILER_ID}_FLAGS}")
+    if(FLAGS)
+      list(APPEND COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:${LANG}>:${FLAGS}>")
+      list(APPEND LINK_OPTIONS "$<$<LINK_LANGUAGE:${LANG}>:${FLAGS}>")
     endif()
-  endforeach ()
+  endforeach()
 
-  list(REMOVE_DUPLICATES TARGET_COMPILER)
-  list(LENGTH TARGET_COMPILER NUM_COMPILERS)
-
-  if(NUM_COMPILERS GREATER 1)
-    message(AUTHOR_WARNING "Coverage disabled for target ${TNAME} because "
-      "it will be compiled by different compilers.")
-    return()
-
-  elseif((NUM_COMPILERS EQUAL 0) OR
-    (NOT DEFINED "COVERAGE_${TARGET_COMPILER}_FLAGS"))
-    message(AUTHOR_WARNING "Coverage disabled for target ${TNAME} "
-      "because there is no sanitizer available for target sources.")
+  if(NOT COMPILE_OPTIONS)
+    message(AUTHOR_WARNING "Coverage disabled for target ${TNAME} because no "
+      "coverage flags are available for any enabled language.")
     return()
   endif()
 
-
   # enable coverage for target
-  set_property(TARGET ${TNAME} APPEND_STRING
-    PROPERTY COMPILE_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
-  set_property(TARGET ${TNAME} APPEND_STRING
-    PROPERTY LINK_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
+  target_compile_options(${TNAME} PRIVATE ${COMPILE_OPTIONS})
+  target_link_options(${TNAME} PRIVATE ${LINK_OPTIONS})
 
 
   # Add gcov files generated by compiler to clean target.
+  get_target_property(TSOURCES ${TNAME} SOURCES)
   set(CLEAN_FILES "")
-  foreach (FILE ${ADDITIONAL_FILES})
-    codecov_path_of_source(${FILE} FILE)
-    list(APPEND CLEAN_FILES "CMakeFiles/${TNAME}.dir/${FILE}")
+  foreach(FILE IN LISTS TSOURCES)
+    codecov_path_of_source("${FILE}" FILE)
+    if(FILE STREQUAL "")
+      continue()
+    endif()
+
+    codecov_lang_of_source("${FILE}" LANG)
+    if(LANG)
+      list(APPEND CLEAN_FILES
+        "CMakeFiles/${TNAME}.dir/${FILE}.gcno"
+        "CMakeFiles/${TNAME}.dir/${FILE}.gcda")
+    endif()
   endforeach()
 
-  set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
-    "${CLEAN_FILES}")
+  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES ${CLEAN_FILES})
 
   add_gcov_target(${TNAME})
 endfunction()
+
+
+# Add coverage support for target ${TNAME} and register target for coverage
+# evaluation.
+function(add_coverage TNAME)
+  foreach(T IN LISTS ARGV)
+    add_coverage_target(${T})
+  endforeach()
+endfunction()
+
 
 # Include modules for parsing the collected data and output it in a readable
 # format (like gcov).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,18 @@ if(_is_coverage_build)
   find_package(codecov)
 endif()
 
+# Instrument the library ${lib} for coverage.
+function(lapack_add_coverage lib)
+  if(NOT _is_coverage_build)
+    return()
+  endif()
+  if(NOT TARGET ${lib})
+    message(FATAL_ERROR "lapack_add_coverage: no such target '${lib}'")
+  endif()
+  add_coverage(${lib})
+  target_link_libraries(${lib} PRIVATE gcov)
+endfunction()
+
 # Use valgrind if it is found
 option( LAPACK_TESTING_USE_PYTHON "Use Python for testing. Disable it on memory checks." ON )
 find_program( MEMORYCHECK_COMMAND valgrind )

--- a/LAPACKE/CMakeLists.txt
+++ b/LAPACKE/CMakeLists.txt
@@ -87,6 +87,7 @@ if(BUILD_DEFAULT_API)
 else()
   add_library(${LAPACKELIB}_obj OBJECT ${COMMON_SOURCES} ${COMMON_UTILS})
 endif()
+lapack_add_coverage(${LAPACKELIB}_obj)
 
 if(BUILD_INDEX64_EXT_API)
   add_library(${LAPACKELIB}_64_obj OBJECT ${SOURCES})
@@ -114,6 +115,7 @@ if(LAPACKE_WITH_TMG)
 endif()
 target_link_libraries(${LAPACKELIB} PRIVATE ${LAPACK_LIBRARIES})
 
+lapack_add_coverage(${LAPACKELIB})
 lapack_install_library(${LAPACKELIB})
 
 if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 ![CMake](https://github.com/Reference-LAPACK/lapack/actions/workflows/cmake.yml/badge.svg)
 ![Makefile](https://github.com/Reference-LAPACK/lapack/actions/workflows/makefile.yml/badge.svg)
 [![Appveyor](https://ci.appveyor.com/api/projects/status/bh38iin398msrbtr?svg=true)](https://ci.appveyor.com/project/langou/lapack/)
-[![codecov](https://codecov.io/gh/Reference-LAPACK/lapack/branch/master/graph/badge.svg)](https://codecov.io/gh/Reference-LAPACK/lapack)
+[![BLAS coverage](https://codecov.io/gh/Reference-LAPACK/lapack/branch/master/graph/badge.svg?component=blas)](https://codecov.io/gh/Reference-LAPACK/lapack?components[]=blas)
+[![CBLAS coverage](https://codecov.io/gh/Reference-LAPACK/lapack/branch/master/graph/badge.svg?component=cblas)](https://codecov.io/gh/Reference-LAPACK/lapack?components[]=cblas)
+[![LAPACK coverage](https://codecov.io/gh/Reference-LAPACK/lapack/branch/master/graph/badge.svg?component=lapack)](https://codecov.io/gh/Reference-LAPACK/lapack?components[]=lapack)
+[![LAPACKE coverage](https://codecov.io/gh/Reference-LAPACK/lapack/branch/master/graph/badge.svg?component=lapacke)](https://codecov.io/gh/Reference-LAPACK/lapack?components[]=lapacke)
 [![Packaging status](https://repology.org/badge/tiny-repos/lapack.svg)](https://repology.org/metapackage/lapack/versions)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Reference-LAPACK/lapack/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Reference-LAPACK/lapack)
 

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -528,14 +528,17 @@ list(REMOVE_DUPLICATES SOURCES)
 # any other files that depend on them
 add_library(const_mod_file OBJECT ${CONSTMOD})
 set_target_properties(const_mod_file PROPERTIES Fortran_PREPROCESS ON)
+lapack_add_coverage(const_mod_file)
 
 add_library(mod_files OBJECT ${NANMOD} $<TARGET_OBJECTS:const_mod_file>)
 set_target_properties(mod_files PROPERTIES Fortran_PREPROCESS ON)
+lapack_add_coverage(mod_files)
 
 if(BUILD_DEFAULT_API)
   add_library(${LAPACKLIB}_obj OBJECT ${SOURCES} ${XSOURCES})
-  target_link_libraries(${LAPACKLIB}_obj mod_files)
+  target_link_libraries(${LAPACKLIB}_obj PUBLIC mod_files)
   set_target_properties(${LAPACKLIB}_obj PROPERTIES Fortran_PREPROCESS ON)
+  lapack_add_coverage(${LAPACKLIB}_obj)
 endif()
 
 if(BUILD_INDEX64_EXT_API)
@@ -543,7 +546,7 @@ if(BUILD_INDEX64_EXT_API)
   generate_64bit_suffixed_sources(${LAPACKLIB} SOURCES SOURCES_64)
 
   add_library(${LAPACKLIB}_64_obj OBJECT ${SOURCES_64})
-  target_link_libraries(${LAPACKLIB}_64_obj mod_files)
+  target_link_libraries(${LAPACKLIB}_64_obj PUBLIC mod_files)
   target_compile_options(${LAPACKLIB}_64_obj PRIVATE ${FOPT_ILP64})
   set_target_properties(${LAPACKLIB}_64_obj PROPERTIES Fortran_PREPROCESS ON)
 endif()
@@ -575,9 +578,5 @@ if(USE_XBLAS)
 endif()
 target_link_libraries(${LAPACKLIB} PRIVATE ${BLAS_LIBRARIES})
 
-if(_is_coverage_build)
-  target_link_libraries(${LAPACKLIB} PRIVATE gcov)
-  add_coverage(${LAPACKLIB}_obj)
-endif()
-
+lapack_add_coverage(${LAPACKLIB})
 lapack_install_library(${LAPACKLIB})

--- a/TESTING/EIG/CMakeLists.txt
+++ b/TESTING/EIG/CMakeLists.txt
@@ -108,7 +108,8 @@ function(add_eig_executable name)
   set(sources ${ARGN})
   if(BUILD_DEFAULT_API)
     add_executable(${name} ${sources})
-    target_link_libraries(${name} ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    target_link_libraries(${name} PRIVATE ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    lapack_add_coverage(${name})
   endif()
 
   if(BUILD_INDEX64_EXT_API)
@@ -117,7 +118,8 @@ function(add_eig_executable name)
 
     add_executable(${name}_64 ${sources_64})
     target_compile_options(${name}_64 PRIVATE ${FOPT_ILP64})
-    target_link_libraries(${name}_64 ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    target_link_libraries(${name}_64 PRIVATE ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    lapack_add_coverage(${name}_64)
 
     # Add dependency to the global codegen target. Since we reuse the same
     # generated source file for multiple tests, the generation could be

--- a/TESTING/EIG/cchkdmd.f90
+++ b/TESTING/EIG/cchkdmd.f90
@@ -60,6 +60,7 @@
                        TOL, TOL2, SVDIFF, TMP, TMP_AU,       &
                        TMP_FQR, TMP_REZ, TMP_REZQ,  TMP_XW, &
                        TMP_EX
+      REAL(KIND=WP) :: S1, S2
 !............................................................
       COMPLEX(KIND=WP) :: CMAX
       INTEGER :: LCWORK
@@ -100,6 +101,8 @@
       INTRINSIC ABS, INT, MIN, MAX, SIGN
 !............................................................
 
+
+      CALL CPU_TIME( S1 )
 
       WRITE(*,*) 'COMPLEX CODE TESTING'
 
@@ -720,5 +723,7 @@
 
       WRITE(*,*)
       WRITE(*,*) 'Test completed.'
+      CALL CPU_TIME( S2 )
+      WRITE(*,'(A,F12.2,A,/)') ' Total time used = ', S2 - S1, ' seconds'
       STOP
       END

--- a/TESTING/EIG/dchkdmd.f90
+++ b/TESTING/EIG/dchkdmd.f90
@@ -81,6 +81,7 @@
                        TOL, TOL2, SVDIFF, TMP, TMP_AU,       &
                        TMP_FQR, TMP_REZ, TMP_REZQ,  TMP_ZXW, &
                        TMP_EX, XNORM, YNORM
+      REAL(KIND=WP) :: S1, S2
 !............................................................
       INTEGER :: K, KQ, LDF, LDS, LDA, LDAU, LDW, LDX, LDY,  &
                  LDZ, LIWORK, LWORK, M, N, L, LLOOP, NRNK
@@ -112,6 +113,8 @@
       ! The test is always in pairs : ( DGEDMD and DGEDMDQ )
       ! because the test includes comparing the results (in pairs).
 !.....................................................................................
+      CALL CPU_TIME( S1 )
+
       TEST_QRDMD = .TRUE. ! This code by default performs tests on DGEDMDQ
                           ! Since the QR factorizations based algorithm is designed for
                           ! single trajectory data, only single trajectory tests will
@@ -811,5 +814,7 @@
 
       WRITE(*,*)
       WRITE(*,*) 'Test completed.'
+      CALL CPU_TIME( S2 )
+      WRITE(*,'(A,F12.2,A,/)') ' Total time used = ', S2 - S1, ' seconds'
       STOP
       END

--- a/TESTING/EIG/schkdmd.f90
+++ b/TESTING/EIG/schkdmd.f90
@@ -81,6 +81,7 @@
                        TOL, TOL2, SVDIFF, TMP, TMP_AU,       &
                        TMP_FQR, TMP_REZ, TMP_REZQ,  TMP_ZXW, &
                        TMP_EX, XNORM, YNORM
+      REAL(KIND=WP) :: S1, S2
 !............................................................
       INTEGER :: K, KQ, LDF, LDS, LDA, LDAU, LDW, LDX, LDY,  &
                  LDZ, LIWORK, LWORK, M, N, L, LLOOP, NRNK
@@ -112,6 +113,8 @@
       ! The test is always in pairs : ( SGEDMD and SGEDMDQ )
       ! because the test includes comparing the results (in pairs).
 !.....................................................................................
+      CALL CPU_TIME( S1 )
+
       TEST_QRDMD = .TRUE. ! This code by default performs tests on SGEDMDQ
                           ! Since the QR factorizations based algorithm is designed for
                           ! single trajectory data, only single trajectory tests will
@@ -790,5 +793,7 @@
 
       WRITE(*,*)
       WRITE(*,*) 'Test completed.'
+      CALL CPU_TIME( S2 )
+      WRITE(*,'(A,F12.2,A,/)') ' Total time used = ', S2 - S1, ' seconds'
       STOP
       END

--- a/TESTING/EIG/zchkdmd.f90
+++ b/TESTING/EIG/zchkdmd.f90
@@ -60,6 +60,7 @@
                        TOL, TOL2, SVDIFF, TMP, TMP_AU,       &
                        TMP_FQR, TMP_REZ, TMP_REZQ,  TMP_ZXW, &
                        TMP_EX
+      REAL(KIND=WP) :: S1, S2
 
 !............................................................
       COMPLEX(KIND=WP) :: ZMAX
@@ -105,6 +106,8 @@
       ! The test is always in pairs : ( ZGEDMD and ZGEDMDQ )
       ! because the test includes comparing the results (in pairs).
 !.....................................................................................
+      CALL CPU_TIME( S1 )
+
       TEST_QRDMD = .TRUE. ! This code by default performs tests on ZGEDMDQ
                           ! Since the QR factorizations based algorithm is designed for
                           ! single trajectory data, only single trajectory tests will
@@ -742,5 +745,7 @@
 
       WRITE(*,*)
       WRITE(*,*) 'Test completed.'
+      CALL CPU_TIME( S2 )
+      WRITE(*,'(A,F12.2,A,/)') ' Total time used = ', S2 - S1, ' seconds'
       STOP
       END

--- a/TESTING/LIN/CMakeLists.txt
+++ b/TESTING/LIN/CMakeLists.txt
@@ -268,7 +268,8 @@ function(add_lin_executable name)
 
   if(BUILD_DEFAULT_API)
     add_executable(${name} ${sources})
-    target_link_libraries(${name} ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    target_link_libraries(${name} PRIVATE ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    lapack_add_coverage(${name})
   endif()
 
   if(BUILD_INDEX64_EXT_API)
@@ -289,7 +290,8 @@ function(add_lin_executable name)
 
     add_executable(${name}_64 ${ext_sources_64})
     target_compile_options(${name}_64 PRIVATE ${FOPT_ILP64})
-    target_link_libraries(${name}_64 ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    target_link_libraries(${name}_64 PRIVATE ${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+    lapack_add_coverage(${name}_64)
 
     # Add depedency to the global codegen target. Since we reuse the same
     # generated source file for multiple tests, the generation could be

--- a/TESTING/MATGEN/CMakeLists.txt
+++ b/TESTING/MATGEN/CMakeLists.txt
@@ -50,6 +50,7 @@ list(REMOVE_DUPLICATES SOURCES)
 if(BUILD_DEFAULT_API)
   add_library(${TMGLIB}_obj OBJECT ${SOURCES})
   set_target_properties(${TMGLIB}_obj PROPERTIES Fortran_PREPROCESS ON)
+  lapack_add_coverage(${TMGLIB}_obj)
 endif()
 
 if(BUILD_INDEX64_EXT_API)
@@ -71,5 +72,6 @@ set_target_properties(
   SOVERSION ${LAPACK_MAJOR_VERSION}
 )
 
-target_link_libraries(${TMGLIB} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+target_link_libraries(${TMGLIB} PRIVATE ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+lapack_add_coverage(${TMGLIB})
 lapack_install_library(${TMGLIB})

--- a/codecov.yml
+++ b/codecov.yml
@@ -74,3 +74,30 @@ component_management:
       paths:
         - LAPACKE/src/**
         - LAPACKE/utils/**
+    - component_id: tmglib
+      name: TMGLIB
+      paths:
+        # The test matrix generators.  Shipped as a library of their own and
+        # used by every LAPACK test to build its inputs, so a generator path
+        # no test asks for shows up here rather than in any of the above.
+        - TESTING/MATGEN/**
+    # The test programs, one component per library they exercise.  These
+    # measure the tests themselves, not the code under test: a routine here
+    # that never runs is a test that was written and then never reached.
+    - component_id: blas_testing
+      name: BLAS testing
+      paths:
+        - BLAS/TESTING/**
+    - component_id: cblas_testing
+      name: CBLAS testing
+      paths:
+        - CBLAS/testing/**
+    - component_id: lapack_testing
+      name: LAPACK testing
+      paths:
+        - TESTING/LIN/**
+        - TESTING/EIG/**
+    - component_id: lapacke_testing
+      name: LAPACKE testing
+      paths:
+        - LAPACKE/testing/**

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,7 @@ codecov:
     wait_for_ci: false
 
 comment:
-  # 'flags' and 'components' are the tables listing BLAS, CBLAS, LAPACK and
-  # LAPACKE separately.
-  layout: "header, diff, flags, components, files, footer"
+  layout: "header, reach, diff, components, files, footer"
   behavior: default
   # Comment on every pull request: also on one that changes no coverage at
   # all ...
@@ -23,10 +21,6 @@ comment:
   # ... and on one for which no coverage was uploaded, so that the test
   # results are reported even when the coverage build did not get that far.
   require_head: false
-  # A flag carried forward from the base commit is labelled as such, so
-  # showing them keeps all four components in the table even when one of
-  # them did not build.
-  show_carryforward_flags: true
 
 flags:
   # The four components are uploaded separately, each from the build

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,18 @@
 #   curl -X POST --data-binary @codecov.yml https://codecov.io/validate
 # See https://docs.codecov.com/docs/codecovyml-reference for the full reference.
 
+codecov:
+  notify:
+    # Comment as soon as a report has been processed instead of holding the
+    # comment back until every other CI status has completed.  A pull request
+    # whose build or tests fail is one where the report is wanted most, and
+    # the comment is updated in place as the remaining uploads arrive.
+    wait_for_ci: false
+
 comment:
-  # 'flags' is the table listing BLAS, CBLAS, LAPACK and LAPACKE separately.
-  layout: "header, diff, flags, files, footer"
+  # 'flags' and 'components' are the tables listing BLAS, CBLAS, LAPACK and
+  # LAPACKE separately.
+  layout: "header, diff, flags, components, files, footer"
   behavior: default
   # Comment on every pull request: also on one that changes no coverage at
   # all ...
@@ -32,3 +41,34 @@ flags:
     carryforward: true
   lapacke:
     carryforward: true
+
+# The same four groups once more, as components.  A flag is attached to an
+# upload and so depends on the coverage job splitting its uploads the way it
+# does; a component is a filter over whatever coverage arrives, so these keep
+# reporting the four libraries separately even if that split ever changes.
+# The paths are the source directories the libraries are built from, which is
+# also how the CMake build directories the uploads use are laid out.
+component_management:
+  individual_components:
+    - component_id: blas
+      name: BLAS
+      paths:
+        - BLAS/SRC/**
+    - component_id: cblas
+      name: CBLAS
+      paths:
+        - CBLAS/src/**
+        - CBLAS/include/**
+    - component_id: lapack
+      name: LAPACK
+      paths:
+        # The LAPACK library is built from SRC together with the machine
+        # parameter and support routines it takes from INSTALL; see the
+        # ../INSTALL/ entries in SRC/CMakeLists.txt.
+        - SRC/**
+        - INSTALL/**
+    - component_id: lapacke
+      name: LAPACKE
+      paths:
+        - LAPACKE/src/**
+        - LAPACKE/utils/**

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,6 +22,14 @@ comment:
   # results are reported even when the coverage build did not get that far.
   require_head: false
 
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
 flags:
   # The four components are uploaded separately, each from the build
   # directory that holds its gcov reports; see the coverage job of

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+# Configuration for https://codecov.io.  After changing it, validate it with
+#   curl -X POST --data-binary @codecov.yml https://codecov.io/validate
+# See https://docs.codecov.com/docs/codecovyml-reference for the full reference.
+
+comment:
+  # 'flags' is the table listing BLAS, CBLAS, LAPACK and LAPACKE separately.
+  layout: "header, diff, flags, files, footer"
+  behavior: default
+  # Comment on every pull request: also on one that changes no coverage at
+  # all ...
+  require_changes: false
+  # ... on one whose base commit has no report to compare against ...
+  require_base: false
+  # ... and on one for which no coverage was uploaded, so that the test
+  # results are reported even when the coverage build did not get that far.
+  require_head: false
+  # A flag carried forward from the base commit is labelled as such, so
+  # showing them keeps all four components in the table even when one of
+  # them did not build.
+  show_carryforward_flags: true
+
+flags:
+  # The four components are uploaded separately, each from the build
+  # directory that holds its gcov reports; see the coverage job of
+  # .github/workflows/cmake.yml.  Their coverage is therefore already
+  # separated at upload time and needs no path filtering here.
+  blas:
+    carryforward: true
+  cblas:
+    carryforward: true
+  lapack:
+    carryforward: true
+  lapacke:
+    carryforward: true

--- a/lapack_testing.py
+++ b/lapack_testing.py
@@ -163,6 +163,14 @@ RESULTS_FILENAME = "testing_results.txt"
 RE_TESTS_RUN = re.compile(r"(\d+)\s+tests run\)")
 RE_TESTS_FAILED = re.compile(r"(\d+)\s+out of\s+(\d+)")
 
+# Footer printed by every test driver, e.g.
+#   " Total time used =        48.32 seconds"
+# This is the time the driver measured itself, so it is available even
+# when this script only analyzes output files it did not run.  The
+# format is F12.2, which prints asterisks on overflow; such a line
+# simply does not match and the case is then reported without a time.
+RE_TOTAL_TIME = re.compile(r"Total time used\s*=\s*(\d+\.?\d*)\s*seconds")
+
 # Failure records printed by the eigencondition checkers (schkec.f and
 # friends), e.g. " Error in STRSYL: RMAX =..." — one per failing routine.
 RE_EC_ERROR = re.compile(r"^ ?Error in \w+")
@@ -294,6 +302,10 @@ class FileReport:
 
     counts: Counts = field(default_factory=Counts)
     notable_lines: "List[str]" = field(default_factory=list)
+    # Run time in seconds as reported by the driver in its footer, or
+    # None for a run that never reached that footer and for output of a
+    # build whose drivers do not print one.
+    elapsed: "Optional[float]" = None
 
 
 @dataclass
@@ -740,6 +752,26 @@ def parse_blas(lines: "Sequence[str]", level_one: bool) -> FileReport:
     return report
 
 
+def parse_elapsed(lines: "Sequence[str]") -> "Optional[float]":
+    """Return the run time the driver reported in its footer.
+
+    Args:
+        lines: The lines of the output file.
+
+    Returns:
+        The run time in seconds, or None when the output carries no
+        readable ``Total time used`` line.  The drivers print the line
+        once, in their footer; should an output carry several, the last
+        one wins.
+    """
+    elapsed: "Optional[float]" = None
+    for line in lines:
+        match = RE_TOTAL_TIME.search(line)
+        if match:
+            elapsed = float(match.group(1))
+    return elapsed
+
+
 def parse_lines(parser: str, lines: "Sequence[str]") -> FileReport:
     """Parse test output lines with the parser kind of a test case.
 
@@ -749,15 +781,21 @@ def parse_lines(parser: str, lines: "Sequence[str]") -> FileReport:
         lines: The lines of the output file.
 
     Returns:
-        The counts and the notable (error) lines of the file.
+        The counts, the notable (error) lines and the reported run time
+        of the file.
     """
     if parser == PARSER_BALANCE:
-        return parse_balance(lines)
-    if parser == PARSER_DMD:
-        return parse_dmd(lines)
-    if parser in (PARSER_BLAS1, PARSER_BLAS23):
-        return parse_blas(lines, level_one=parser == PARSER_BLAS1)
-    return parse_standard(lines)
+        report = parse_balance(lines)
+    elif parser == PARSER_DMD:
+        report = parse_dmd(lines)
+    elif parser in (PARSER_BLAS1, PARSER_BLAS23):
+        report = parse_blas(lines, level_one=parser == PARSER_BLAS1)
+    else:
+        report = parse_standard(lines)
+    # The footer is formatted the same way by every driver that prints
+    # one at all, so it is read here rather than in each parser.
+    report.elapsed = parse_elapsed(lines)
+    return report
 
 
 def find_unrecognized_outputs(directories: "Dict[str, Path]") -> "List[str]":
@@ -1142,6 +1180,24 @@ def counts_message(counts: Counts) -> str:
     return ", ".join(parts)
 
 
+def case_time(outcome: CaseOutcome) -> "Optional[float]":
+    """Return the run time to report for one test case.
+
+    Args:
+        outcome: The analysis outcome of the test case.
+
+    Returns:
+        The wall-clock time of the driver run when this script ran it
+        itself, otherwise the time the driver reported in its output,
+        or None when neither is available.
+    """
+    if outcome.duration is not None:
+        return outcome.duration
+    if outcome.report is not None:
+        return outcome.report.elapsed
+    return None
+
+
 def junit_testcase(outcome: CaseOutcome) -> "ET.Element":
     """Build the JUnit ``<testcase>`` element of one analyzed test case.
 
@@ -1181,8 +1237,9 @@ def junit_testcase(outcome: CaseOutcome) -> "ET.Element":
     report = outcome.report
     if report is not None:
         element.set("assertions", str(report.counts.runs))
-    if outcome.duration is not None:
-        element.set("time", "{:.3f}".format(outcome.duration))
+    duration = case_time(outcome)
+    if duration is not None:
+        element.set("time", "{:.3f}".format(duration))
 
     details: "List[str]" = []
     if outcome.run_error is not None:
@@ -1224,6 +1281,14 @@ def build_junit_tree(
     that the report does not look clean while ``--fail-on-unrecognized``
     fails the run.
 
+    Every suite and the document itself carry the totals of their test
+    cases: ``tests``, ``failures``, ``errors``, ``skipped``, the number
+    of individual test results behind them (``assertions``) and their
+    summed run time (``time``).  A case whose time is unknown — a
+    missing output file, or a run that never reached its footer —
+    contributes nothing to the sum rather than a zero, and a suite
+    without a single timed case carries no ``time`` at all.
+
     Args:
         outcomes: The analysis outcomes, in analysis order.
         unrecognized: The names of the unrecognized ``.out`` files.
@@ -1240,6 +1305,9 @@ def build_junit_tree(
     total_failures = 0
     total_errors = 0
     total_skipped = 0
+    total_assertions = 0
+    total_time = 0.0
+    total_timed = False
     for (library, suffix), suite_outcomes in grouped.items():
         suite = ET.SubElement(
             root, "testsuite", {"name": section_title(library, [suffix])}
@@ -1247,6 +1315,7 @@ def build_junit_tree(
         failures = 0
         errors = 0
         skipped = 0
+        assertions = 0
         suite_time = 0.0
         timed = False
         for outcome in suite_outcomes:
@@ -1258,19 +1327,26 @@ def build_junit_tree(
                 errors += 1
             elif element.find("skipped") is not None:
                 skipped += 1
-            if outcome.duration is not None:
-                suite_time += outcome.duration
+            if outcome.report is not None:
+                assertions += outcome.report.counts.runs
+            duration = case_time(outcome)
+            if duration is not None:
+                suite_time += duration
                 timed = True
         suite.set("tests", str(len(suite_outcomes)))
         suite.set("failures", str(failures))
         suite.set("errors", str(errors))
         suite.set("skipped", str(skipped))
+        suite.set("assertions", str(assertions))
         if timed:
             suite.set("time", "{:.3f}".format(suite_time))
         total_tests += len(suite_outcomes)
         total_failures += failures
         total_errors += errors
         total_skipped += skipped
+        total_assertions += assertions
+        total_time += suite_time
+        total_timed = total_timed or timed
 
     if unrecognized:
         message = (
@@ -1286,6 +1362,7 @@ def build_junit_tree(
                 "failures": "1",
                 "errors": "0",
                 "skipped": "0",
+                "assertions": "0",
             },
         )
         testcase = ET.SubElement(
@@ -1303,6 +1380,9 @@ def build_junit_tree(
     root.set("failures", str(total_failures))
     root.set("errors", str(total_errors))
     root.set("skipped", str(total_skipped))
+    root.set("assertions", str(total_assertions))
+    if total_timed:
+        root.set("time", "{:.3f}".format(total_time))
     return ET.ElementTree(root)
 
 

--- a/lapack_testing.py
+++ b/lapack_testing.py
@@ -410,6 +410,12 @@ class CaseOutcome:
     run_error: "Optional[str]" = None
     report: "Optional[FileReport]" = None
     duration: "Optional[float]" = None
+    # When the run behind this outcome took place, in seconds since the
+    # epoch: the wall-clock start of the driver under ``--run``,
+    # otherwise the modification time of the output file, which is when
+    # the driver that wrote it finished.  None when there is no output
+    # file to go by.
+    started: "Optional[float]" = None
 
 
 def build_test_cases(letters: str, families: "Sequence[str]") -> "List[TestCase]":
@@ -1198,6 +1204,37 @@ def case_time(outcome: CaseOutcome) -> "Optional[float]":
     return None
 
 
+def junit_timestamp(seconds: float) -> str:
+    """Format a point in time for a JUnit ``timestamp`` attribute.
+
+    Local time without a UTC offset, as in the Ant convention that the
+    JUnit XML dialects follow.
+
+    Args:
+        seconds: The point in time, in seconds since the epoch.
+
+    Returns:
+        The time as ``YYYY-MM-DDThh:mm:ss``.
+    """
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(seconds))
+
+
+def output_mtime(path: Path) -> "Optional[float]":
+    """Return the modification time of a test output file.
+
+    Args:
+        path: The output file to inspect.
+
+    Returns:
+        The modification time in seconds since the epoch, or None when
+        the file cannot be stat'ed.
+    """
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
 def junit_testcase(outcome: CaseOutcome) -> "ET.Element":
     """Build the JUnit ``<testcase>`` element of one analyzed test case.
 
@@ -1289,6 +1326,13 @@ def build_junit_tree(
     contributes nothing to the sum rather than a zero, and a suite
     without a single timed case carries no ``time`` at all.
 
+    Every suite also carries a ``timestamp`` of when it ran: the
+    earliest start among its cases, which is when this script launched
+    the first of them under ``--run`` and otherwise how old the oldest
+    of their output files is.  A suite none of whose cases left an
+    output file behind falls back to the time the report was built, so
+    that the attribute is always present.
+
     Args:
         outcomes: The analysis outcomes, in analysis order.
         unrecognized: The names of the unrecognized ``.out`` files.
@@ -1297,6 +1341,7 @@ def build_junit_tree(
         The document; its root is a ``<testsuites>`` element.
     """
     root = ET.Element("testsuites", {"name": "lapack_testing"})
+    report_time = time.time()
     grouped: "Dict[Tuple[str, str], List[CaseOutcome]]" = {}
     for outcome in outcomes:
         grouped.setdefault((outcome.case.library, outcome.suffix), []).append(outcome)
@@ -1309,8 +1354,14 @@ def build_junit_tree(
     total_time = 0.0
     total_timed = False
     for (library, suffix), suite_outcomes in grouped.items():
+        starts = [o.started for o in suite_outcomes if o.started is not None]
         suite = ET.SubElement(
-            root, "testsuite", {"name": section_title(library, [suffix])}
+            root,
+            "testsuite",
+            {
+                "name": section_title(library, [suffix]),
+                "timestamp": junit_timestamp(min(starts) if starts else report_time),
+            },
         )
         failures = 0
         errors = 0
@@ -1353,22 +1404,30 @@ def build_junit_tree(
             "{} .out file(s) in the testing directories are not known to "
             "this script and were not analyzed".format(len(unrecognized))
         )
+        # This suite is a check this script makes rather than a driver it
+        # timed, so its run time is a true zero rather than an unknown.
         suite = ET.SubElement(
             root,
             "testsuite",
             {
                 "name": "lapack_testing.py",
+                "timestamp": junit_timestamp(report_time),
                 "tests": "1",
                 "failures": "1",
                 "errors": "0",
                 "skipped": "0",
                 "assertions": "0",
+                "time": "0.000",
             },
         )
         testcase = ET.SubElement(
             suite,
             "testcase",
-            {"classname": "lapack_testing", "name": "unrecognized .out files"},
+            {
+                "classname": "lapack_testing",
+                "name": "unrecognized .out files",
+                "time": "0.000",
+            },
         )
         failure = ET.SubElement(testcase, "failure")
         failure.set("message", sanitize_xml_text(message))
@@ -2069,6 +2128,7 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
                 output_name = case.suffixed_output(suffix)
                 run_error: "Optional[str]" = None
                 duration: "Optional[float]" = None
+                started: "Optional[float]" = None
                 if not just_errors and not short_summary:
                     print(
                         "Testing {} '{}' ({})".format(
@@ -2077,6 +2137,7 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
                         end=" ",
                     )
                 if args.run:
+                    started = time.time()
                     start = time.monotonic()
                     run_error = run_test_case(case, suffix, directory, args.bin)
                     duration = time.monotonic() - start
@@ -2097,8 +2158,10 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
                                 output_name
                             )
                         )
+                    if started is None:
+                        started = output_mtime(directory / output_name)
                     outcomes.append(
-                        CaseOutcome(case, suffix, run_error, None, duration)
+                        CaseOutcome(case, suffix, run_error, None, duration, started)
                     )
                     missing_files += 1
                     if not short_summary:
@@ -2119,8 +2182,12 @@ def main(argv: "Optional[Sequence[str]]" = None) -> int:
                     ),
                     lines,
                 )
+                if started is None:
+                    started = output_mtime(directory / output_name)
                 report = parse_lines(case.parser, lines)
-                outcomes.append(CaseOutcome(case, suffix, run_error, report, duration))
+                outcomes.append(
+                    CaseOutcome(case, suffix, run_error, report, duration, started)
+                )
                 precision_total.add(report.counts)
                 result.case_counts[case.output_name] = report.counts
 


### PR DESCRIPTION
**Description**

The Codecov report was a single number for the whole repository, built from a
coverage job that measured almost nothing, and the test results were not
reported at all.

* **Coverage per library.** BLAS, CBLAS, LAPACK and LAPACKE are instrumented and uploaded separately, each from its own build directory, under a flag and a component of its own (`codecov.yml`). The test programs and tmglib are components too: a routine that never runs there is a test that was written and never reached. The README badge becomes one badge per library.
* **The coverage job now measures something.** The instrumentation is applied through one `lapack_add_coverage()` helper instead of ad-hoc per-directory code, gcov runs with `-b -c` so branch coverage exists, and the job prints a per-component table and fails when a component measured nothing — an empty flag would otherwise disappear from the report silently.
* **Test results.** The JUnit XML from `lapack_testing.py` is uploaded as a test-results report from every test job, so failures show up in the pull request comment (this is a preview feature on codecov.io and doesn't work reliably yet).  Each `<testsuite>` gained `assertions` and `time`, and the BLAS, CBLAS and DMD drivers gained the `Total time used` footer the LAPACK drivers already printed, so that every test case is timed.

`CODECOV_TOKEN` has to be set as a secret of the `codecov` environment for the uploads to be attributed.
