### PR TITLE
Guard against a NaN pivot in the packed symmetric-indefinite factorizations

### DIFF
--- a/SRC/chptrf.f
+++ b/SRC/chptrf.f
@@ -186,10 +186,10 @@
       COMPLEX            D12, D21, T, WK, WKM1, WKP1, ZDUM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       INTEGER            ICAMAX
       REAL               SLAPY2
-      EXTERNAL           LSAME, ICAMAX, SLAPY2
+      EXTERNAL           LSAME, ICAMAX, SLAPY2, SISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CHPR, CSSCAL, CSWAP, XERBLA
@@ -256,9 +256,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       SISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K
@@ -459,9 +461,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       SISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K

--- a/SRC/csptrf.f
+++ b/SRC/csptrf.f
@@ -186,9 +186,9 @@
       COMPLEX            D11, D12, D21, D22, R1, T, WK, WKM1, WKP1, ZDUM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       INTEGER            ICAMAX
-      EXTERNAL           LSAME, ICAMAX
+      EXTERNAL           LSAME, ICAMAX, SISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CSCAL, CSPR, CSWAP, XERBLA
@@ -255,9 +255,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       SISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K
@@ -442,9 +444,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       SISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K

--- a/SRC/dsptrf.f
+++ b/SRC/dsptrf.f
@@ -185,9 +185,9 @@
      $                   ROWMAX, T, WK, WKM1, WKP1
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, DISNAN
       INTEGER            IDAMAX
-      EXTERNAL           LSAME, IDAMAX
+      EXTERNAL           LSAME, IDAMAX, DISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DSCAL, DSPR, DSWAP, XERBLA
@@ -248,9 +248,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       DISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K
@@ -436,9 +438,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       DISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K

--- a/SRC/ssptrf.f
+++ b/SRC/ssptrf.f
@@ -183,9 +183,9 @@
      $                   ROWMAX, T, WK, WKM1, WKP1
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, SISNAN
       INTEGER            ISAMAX
-      EXTERNAL           LSAME, ISAMAX
+      EXTERNAL           LSAME, ISAMAX, SISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SSCAL, SSPR, SSWAP, XERBLA
@@ -246,9 +246,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       SISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K
@@ -434,9 +436,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       SISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K

--- a/SRC/zhptrf.f
+++ b/SRC/zhptrf.f
@@ -186,10 +186,10 @@
       COMPLEX*16         D12, D21, T, WK, WKM1, WKP1, ZDUM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, DISNAN
       INTEGER            IZAMAX
       DOUBLE PRECISION   DLAPY2
-      EXTERNAL           LSAME, IZAMAX, DLAPY2
+      EXTERNAL           LSAME, IZAMAX, DLAPY2, DISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZDSCAL, ZHPR, ZSWAP
@@ -256,9 +256,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       DISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K
@@ -459,9 +461,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       DISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K

--- a/SRC/zsptrf.f
+++ b/SRC/zsptrf.f
@@ -186,9 +186,9 @@
       COMPLEX*16         D11, D12, D21, D22, R1, T, WK, WKM1, WKP1, ZDUM
 *     ..
 *     .. External Functions ..
-      LOGICAL            LSAME
+      LOGICAL            LSAME, DISNAN
       INTEGER            IZAMAX
-      EXTERNAL           LSAME, IZAMAX
+      EXTERNAL           LSAME, IZAMAX, DISNAN
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           XERBLA, ZSCAL, ZSPR, ZSWAP
@@ -255,9 +255,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       DISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K
@@ -442,9 +444,11 @@
             COLMAX = ZERO
          END IF
 *
-         IF( MAX( ABSAKK, COLMAX ).EQ.ZERO ) THEN
+         IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR.
+     $       DISNAN(ABSAKK) ) THEN
 *
-*           Column K is zero: set INFO and continue
+*           Column K is zero or underflow, or contains a NaN:
+*           set INFO and continue
 *
             IF( INFO.EQ.0 )
      $         INFO = K


### PR DESCRIPTION
**Disclaimer:** This PR was prepared using Claude Code.

**Summary**

