### PR TITLE
Make the SLALN2/DLALN2 residual test robust to fused multiply-add

### DIFF
--- a/TESTING/EIG/dget31.f
+++ b/TESTING/EIG/dget31.f
@@ -117,8 +117,8 @@
 *     .. Local Scalars ..
       INTEGER            IA, IB, ICA, ID1, ID2, INFO, ISMIN, ITRANS,
      $                   IWI, IWR, NA, NW
-      DOUBLE PRECISION   BIGNUM, CA, D1, D2, DEN, EPS, RES, SCALE, SMIN,
-     $                   SMLNUM, TMP, UNFL, WI, WR, XNORM
+      DOUBLE PRECISION   BIGNUM, CA, CNORM, D1, D2, DEN, EPS, RES,
+     $                   SCALE, SMIN, SMLNUM, TMP, UNFL, WI, WR, XNORM
 *     ..
 *     .. Local Arrays ..
       LOGICAL            LTRANS( 0: 1 )
@@ -217,13 +217,13 @@
      $                           NINFO( 2 ) = NINFO( 2 ) + 1
                               RES = ABS( ( CA*A( 1, 1 )-WR*D1 )*
      $                              X( 1, 1 )-SCALE*B( 1, 1 ) )
+                              CNORM = ABS( CA*A( 1, 1 ) ) + ABS( WR*D1 )
                               IF( INFO.EQ.0 ) THEN
-                                 DEN = MAX( EPS*( ABS( ( CA*A( 1,
-     $                                 1 )-WR*D1 )*X( 1, 1 ) ) ),
+                                 DEN = MAX( EPS*CNORM*ABS( X( 1, 1 ) ),
      $                                 SMLNUM )
                               ELSE
-                                 DEN = MAX( SMIN*ABS( X( 1, 1 ) ),
-     $                                 SMLNUM )
+                                 DEN = MAX( MAX( SMIN, EPS*CNORM )*
+     $                                 ABS( X( 1, 1 ) ), SMLNUM )
                               END IF
                               RES = RES / DEN
                               IF( ABS( X( 1, 1 ) ).LT.UNFL .AND.
@@ -279,15 +279,16 @@
                                  RES = RES + ABS( ( -WI*D1 )*X( 1, 1 )+
      $                                 ( CA*A( 1, 1 )-WR*D1 )*X( 1, 2 )-
      $                                 SCALE*B( 1, 2 ) )
+                                 CNORM = ABS( CA*A( 1, 1 ) ) +
+     $                                   ABS( WR*D1 ) + ABS( WI*D1 )
                                  IF( INFO.EQ.0 ) THEN
-                                    DEN = MAX( EPS*( MAX( ABS( CA*A( 1,
-     $                                    1 )-WR*D1 ), ABS( D1*WI ) )*
+                                    DEN = MAX( EPS*CNORM*
      $                                    ( ABS( X( 1, 1 ) )+ABS( X( 1,
-     $                                    2 ) ) ) ), SMLNUM )
+     $                                    2 ) ) ), SMLNUM )
                                  ELSE
