### PR TITLE
xLAEIN: apply the growth test to the growth, not to |x| alone

### DIFF
--- a/SRC/claein.f
+++ b/SRC/claein.f
@@ -173,8 +173,8 @@
 *     .. Local Scalars ..
       CHARACTER          NORMIN, TRANS
       INTEGER            I, IERR, ITS, J
-      REAL               GROWTO, NRMSML, ROOTN, RTEMP, SCALE, VI_NORM,
-     $                   VIP1_NORM
+      REAL               GROWTO, NRMSML, ROOTN, RTEMP, SCALE, V0NORM,
+     $                   V1NORM
       COMPLEX            CDUM, EI, EJ, TEMP, X
 *     ..
 *     .. External Functions ..
@@ -199,11 +199,10 @@
 *
       INFO = 0
 *
-*     The residual of the vector x that a solve returns is SCALE times
-*     the norm of the starting vector, over the norm of x, so GROWTO is
-*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
-*     below requires, where VI_NORM and VIP1_NORM are the norms of the
-*     vectors the current iteration started from and produced.
+*     Each starting vector gets one solve, from v0 to v1.  The residual
+*     of v1 is SCALE times the norm of v0, over the norm of v1, so
+*     GROWTO is the growth V1NORM/(SCALE*V0NORM) that the acceptance
+*     test below requires.
 *
       ROOTN = SQRT( REAL( N ) )
       GROWTO = TENTH / ( REAL( N )*EPS3 )
@@ -230,8 +229,8 @@
 *
 *        Scale supplied initial vector.
 *
-         VI_NORM = SCNRM2( N, V, 1 )
-         CALL CSSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), V,
+         V0NORM = SCNRM2( N, V, 1 )
+         CALL CSSCAL( N, ( EPS3*ROOTN ) / MAX( V0NORM, NRMSML ), V,
      $                1 )
       END IF
 *
@@ -313,7 +312,7 @@
 *
       NORMIN = 'N'
       DO 110 ITS = 1, N
-         VI_NORM = SCASUM( N, V, 1 )
+         V0NORM = SCASUM( N, V, 1 )
 *
 *        Solve U*x = scale*v for a right eigenvector
 *          or U**H *x = scale*v for a left eigenvector,
@@ -326,8 +325,8 @@
 *
 *        Test for sufficient growth in the norm of v.
 *
-         VIP1_NORM = SCASUM( N, V, 1 )
-         IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
+         V1NORM = SCASUM( N, V, 1 )
+         IF( V1NORM.GE.GROWTO*SCALE*V0NORM )
      $      GO TO 120
 *
 *        Choose new orthogonal starting vector and try again.

--- a/SRC/claein.f
+++ b/SRC/claein.f
@@ -173,7 +173,8 @@
 *     .. Local Scalars ..
       CHARACTER          NORMIN, TRANS
       INTEGER            I, IERR, ITS, J
-      REAL               GROWTO, NRMSML, ROOTN, RTEMP, SCALE, VNORM
+      REAL               GROWTO, NRMSML, ROOTN, RTEMP, SCALE, VI_NORM,
+     $                   VIP1_NORM
       COMPLEX            CDUM, EI, EJ, TEMP, X
 *     ..
 *     .. External Functions ..
@@ -198,11 +199,14 @@
 *
       INFO = 0
 *
-*     GROWTO is the threshold used in the acceptance test for an
-*     eigenvector.
+*     The residual of the vector x that a solve returns is SCALE times
+*     the norm of the starting vector, over the norm of x, so GROWTO is
+*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
+*     below requires, where VI_NORM and VIP1_NORM are the norms of the
+*     vectors the current iteration started from and produced.
 *
       ROOTN = SQRT( REAL( N ) )
-      GROWTO = TENTH / ROOTN
+      GROWTO = TENTH / ( REAL( N )*EPS3 )
       NRMSML = MAX( ONE, EPS3*ROOTN )*SMLNUM
 *
 *     Form B = H - W*I (except that the subdiagonal elements are not
@@ -226,8 +230,8 @@
 *
 *        Scale supplied initial vector.
 *
-         VNORM = SCNRM2( N, V, 1 )
-         CALL CSSCAL( N, ( EPS3*ROOTN ) / MAX( VNORM, NRMSML ), V,
+         VI_NORM = SCNRM2( N, V, 1 )
+         CALL CSSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), V,
      $                1 )
       END IF
 *
@@ -309,6 +313,7 @@
 *
       NORMIN = 'N'
       DO 110 ITS = 1, N