The packed Bunch-Kaufman factorizations `xSPTRF` and `xHPTRF` (all six: `SSPTRF`, `DSPTRF`, `CSPTRF`, `ZSPTRF`, `CHPTRF`, `ZHPTRF`) have no NaN check on the candidate pivot. When the diagonal entry of the last column the pivot loop visits is a NaN, the routine falls through to the 2-by-2 pivot branch with `IMAX` uninitialized, reads `AP` at an arbitrary offset, writes one element past the end of `IPIV`, and returns `INFO = 0`. The solve drivers `?SPSV` / `?HPSV` then run `xSPTRS` on the inconsistent `IPIV`, which either returns a wrong answer or corrupts the heap. The dense twins `xSYTF2` / `xHETF2` have had the missing `DISNAN(ABSAKK)` term since 2006; this PR adds the same term to the six packed routines. Nothing changes for a matrix without a NaN.

**Description**

`xSYTF2` and `xHETF2` reject a column they cannot pivot on with

```fortran
IF( (MAX( ABSAKK, COLMAX ).EQ.ZERO) .OR. DISNAN(ABSAKK) ) THEN
```

The `DISNAN` term is the 2006 patch recorded in their own Contributors block. Their packed-storage twins `xSPTRF` and `xHPTRF` run the same algorithm through the same pivot loop, but never received it: all six still test `MAX( ABSAKK, COLMAX ).EQ.ZERO` alone. Of the whole Bunch-Kaufman family only these six are affected, and they are the only ones where it matters:

| routine family | NaN handling today |
|---|---|
| `xSYTF2`, `xHETF2` | explicit `DISNAN(ABSAKK)` term |
| `xSYTF2_ROOK`, `xSYTF2_RK`, and the Hermitian counterparts | `IF( .NOT.( ABSAKK.LT.ALPHA*COLMAX ) )`, commented in-source as "used to handle NaN and Inf" |
| `xLASYF`, `xLAHEF` and their ROOK/RK variants | no guard, but the panel never visits the boundary column: `xSYTRF` leaves the leading or trailing block to `xSYTF2`, which is guarded |
| **`xSPTRF`, `xHPTRF`** | **no guard, and no dense routine behind them** |

Whether the surviving test catches a NaN is not specified by the language. It turns on which operand `MAX` returns when one is a NaN, so it varies with the compiler, the optimization level, and the code generated around it. Built as `-O1` or higher, GCC 13.3 does not catch it; at `-O0`, and with NVIDIA `nvfortran` 26.1 at every level tried, it happens to catch it. A guard that holds only by accident of code generation is the thing being replaced here.

Where it is not caught, the damage is not confined to the numerics. On the last column the loop visits, `K = N` for `UPLO = 'L'` and `K = 1` for `UPLO = 'U'`, there is no off-diagonal candidate, so `COLMAX` is zero and **`IMAX` is never assigned**. A NaN on that diagonal makes every subsequent pivot comparison false, the code falls through to the 2-by-2 branch, and it then

- reads `AP` at `KX` computed from the uninitialized `IMAX`, and
- writes `IPIV( K+1 )` or `IPIV( K-1 )`, one element past the end of `IPIV`,

while leaving `INFO` at zero, so the caller is told the factorization succeeded. `xSPTRS` is then handed the inconsistent `IPIV` and walks off the end of its own arrays.

**Fix.** Add the `DISNAN` / `SISNAN` term to both pivot tests in all six routines, in the form the dense twins already use. Six files, two sites each, plus the function declaration.

**Minimal reproducer**

`IPIV` is declared with one guard element at each end. LAPACK is handed `IPIV(1)` and may only touch elements `1..N`, so a change to a guard is an out-of-bounds write.

```fortran
program minimal
  implicit none
  integer, parameter :: n = 4, guard = -12345
  double precision :: ap(n*(n+1)/2), z
  integer :: ipiv(0:n+1), info, i, j, k
  z = 0
  ! identity of order n, packed lower, with a NaN on the last diagonal entry
  k = 0
  do j = 1, n
     do i = j, n
        k = k + 1
        ap(k) = merge(1d0, 0d0, i == j)
     end do
  end do
  ap(k) = z / z
  ipiv = guard
  info = -99
  call dsptrf('L', n, ap, ipiv(1), info)
  print '(a,i0,a,i0)', 'DSPTRF L: info = ', info, '   IPIV(n+1) = ', ipiv(n+1)
  print '(a,i0)', 'expected: info = 4, IPIV(n+1) = ', guard
end program
```

```
BEFORE (master, gfortran 13.3 -O2):
DSPTRF L: info = 0   IPIV(n+1) = -4
expected: info = 4, IPIV(n+1) = -12345

AFTER (this branch):
DSPTRF L: info = 4   IPIV(n+1) = -12345
expected: info = 4, IPIV(n+1) = -12345
```