-                                    DEN = MAX( SMIN*( ABS( X( 1,
-     $                                    1 ) )+ABS( X( 1, 2 ) ) ),
-     $                                    SMLNUM )
+                                    DEN = MAX( MAX( SMIN, EPS*CNORM )*
+     $                                    ( ABS( X( 1, 1 ) )+ABS( X( 1,
+     $                                    2 ) ) ), SMLNUM )
                                  END IF
                                  RES = RES / DEN
                                  IF( ABS( X( 1, 1 ) ).LT.UNFL .AND.

--- a/TESTING/EIG/sget31.f
+++ b/TESTING/EIG/sget31.f
@@ -117,8 +117,8 @@
 *     .. Local Scalars ..
       INTEGER            IA, IB, ICA, ID1, ID2, INFO, ISMIN, ITRANS,
      $                   IWI, IWR, NA, NW
-      REAL               BIGNUM, CA, D1, D2, DEN, EPS, RES, SCALE, SMIN,
-     $                   SMLNUM, TMP, UNFL, WI, WR, XNORM
+      REAL               BIGNUM, CA, CNORM, D1, D2, DEN, EPS, RES,
+     $                   SCALE, SMIN, SMLNUM, TMP, UNFL, WI, WR, XNORM
 *     ..
 *     .. Local Arrays ..
       LOGICAL            LTRANS( 0: 1 )
@@ -217,13 +217,13 @@
      $                           NINFO( 2 ) = NINFO( 2 ) + 1
                               RES = ABS( ( CA*A( 1, 1 )-WR*D1 )*
      $                              X( 1, 1 )-SCALE*B( 1, 1 ) )
+                              CNORM = ABS( CA*A( 1, 1 ) ) + ABS( WR*D1 )
                               IF( INFO.EQ.0 ) THEN
-                                 DEN = MAX( EPS*( ABS( ( CA*A( 1,
-     $                                 1 )-WR*D1 )*X( 1, 1 ) ) ),
+                                 DEN = MAX( EPS*CNORM*ABS( X( 1, 1 ) ),
      $                                 SMLNUM )
                               ELSE
-                                 DEN = MAX( SMIN*ABS( X( 1, 1 ) ),
-     $                                 SMLNUM )
+                                 DEN = MAX( MAX( SMIN, EPS*CNORM )*
+     $                                 ABS( X( 1, 1 ) ), SMLNUM )
                               END IF
                               RES = RES / DEN
                               IF( ABS( X( 1, 1 ) ).LT.UNFL .AND.
@@ -279,15 +279,16 @@
                                  RES = RES + ABS( ( -WI*D1 )*X( 1, 1 )+
      $                                 ( CA*A( 1, 1 )-WR*D1 )*X( 1, 2 )-
      $                                 SCALE*B( 1, 2 ) )
+                                 CNORM = ABS( CA*A( 1, 1 ) ) +
+     $                                   ABS( WR*D1 ) + ABS( WI*D1 )
                                  IF( INFO.EQ.0 ) THEN
-                                    DEN = MAX( EPS*( MAX( ABS( CA*A( 1,
-     $                                    1 )-WR*D1 ), ABS( D1*WI ) )*
+                                    DEN = MAX( EPS*CNORM*
      $                                    ( ABS( X( 1, 1 ) )+ABS( X( 1,
-     $                                    2 ) ) ) ), SMLNUM )
+     $                                    2 ) ) ), SMLNUM )
                                  ELSE
-                                    DEN = MAX( SMIN*( ABS( X( 1,
-     $                                    1 ) )+ABS( X( 1, 2 ) ) ),
-     $                                    SMLNUM )
+                                    DEN = MAX( MAX( SMIN, EPS*CNORM )*
+     $                                    ( ABS( X( 1, 1 ) )+ABS( X( 1,
+     $                                    2 ) ) ), SMLNUM )
                                  END IF
                                  RES = RES / DEN
                                  IF( ABS( X( 1, 1 ) ).LT.UNFL .AND.


### PR DESCRIPTION
Fixes #598.

## Problem

The macOS nagfor CI jobs (static and shared) report in `sec.out`:

```
Error in SLALN2: RMAX =   0.622E+07
LMAX =    60625 NINFO=       0   71553 KNT=  230400
```

Test case 60625 is the complex 1x1 system with `CA = sqrt(SMLNUM)`,
`A = sqrt(BIGNUM)`, `WR = D1 = 1`, so `C = CA*A - WR*D1` cancels almost
completely. `SLALN2` computes it with a fused multiply-add (`-3.42E-08`,
the exact product minus one), whereas nagfor at `-O2` and above evaluates
the products in `SGET31`'s residual expression separately (`-5.96E-08`).
The test then divides the resulting residual by `EPS * |C| * |X|`, i.e. by
the size of the *cancelled* difference, and the ratio explodes. This is the
same case David Hough reported in #598 in 2014; which compilers hit it just
depends on where they happen to fuse.

## Changes

`[sd]get31.f`: for the two 1x1 systems (real and complex `w`), scale the
residual by the size of the terms that form `C`,

```
CNORM = |CA*A(1,1)| + |WR*D1| ( + |WI*D1| )
```

instead of by `|C|` itself, and use `MAX( SMIN, EPS*CNORM )` in the
perturbed (`INFO /= 0`) branch. This is the rounding-error bound of forming
`C`, and it matches the perturbation bound documented in `SLALN2`
("a small multiple of `max( SMIN, ulp*norm(ca A - w D) )`"). The
denominators only grow, and only where cancellation occurs, so no
compiler can regress. The 2x2 blocks are unchanged: their row norms are
dominated by the off-diagonal entries, which cannot cancel.

## Verification

Standalone driver over `[sd]get31 + [sd]laln2`: nagfor `-O0`..`-O4`,
gfortran 14/16 `-O3` with and without `-ffp-contract=off`, flang `-O0`/`-O3`
now all give `RMAX = 1.77` (before: `0.622E+07` with nagfor `-O2`+).
