### PR TITLE
Fix the leading dimension of WORK in xTPRFB and the dead LB = 0 arms of xTPMLQT (#1376)

### DIFF
--- a/SRC/ctpmlqt.f
+++ b/SRC/ctpmlqt.f
@@ -285,7 +285,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL CTPRFB( 'L', 'C', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,
@@ -316,7 +316,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL CTPRFB( 'L', 'N', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,

--- a/SRC/ctprfb.f
+++ b/SRC/ctprfb.f
@@ -591,7 +591,7 @@
             END DO
          END DO
          CALL CTRMM( 'L', 'L', 'N', 'N', L, N, ONE, V( 1, MP ), LDV,
-     $               WORK, LDB )
+     $               WORK, LDWORK )
          CALL CGEMM( 'N', 'N', L, N, M-L, ONE, V, LDV,B, LDB,
      $               ONE, WORK, LDWORK )
          CALL CGEMM( 'N', 'N', K-L, N, M, ONE, V( KP, 1 ), LDV,

--- a/SRC/dtpmlqt.f
+++ b/SRC/dtpmlqt.f
@@ -298,7 +298,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL DTPRFB( 'L', 'T', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,
@@ -329,7 +329,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL DTPRFB( 'L', 'N', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,

--- a/SRC/dtprfb.f
+++ b/SRC/dtprfb.f
@@ -588,7 +588,7 @@
             END DO
          END DO
          CALL DTRMM( 'L', 'L', 'N', 'N', L, N, ONE, V( 1, MP ), LDV,
-     $               WORK, LDB )
+     $               WORK, LDWORK )
          CALL DGEMM( 'N', 'N', L, N, M-L, ONE, V, LDV,B, LDB,
      $               ONE, WORK, LDWORK )
          CALL DGEMM( 'N', 'N', K-L, N, M, ONE, V( KP, 1 ), LDV,

--- a/SRC/stpmlqt.f
+++ b/SRC/stpmlqt.f
@@ -298,7 +298,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL STPRFB( 'L', 'T', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,
@@ -329,7 +329,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL STPRFB( 'L', 'N', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,

--- a/SRC/stprfb.f
+++ b/SRC/stprfb.f
@@ -588,7 +588,7 @@
             END DO
          END DO
          CALL STRMM( 'L', 'L', 'N', 'N', L, N, ONE, V( 1, MP ), LDV,
-     $               WORK, LDB )
+     $               WORK, LDWORK )
          CALL SGEMM( 'N', 'N', L, N, M-L, ONE, V, LDV,B, LDB,
      $               ONE, WORK, LDWORK )
          CALL SGEMM( 'N', 'N', K-L, N, M, ONE, V( KP, 1 ), LDV,

--- a/SRC/ztpmlqt.f
+++ b/SRC/ztpmlqt.f
@@ -298,7 +298,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL ZTPRFB( 'L', 'C', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,
@@ -329,7 +329,7 @@
             IF( I.GE.L ) THEN
                LB = 0
             ELSE
-               LB = 0
+               LB = NB-M+L-I+1
             END IF
             CALL ZTPRFB( 'L', 'N', 'F', 'R', NB, N, IB, LB,
      $                   V( I, 1 ), LDV, T( 1, I ), LDT,

--- a/SRC/ztprfb.f
+++ b/SRC/ztprfb.f
@@ -591,7 +591,7 @@
             END DO
          END DO
          CALL ZTRMM( 'L', 'L', 'N', 'N', L, N, ONE, V( 1, MP ), LDV,
-     $               WORK, LDB )
+     $               WORK, LDWORK )
          CALL ZGEMM( 'N', 'N', L, N, M-L, ONE, V, LDV,B, LDB,
      $               ONE, WORK, LDWORK )
          CALL ZGEMM( 'N', 'N', K-L, N, M, ONE, V( KP, 1 ), LDV,


### PR DESCRIPTION
**Disclaimer:** This PR was prepared using Claude Code.

**Summary**

Fixes #1376: in the `STOREV='R'`, `DIRECT='F'`, `SIDE='L'` branch of `xTPRFB` the first `xTRMM` is passed `LDB` as the leading dimension of `WORK` instead of `LDWORK`, so for `L > 0` and `LDB != LDWORK` the routine returns a wrong result and writes past the documented end of `WORK`. This PR passes `LDWORK` in the four routines and also lets the `SIDE='L'` arms of `xTPMLQT`, the only in-tree caller of that branch, pass the true trapezoid order `LB` instead of the constant `0` they have carried since the routine was added. With that second change the existing `xTPLQT` tests exercise the fixed branch: on master's `xTPRFB` they fail 180 of 1482 tests in every precision, with this PR all pass.

**Description**

The reporter's analysis is confirmed as written. `WORK` is declared `WORK( LDWORK, * )`, the fill loop immediately above the call stores `B( M-L+I, J )` into `WORK( I, J )` with stride `LDWORK`, and the seven other BLAS calls of the branch pass `LDWORK`; only the first `xTRMM` passes `LDB`. The documented constraints `LDB >= max(1,M)` and `LDWORK >= K` are independent, so a conforming caller normally has `LDB != LDWORK`.

Why the suite never saw it: `xTPMLQT` is the only routine that calls `xTPRFB` with `STOREV='R'` and `SIDE='L'`, and its two `SIDE='L'` arms read

```fortran
            IF( I.GE.L ) THEN
               LB = 0
            ELSE
               LB = 0
            END IF
```

while the `SIDE='R'` arms compute `LB = NB-N+L-I+1` and `xTPMQRT`'s `SIDE='L'` arms compute `LB = MB-M+L-I+1`. The dead `IF` dates from the commit that introduced the routine (a6afc403f, 2016). With `L = 0` the offending `xTRMM` is a zero-row no-op, so the defect was latent for every in-tree caller.

**Fix.** Two coupled changes, eight files:

* `{s,d,c,z}tprfb.f`: `WORK, LDB` becomes `WORK, LDWORK` in the first `xTRMM` of the `ROW .AND. FORWARD .AND. LEFT` branch. The operation count is unchanged; only the addressing of the `L`-by-`N` temporary differs.
* `{s,d,c,z}tpmlqt.f`: the `ELSE` arm of both `SIDE='L'` blocks becomes `LB = NB-M+L-I+1`, the mirror image of the `SIDE='R'` formula (`NB` counts columns of `V` here, `M` is the row count of `B`). For the block of reflectors `I:I+IB-1`, columns `M-L+I` to `NB` of `V` are the lower-trapezoidal part, so `LB` is their count, and `LB <= IB` and `LB <= NB` follow from the definition of `NB`. `xTPMLQT` then applies the pentagonal `V` exactly as its documentation describes and no longer multiplies by the structurally zero triangle above the diagonal of the trapezoid, which `xTPLQT` never references or writes.

**Minimal reproducer**

The reporter's `repro.f` from #1376, unchanged, built against the sources of this tree (`gfortran -O2 -std=legacy repro.f dtprfb.f dtrmm.f dgemm.f lsame.f xerbla.f`):

```
master f96546fc9:  DTPRFB('L','N','F','R')  M= 7  N= 6  K= 3  L= 2  LDB= 7  LDWORK= 3
                   WORK declared length  =   18   elements written past the end =    6
                   relative error vs dense definition =  2.883E-01
this branch:       WORK declared length  =   18   elements written past the end =    0
                   relative error vs dense definition =  1.434E-16
```

**Validation**

*Existing tests now reach the branch.* Building only the `xTPMLQT` change on top of master (`xTPRFB` unfixed) and running `xlintst{s,d,c,z}`, the `xXQ` path (`xCHKLQTP`, tests of `xTPLQT` and `xTPMLQT`) reports `180 out of 1482 tests failed to pass the threshold` in each precision: 90 failures of test 3, `|Q C - Q C|`, and 90 of test 4, `|Q**H C - Q**H C|`, i.e. every `SIDE='L'` check with `L > 0`, with residuals of 1e13 to 1e16 in units of `EPS`. Tests 1, 2, 5 and 6 are unaffected, as expected. With both changes the path passes all 1482 tests in each precision.

<details>
<summary>Direct sweep of xTPRFB, 3600 cases per precision</summary>

`repro/sweep.F90` calls `xTPRFB( 'L', TRANS, 'F', 'R' )` directly for `M` in 1..7, `N` in 1..5, `K` in 1..5, `L` in `0..min(K,M)`, both values of `TRANS`, `LDWORK` in `{K, K+3, K+6}` and `LDB = M+2`, with `V`, `T`, `A`, `B` random in `[-0.5, 0.5]` (the entries above the diagonal of the trapezoidal part of `V` are left random, since the routine must not reference them). `WORK` holds exactly `LDWORK*N` elements followed by 64 guard cells. Each result is compared with the dense definition `C := C - W**H op(T) W C`, `W = [I V]`, from the routine's Further Details; a case counts as wrong when the error exceeds `100*EPS` times the size of the result.

| routine | cases | wrong, master | WORK overrun, master | wrong, this branch | overrun, this branch | max relative error, this branch |
|---|---|---|---|---|---|---|
| `STPRFB` | 3600 | 1824 | 662 | 0 | 0 | 1.7e-7 |
| `DTPRFB` | 3600 | 1824 | 662 | 0 | 0 | 3.2e-16 |
| `CTPRFB` | 3600 | 1824 | 662 | 0 | 0 | 2.0e-7 |
| `ZTPRFB` | 3600 | 1824 | 662 | 0 | 0 | 4.3e-16 |

The 1824 wrong cases on master are exactly those with `L > 0` and `LDB != LDWORK`; the overruns are the subset with `L + LDB*(N-1) > LDWORK*N`.

</details>

<details>
<summary>Full test suite</summary>

`cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_INDEX64_EXT_API=ON -DBUILD_TESTING=ON`, `ctest -j 12`: 215 of 215 tests pass; 5441901 LAPACK tests and 315872 BLAS tests, 0 numerical errors, 0 other errors, the same totals as master f96546fc9 built the same way. gfortran 13.3, x86-64 Linux.

</details>

**Performance.** Not benchmarked: the `xTPRFB` change alters only the addressing of an `L`-by-`N` temporary, and the `xTPMLQT` change replaces a dense `IB`-by-`LB` block product with the triangular one the algorithm was designed around, so the operation count can only go down.