+         VI_NORM = SCASUM( N, V, 1 )
 *
 *        Solve U*x = scale*v for a right eigenvector
 *          or U**H *x = scale*v for a left eigenvector,
@@ -321,8 +326,8 @@
 *
 *        Test for sufficient growth in the norm of v.
 *
-         VNORM = SCASUM( N, V, 1 )
-         IF( VNORM.GE.GROWTO*SCALE )
+         VIP1_NORM = SCASUM( N, V, 1 )
+         IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
      $      GO TO 120
 *
 *        Choose new orthogonal starting vector and try again.

--- a/SRC/dlaein.f
+++ b/SRC/dlaein.f
@@ -194,8 +194,8 @@
       CHARACTER          NORMIN, TRANS
       INTEGER            I, I1, I2, I3, IERR, ITS, J
       DOUBLE PRECISION   ABSBII, ABSBJJ, EI, EJ, GROWTO, NORM, NRMSML,
-     $                   REC, ROOTN, SCALE, TEMP, VCRIT, VMAX, VNORM, W,
-     $                   W1, X, XI, XR, Y
+     $                   REC, ROOTN, SCALE, TEMP, VCRIT, VI_NORM,
+     $                   VIP1_NORM, VMAX, W, W1, X, XI, XR, Y
 *     ..
 *     .. External Functions ..
       INTEGER            IDAMAX
@@ -212,11 +212,14 @@
 *
       INFO = 0
 *
-*     GROWTO is the threshold used in the acceptance test for an
-*     eigenvector.
+*     The residual of the vector x that a solve returns is SCALE times
+*     the norm of the starting vector, over the norm of x, so GROWTO is
+*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
+*     below requires, where VI_NORM and VIP1_NORM are the norms of the
+*     vectors the current iteration started from and produced.
 *
       ROOTN = SQRT( DBLE( N ) )
-      GROWTO = TENTH / ROOTN
+      GROWTO = TENTH / ( DBLE( N )*EPS3 )
       NRMSML = MAX( ONE, EPS3*ROOTN )*SMLNUM
 *
 *     Form B = H - (WR,WI)*I (except that the subdiagonal elements and
@@ -244,8 +247,8 @@
 *
 *           Scale supplied initial vector.
 *
-            VNORM = DNRM2( N, VR, 1 )
-            CALL DSCAL( N, ( EPS3*ROOTN ) / MAX( VNORM, NRMSML ), VR,
+            VI_NORM = DNRM2( N, VR, 1 )
+            CALL DSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), VR,
      $                  1 )
          END IF
 *
@@ -327,6 +330,7 @@
 *
          NORMIN = 'N'
          DO 110 ITS = 1, N
+            VI_NORM = DASUM( N, VR, 1 )
 *
 *           Solve U*x = scale*v for a right eigenvector
 *             or U**T*x = scale*v for a left eigenvector,
@@ -339,8 +343,8 @@
 *
 *           Test for sufficient growth in the norm of v.
 *
-            VNORM = DASUM( N, VR, 1 )
-            IF( VNORM.GE.GROWTO*SCALE )
+            VIP1_NORM = DASUM( N, VR, 1 )
+            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
      $         GO TO 120
 *
 *           Choose new orthogonal starting vector and try again.
@@ -521,6 +525,7 @@
          END IF
 *
          DO 270 ITS = 1, N
+            VI_NORM = DASUM( N, VR, 1 ) + DASUM( N, VI, 1 )
             SCALE = ONE
             VMAX = ONE
             VCRIT = BIGNUM
@@ -591,8 +596,8 @@
 *
 *           Test for sufficient growth in the norm of (VR,VI).
 *
-            VNORM = DASUM( N, VR, 1 ) + DASUM( N, VI, 1 )
-            IF( VNORM.GE.GROWTO*SCALE )
+            VIP1_NORM = DASUM( N, VR, 1 ) + DASUM( N, VI, 1 )
+            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
      $         GO TO 280
 *
 *           Choose a new orthogonal starting vector and try again.
@@ -616,12 +621,12 @@
 *
 *        Normalize eigenvector.
 *
-         VNORM = ZERO
+         VIP1_NORM = ZERO
          DO 290 I = 1, N
-            VNORM = MAX( VNORM, ABS( VR( I ) )+ABS( VI( I ) ) )
+            VIP1_NORM = MAX( VIP1_NORM, ABS( VR( I ) )+ABS( VI( I ) ) )
   290    CONTINUE
