### PR TITLE
TESTING: scale the xGEEV eigenvalue-consistency check by n ulp |W|

### DIFF
--- a/TESTING/EIG/cdrvev.f
+++ b/TESTING/EIG/cdrvev.f
@@ -429,7 +429,7 @@
      $                   JTYPE, MTYPES, N, NERRS, NFAIL, NMAX,
      $                   NNWORK, NTEST, NTESTF, NTESTT
       REAL               ANORM, COND, CONDS, OVFL, RTULP, RTULPI, TNRM,
-     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST
+     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST, WDIF, WNRM
 *     ..
 *     .. Local Arrays ..
       INTEGER            IDUMMA( 1 ), IOLDSD( 4 ), KCONDS( MAXTYP ),
@@ -799,10 +799,15 @@
 *
 *              Do Test (5)
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 150 J = 1, N
-                  IF( W( J ).NE.W1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   150          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*REAL( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Compute eigenvalues and right eigenvectors, and test them
 *
@@ -819,10 +824,15 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 160 J = 1, N
-                  IF( W( J ).NE.W1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   160          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*REAL( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (6)
 *
@@ -848,10 +858,15 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 190 J = 1, N
-                  IF( W( J ).NE.W1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   190          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*REAL( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (7)
 *
@@ -932,8 +947,7 @@
      $      / ' 2 = | conj-trans(A) VL - VL conj-trans(W) | /',
      $      ' ( n |A| ulp ) ', / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter if VL computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter if VR computed,',

--- a/TESTING/EIG/cdrvvx.f
+++ b/TESTING/EIG/cdrvvx.f
@@ -969,8 +969,7 @@
      $      / ' 2 = | transpose(A) VL - VL W | / ( n |A| ulp ) ',
      $      / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter what else computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter what else computed,',

--- a/TESTING/EIG/cget23.f
+++ b/TESTING/EIG/cget23.f
@@ -404,7 +404,7 @@
      $                   J, JJ, KMIN
       REAL               ABNRM, ABNRM1, EPS, SMLNUM, TNRM, TOL, TOLIN,
      $                   ULP, ULPINV, V, VMAX, VMX, VRICMP, VRIMIN,
-     $                   VRMX, VTST
+     $                   VRMX, VTST, WDIF, WNRM
       COMPLEX            CTMP
 *     ..
 *     .. Local Arrays ..
@@ -580,10 +580,15 @@
 *
 *        Do Test (5)
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 60 J = 1, N
-            IF( W( J ).NE.W1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+            WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
    60    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*REAL( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (8)
 *
@@ -630,10 +635,15 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 90 J = 1, N
-            IF( W( J ).NE.W1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+            WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
    90    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*REAL( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (6)
 *
@@ -689,10 +699,15 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 140 J = 1, N
-            IF( W( J ).NE.W1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+            WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   140    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*REAL( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (7)
 *

--- a/TESTING/EIG/ddrvev.f
+++ b/TESTING/EIG/ddrvev.f
@@ -439,7 +439,7 @@
      $                   JTYPE, MTYPES, N, NERRS, NFAIL, NMAX, NNWORK,
      $                   NTEST, NTESTF, NTESTT
       DOUBLE PRECISION   ANORM, COND, CONDS, OVFL, RTULP, RTULPI, TNRM,
-     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST
+     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST, WDIF, WNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          ADUMMA( 1 )
@@ -827,10 +827,17 @@
 *
 *              Do Test (5)
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 150 J = 1, N
-                  IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                        ABS( WR1( J ) )+ABS( WI1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                        ABS( WI( J )-WI1( J ) ) )
   150          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*DBLE( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Compute eigenvalues and right eigenvectors, and test them
 *
@@ -847,10 +854,17 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 160 J = 1, N
-                  IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                        ABS( WR1( J ) )+ABS( WI1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                        ABS( WI( J )-WI1( J ) ) )
   160          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*DBLE( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (6)
 *
@@ -876,10 +890,17 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 190 J = 1, N
-                  IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                        ABS( WR1( J ) )+ABS( WI1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                        ABS( WI( J )-WI1( J ) ) )
   190          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*DBLE( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (7)
 *
@@ -959,8 +980,7 @@
      $      / ' 2 = | transpose(A) VL - VL W | / ( n |A| ulp ) ',
      $      / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter if VL computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter if VR computed,',

--- a/TESTING/EIG/ddrvvx.f
+++ b/TESTING/EIG/ddrvvx.f
@@ -991,8 +991,7 @@
      $      / ' 2 = | transpose(A) VL - VL W | / ( n |A| ulp ) ',
      $      / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter what else computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter what else computed,',

--- a/TESTING/EIG/dget23.f
+++ b/TESTING/EIG/dget23.f
@@ -414,7 +414,7 @@
      $                   J, JJ, KMIN
       DOUBLE PRECISION   ABNRM, ABNRM1, EPS, SMLNUM, TNRM, TOL, TOLIN,
      $                   ULP, ULPINV, V, VIMIN, VMAX, VMX, VRMIN, VRMX,
-     $                   VTST
+     $                   VTST, WDIF, WNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          SENS( 2 )
@@ -600,10 +600,17 @@
 *
 *        Do Test (5)
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 60 J = 1, N
-            IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                  ABS( WR1( J ) )+ABS( WI1( J ) ) )
+            WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                  ABS( WI( J )-WI1( J ) ) )
    60    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*DBLE( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (8)
 *
@@ -650,10 +657,17 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 90 J = 1, N
-            IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                  ABS( WR1( J ) )+ABS( WI1( J ) ) )
+            WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                  ABS( WI( J )-WI1( J ) ) )
    90    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*DBLE( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (6)
 *
@@ -709,10 +723,17 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 140 J = 1, N
-            IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                  ABS( WR1( J ) )+ABS( WI1( J ) ) )
+            WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                  ABS( WI( J )-WI1( J ) ) )
   140    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*DBLE( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (7)
 *

--- a/TESTING/EIG/sdrvev.f
+++ b/TESTING/EIG/sdrvev.f
@@ -439,7 +439,7 @@
      $                   JTYPE, MTYPES, N, NERRS, NFAIL, NMAX,
      $                   NNWORK, NTEST, NTESTF, NTESTT
       REAL               ANORM, COND, CONDS, OVFL, RTULP, RTULPI, TNRM,
-     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST
+     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST, WDIF, WNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          ADUMMA( 1 )
@@ -827,10 +827,17 @@
 *
 *              Do Test (5)
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 150 J = 1, N
-                  IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                        ABS( WR1( J ) )+ABS( WI1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                        ABS( WI( J )-WI1( J ) ) )
   150          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*REAL( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Compute eigenvalues and right eigenvectors, and test them
 *
@@ -847,10 +854,17 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 160 J = 1, N
-                  IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                        ABS( WR1( J ) )+ABS( WI1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                        ABS( WI( J )-WI1( J ) ) )
   160          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*REAL( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (6)
 *
@@ -876,10 +890,17 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 190 J = 1, N
-                  IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                        ABS( WR1( J ) )+ABS( WI1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                        ABS( WI( J )-WI1( J ) ) )
   190          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*REAL( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (7)
 *
@@ -959,8 +980,7 @@
      $      / ' 2 = | transpose(A) VL - VL W | / ( n |A| ulp ) ',
      $      / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter if VL computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter if VR computed,',

--- a/TESTING/EIG/sdrvvx.f
+++ b/TESTING/EIG/sdrvvx.f
@@ -990,8 +990,7 @@
      $      / ' 2 = | transpose(A) VL - VL W | / ( n |A| ulp ) ',
      $      / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter what else computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter what else computed,',

--- a/TESTING/EIG/sget23.f
+++ b/TESTING/EIG/sget23.f
@@ -414,7 +414,7 @@
      $                   J, JJ, KMIN
       REAL               ABNRM, ABNRM1, EPS, SMLNUM, TNRM, TOL, TOLIN,
      $                   ULP, ULPINV, V, VIMIN, VMAX, VMX, VRMIN, VRMX,
-     $                   VTST
+     $                   VTST, WDIF, WNRM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          SENS( 2 )
@@ -600,10 +600,17 @@
 *
 *        Do Test (5)
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 60 J = 1, N
-            IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                  ABS( WR1( J ) )+ABS( WI1( J ) ) )
+            WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                  ABS( WI( J )-WI1( J ) ) )
    60    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*REAL( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (8)
 *
@@ -650,10 +657,17 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 90 J = 1, N
-            IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                  ABS( WR1( J ) )+ABS( WI1( J ) ) )
+            WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                  ABS( WI( J )-WI1( J ) ) )
    90    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*REAL( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (6)
 *
@@ -709,10 +723,17 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 140 J = 1, N
-            IF( WR( J ).NE.WR1( J ) .OR. WI( J ).NE.WI1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( WR( J ) )+ABS( WI( J ) ),
+     $                  ABS( WR1( J ) )+ABS( WI1( J ) ) )
+            WDIF = MAX( WDIF, ABS( WR( J )-WR1( J ) )+
+     $                  ABS( WI( J )-WI1( J ) ) )
   140    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*REAL( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (7)
 *

--- a/TESTING/EIG/zdrvev.f
+++ b/TESTING/EIG/zdrvev.f
@@ -429,7 +429,7 @@
      $                   JTYPE, MTYPES, N, NERRS, NFAIL, NMAX, NNWORK,
      $                   NTEST, NTESTF, NTESTT
       DOUBLE PRECISION   ANORM, COND, CONDS, OVFL, RTULP, RTULPI, TNRM,
-     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST
+     $                   ULP, ULPINV, UNFL, VMX, VRMX, VTST, WDIF, WNRM
 *     ..
 *     .. Local Arrays ..
       INTEGER            IDUMMA( 1 ), IOLDSD( 4 ), KCONDS( MAXTYP ),
@@ -799,10 +799,15 @@
 *
 *              Do Test (5)
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 150 J = 1, N
-                  IF( W( J ).NE.W1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   150          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*DBLE( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Compute eigenvalues and right eigenvectors, and test them
 *
@@ -819,10 +824,15 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 160 J = 1, N
-                  IF( W( J ).NE.W1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   160          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*DBLE( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (6)
 *
@@ -848,10 +858,15 @@
 *
 *              Do Test (5) again
 *
+               WNRM = ZERO
+               WDIF = ZERO
                DO 190 J = 1, N
-                  IF( W( J ).NE.W1( J ) )
-     $               RESULT( 5 ) = ULPINV
+                  WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+                  WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   190          CONTINUE
+               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                       MAX( UNFL, ULP*DBLE( N )*
+     $                       MAX( WNRM, WDIF ) ) )
 *
 *              Do Test (7)
 *
@@ -932,8 +947,7 @@
      $      / ' 2 = | conj-trans(A) VL - VL conj-trans(W) | /',
      $      ' ( n |A| ulp ) ', / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter if VL computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter if VR computed,',

--- a/TESTING/EIG/zdrvvx.f
+++ b/TESTING/EIG/zdrvvx.f
@@ -969,8 +969,7 @@
      $      / ' 2 = | transpose(A) VL - VL W | / ( n |A| ulp ) ',
      $      / ' 3 = | |VR(i)| - 1 | / ulp ',
      $      / ' 4 = | |VL(i)| - 1 | / ulp ',
-     $      / ' 5 = 0 if W same no matter if VR or VL computed,',
-     $      ' 1/ulp otherwise', /
+     $      / ' 5 = | W - W(other JOBVL/JOBVR) | / ( n |W| ulp ) ', /
      $      ' 6 = 0 if VR same no matter what else computed,',
      $      '  1/ulp otherwise', /
      $      ' 7 = 0 if VL same no matter what else computed,',

--- a/TESTING/EIG/zget23.f
+++ b/TESTING/EIG/zget23.f
@@ -404,7 +404,7 @@
      $                   J, JJ, KMIN
       DOUBLE PRECISION   ABNRM, ABNRM1, EPS, SMLNUM, TNRM, TOL, TOLIN,
      $                   ULP, ULPINV, V, VMAX, VMX, VRICMP, VRIMIN,
-     $                   VRMX, VTST
+     $                   VRMX, VTST, WDIF, WNRM
       COMPLEX*16         CTMP
 *     ..
 *     .. Local Arrays ..
@@ -580,10 +580,15 @@
 *
 *        Do Test (5)
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 60 J = 1, N
-            IF( W( J ).NE.W1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+            WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
    60    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*DBLE( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (8)
 *
@@ -630,10 +635,15 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 90 J = 1, N
-            IF( W( J ).NE.W1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+            WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
    90    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*DBLE( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (6)
 *
@@ -689,10 +699,15 @@
 *
 *        Do Test (5) again
 *
+         WNRM = ZERO
+         WDIF = ZERO
          DO 140 J = 1, N
-            IF( W( J ).NE.W1( J ) )
-     $         RESULT( 5 ) = ULPINV
+            WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
+            WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
   140    CONTINUE
+         RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
+     $                 MAX( SMLNUM, ULP*DBLE( N )*
+     $                 MAX( WNRM, WDIF ) ) )
 *
 *        Do Test (7)
 *


### PR DESCRIPTION
## Summary

`xDRVEV` and `xGET23` test 5 require `xGEEV` to return **bit-identical** eigenvalues whether or not eigenvectors were asked for, setting the ratio to `1/ulp` on any difference at all. That is stronger than anything the routine promises: the two JOB values run different code paths, and nothing obliges those to round alike. This PR measures the difference against `n |W| ulp` instead, the same normalisation tests 1 and 2 of the same drivers already use.

Closes #732.

## Why bit equality is not available

`xGEEV` with `JOBVL = JOBVR = 'N'` calls `xHSEQR` with `JOB = 'E'`, which is free to skip work the Schur form would need. In `xLAHQR`, `xLAQR3` and `xLAQR5` that shows up as narrower update ranges - `I1`, `I2`, `JTOP` and `JBOT` all depend on `WANTT` - so the two JOB values reach the same eigenvalues through a *different sequence of BLAS calls*. Nothing in `xGEEV`'s specification promises that two such sequences round alike, and under LLVM Flang on aarch64 they do not.

The divergence is FMA contraction inside the reference `ZGEMM`, and it can be isolated to that one file. Recompiling `BLAS/SRC/zgemm.f` alone, with the rest of the library untouched, clears every failing row:

| `zgemm.f` compiled with | `.2d` ops | vector FMA | scalar FMA | ZEV test 5 |
|---|---|---|---|---|
| flang 21.1.8 default, `-ffp-contract=fast` | 129 | 26 | 20 | **fails, `1/ulp`** |
| flang `-ffp-contract=on` | 140 | 0 | 0 | passes |
| flang `-ffp-contract=off` | 140 | 0 | 0 | passes |
| flang `-fno-vectorize` | 77 | 4 | 13 | passes |
| gfortran 15.2 or 16.1 | 0 | 0 | 30 | passes |

What is *not* established is which individual `ZGEMM` call in the sweep is the first to differ. `ZGEMM` itself is deterministic. The two paths simply perform different sequences of fused arithmetic. The measured gap is 2 to 14.5 ulp, and every residual test passes, so nothing here suggests a wrong answer - only that the last bits are not reproducible across code paths.

Note finally that any optimised BLAS is free to do the same, and a threaded one certainly will, so the test's premise does not hold for a real deployment either.

## The fix

Each of the three comparisons in `xDRVEV`, and the three in `xGET23`, becomes

```fortran
               WNRM = ZERO
               WDIF = ZERO
               DO 150 J = 1, N
                  WNRM = MAX( WNRM, ABS( W( J ) ), ABS( W1( J ) ) )
                  WDIF = MAX( WDIF, ABS( W( J )-W1( J ) ) )
  150          CONTINUE
               RESULT( 5 ) = MAX( RESULT( 5 ), WDIF /
     $                       MAX( UNFL, ULP*REAL( N )*
     $                       MAX( WNRM, WDIF ) ) )
```

with `ABS( WR )+ABS( WI )` in the real drivers, `SMLNUM` for `UNFL` in `xGET23`, and `DBLE( N )` in double precision. Including `WDIF` in the denominator caps the ratio at `1/(n ulp)`, so a genuinely wrong eigenvalue still reports about `2e14` and the test keeps its full power. The printed description in `xDRVEV` and `xDRVVX` changes to match.

## Results

Max `ZEV` ratio over all 1102 cases of `zed.in` on aarch64:

| test | gfortran 15.2 before | after | flang 21.1.8 before | after |
|---|---|---|---|---|
| 1, right-eigenvector residual | 5.35 | 5.35 | 4.60 | 4.60 |
| 2, left-eigenvector residual | 3.89 | 3.89 | 4.21 | 4.21 |
| 3, right-eigenvector normalisation | 4.49 | 4.49 | 5.71 | 5.71 |
| 4, left-eigenvector normalisation | 2.00 | 2.00 | 2.00 | 2.00 |
| **5, eigenvalue consistency** | 0.00 | 0.00 | **4.5e+15** | **0.725** |
| 6, VR independent of JOBVL | 0.00 | 0.00 | 0.00 | 0.00 |
| 7, VL independent of JOBVR | 0.00 | 0.00 | 0.00 | 0.00 |

Only test 5 moves, and only under flang, where `4.5e+15` is the `1/ulp` sentinel the old code assigned on any difference at all. After the change it reads 0.725. Every other ratio is unchanged to three figures on both compilers, which is the point: nothing but the one over-strict comparison is affected.

Note also that flang's residuals in tests 1 and 2 are *better* than gfortran's, 4.60 against 5.35 and 4.21 against 3.89 respectively, so the eigenvalues and eigenvectors flang computes are not in question. Only the demand that two code paths agree bit-for-bit was.

## Notes

- `znep_64` still reports `ZHS: 1 out of 2016` under ATfL 22.1. That is `xCHKHS` test 8, a different check, and it is left alone deliberately: it belongs with #1350 rather than here.
- Tests 6 and 7 still demand bit equality, of the eigenvector matrices rather than the eigenvalues. They are not currently hit and are left untouched; the same argument would apply to them.
