### PR TITLE
CBLAS: fix infinite loop in c/z gemv and gbmv (RowMajor, ConjTrans, M=0)

### DIFF
--- a/CBLAS/src/cblas_cgbmv.c
+++ b/CBLAS/src/cblas_cgbmv.c
@@ -155,7 +155,7 @@ void API_SUFFIX(cblas_cgbmv)(const CBLAS_LAYOUT layout,
       if (TransA == CblasConjTrans)
       {
          if (x != X) free(x);
-         if (N > 0)
+         if (M > 0 && N > 0)
          {
             do
             {

--- a/CBLAS/src/cblas_cgemv.c
+++ b/CBLAS/src/cblas_cgemv.c
@@ -149,7 +149,7 @@ void API_SUFFIX(cblas_cgemv)(const CBLAS_LAYOUT layout,
       if (TransA == CblasConjTrans)
       {
          if (x != (const float *)X) free(x);
-         if (N > 0)
+         if (M > 0 && N > 0)
          {
             do
             {

--- a/CBLAS/src/cblas_zgbmv.c
+++ b/CBLAS/src/cblas_zgbmv.c
@@ -154,7 +154,7 @@ void API_SUFFIX(cblas_zgbmv)(const CBLAS_LAYOUT layout,
       if (TransA == CblasConjTrans)
       {
          if (x != X) free(x);
-         if (N > 0)
+         if (M > 0 && N > 0)
          {
             do
             {

--- a/CBLAS/src/cblas_zgemv.c
+++ b/CBLAS/src/cblas_zgemv.c
@@ -152,7 +152,7 @@ void API_SUFFIX(cblas_zgemv)(const CBLAS_LAYOUT layout,
       if (TransA == CblasConjTrans)
       {
          if (x != X) free(x);
-         if (N > 0)
+         if (M > 0 && N > 0)
          {
             do
             {


### PR DESCRIPTION
### Problem

The hand-written row-major shims in the C interface loop forever on a valid (if degenerate) call.

In `cblas_cgemv`, `cblas_zgemv`, `cblas_cgbmv` and `cblas_zgbmv`, the `CblasRowMajor` + `CblasConjTrans` path conjugates `Y` (and sets the loop stride `i` and the sentinel `st`) only inside:

```c
if (M > 0) {
   ...
   if (N > 0) { i = ...; st = y + n; do { *y = -(*y); y += i; } while (y != st); ... }
}
```

but the post-call loop that un-conjugates `Y` is gated on `if (N > 0)` alone:

```c
if (x != X) free(x);
if (N > 0) {           /* <-- runs even when M == 0 */
   do { *y = -(*y); y += i; } while (y != st);
}
```

When `M == 0` and `N > 0`, the forward block is skipped, so `i` is still `0` and `st` is still `NULL`. The restore loop then advances `y` by `0` and compares against `NULL`, so it never terminates — an infinite loop that also keeps negating `Y[0]`. `M = 0` is a documented, in-range argument for these routines (`xerbla` only rejects `M < 0`), so this is reachable from a conforming caller.

### Fix

Gate the un-conjugation on the same condition under which `Y` was conjugated, `if (M > 0 && N > 0)`, in all four files. One line each; a normal `M > 0` ConjTrans call is byte-for-byte unchanged.

### Reproducer / validation

BLIS carries a copy of these same netlib CBLAS wrappers, so I reproduced it there against a real build:

```c
float A[256]={0}, X[256]={0}, Y[256]={0};
float alpha[2]={1,0}, beta[2]={1,0};
cblas_cgbmv(CblasRowMajor, CblasConjTrans, /*M*/0, /*N*/2, /*KL*/0, /*KU*/0,
            alpha, A, 1, X, 1, beta, Y, 1);   /* never returns */
```

Linked against the unpatched wrapper this is killed by a 5 s timeout; with the one-line gate it returns immediately and leaves `Y` unchanged. The `gemv` path behaves the same way.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed and validated before submission.
