### PR TITLE
GEDMD: Add missing RETURN after XERBLA in NaN checks

### DIFF
--- a/SRC/cgedmd.f90
+++ b/SRC/cgedmd.f90
@@ -768,6 +768,7 @@
                 K    =  0
                 INFO = -8
                 CALL XERBLA('CGEDMD',-INFO)
+                RETURN
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
@@ -844,6 +845,7 @@
                 K    =  0
                 INFO = -10
                 CALL XERBLA('CGEDMD',-INFO)
+                RETURN
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)

--- a/SRC/dgedmd.f90
+++ b/SRC/dgedmd.f90
@@ -789,6 +789,7 @@
                 K    =  0
                 INFO = -8
                 CALL XERBLA('DGEDMD',-INFO)
+                RETURN
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
@@ -865,6 +866,7 @@
                 K    =  0
                 INFO = -10
                 CALL XERBLA('DGEDMD',-INFO)
+                RETURN
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)

--- a/SRC/sgedmd.f90
+++ b/SRC/sgedmd.f90
@@ -789,6 +789,7 @@
                 K    =  0
                 INFO = -8
                 CALL XERBLA('SGEDMD',-INFO)
+                RETURN
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
@@ -865,6 +866,7 @@
                 K    =  0
                 INFO = -10
                 CALL XERBLA('SGEDMD',-INFO)
+                RETURN
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)

--- a/SRC/zgedmd.f90
+++ b/SRC/zgedmd.f90
@@ -768,6 +768,7 @@
                 K    =  0
                 INFO = -8
                 CALL XERBLA('ZGEDMD',-INFO)
+                RETURN
             END IF
             IF ( (SCALE /= ZERO) .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)
@@ -844,6 +845,7 @@
                 K    =  0
                 INFO = -10
                 CALL XERBLA('ZGEDMD',-INFO)
+                RETURN
             END IF
             IF ( SCALE /= ZERO  .AND. (SSUM /= ZERO) ) THEN
                ROOTSC = SQRT(SSUM)


### PR DESCRIPTION
Two NaN-detection blocks (column norms of X and Y) called XERBLA with INFO=-8/-10 but did not RETURN, so with a non-aborting XERBLA execution continued into the SVD on NaN data. Add RETURN after each XERBLA to match standard LAPACK convention and the existing all-zero-column check.

Part of #1312 