At the driver level, on the same matrix, every one of the six packed drivers is affected. `?SPSV` and `?HPSV`, both `UPLO`, `n = 4` and `n = 33`: before, 20 of 24 return `INFO = 0` after writing outside `IPIV`, and the remaining 4 (`ZSPSV`, `ZHPSV`, `UPLO = 'L'`) abort in glibc with `malloc(): corrupted top size`. After, all 24 return `INFO = N` or `INFO = 1` and leave `IPIV` alone.

**Validation**

<details>
<summary>Packed versus dense equivalence, 4032 cases per build</summary>

Each packed routine is run against the dense unblocked twin that implements the same algorithm in full storage, on the same matrix: six routines, `n = 1..16`, both `UPLO`, and four base matrices (tridiagonal, zero-diagonal so 2-by-2 pivots are forced, pseudo-random, pseudo-random with tiny diagonal) crossed with no perturbation, a NaN at each diagonal position, a NaN at each off-diagonal position, and an Inf. Counted are out-of-bounds writes to `IPIV`, and disagreement with the dense twin in `INFO`, in `IPIV`, and in the factor, the last compared bit for bit with two NaNs treated as equal. Each case runs in its own process, since on master a case may crash or hang.

| | cases | crash | OOB | INFO | IPIV | factor |
|---|---|---|---|---|---|---|
| **master**, finite | 768 | 0 | 0 | 0 | 0 | 0 |
| **master**, diagonal NaN | 1364 | \* | 926 | 420 | 420 | 228 |
| **master**, off-diagonal NaN | 1208 | \* | 740 | 448 | 448 | 280 |
| **master**, diagonal Inf | 190 | \* | 20 | 16 | 16 | 0 |
| **master**, all | 3530 | 502 | 1686 | 884 | 884 | 508 |
| **this branch**, finite | 768 | 0 | 0 | 0 | 0 | 0 |
| **this branch**, diagonal NaN | 1632 | 0 | **0** | **0** | **0** | **0** |
| **this branch**, off-diagonal NaN | 1440 | 0 | **0** | 172 | 182 | 182 |
| **this branch**, diagonal Inf | 192 | 0 | **0** | **0** | **0** | **0** |
| **this branch**, all | 4032 | **0** | **0** | 172 | 182 | 182 |

\* the 502 crashes are distributed across the NaN and Inf categories; only completed cases are counted in the columns.

Every out-of-bounds write and every crash is gone, and the packed routines now agree with their dense twins exactly on finite input, on diagonal NaN and on Inf.

The residual 172 off-diagonal-NaN disagreements are a pre-existing difference in pivot selection, not something this patch introduces or is meant to remove: `xSPTRF` finds `ROWMAX` with an explicit `IF( ABS( AP( KX ) ).GT.ROWMAX )` loop seeded at zero, which skips a NaN, whereas `xSYTF2` takes `IDAMAX` and then `ROWMAX = ABS( A( IMAX, JMAX ) )` unconditionally. On a row segment that is entirely NaN the first yields zero and the second a NaN. On master 448 of 1208 completed cases in this category already disagreed.

</details>

<details>
<summary>Compilers and optimization levels</summary>

The minimal reproducer against a standalone build of the routines involved:

| compiler | master | this branch |
|---|---|---|
| GCC 13.3 `-O0` | guard happens to fire, no OOB | clean |
| GCC 13.3 `-O1`, `-O2`, `-O3`, `-O3 -march=native`, `-O2 -ffp-contract=off` | OOB, `INFO = 0` | clean |
| nvfortran 26.1 `-O0`, `-O1`, `-O2`, `-O3`, `-O2 -Mvect` | guard happens to fire, no OOB | clean |

</details>

**Test suite.** The full LAPACK test suite passes on this branch, 315872 tests, 0 numerical errors and 0 other errors, byte-identical totals to the parent commit `cee01836d`. This includes the `SSP`, `DSP`, `CSP`, `ZSP`, `CHP` and `ZHP` routine and driver families and the `_64` extended-API variants. Built with GCC 13.3, `CMAKE_BUILD_TYPE=Release`, `BUILD_INDEX64_EXT_API=ON`.

**Checklist**

- [x] The documentation has been updated. (The inline comment at both sites now reads "Column K is zero or underflow, or contains a NaN", as in the dense routines. The Contributors blocks are left alone.)
- [ ] If the PR solves a specific issue, it is set to be closed on merge. (No tracking issue; happy to open one.)
