### PR TITLE
TESTING/MATGEN: guard zero leading element in CLAGHE

### DIFF
--- a/TESTING/MATGEN/claghe.f
+++ b/TESTING/MATGEN/claghe.f
@@ -175,10 +175,15 @@
 *
          CALL CLARNV( 3, ISEED, N-I+1, WORK )
          WN = SCNRM2( N-I+1, WORK, 1 )
-         WA = ( WN / ABS( WORK( 1 ) ) )*WORK( 1 )
          IF( WN.EQ.ZERO ) THEN
+            WA = ZERO
             TAU = ZERO
          ELSE
+            IF( ABS( WORK( 1 ) ).EQ.0.0E+0 ) THEN
+               WA = CMPLX( WN, 0.0E+0 )
+            ELSE
+               WA = ( WN / ABS( WORK( 1 ) ) )*WORK( 1 )
+            END IF
             WB = WORK( 1 ) + WA
             CALL CSCAL( N-I, ONE / WB, WORK( 2 ), 1 )
             WORK( 1 ) = ONE
@@ -211,10 +216,15 @@
 *        generate reflection to annihilate A(k+i+1:n,i)
 *
          WN = SCNRM2( N-K-I+1, A( K+I, I ), 1 )
-         WA = ( WN / ABS( A( K+I, I ) ) )*A( K+I, I )
          IF( WN.EQ.ZERO ) THEN
+            WA = ZERO
             TAU = ZERO
          ELSE
+            IF( ABS( A( K+I, I ) ).EQ.0.0E+0 ) THEN
+               WA = CMPLX( WN, 0.0E+0 )
+            ELSE
+               WA = ( WN / ABS( A( K+I, I ) ) )*A( K+I, I )
+            END IF
             WB = A( K+I, I ) + WA
             CALL CSCAL( N-K-I, ONE / WB, A( K+I+1, I ), 1 )
             A( K+I, I ) = ONE


### PR DESCRIPTION
## Summary

This is a follow-up to #1365 for the complex-single counterpart, `CLAGHE`.

`CLAGHE` computes the phase of a Householder reflector using expressions of the form

```fortran
WA = ( WN / ABS( WORK( 1 ) ) )*WORK( 1 )
```

When `WN` is nonzero but the leading element is exactly zero, the expression evaluates as `Inf * 0` and can produce NaNs. This is possible at higher precision when rounding makes the leading element zero while the remaining vector still has a nonzero norm. The same expression occurs in both reflector-generation loops in `CLAGHE`.

The patch:

- sets `WA = ZERO` and `TAU = ZERO` for a zero norm;
- selects the finite positive-real phase `WA = CMPLX(WN, 0.0E+0)` for a nonzero norm with a zero leading element;
- preserves the existing phase computation otherwise.

The positive-real phase is valid for a zero leading element and yields a finite reflector with `TAU = 1`.

## Validation

- `gfortran -ffixed-form -ffixed-line-length-72 -fsyntax-only TESTING/MATGEN/claghe.f`
