### PR TITLE
bdsvdx: fix docs to match code, D and E are not const

### DIFF
--- a/SRC/dbdsvdx.f
+++ b/SRC/dbdsvdx.f
@@ -100,17 +100,19 @@
 *>          The order of the bidiagonal matrix.  N >= 0.
 *> \endverbatim
 *>
-*> \param[in] D
+*> \param[in,out] D
 *> \verbatim
 *>          D is DOUBLE PRECISION array, dimension (N)
 *>          The n diagonal elements of the bidiagonal matrix B.
+*>          On exit, very small entries are set to 0.
 *> \endverbatim
 *>
-*> \param[in] E
+*> \param[in,out] E
 *> \verbatim
 *>          E is DOUBLE PRECISION array, dimension (max(1,N-1))
 *>          The (n-1) superdiagonal elements of the bidiagonal matrix
 *>          B in elements 1 to N-1.
+*>          On exit, very small entries are set to 0.
 *> \endverbatim
 *>
 *> \param[in] VL

--- a/SRC/sbdsvdx.f
+++ b/SRC/sbdsvdx.f
@@ -100,17 +100,19 @@
 *>          The order of the bidiagonal matrix.  N >= 0.
 *> \endverbatim
 *>
-*> \param[in] D
+*> \param[in,out] D
 *> \verbatim
 *>          D is REAL array, dimension (N)
 *>          The n diagonal elements of the bidiagonal matrix B.
+*>          On exit, very small entries are set to 0.
 *> \endverbatim
 *>
-*> \param[in] E
+*> \param[in,out] E
 *> \verbatim
 *>          E is REAL array, dimension (max(1,N-1))
 *>          The (n-1) superdiagonal elements of the bidiagonal matrix
 *>          B in elements 1 to N-1.
+*>          On exit, very small entries are set to 0.
 *> \endverbatim
 *>
 *> \param[in] VL


### PR DESCRIPTION
**Description**

In bdsvdx, D and E were documented to be `[in]`, equivalent to `const`. But in fact they are updated to set very small entries < threshold to 0. This corrects the documentation.

**Checklist**

- [x] The documentation has been updated.
- NA: If the PR solves a specific issue, it is set to be closed on merge.