### PR TITLE
{d/s}laed2/8: Revert deflation tolerance increase

### DIFF
--- a/SRC/dlaed2.f
+++ b/SRC/dlaed2.f
@@ -313,7 +313,7 @@
       IMAX = IDAMAX( N, Z, 1 )
       JMAX = IDAMAX( N, D, 1 )
       EPS = DLAMCH( 'Epsilon' )
-      TOL = EIGHT*EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
+      TOL = EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the

--- a/SRC/dlaed8.f
+++ b/SRC/dlaed8.f
@@ -355,7 +355,7 @@
       IMAX = IDAMAX( N, Z, 1 )
       JMAX = IDAMAX( N, D, 1 )
       EPS = DLAMCH( 'Epsilon' )
-      TOL = EIGHT*EIGHT*EPS*ABS( D( JMAX ) )
+      TOL = EIGHT*EPS*ABS( D( JMAX ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the

--- a/SRC/slaed2.f
+++ b/SRC/slaed2.f
@@ -313,7 +313,7 @@
       IMAX = ISAMAX( N, Z, 1 )
       JMAX = ISAMAX( N, D, 1 )
       EPS = SLAMCH( 'Epsilon' )
-      TOL = EIGHT*EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
+      TOL = EIGHT*EPS*MAX( ABS( D( JMAX ) ), ABS( Z( IMAX ) ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the

--- a/SRC/slaed8.f
+++ b/SRC/slaed8.f
@@ -355,7 +355,7 @@
       IMAX = ISAMAX( N, Z, 1 )
       JMAX = ISAMAX( N, D, 1 )
       EPS = SLAMCH( 'Epsilon' )
-      TOL = EIGHT*EIGHT*EPS*ABS( D( JMAX ) )
+      TOL = EIGHT*EPS*ABS( D( JMAX ) )
 *
 *     If the rank-1 modifier is small enough, no more needs to be done
 *     except to reorganize Q so that its columns correspond with the


### PR DESCRIPTION
Revert the 8x tolerance increase (EIGHT*EPS -> EIGHT*EIGHT*EPS) in slaed2, slaed8, dlaed2, dlaed8 back to the original EIGHT*EPS.

The wider tolerance introduced in #1317 was intended to match the SVD path (slasd2/dlasd2) and prevent catastrophic cancellation in DLAED3's eigenvalue differences. However, the eigenvalue divide-and-conquer merge has deeper recursion (~7 levels for n=100) where local gaps between intermediate eigenvalues can be much smaller than the global gap. The aggressive deflation causes near-degenerate pairs to be skipped rather than solved, degrading eigenvector accuracy (see #1370, OpenBLAS#5995).

The original issue #255 was specific to DBDSDC (bidiagonal SVD) and remains fixed by PR #1286 in slasd2/dlasd2, which is not affected.

Closes #1370
