### PR TITLE
TESTING: scale the RFP xTFSM forward error by the solution norm

### DIFF
--- a/TESTING/LIN/cdrvrf3.f
+++ b/TESTING/LIN/cdrvrf3.f
@@ -150,7 +150,7 @@
       INTEGER            I, IFORM, IIM, IIN, INFO, IUPLO, J, M, N, NA,
      +                   NFAIL, NRUN, ISIDE, IDIAG, IALPHA, ITRANS
       COMPLEX            ALPHA
-      REAL               EPS
+      REAL               EPS, SOLNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          UPLOS( 2 ), FORMS( 2 ), TRANSS( 2 ),
@@ -362,6 +362,9 @@
 *
 *                             Check that the result agrees.
 *
+                              SOLNRM = CLANGE( 'I', M, N, B1, LDA,
+     +                                        S_WORK_CLANGE )
+*
                               DO J = 1, N
                                  DO I = 1, M
                                     B1( I, J ) = B2( I, J ) - B1( I, J )
@@ -373,6 +376,7 @@
 *
                               RESULT( 1 ) = RESULT( 1 ) / SQRT( EPS )
      +                                    / REAL( MAX( M, N, 1 ) )
+     +                                    / MAX( SOLNRM, 1.0E+0 )
 *
                               IF( RESULT( 1 ).GE.THRESH ) THEN
                                  IF( NFAIL.EQ.0 ) THEN

--- a/TESTING/LIN/ddrvrf3.f
+++ b/TESTING/LIN/ddrvrf3.f
@@ -146,7 +146,7 @@
       CHARACTER          UPLO, CFORM, DIAG, TRANS, SIDE
       INTEGER            I, IFORM, IIM, IIN, INFO, IUPLO, J, M, N, NA,
      +                   NFAIL, NRUN, ISIDE, IDIAG, IALPHA, ITRANS
-      DOUBLE PRECISION   EPS, ALPHA
+      DOUBLE PRECISION   EPS, ALPHA, SOLNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          UPLOS( 2 ), FORMS( 2 ), TRANSS( 2 ),
@@ -347,6 +347,9 @@
 *
 *                             Check that the result agrees.
 *
+                              SOLNRM = DLANGE( 'I', M, N, B1, LDA,
+     +                                        D_WORK_DLANGE )
+*
                               DO J = 1, N
                                  DO I = 1, M
                                     B1( I, J ) = B2( I, J ) - B1( I, J )
@@ -358,6 +361,7 @@
 *
                               RESULT( 1 ) = RESULT( 1 ) / SQRT( EPS )
      +                                    / MAX ( MAX( M, N ), 1 )
+     +                                    / MAX( SOLNRM, 1.0D+0 )
 *
                               IF( RESULT( 1 ).GE.THRESH ) THEN
                                  IF( NFAIL.EQ.0 ) THEN

--- a/TESTING/LIN/sdrvrf3.f
+++ b/TESTING/LIN/sdrvrf3.f
@@ -146,7 +146,7 @@
       CHARACTER          UPLO, CFORM, DIAG, TRANS, SIDE
       INTEGER            I, IFORM, IIM, IIN, INFO, IUPLO, J, M, N, NA,
      +                   NFAIL, NRUN, ISIDE, IDIAG, IALPHA, ITRANS
-      REAL               EPS, ALPHA
+      REAL               EPS, ALPHA, SOLNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          UPLOS( 2 ), FORMS( 2 ), TRANSS( 2 ),
@@ -347,6 +347,9 @@
 *
 *                             Check that the result agrees.
 *
+                              SOLNRM = SLANGE( 'I', M, N, B1, LDA,
+     +                                        S_WORK_SLANGE )
+*
                               DO J = 1, N
                                  DO I = 1, M
                                     B1( I, J ) = B2( I, J ) - B1( I, J )
@@ -358,6 +361,7 @@
 *
                               RESULT( 1 ) = RESULT( 1 ) / SQRT( EPS )
      +                                    / REAL( MAX( M, N, 1 ) )
+     +                                    / MAX( SOLNRM, 1.0E+0 )
 *
                               IF( RESULT( 1 ).GE.THRESH ) THEN
                                  IF( NFAIL.EQ.0 ) THEN

--- a/TESTING/LIN/zdrvrf3.f
+++ b/TESTING/LIN/zdrvrf3.f
@@ -150,7 +150,7 @@
       INTEGER            I, IFORM, IIM, IIN, INFO, IUPLO, J, M, N, NA,
      +                   NFAIL, NRUN, ISIDE, IDIAG, IALPHA, ITRANS
       COMPLEX*16         ALPHA
-      DOUBLE PRECISION   EPS
+      DOUBLE PRECISION   EPS, SOLNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          UPLOS( 2 ), FORMS( 2 ), TRANSS( 2 ),
@@ -362,6 +362,9 @@
 *
 *                             Check that the result agrees.
 *
+                              SOLNRM = ZLANGE( 'I', M, N, B1, LDA,
+     +                                        D_WORK_ZLANGE )
+*
                               DO J = 1, N
                                  DO I = 1, M
                                     B1( I, J ) = B2( I, J ) - B1( I, J )
@@ -373,6 +376,7 @@
 *
                               RESULT( 1 ) = RESULT( 1 ) / SQRT( EPS )
      +                                    / MAX ( MAX( M, N ), 1 )
+     +                                    / MAX( SOLNRM, 1.0D+0 )
 *
                               IF( RESULT( 1 ).GE.THRESH ) THEN
                                  IF( NFAIL.EQ.0 ) THEN


### PR DESCRIPTION
Fixes #679

### Problem

`stest_rfp` reports `STFSM: 1 out of 7776 tests failed to pass the threshold` on the x86-64 gfortran CI jobs (static and shared, plain and OpenMP).

### Cause

`xDRVRF3` checks xTFSM against xTRSM with an *absolute* forward error:

    RESULT(1) = |X_tfsm - X_trsm|_inf / sqrt(eps) / max(M,N)

Nothing in that refers to the size of the solution, and the driver deliberately builds ill-conditioned systems — see its own comment, "Forcing main diagonal of test matrix to be unit makes it ill-conditioned for some test cases". When the solution grows large the test fails on a difference that is negligible in relative terms.

Measured on the failing case (`CFORM='T' SIDE='L' UPLO='U' TRANS='T' DIAG='N' M=N=50`): `|X|_inf = 3.88e6`, `|dX|_inf = 0.788`, i.e. a relative difference of **2.03e-07 — under 2 single-precision ulp** — reported as `test = 45.665` against a threshold of 30. The two routines agree to rounding; only the measure is wrong.

### Change

Divide by `MAX(SOLNRM, 1)`, where `SOLNRM` is the norm of the xTRSM solution.

Applied identically in all four precisions.