-         CALL DSCAL( N, ONE / VNORM, VR, 1 )
-         CALL DSCAL( N, ONE / VNORM, VI, 1 )
+         CALL DSCAL( N, ONE / VIP1_NORM, VR, 1 )
+         CALL DSCAL( N, ONE / VIP1_NORM, VI, 1 )
 *
       END IF
 *

--- a/SRC/dlaein.f
+++ b/SRC/dlaein.f
@@ -194,8 +194,8 @@
       CHARACTER          NORMIN, TRANS
       INTEGER            I, I1, I2, I3, IERR, ITS, J
       DOUBLE PRECISION   ABSBII, ABSBJJ, EI, EJ, GROWTO, NORM, NRMSML,
-     $                   REC, ROOTN, SCALE, TEMP, VCRIT, VI_NORM,
-     $                   VIP1_NORM, VMAX, W, W1, X, XI, XR, Y
+     $                   REC, ROOTN, SCALE, TEMP, V0NORM, V1NORM,
+     $                   VCRIT, VMAX, W, W1, X, XI, XR, Y
 *     ..
 *     .. External Functions ..
       INTEGER            IDAMAX
@@ -212,11 +212,10 @@
 *
       INFO = 0
 *
-*     The residual of the vector x that a solve returns is SCALE times
-*     the norm of the starting vector, over the norm of x, so GROWTO is
-*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
-*     below requires, where VI_NORM and VIP1_NORM are the norms of the
-*     vectors the current iteration started from and produced.
+*     Each starting vector gets one solve, from v0 to v1.  The residual
+*     of v1 is SCALE times the norm of v0, over the norm of v1, so
+*     GROWTO is the growth V1NORM/(SCALE*V0NORM) that the acceptance
+*     test below requires.
 *
       ROOTN = SQRT( DBLE( N ) )
       GROWTO = TENTH / ( DBLE( N )*EPS3 )
@@ -247,8 +246,8 @@
 *
 *           Scale supplied initial vector.
 *
-            VI_NORM = DNRM2( N, VR, 1 )
-            CALL DSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), VR,
+            V0NORM = DNRM2( N, VR, 1 )
+            CALL DSCAL( N, ( EPS3*ROOTN ) / MAX( V0NORM, NRMSML ), VR,
      $                  1 )
          END IF
 *
@@ -330,7 +329,7 @@
 *
          NORMIN = 'N'
          DO 110 ITS = 1, N
-            VI_NORM = DASUM( N, VR, 1 )
+            V0NORM = DASUM( N, VR, 1 )
 *
 *           Solve U*x = scale*v for a right eigenvector
 *             or U**T*x = scale*v for a left eigenvector,
@@ -343,8 +342,8 @@
 *
 *           Test for sufficient growth in the norm of v.
 *
-            VIP1_NORM = DASUM( N, VR, 1 )
-            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
+            V1NORM = DASUM( N, VR, 1 )
+            IF( V1NORM.GE.GROWTO*SCALE*V0NORM )
      $         GO TO 120
 *
 *           Choose new orthogonal starting vector and try again.
@@ -525,7 +524,7 @@
          END IF
 *
          DO 270 ITS = 1, N
-            VI_NORM = DASUM( N, VR, 1 ) + DASUM( N, VI, 1 )
+            V0NORM = DASUM( N, VR, 1 ) + DASUM( N, VI, 1 )
             SCALE = ONE
             VMAX = ONE
             VCRIT = BIGNUM
@@ -596,8 +595,8 @@
 *
 *           Test for sufficient growth in the norm of (VR,VI).
 *
-            VIP1_NORM = DASUM( N, VR, 1 ) + DASUM( N, VI, 1 )
-            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
+            V1NORM = DASUM( N, VR, 1 ) + DASUM( N, VI, 1 )
+            IF( V1NORM.GE.GROWTO*SCALE*V0NORM )
      $         GO TO 280
 *
 *           Choose a new orthogonal starting vector and try again.
@@ -621,12 +620,12 @@
 *
 *        Normalize eigenvector.
 *
-         VIP1_NORM = ZERO
+         V1NORM = ZERO
          DO 290 I = 1, N
-            VIP1_NORM = MAX( VIP1_NORM, ABS( VR( I ) )+ABS( VI( I ) ) )
+            V1NORM = MAX( V1NORM, ABS( VR( I ) )+ABS( VI( I ) ) )
   290    CONTINUE
