### PR TITLE
TESTING/MATGEN: guard zero leading element in ZLAGHE

### DIFF
--- a/TESTING/MATGEN/zlaghe.f
+++ b/TESTING/MATGEN/zlaghe.f
@@ -175,10 +175,15 @@
 *
          CALL ZLARNV( 3, ISEED, N-I+1, WORK )
          WN = DZNRM2( N-I+1, WORK, 1 )
-         WA = ( WN / ABS( WORK( 1 ) ) )*WORK( 1 )
          IF( WN.EQ.ZERO ) THEN
+            WA = ZERO
             TAU = ZERO
          ELSE
+            IF( ABS( WORK( 1 ) ).EQ.0.0D+0 ) THEN
+               WA = DCMPLX( WN, 0.0D+0 )
+            ELSE
+               WA = ( WN / ABS( WORK( 1 ) ) )*WORK( 1 )
+            END IF
             WB = WORK( 1 ) + WA
             CALL ZSCAL( N-I, ONE / WB, WORK( 2 ), 1 )
             WORK( 1 ) = ONE
@@ -211,10 +216,15 @@
 *        generate reflection to annihilate A(k+i+1:n,i)
 *
          WN = DZNRM2( N-K-I+1, A( K+I, I ), 1 )
-         WA = ( WN / ABS( A( K+I, I ) ) )*A( K+I, I )
          IF( WN.EQ.ZERO ) THEN
+            WA = ZERO
             TAU = ZERO
          ELSE
+            IF( ABS( A( K+I, I ) ).EQ.0.0D+0 ) THEN
+               WA = DCMPLX( WN, 0.0D+0 )
+            ELSE
+               WA = ( WN / ABS( A( K+I, I ) ) )*A( K+I, I )
+            END IF
             WB = A( K+I, I ) + WA
             CALL ZSCAL( N-K-I, ONE / WB, A( K+I+1, I ), 1 )
             A( K+I, I ) = ONE


### PR DESCRIPTION
## Summary

`ZLAGHE` computes the phase of a Householder reflector with expressions of the form:

```fortran
WA = ( WN / ABS( A( K+I, I ) ) )*A( K+I, I )
```

When `WN` is nonzero but the leading element is exactly zero, this evaluates as `Inf * 0` and produces NaNs. This can occur at higher precision because rounding may make the leading element exactly zero while the remaining vector has a nonzero norm.

This patch handles both reflector-generation loops:

- zero norm: use `WA = ZERO`, `TAU = ZERO`;
- nonzero norm with zero leading element: use `WA = DCMPLX(WN,0)`;
- otherwise preserve the existing phase computation.

Choosing a positive-real phase is valid for a zero leading element and produces a finite reflector with `TAU = 1`.

## Motivation

The issue was observed through MPLAPACK's MPFR binary128 (`113`-bit) ZHB test with `N=20`, `K=16`, clustered eigenvalues. `ZLAGHE` returned a matrix containing NaN, which later caused `CSTEQR` to fail. The same case did not reproduce at 112 or 114 bits.

## Validation

- `gfortran -ffixed-form -ffixed-line-length-72 -fsyntax-only TESTING/MATGEN/zlaghe.f`
- The corresponding generated C++ path in MPLAPACK was tested with the 113-bit reproducer; the ZHB case completed without NaN and passed all six checks.
