### PR TITLE
TESTING/LIN: fix short-wide TSQR residual checks

### DIFF
--- a/TESTING/LIN/ctsqr01.f
+++ b/TESTING/LIN/ctsqr01.f
@@ -424,7 +424,7 @@
 *     Compute |C*Q - C*Q| / |C|
 *
       CALL CGEMM( 'N', 'N', M, N, N, -ONE, C, M, Q, N, ONE, CF, M )
-      RESID = CLANGE( '1', N, M, DF, N, RWORK )
+      RESID = CLANGE( '1', M, N, CF, M, RWORK )
       IF( CNORM.GT.ZERO ) THEN
          RESULT( 5 ) = RESID / (EPS*MAX(1,N)*CNORM)
       ELSE

--- a/TESTING/LIN/dtsqr01.f
+++ b/TESTING/LIN/dtsqr01.f
@@ -424,7 +424,7 @@
 *     Compute |C*Q - C*Q| / |C|
 *
       CALL DGEMM( 'N', 'N', M, N, N, -ONE, C, M, Q, N, ONE, CF, M )
-      RESID = DLANGE( '1', N, M, DF, N, RWORK )
+      RESID = DLANGE( '1', M, N, CF, M, RWORK )
       IF( CNORM.GT.ZERO ) THEN
          RESULT( 5 ) = RESID / (EPS*MAX(1,N)*CNORM)
       ELSE


### PR DESCRIPTION
## Problem

In the short-wide (`SW`) branch of `DTSQR01` and `CTSQR01`, the test computes the residual for the `C*Q` operation into `CF`, but then measures a different workspace `DF`.

The current code is effectively:

```fortran
CALL DGEMM( 'N', 'N', M, N, N, -ONE, C, M, Q, N, ONE, CF, M )
RESID = DLANGE( '1', N, M, DF, N, RWORK )
```

The same issue exists in the complex routine with `CGEMM` and `CLANGE`.

## Why this is wrong

In this part of the test:

- `C` is an `M-by-N` input matrix.
- `CF` is its `M-by-N` work copy and receives the `C*Q` residual.
- `DF` belongs to the preceding `Q^T*D` test and contains stale data at this point.
- The norm dimensions and leading dimension must therefore be `M, N, M`, not `N, M, N`.

This can make the test report a failure based on the previous `DF` workspace rather than on the `C*Q` residual. For example, the issue was exposed by a short-wide case with `M=1`, `N=3`, `MB=20`, and `NB=3`.

## Fix

Use the result buffer and dimensions corresponding to the `C*Q` computation:

```fortran
RESID = DLANGE( '1', M, N, CF, M, RWORK )
```

and the analogous `CLANGE` call in `CTSQR01`.

## Validation

- `gfortran -c -ffixed-form -std=legacy TESTING/LIN/dtsqr01.f`
- `gfortran -c -ffixed-form -std=legacy TESTING/LIN/ctsqr01.f`
- `git diff --check`