-         CALL DSCAL( N, ONE / VIP1_NORM, VR, 1 )
-         CALL DSCAL( N, ONE / VIP1_NORM, VI, 1 )
+         CALL DSCAL( N, ONE / V1NORM, VR, 1 )
+         CALL DSCAL( N, ONE / V1NORM, VI, 1 )
 *
       END IF
 *

--- a/SRC/slaein.f
+++ b/SRC/slaein.f
@@ -194,8 +194,8 @@
       CHARACTER          NORMIN, TRANS
       INTEGER            I, I1, I2, I3, IERR, ITS, J
       REAL               ABSBII, ABSBJJ, EI, EJ, GROWTO, NORM, NRMSML,
-     $                   REC, ROOTN, SCALE, TEMP, VCRIT, VI_NORM,
-     $                   VIP1_NORM, VMAX, W, W1, X, XI, XR, Y
+     $                   REC, ROOTN, SCALE, TEMP, V0NORM, V1NORM,
+     $                   VCRIT, VMAX, W, W1, X, XI, XR, Y
 *     ..
 *     .. External Functions ..
       INTEGER            ISAMAX
@@ -212,11 +212,10 @@
 *
       INFO = 0
 *
-*     The residual of the vector x that a solve returns is SCALE times
-*     the norm of the starting vector, over the norm of x, so GROWTO is
-*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
-*     below requires, where VI_NORM and VIP1_NORM are the norms of the
-*     vectors the current iteration started from and produced.
+*     Each starting vector gets one solve, from v0 to v1.  The residual
+*     of v1 is SCALE times the norm of v0, over the norm of v1, so
+*     GROWTO is the growth V1NORM/(SCALE*V0NORM) that the acceptance
+*     test below requires.
 *
       ROOTN = SQRT( REAL( N ) )
       GROWTO = TENTH / ( REAL( N )*EPS3 )
@@ -247,8 +246,8 @@
 *
 *           Scale supplied initial vector.
 *
-            VI_NORM = SNRM2( N, VR, 1 )
-            CALL SSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), VR,
+            V0NORM = SNRM2( N, VR, 1 )
+            CALL SSCAL( N, ( EPS3*ROOTN ) / MAX( V0NORM, NRMSML ), VR,
      $                  1 )
          END IF
 *
@@ -330,7 +329,7 @@
 *
          NORMIN = 'N'
          DO 110 ITS = 1, N
-            VI_NORM = SASUM( N, VR, 1 )
+            V0NORM = SASUM( N, VR, 1 )
 *
 *           Solve U*x = scale*v for a right eigenvector
 *             or U**T*x = scale*v for a left eigenvector,
@@ -343,8 +342,8 @@
 *
 *           Test for sufficient growth in the norm of v.
 *
-            VIP1_NORM = SASUM( N, VR, 1 )
-            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
+            V1NORM = SASUM( N, VR, 1 )
+            IF( V1NORM.GE.GROWTO*SCALE*V0NORM )
      $         GO TO 120
 *
 *           Choose new orthogonal starting vector and try again.
@@ -525,7 +524,7 @@
          END IF
 *
          DO 270 ITS = 1, N
-            VI_NORM = SASUM( N, VR, 1 ) + SASUM( N, VI, 1 )
+            V0NORM = SASUM( N, VR, 1 ) + SASUM( N, VI, 1 )
             SCALE = ONE
             VMAX = ONE
             VCRIT = BIGNUM
@@ -596,8 +595,8 @@
 *
 *           Test for sufficient growth in the norm of (VR,VI).
 *
-            VIP1_NORM = SASUM( N, VR, 1 ) + SASUM( N, VI, 1 )
-            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
+            V1NORM = SASUM( N, VR, 1 ) + SASUM( N, VI, 1 )
+            IF( V1NORM.GE.GROWTO*SCALE*V0NORM )
      $         GO TO 280
 *
 *           Choose a new orthogonal starting vector and try again.
@@ -621,12 +620,12 @@
 *
 *        Normalize eigenvector.
 *
-         VIP1_NORM = ZERO
+         V1NORM = ZERO
          DO 290 I = 1, N
-            VIP1_NORM = MAX( VIP1_NORM, ABS( VR( I ) )+ABS( VI( I ) ) )
+            V1NORM = MAX( V1NORM, ABS( VR( I ) )+ABS( VI( I ) ) )
   290    CONTINUE
-         CALL SSCAL( N, ONE / VIP1_NORM, VR, 1 )
-         CALL SSCAL( N, ONE / VIP1_NORM, VI, 1 )
+         CALL SSCAL( N, ONE / V1NORM, VR, 1 )
+         CALL SSCAL( N, ONE / V1NORM, VI, 1 )
 *
       END IF
 *

