### PR TITLE
Disable SLP vectorization for gfortran 15.0-15.2 due to a compiler bug.

### DIFF
--- a/CMAKE/CheckLAPACKCompilerFlags.cmake
+++ b/CMAKE/CheckLAPACKCompilerFlags.cmake
@@ -59,17 +59,27 @@ macro(CheckLAPACKCompilerFlags)
     # Disabling loop vectorization for GNU Fortran versions affected by
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122408. See issue
     # https://github.com/Reference-LAPACK/lapack/issues/1160 as well.
-    if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|arm64|aarch64")
-      if((CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0" AND
-          CMAKE_Fortran_COMPILER_VERSION VERSION_LESS_EQUAL "14.4") OR
-         (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0" AND
-          CMAKE_Fortran_COMPILER_VERSION VERSION_LESS_EQUAL "15.2"))
-        message(WARNING
-          "Disabling loop vectorization for GNU Fortran (14.0-14.4, 15.0-15.2) on ARM "
-          "due to a compiler bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122408). "
-          "For full performance, consider changing to a different compiler or compiler version.")
-        add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fno-tree-loop-vectorize>")
-      endif()
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|arm64|aarch64" AND
+       ((CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0" AND
+         CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "14.5") OR
+        (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0" AND
+         CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "15.3")))
+      message(WARNING
+        "Disabling loop vectorization for GNU Fortran (14.0-14.4, 15.0-15.2) on ARM "
+        "due to a compiler bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122408). "
+        "For full performance, consider changing to a different compiler or compiler version.")
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fno-tree-loop-vectorize>")
+    endif()
+
+    # Disabling SLP vectorization for GNU Fortran versions affected by
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=124802.
+    if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0" AND
+       CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "15.3")
+      message(WARNING
+        "Disabling SLP vectorization for GNU Fortran (15.0-15.2) "
+        "due to a compiler bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=124802). "
+        "For full performance, consider changing to a different compiler or compiler version.")
+      add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:-fno-tree-slp-vectorize>")
     endif()
 
   # Intel Fortran


### PR DESCRIPTION
**Description**

Similar to #1160 we've been hit with another gfortran compiler bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=124802). This time it affects the SLP vectorization with gfortran 15.0-15.2.

This issue came up due to the upgrade of the GH action runner images (Ubuntu 26.04) which also bumped the compiler versions.

This should fix these complex errors:

```
                        -->  LAPACK TESTING SUMMARY  <--
                   Processing LAPACK Testing output found in:
                 /home/runner/work/lapack/lapack/build/TESTING

 ----------------- LAPACK: Default API and Extended API (_64) ----------------- 

  SUMMARY                nb test run      numerical error          other error
  ==================   =============   ==================   ==================
  REAL                       1630125          1   (0.01%)          0   (0.00%)
  DOUBLE PRECISION           1630947          0   (0.00%)          0   (0.00%)
  COMPLEX                    1089905        576   (0.05%)         48   (0.01%)
  COMPLEX16                  1090946        226   (0.02%)          0   (0.00%)

  --> ALL PRECISIONS         5441923        803   (0.01%)         48   (0.01%)
```