--- a/SRC/slaein.f
+++ b/SRC/slaein.f
@@ -194,8 +194,8 @@
       CHARACTER          NORMIN, TRANS
       INTEGER            I, I1, I2, I3, IERR, ITS, J
       REAL               ABSBII, ABSBJJ, EI, EJ, GROWTO, NORM, NRMSML,
-     $                   REC, ROOTN, SCALE, TEMP, VCRIT, VMAX, VNORM, W,
-     $                   W1, X, XI, XR, Y
+     $                   REC, ROOTN, SCALE, TEMP, VCRIT, VI_NORM,
+     $                   VIP1_NORM, VMAX, W, W1, X, XI, XR, Y
 *     ..
 *     .. External Functions ..
       INTEGER            ISAMAX
@@ -212,11 +212,14 @@
 *
       INFO = 0
 *
-*     GROWTO is the threshold used in the acceptance test for an
-*     eigenvector.
+*     The residual of the vector x that a solve returns is SCALE times
+*     the norm of the starting vector, over the norm of x, so GROWTO is
+*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
+*     below requires, where VI_NORM and VIP1_NORM are the norms of the
+*     vectors the current iteration started from and produced.
 *
       ROOTN = SQRT( REAL( N ) )
-      GROWTO = TENTH / ROOTN
+      GROWTO = TENTH / ( REAL( N )*EPS3 )
       NRMSML = MAX( ONE, EPS3*ROOTN )*SMLNUM
 *
 *     Form B = H - (WR,WI)*I (except that the subdiagonal elements and
@@ -244,8 +247,8 @@
 *
 *           Scale supplied initial vector.
 *
-            VNORM = SNRM2( N, VR, 1 )
-            CALL SSCAL( N, ( EPS3*ROOTN ) / MAX( VNORM, NRMSML ), VR,
+            VI_NORM = SNRM2( N, VR, 1 )
+            CALL SSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), VR,
      $                  1 )
          END IF
 *
@@ -327,6 +330,7 @@
 *
          NORMIN = 'N'
          DO 110 ITS = 1, N
+            VI_NORM = SASUM( N, VR, 1 )
 *
 *           Solve U*x = scale*v for a right eigenvector
 *             or U**T*x = scale*v for a left eigenvector,
@@ -339,8 +343,8 @@
 *
 *           Test for sufficient growth in the norm of v.
 *
-            VNORM = SASUM( N, VR, 1 )
-            IF( VNORM.GE.GROWTO*SCALE )
+            VIP1_NORM = SASUM( N, VR, 1 )
+            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
      $         GO TO 120
 *
 *           Choose new orthogonal starting vector and try again.
@@ -521,6 +525,7 @@
          END IF
 *
          DO 270 ITS = 1, N
+            VI_NORM = SASUM( N, VR, 1 ) + SASUM( N, VI, 1 )
             SCALE = ONE
             VMAX = ONE
             VCRIT = BIGNUM
@@ -591,8 +596,8 @@
 *
 *           Test for sufficient growth in the norm of (VR,VI).
 *
-            VNORM = SASUM( N, VR, 1 ) + SASUM( N, VI, 1 )
-            IF( VNORM.GE.GROWTO*SCALE )
+            VIP1_NORM = SASUM( N, VR, 1 ) + SASUM( N, VI, 1 )
+            IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
      $         GO TO 280
 *
 *           Choose a new orthogonal starting vector and try again.
@@ -616,12 +621,12 @@
 *
 *        Normalize eigenvector.
 *
-         VNORM = ZERO
+         VIP1_NORM = ZERO
          DO 290 I = 1, N
-            VNORM = MAX( VNORM, ABS( VR( I ) )+ABS( VI( I ) ) )
+            VIP1_NORM = MAX( VIP1_NORM, ABS( VR( I ) )+ABS( VI( I ) ) )
   290    CONTINUE
-         CALL SSCAL( N, ONE / VNORM, VR, 1 )
-         CALL SSCAL( N, ONE / VNORM, VI, 1 )
+         CALL SSCAL( N, ONE / VIP1_NORM, VR, 1 )
+         CALL SSCAL( N, ONE / VIP1_NORM, VI, 1 )
 *
       END IF
 *

--- a/SRC/zlaein.f
+++ b/SRC/zlaein.f
@@ -173,8 +173,8 @@
 *     .. Local Scalars ..
       CHARACTER          NORMIN, TRANS
       INTEGER            I, IERR, ITS, J
-      DOUBLE PRECISION   GROWTO, NRMSML, ROOTN, RTEMP, SCALE, VI_NORM,
-     $                   VIP1_NORM
+      DOUBLE PRECISION   GROWTO, NRMSML, ROOTN, RTEMP, SCALE, V0NORM,
+     $                   V1NORM
       COMPLEX*16         CDUM, EI, EJ, TEMP, X
 *     ..
 *     .. External Functions ..
@@ -199,11 +199,10 @@
 *
       INFO = 0
 *
-*     The residual of the vector x that a solve returns is SCALE times
-*     the norm of the starting vector, over the norm of x, so GROWTO is
-*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
-*     below requires, where VI_NORM and VIP1_NORM are the norms of the
-*     vectors the current iteration started from and produced.
+*     Each starting vector gets one solve, from v0 to v1.  The residual
+*     of v1 is SCALE times the norm of v0, over the norm of v1, so
+*     GROWTO is the growth V1NORM/(SCALE*V0NORM) that the acceptance
+*     test below requires.
 *
       ROOTN = SQRT( DBLE( N ) )
       GROWTO = TENTH / ( DBLE( N )*EPS3 )
@@ -230,8 +229,8 @@
 *
 *        Scale supplied initial vector.
 *
-         VI_NORM = DZNRM2( N, V, 1 )
-         CALL ZDSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), V,
+         V0NORM = DZNRM2( N, V, 1 )
+         CALL ZDSCAL( N, ( EPS3*ROOTN ) / MAX( V0NORM, NRMSML ), V,
      $                1 )
       END IF
 *
@@ -313,7 +312,7 @@
 *
       NORMIN = 'N'
       DO 110 ITS = 1, N
-         VI_NORM = DZASUM( N, V, 1 )
+         V0NORM = DZASUM( N, V, 1 )
 *
 *        Solve U*x = scale*v for a right eigenvector
 *          or U**H *x = scale*v for a left eigenvector,
@@ -326,8 +325,8 @@
 *
 *        Test for sufficient growth in the norm of v.
 *
-         VIP1_NORM = DZASUM( N, V, 1 )
-         IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
+         V1NORM = DZASUM( N, V, 1 )
+         IF( V1NORM.GE.GROWTO*SCALE*V0NORM )
      $      GO TO 120
 *
 *        Choose new orthogonal starting vector and try again.

--- a/SRC/zlaein.f
+++ b/SRC/zlaein.f
@@ -173,7 +173,8 @@
 *     .. Local Scalars ..
       CHARACTER          NORMIN, TRANS
       INTEGER            I, IERR, ITS, J
-      DOUBLE PRECISION   GROWTO, NRMSML, ROOTN, RTEMP, SCALE, VNORM
+      DOUBLE PRECISION   GROWTO, NRMSML, ROOTN, RTEMP, SCALE, VI_NORM,
+     $                   VIP1_NORM
       COMPLEX*16         CDUM, EI, EJ, TEMP, X
 *     ..
 *     .. External Functions ..
@@ -198,11 +199,14 @@
 *
       INFO = 0
 *
-*     GROWTO is the threshold used in the acceptance test for an
-*     eigenvector.
+*     The residual of the vector x that a solve returns is SCALE times
+*     the norm of the starting vector, over the norm of x, so GROWTO is
+*     the growth VIP1_NORM/(SCALE*VI_NORM) that the acceptance test
+*     below requires, where VI_NORM and VIP1_NORM are the norms of the
+*     vectors the current iteration started from and produced.
 *
       ROOTN = SQRT( DBLE( N ) )
-      GROWTO = TENTH / ROOTN
+      GROWTO = TENTH / ( DBLE( N )*EPS3 )
       NRMSML = MAX( ONE, EPS3*ROOTN )*SMLNUM
 *
 *     Form B = H - W*I (except that the subdiagonal elements are not
@@ -226,8 +230,8 @@
 *
 *        Scale supplied initial vector.
 *
-         VNORM = DZNRM2( N, V, 1 )
-         CALL ZDSCAL( N, ( EPS3*ROOTN ) / MAX( VNORM, NRMSML ), V,
+         VI_NORM = DZNRM2( N, V, 1 )
+         CALL ZDSCAL( N, ( EPS3*ROOTN ) / MAX( VI_NORM, NRMSML ), V,
      $                1 )
       END IF
 *
@@ -309,6 +313,7 @@
 *
       NORMIN = 'N'
       DO 110 ITS = 1, N
+         VI_NORM = DZASUM( N, V, 1 )
 *
 *        Solve U*x = scale*v for a right eigenvector
 *          or U**H *x = scale*v for a left eigenvector,
@@ -321,8 +326,8 @@
 *
 *        Test for sufficient growth in the norm of v.
 *
-         VNORM = DZASUM( N, V, 1 )
-         IF( VNORM.GE.GROWTO*SCALE )
+         VIP1_NORM = DZASUM( N, V, 1 )
+         IF( VIP1_NORM.GE.GROWTO*SCALE*VI_NORM )
      $      GO TO 120
 *
 *        Choose new orthogonal starting vector and try again.


### PR DESCRIPTION
## Summary

`xLAEIN` decides when one step of inverse iteration has produced an acceptable eigenvector. The residual of that step is governed by how much the solution grew **relative to the starting vector**, but the test compared the **solution norm** against `GROWTO` on its own. That silently assumes every starting vector has the same constant norm, which is not the case.

## The criterion

One step of inverse iteration with shift `sigma` is

```
        ( A - sigma I ) v^(i+1)  =  tau^(i) v^(i)
```

The residual of the vector it produces is an identity, not a bound:

```
        || ( A - sigma I ) v^(i+1) ||        || tau^(i) v^(i) ||
        ------------------------------  =  ---------------------      (1)
              || v^(i+1) ||                    || v^(i+1) ||
```

The reciprocal of the right-hand side is the **norm growth**, and the vector is accepted once that growth is large enough that (1) delivers a residual at the level of the accuracy of the eigenvalue:

```
             || v^(i+1) ||                       1
        --------------------------  >=  C  ---------------            (2)
          || tau^(i) v^(i) ||               n eps || A ||
```

Then `|| r || <= (1/C) n eps ||A|| || v^(i+1) ||`, the standard requirement on an approximate eigenpair. The essential point is that the criterion is a statement about the **ratio**: the norm of the starting vector belongs in it.

This is Dhillon's section 3, issue IV ([PDF](https://www.cs.utexas.edu/~inderjit/public_papers/invit_fail.pdf)), which attributes the criterion to Wilkinson's *The Algebraic Eigenvalue Problem*, p. 324.

## What the old code did

```fortran
      GROWTO = TENTH / ROOTN
      ...
            VNORM = SASUM( N, VR, 1 )
            IF( VNORM.GE.GROWTO*SCALE )
     $         GO TO 120
```

Here `VNORM` is the 1-norm of the solution and `SCALE` is `xLATRS`'s scale factor, so dividing the test through by `SCALE` times the *starting* vector's 1-norm puts it in the same form as (2):

```
             ||   solution   ||                 TENTH
        ----------------------------  >=  ----------------------
         SCALE || start vector ||          ROOTN || start vector ||
```

The right-hand side is what (2) asks for only if

```
        ROOTN * || start vector ||  ==  N * EPS3       i.e.
        || start vector ||          ==  ROOTN * EPS3
```

So the starting vector's norm was not so much ignored as **assumed constant**, and assumed equal to `ROOTN*EPS3` in particular. That is close to the norm of the *restarting* vectors the routine builds after a failed attempt, so the assumption holds to within a factor of two for those. It does not hold for the vector the iteration actually starts from:

| starting vector | how it is built | its 1-norm | assumption off by |
|---|---|---|---|
| initial (`NOINIT`) | every entry `EPS3` | `N*EPS3` | **`ROOTN`** |
| restart | `EPS3`, then `EPS3/(ROOTN+1)`, one entry `- EPS3*ROOTN` | `~2*ROOTN*EPS3` | `~2` |
| supplied (`INITV='U'`) | rescaled to 2-norm `ROOTN*EPS3` | `ROOTN*EPS3 .. N*EPS3` | `1 .. ROOTN` |

The consequence follows from (1). Accepting a growth `ROOTN` times smaller than required admits a residual `ROOTN` times larger, so the bound degrades from `O( n eps ||H|| )` to `O( n**1.5 eps ||H|| )`. NEP test 11 measures exactly that quantity divided by `n` against a threshold of 20, so the old bound permits a ratio of order `10*ROOTN` and exceeds the threshold as soon as `N > 4`. The initial vector is where 28,451 of the 28,452 eigenvectors in the NEP test suite are accepted, so it is the case that usually decides the outcome, and one matrix crossed the threshold on aarch64 gfortran:

```
Matrix order=   10, type=12, seed= 686, 215, 995,3397, result  11 is   27.24
SHS:    1 out of  2016 tests failed to pass the threshold
```

Instrumenting the routine to print the residual of every accepted vector shows that case as `n=10, try 1, residual 27.9` in units of `N*EPS3*|x|`, while the very next starting vector gives `0.0209` - a residual **1300 times smaller for the same eigenvalue**. So this was never an ill-conditioned eigenvector that no starting vector could resolve. A far better one was one restart away, and the test stopped short because it wasn't strict enough.

## The fix

`xLAEIN` takes exactly one solve from each starting vector - on insufficient growth it chooses a *new* starting vector rather than iterating on the result - so `i` is always 0 here. Mapping the notation of (2) onto this routine:

| theory | xLAEIN | note |
|---|---|---|
| `A - sigma I` | `B` | the U factor, zero pivots replaced by `EPS3` |
| `tau^(0)` | `SCALE` | chosen by `xLATRS` to avoid overflow |
| `v^(0)` | `VR` on entry, the starting vector | 1-norm `V0NORM` |
| `v^(1)` | `VR` after the solve | 1-norm `V1NORM` |
| `eps` times the norm of A | `EPS3` | set by `xHSEIN` to `ULP` times the block norm |
| `n` | `N` | |
| `C` | `TENTH` | the existing constant, unchanged |

so (2) reads

```
                 V1NORM                    TENTH
        -------------------------   >=   -----------                  (3)
             SCALE * V0NORM              N * EPS3
```

`GROWTO` becomes the right-hand side of (3), and the test is then (3) verbatim:

```fortran
      GROWTO = TENTH / ( REAL( N )*EPS3 )
      ...
            V0NORM = SASUM( N, VR, 1 )
*
            CALL SLATRS( 'Upper', TRANS, 'Nonunit', NORMIN, N, B, LDB,
     $                   VR, SCALE, WORK, IERR )
*
            V1NORM = SASUM( N, VR, 1 )
            IF( V1NORM.GE.GROWTO*SCALE*V0NORM )
     $         GO TO 120
```

`GROWTO` changes value, from `0.1/SQRT(N)` to `0.1/(N*EPS3)`, because it changes meaning: it is no longer a bound on `||x||` but the growth ratio that (3) requires. Nothing else in the routine uses it.

The effective threshold each starting vector now faces, relative to before:

| starting vector | before | now |
|---|---|---|
| initial | `TENTH*SCALE/ROOTN` | `ROOTN` times stricter |
| restart | `TENTH*SCALE/ROOTN` | `~2` times stricter |
| supplied | `TENTH*SCALE/ROOTN` | `1` to `ROOTN` times stricter |

## Effect

Worst `xnep` test-11 ratio, `|HX - XW| / (|H| |X| ulp)` on aarch64 now:

| precision | before (gfortran 15.2) | after (gfortran 15.2) | after (flang 21.1.8) |
|---|---|---|---|
| S | **27.24** | 4.17 | 2.74 |
| D | 3.05 | 3.05 | 3.05 |
| C | 3.95 | 3.95 | 6.20 |
| Z | 4.52 | 4.52 | 3.41 |

Because only the accept/reject decision changes and no iterate is touched, vectors that already passed come back bit-identical - visible above in the D and Z columns.

## Notes

The `0.1/SQRT(N)` threshold is inherited verbatim from EISPACK's `invit`, which has `growto = 0.1d0 / ukroot`, `ukroot = dsqrt(uk)` under the comment `growto is the criterion for the growth`, and which implements [3]. The same missing normalisation is therefore present there. Every commit to `SRC/[scdz]laein.f` on master is cosmetic, so the criterion is untouched since that import.

`xSTEIN` avoids the problem from the other direction: `SRC/dstein.f` rescales the right-hand side before *every* solve so its norm is a known constant, which is what makes its absolute test on `NRM` sound. 

### References

1. I. S. Dhillon, *Current inverse iteration software can fail*, BIT Numerical Mathematics 38 (1998). [PDF](https://www.cs.utexas.edu/~inderjit/public_papers/invit_fail.pdf)
2. J. H. Wilkinson, *The Algebraic Eigenvalue Problem*, Oxford University Press, 1965.
3. G. Peters and J. H. Wilkinson, *The calculation of specified eigenvectors by inverse iteration*, in Wilkinson & Reinsch, Handbook for Automatic Computation II: Linear Algebra, Springer, 1971.
