### PR TITLE
TESTING: Improve eigenvalue consistency tests (chkhs)

### DIFF
--- a/TESTING/EIG/cchkee.F
+++ b/TESTING/EIG/cchkee.F
@@ -1842,10 +1842,10 @@
             CALL CCHKHS( NN, NVAL, MAXTYP, DOTYPE, ISEED, THRESH, NOUT,
      $                   A( 1, 1 ), NMAX, A( 1, 2 ), A( 1, 3 ),
      $                   A( 1, 4 ), A( 1, 5 ), NMAX, A( 1, 6 ),
-     $                   A( 1, 7 ), DC( 1, 1 ), DC( 1, 2 ), A( 1, 8 ),
-     $                   A( 1, 9 ), A( 1, 10 ), A( 1, 11 ), A( 1, 12 ),
-     $                   DC( 1, 3 ), WORK, LWORK, RWORK, IWORK, LOGWRK,
-     $                   RESULT, INFO )
+     $                   A( 1, 7 ), DC( 1, 1 ), DC( 1, 4 ), DC( 1, 2 ),
+     $                   A( 1, 8 ), A( 1, 9 ), A( 1, 10 ), A( 1, 11 ),
+     $                   A( 1, 12 ), DC( 1, 3 ), WORK, LWORK, RWORK,
+     $                   IWORK, LOGWRK, RESULT, INFO )
             IF( INFO.NE.0 )
      $         WRITE( NOUT, FMT = 9980 )'CCHKHS', INFO
   270    CONTINUE

--- a/TESTING/EIG/cchkhs.f
+++ b/TESTING/EIG/cchkhs.f
@@ -21,7 +21,7 @@
 *       .. Array Arguments ..
 *       LOGICAL            DOTYPE( * ), SELECT( * )
 *       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
-*       REAL               RESULT( 16 ), RWORK( * )
+*       REAL               RESULT( 17 ), RWORK( * )
 *       COMPLEX            A( LDA, * ), EVECTL( LDU, * ),
 *      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
 *      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
@@ -95,17 +95,21 @@
 *>
 *>    (10)    | L**H T - W**H L | / ( |T| |L| ulp )
 *>
-*>    (11)    | HX - XW | / ( |H| |X| ulp )
+*>    (11)    | ( W(Schur form) - W(eigenvalues only) ) s | / ( |W| ulp )
+*>            over the eigenvalues whose reciprocal condition number s
+*>            is at least sqrt(ulp); s = 1 for a normal matrix
 *>
-*>    (12)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
+*>    (12)    | HX - XW | / ( |H| |X| ulp )
 *>
-*>    (13)    | AX - XW | / ( |A| |X| ulp )
+*>    (13)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
 *>
-*>    (14)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
+*>    (14)    | AX - XW | / ( |A| |X| ulp )
 *>
-*>    (15)    | AR - RW | / ( |A| |R| ulp )
+*>    (15)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
 *>
-*>    (16)    | LA - WL | / ( |A| |L| ulp )
+*>    (16)    | AR - RW | / ( |A| |R| ulp )
+*>
+*>    (17)    | LA - WL | / ( |A| |L| ulp )
 *>
 *>    The "sizes" are specified by an array NN(1:NSIZES); the value of
 *>    each element NN(j) specifies one size.
@@ -437,7 +441,7 @@
 *     .. Array Arguments ..
       LOGICAL            DOTYPE( * ), SELECT( * )
       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
-      REAL               RESULT( 16 ), RWORK( * )
+      REAL               RESULT( 17 ), RWORK( * )
       COMPLEX            A( LDA, * ), EVECTL( LDU, * ),
      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
@@ -463,7 +467,8 @@
      $                   JJ, JSIZE, JTYPE, K, MTYPES, N, N1, NERRS,
      $                   NMATS, NMAX, NTEST, NTESTT
       REAL               ANINV, ANORM, COND, CONDS, OVFL, RTOVFL, RTULP,
-     $                   RTULPI, RTUNFL, TEMP1, TEMP2, ULP, ULPINV, UNFL
+     $                   RTULPI, RTUNFL, SJ, TEMP1, TEMP2, ULP, ULPINV,
+     $                   UNFL, XNORM, YNORM
 *     ..
 *     .. Local Arrays ..
       INTEGER            IDUMMA( 1 ), IOLDSD( 4 ), KCONDS( MAXTYP ),
@@ -473,8 +478,9 @@
       COMPLEX            CDUMMA( 4 )
 *     ..
 *     .. External Functions ..
-      REAL               SLAMCH
-      EXTERNAL           SLAMCH
+      REAL               SCNRM2, SLAMCH
+      COMPLEX            CDOTC
+      EXTERNAL           CDOTC, SCNRM2, SLAMCH
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           CCOPY, CGEHRD, CGEMM, CGET10, CGET22, CHSEIN,
@@ -940,6 +946,38 @@
      $            N, JTYPE, IOLDSD
             END IF
 *
+*           Do Test 11: | ( W3 - W1 ) s | / ( max(|W1|,|W3|) ulp )
+*
+*           W1 comes from JOB = 'S' and W3 from JOB = 'E'.  Unlike test
+*           8, which varies only COMPZ, these two are not expected to
+*           agree exactly: the paths cover different index ranges and
+*           need not round alike.  s(j) = |y(j)**H x(j)| over
+*           ||y(j)|| ||x(j)||, the reciprocal condition number of
+*           eigenvalue j of T1, is what makes the comparison meaningful.
+*           A backward error eps in H moves that eigenvalue by
+*           eps / s(j), so the two can only be asked to agree to within
+*           |dW(j)| s(j); s(j) = 1 for a normal matrix.  Eigenvalues
+*           with s(j) < sqrt(ulp) are skipped: those are the ones the
+*           two paths have been seen to return in a different order,
+*           which the index-wise comparison could not tell apart from a
+*           real error.
+*
+            NTEST = 11
+            RESULT( 11 ) = ULPINV
+            TEMP1 = ZERO
+            TEMP2 = ZERO
+            DO 155 J = 1, N
+               XNORM = SCNRM2( N, EVECTR( 1, J ), 1 )
+               YNORM = SCNRM2( N, EVECTL( 1, J ), 1 )
+               SJ = ABS( CDOTC( N, EVECTL( 1, J ), 1,
+     $              EVECTR( 1, J ), 1 ) ) / MAX( XNORM*YNORM, UNFL )
+               TEMP1 = MAX( TEMP1, ABS( W1( J ) ), ABS( W3( J ) ) )
+               IF( SJ.GE.RTULP )
+     $            TEMP2 = MAX( TEMP2, SJ*ABS( W1( J )-W3( J ) ) )
+  155       CONTINUE
+*
+            RESULT( 11 ) = TEMP2 / MAX( UNFL, ULP*MAX( TEMP1, TEMP2 ) )
+*
 *           Compute selected left eigenvectors and confirm that
 *           they agree with previous left eigenvectors
 *
@@ -970,10 +1008,10 @@
      $         WRITE( NOUNIT, FMT = 9997 )'Left', 'CTREVC', N, JTYPE,
      $         IOLDSD
 *
-*           Call CHSEIN for Right eigenvectors of H, do test 11
+*           Call CHSEIN for Right eigenvectors of H, do test 12
 *
-            NTEST = 11
-            RESULT( 11 ) = ULPINV
+            NTEST = 12
+            RESULT( 12 ) = ULPINV
             DO 220 J = 1, N
                SELECT( J ) = .TRUE.
   220       CONTINUE
@@ -989,24 +1027,24 @@
      $            GO TO 240
             ELSE
 *
-*              Test 11:  | HX - XW | / ( |H| |X| ulp )
+*              Test 12:  | HX - XW | / ( |H| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL CGET22( 'N', 'N', 'N', N, H, LDA, EVECTX, LDU, W3,
      $                      WORK, RWORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 11 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 12 ) = DUMMA( 1 )*ANINV
                IF( DUMMA( 2 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Right', 'CHSEIN',
      $               DUMMA( 2 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call CHSEIN for Left eigenvectors of H, do test 12
+*           Call CHSEIN for Left eigenvectors of H, do test 13
 *
-            NTEST = 12
-            RESULT( 12 ) = ULPINV
+            NTEST = 13
+            RESULT( 13 ) = ULPINV
             DO 230 J = 1, N
                SELECT( J ) = .TRUE.
   230       CONTINUE
@@ -1022,24 +1060,24 @@
      $            GO TO 240
             ELSE
 *
-*              Test 12:  | YH - WY | / ( |H| |Y| ulp )
+*              Test 13:  | YH - WY | / ( |H| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL CGET22( 'C', 'N', 'C', N, H, LDA, EVECTY, LDU, W3,
      $                      WORK, RWORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 12 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 13 ) = DUMMA( 3 )*ANINV
                IF( DUMMA( 4 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Left', 'CHSEIN',
      $               DUMMA( 4 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call CUNMHR for Right eigenvectors of A, do test 13
+*           Call CUNMHR for Right eigenvectors of A, do test 14
 *
-            NTEST = 13
-            RESULT( 13 ) = ULPINV
+            NTEST = 14
+            RESULT( 14 ) = ULPINV
 *
             CALL CUNMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTX, LDU, WORK, NWORK, IINFO )
@@ -1051,20 +1089,20 @@
      $            GO TO 240
             ELSE
 *
-*              Test 13:  | AX - XW | / ( |A| |X| ulp )
+*              Test 14:  | AX - XW | / ( |A| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL CGET22( 'N', 'N', 'N', N, A, LDA, EVECTX, LDU, W3,
      $                      WORK, RWORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 13 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 14 ) = DUMMA( 1 )*ANINV
             END IF
 *
-*           Call CUNMHR for Left eigenvectors of A, do test 14
+*           Call CUNMHR for Left eigenvectors of A, do test 15
 *
-            NTEST = 14
-            RESULT( 14 ) = ULPINV
+            NTEST = 15
+            RESULT( 15 ) = ULPINV
 *
             CALL CUNMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTY, LDU, WORK, NWORK, IINFO )
@@ -1076,22 +1114,22 @@
      $            GO TO 240
             ELSE
 *
-*              Test 14:  | YA - WY | / ( |A| |Y| ulp )
+*              Test 15:  | YA - WY | / ( |A| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL CGET22( 'C', 'N', 'C', N, A, LDA, EVECTY, LDU, W3,
      $                      WORK, RWORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 14 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 15 ) = DUMMA( 3 )*ANINV
             END IF
 *
 *           Compute Left and Right Eigenvectors of A
 *
 *           Compute a Right eigenvector matrix:
 *
-            NTEST = 15
-            RESULT( 15 ) = ULPINV
+            NTEST = 16
+            RESULT( 16 ) = ULPINV
 *
             CALL CLACPY( ' ', N, N, UZ, LDU, EVECTR, LDU )
 *
@@ -1105,13 +1143,13 @@
                GO TO 250
             END IF
 *
-*           Test 15:  | AR - RW | / ( |A| |R| ulp )
+*           Test 16:  | AR - RW | / ( |A| |R| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL CGET22( 'N', 'N', 'N', N, A, LDA, EVECTR, LDU, W1,
      $                   WORK, RWORK, DUMMA( 1 ) )
-            RESULT( 15 ) = DUMMA( 1 )
+            RESULT( 16 ) = DUMMA( 1 )
             IF( DUMMA( 2 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Right', 'CTREVC3',
      $            DUMMA( 2 ), N, JTYPE, IOLDSD
@@ -1119,8 +1157,8 @@
 *
 *           Compute a Left eigenvector matrix:
 *
-            NTEST = 16
-            RESULT( 16 ) = ULPINV
+            NTEST = 17
+            RESULT( 17 ) = ULPINV
 *
             CALL CLACPY( ' ', N, N, UZ, LDU, EVECTL, LDU )
 *
@@ -1134,13 +1172,13 @@
                GO TO 250
             END IF
 *
-*           Test 16:  | LA - WL | / ( |A| |L| ulp )
+*           Test 17:  | LA - WL | / ( |A| |L| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL CGET22( 'Conj', 'N', 'Conj', N, A, LDA, EVECTL, LDU,
      $                   W1, WORK, RWORK, DUMMA( 3 ) )
-            RESULT( 16 ) = DUMMA( 3 )
+            RESULT( 17 ) = DUMMA( 3 )
             IF( DUMMA( 4 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Left', 'CTREVC3', DUMMA( 4 ),
      $            N, JTYPE, IOLDSD

--- a/TESTING/EIG/cchkhs.f
+++ b/TESTING/EIG/cchkhs.f
@@ -10,9 +10,9 @@
 *
 *       SUBROUTINE CCHKHS( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
 *                          NOUNIT, A, LDA, H, T1, T2, U, LDU, Z, UZ, W1,
-*                          W3, EVECTL, EVECTR, EVECTY, EVECTX, UU, TAU,
-*                          WORK, NWORK, RWORK, IWORK, SELECT, RESULT,
-*                          INFO )
+*                          W2, W3, EVECTL, EVECTR, EVECTY, EVECTX, UU,
+*                          TAU, WORK, NWORK, RWORK, IWORK, SELECT,
+*                          RESULT, INFO )
 *
 *       .. Scalar Arguments ..
 *       INTEGER            INFO, LDA, LDU, NOUNIT, NSIZES, NTYPES, NWORK
@@ -26,8 +26,8 @@
 *      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
 *      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
 *      $                   T2( LDA, * ), TAU( * ), U( LDU, * ),
-*      $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W3( * ),
-*      $                   WORK( * ), Z( LDU, * )
+*      $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W2( * ),
+*      $                   W3( * ), WORK( * ), Z( LDU, * )
 *       ..
 *
 *
@@ -286,6 +286,12 @@
 *>           eigenvalues of the matrix in A.
 *>           Modified.
 *>
+*>  W2     - COMPLEX array, dimension (max(NN))
+*>           The eigenvalues of A, as computed when T is computed but
+*>           not Z.  On exit, W2 contains the eigenvalues of the matrix
+*>           in A.
+*>           Modified.
+*>
 *>  W3     - COMPLEX array, dimension (max(NN))
 *>           The eigenvalues of A, as computed by a partial Schur
 *>           decomposition (Z not computed, T only computed as much
@@ -415,8 +421,8 @@
 *  =====================================================================
       SUBROUTINE CCHKHS( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
      $                   NOUNIT, A, LDA, H, T1, T2, U, LDU, Z, UZ, W1,
-     $                   W3, EVECTL, EVECTR, EVECTY, EVECTX, UU, TAU,
-     $                   WORK, NWORK, RWORK, IWORK, SELECT, RESULT,
+     $                   W2, W3, EVECTL, EVECTR, EVECTY, EVECTX, UU,
+     $                   TAU, WORK, NWORK, RWORK, IWORK, SELECT, RESULT,
      $                   INFO )
       IMPLICIT NONE
 *
@@ -436,8 +442,8 @@
      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
      $                   T2( LDA, * ), TAU( * ), U( LDU, * ),
-     $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W3( * ),
-     $                   WORK( * ), Z( LDU, * )
+     $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W2( * ),
+     $                   W3( * ), WORK( * ), Z( LDU, * )
 *     ..
 *
 *  =====================================================================
@@ -782,11 +788,11 @@
                END IF
             END IF
 *
-*           Eigenvalues (W1) and Full Schur Form (T2)
+*           Eigenvalues (W2) and Full Schur Form (T2)
 *
             CALL CLACPY( ' ', N, N, H, LDA, T2, LDA )
 *
-            CALL CHSEQR( 'S', 'N', N, ILO, IHI, T2, LDA, W1, UZ, LDU,
+            CALL CHSEQR( 'S', 'N', N, ILO, IHI, T2, LDA, W2, UZ, LDU,
      $                   WORK, NWORK, IINFO )
             IF( IINFO.NE.0 .AND. IINFO.LE.N+2 ) THEN
                WRITE( NOUNIT, FMT = 9999 )'CHSEQR(S)', IINFO, N, JTYPE,
@@ -832,13 +838,17 @@
             CALL CGET10( N, N, T2, LDA, T1, LDA, WORK, RWORK,
      $                   RESULT( 7 ) )
 *
-*           Do Test 8: | W3 - W1 | / ( max(|W1|,|W3|) ulp )
+*           Do Test 8: | W2 - W1 | / ( max(|W1|,|W2|) ulp )
+*
+*           Both lists come from JOB = 'S'; only COMPZ differs, and COMPZ
+*           decides nothing but whether Z is accumulated, so the two are
+*           expected to agree exactly.
 *
             TEMP1 = ZERO
             TEMP2 = ZERO
             DO 130 J = 1, N
-               TEMP1 = MAX( TEMP1, ABS( W1( J ) ), ABS( W3( J ) ) )
-               TEMP2 = MAX( TEMP2, ABS( W1( J )-W3( J ) ) )
+               TEMP1 = MAX( TEMP1, ABS( W1( J ) ), ABS( W2( J ) ) )
+               TEMP2 = MAX( TEMP2, ABS( W1( J )-W2( J ) ) )
   130       CONTINUE
 *
             RESULT( 8 ) = TEMP2 / MAX( UNFL, ULP*MAX( TEMP1, TEMP2 ) )

--- a/TESTING/EIG/dchkhs.f
+++ b/TESTING/EIG/dchkhs.f
@@ -23,7 +23,7 @@
 *       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
 *       DOUBLE PRECISION   A( LDA, * ), EVECTL( LDU, * ),
 *      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
-*      $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 16 ),
+*      $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 17 ),
 *      $                   T1( LDA, * ), T2( LDA, * ), TAU( * ),
 *      $                   U( LDU, * ), UU( LDU, * ), UZ( LDU, * ),
 *      $                   WI1( * ), WI2( * ), WI3( * ), WORK( * ),
@@ -86,17 +86,21 @@
 *>
 *>    (10)    | L**H T - W**H L | / ( |T| |L| ulp )
 *>
-*>    (11)    | HX - XW | / ( |H| |X| ulp )
+*>    (11)    | ( W(Schur form) - W(eigenvalues only) ) s | / ( |W| ulp )
+*>            over the eigenvalues whose reciprocal condition number s
+*>            is at least sqrt(ulp); s = 1 for a normal matrix
 *>
-*>    (12)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
+*>    (12)    | HX - XW | / ( |H| |X| ulp )
 *>
-*>    (13)    | AX - XW | / ( |A| |X| ulp )
+*>    (13)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
 *>
-*>    (14)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
+*>    (14)    | AX - XW | / ( |A| |X| ulp )
 *>
-*>    (15)    | AR - RW | / ( |A| |R| ulp )
+*>    (15)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
 *>
-*>    (16)    | LA - WL | / ( |A| |L| ulp )
+*>    (16)    | AR - RW | / ( |A| |R| ulp )
+*>
+*>    (17)    | LA - WL | / ( |A| |L| ulp )
 *>
 *>    The "sizes" are specified by an array NN(1:NSIZES); the value of
 *>    each element NN(j) specifies one size.
@@ -434,7 +438,7 @@
       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
       DOUBLE PRECISION   A( LDA, * ), EVECTL( LDU, * ),
      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
-     $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 16 ),
+     $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 17 ),
      $                   T1( LDA, * ), T2( LDA, * ), TAU( * ),
      $                   U( LDU, * ), UU( LDU, * ), UZ( LDU, * ),
      $                   WI1( * ), WI2( * ), WI3( * ), WORK( * ),
@@ -452,10 +456,11 @@
 *     .. Local Scalars ..
       LOGICAL            BADNN, MATCH
       INTEGER            I, IHI, IINFO, ILO, IMODE, IN, ITYPE, J, JCOL,
-     $                   JJ, JSIZE, JTYPE, K, MTYPES, N, N1, NERRS,
+     $                   JJ, JP, JSIZE, JTYPE, K, MTYPES, N, N1, NERRS,
      $                   NMATS, NMAX, NSELC, NSELR, NTEST, NTESTT
-      DOUBLE PRECISION   ANINV, ANORM, COND, CONDS, OVFL, RTOVFL, RTULP,
-     $                   RTULPI, RTUNFL, TEMP1, TEMP2, ULP, ULPINV, UNFL
+      DOUBLE PRECISION   ANINV, ANORM, COND, CONDS, OVFL, PRODI, PRODR,
+     $                   RTOVFL, RTULP, RTULPI, RTUNFL, SJ, TEMP1,
+     $                   TEMP2, ULP, ULPINV, UNFL, XNORM, YNORM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          ADUMMA( 1 )
@@ -465,8 +470,8 @@
       DOUBLE PRECISION   DUMMA( 6 )
 *     ..
 *     .. External Functions ..
-      DOUBLE PRECISION   DLAMCH
-      EXTERNAL           DLAMCH
+      DOUBLE PRECISION   DDOT, DLAMCH, DLAPY2, DNRM2
+      EXTERNAL           DDOT, DLAMCH, DLAPY2, DNRM2
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DCOPY, DGEHRD, DGEMM, DGET10, DGET22, DHSEIN,
@@ -963,6 +968,62 @@
      $            N, JTYPE, IOLDSD
             END IF
 *
+*           Do Test 11: | ( W3 - W1 ) s | / ( max(|W1|,|W3|) ulp )
+*
+*           W1 comes from JOB = 'S' and W3 from JOB = 'E'.  Unlike test
+*           8, which varies only COMPZ, these two are not expected to
+*           agree exactly: the paths cover different index ranges and
+*           need not round alike.  s(j) = |y(j)**H x(j)| over
+*           ||y(j)|| ||x(j)||, the reciprocal condition number of
+*           eigenvalue j of T1, is what makes the comparison meaningful.
+*           A backward error eps in H moves that eigenvalue by
+*           eps / s(j), so the two can only be asked to agree to within
+*           |dW(j)| s(j); s(j) = 1 for a normal matrix.  Eigenvalues
+*           with s(j) < sqrt(ulp) are skipped: those are the ones the
+*           two paths have been seen to return in a different order,
+*           which the index-wise comparison could not tell apart from a
+*           real error.
+*
+            NTEST = 11
+            RESULT( 11 ) = ULPINV
+            TEMP1 = ZERO
+            TEMP2 = ZERO
+            DO 155 J = 1, N
+               IF( WI1( J ).LT.ZERO ) THEN
+                  JP = J - 1
+               ELSE
+                  JP = J
+               END IF
+               IF( WI1( JP ).EQ.ZERO ) THEN
+                  XNORM = DNRM2( N, EVECTR( 1, JP ), 1 )
+                  YNORM = DNRM2( N, EVECTL( 1, JP ), 1 )
+                  SJ = ABS( DDOT( N, EVECTL( 1, JP ), 1,
+     $                 EVECTR( 1, JP ), 1 ) )
+               ELSE
+                  XNORM = DLAPY2( DNRM2( N, EVECTR( 1, JP ), 1 ),
+     $                    DNRM2( N, EVECTR( 1, JP+1 ), 1 ) )
+                  YNORM = DLAPY2( DNRM2( N, EVECTL( 1, JP ), 1 ),
+     $                    DNRM2( N, EVECTL( 1, JP+1 ), 1 ) )
+                  PRODR = DDOT( N, EVECTL( 1, JP ), 1,
+     $                    EVECTR( 1, JP ), 1 )
+                  PRODR = PRODR + DDOT( N, EVECTL( 1, JP+1 ), 1,
+     $                    EVECTR( 1, JP+1 ), 1 )
+                  PRODI = DDOT( N, EVECTL( 1, JP ), 1,
+     $                    EVECTR( 1, JP+1 ), 1 )
+                  PRODI = PRODI - DDOT( N, EVECTL( 1, JP+1 ), 1,
+     $                    EVECTR( 1, JP ), 1 )
+                  SJ = DLAPY2( PRODR, PRODI )
+               END IF
+               SJ = SJ / MAX( XNORM*YNORM, UNFL )
+               TEMP1 = MAX( TEMP1, ABS( WR1( J ) )+ABS( WI1( J ) ),
+     $                 ABS( WR3( J ) )+ABS( WI3( J ) ) )
+               IF( SJ.GE.RTULP )
+     $            TEMP2 = MAX( TEMP2, SJ*( ABS( WR1( J )-WR3( J ) )+
+     $                 ABS( WI1( J )-WI3( J ) ) ) )
+  155       CONTINUE
+*
+            RESULT( 11 ) = TEMP2 / MAX( UNFL, ULP*MAX( TEMP1, TEMP2 ) )
+*
 *           Compute selected left eigenvectors and confirm that
 *           they agree with previous left eigenvectors
 *
@@ -1002,10 +1063,10 @@
      $         WRITE( NOUNIT, FMT = 9997 )'Left', 'DTREVC', N, JTYPE,
      $         IOLDSD
 *
-*           Call DHSEIN for Right eigenvectors of H, do test 11
+*           Call DHSEIN for Right eigenvectors of H, do test 12
 *
-            NTEST = 11
-            RESULT( 11 ) = ULPINV
+            NTEST = 12
+            RESULT( 12 ) = ULPINV
             DO 230 J = 1, N
                SELECT( J ) = .TRUE.
   230       CONTINUE
@@ -1021,24 +1082,24 @@
      $            GO TO 250
             ELSE
 *
-*              Test 11:  | HX - XW | / ( |H| |X| ulp )
+*              Test 12:  | HX - XW | / ( |H| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL DGET22( 'N', 'N', 'N', N, H, LDA, EVECTX, LDU, WR3,
      $                      WI3, WORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 11 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 12 ) = DUMMA( 1 )*ANINV
                IF( DUMMA( 2 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Right', 'DHSEIN',
      $               DUMMA( 2 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call DHSEIN for Left eigenvectors of H, do test 12
+*           Call DHSEIN for Left eigenvectors of H, do test 13
 *
-            NTEST = 12
-            RESULT( 12 ) = ULPINV
+            NTEST = 13
+            RESULT( 13 ) = ULPINV
             DO 240 J = 1, N
                SELECT( J ) = .TRUE.
   240       CONTINUE
@@ -1054,24 +1115,24 @@
      $            GO TO 250
             ELSE
 *
-*              Test 12:  | YH - WY | / ( |H| |Y| ulp )
+*              Test 13:  | YH - WY | / ( |H| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL DGET22( 'C', 'N', 'C', N, H, LDA, EVECTY, LDU, WR3,
      $                      WI3, WORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 12 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 13 ) = DUMMA( 3 )*ANINV
                IF( DUMMA( 4 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Left', 'DHSEIN',
      $               DUMMA( 4 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call DORMHR for Right eigenvectors of A, do test 13
+*           Call DORMHR for Right eigenvectors of A, do test 14
 *
-            NTEST = 13
-            RESULT( 13 ) = ULPINV
+            NTEST = 14
+            RESULT( 14 ) = ULPINV
 *
             CALL DORMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTX, LDU, WORK, NWORK, IINFO )
@@ -1083,20 +1144,20 @@
      $            GO TO 250
             ELSE
 *
-*              Test 13:  | AX - XW | / ( |A| |X| ulp )
+*              Test 14:  | AX - XW | / ( |A| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL DGET22( 'N', 'N', 'N', N, A, LDA, EVECTX, LDU, WR3,
      $                      WI3, WORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 13 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 14 ) = DUMMA( 1 )*ANINV
             END IF
 *
-*           Call DORMHR for Left eigenvectors of A, do test 14
+*           Call DORMHR for Left eigenvectors of A, do test 15
 *
-            NTEST = 14
-            RESULT( 14 ) = ULPINV
+            NTEST = 15
+            RESULT( 15 ) = ULPINV
 *
             CALL DORMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTY, LDU, WORK, NWORK, IINFO )
@@ -1108,22 +1169,22 @@
      $            GO TO 250
             ELSE
 *
-*              Test 14:  | YA - WY | / ( |A| |Y| ulp )
+*              Test 15:  | YA - WY | / ( |A| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL DGET22( 'C', 'N', 'C', N, A, LDA, EVECTY, LDU, WR3,
      $                      WI3, WORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 14 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 15 ) = DUMMA( 3 )*ANINV
             END IF
 *
 *           Compute Left and Right Eigenvectors of A
 *
 *           Compute a Right eigenvector matrix:
 *
-            NTEST = 15
-            RESULT( 15 ) = ULPINV
+            NTEST = 16
+            RESULT( 16 ) = ULPINV
 *
             CALL DLACPY( ' ', N, N, UZ, LDU, EVECTR, LDU )
 *
@@ -1136,13 +1197,13 @@
                GO TO 250
             END IF
 *
-*           Test 15:  | AR - RW | / ( |A| |R| ulp )
+*           Test 16:  | AR - RW | / ( |A| |R| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL DGET22( 'N', 'N', 'N', N, A, LDA, EVECTR, LDU, WR1,
      $                   WI1, WORK, DUMMA( 1 ) )
-            RESULT( 15 ) = DUMMA( 1 )
+            RESULT( 16 ) = DUMMA( 1 )
             IF( DUMMA( 2 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Right', 'DTREVC3',
      $            DUMMA( 2 ), N, JTYPE, IOLDSD
@@ -1150,8 +1211,8 @@
 *
 *           Compute a Left eigenvector matrix:
 *
-            NTEST = 16
-            RESULT( 16 ) = ULPINV
+            NTEST = 17
+            RESULT( 17 ) = ULPINV
 *
             CALL DLACPY( ' ', N, N, UZ, LDU, EVECTL, LDU )
 *
@@ -1164,13 +1225,13 @@
                GO TO 250
             END IF
 *
-*           Test 16:  | LA - WL | / ( |A| |L| ulp )
+*           Test 17:  | LA - WL | / ( |A| |L| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL DGET22( 'Trans', 'N', 'Conj', N, A, LDA, EVECTL, LDU,
      $                   WR1, WI1, WORK, DUMMA( 3 ) )
-            RESULT( 16 ) = DUMMA( 3 )
+            RESULT( 17 ) = DUMMA( 3 )
             IF( DUMMA( 4 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Left', 'DTREVC3', DUMMA( 4 ),
      $            N, JTYPE, IOLDSD

--- a/TESTING/EIG/schkhs.f
+++ b/TESTING/EIG/schkhs.f
@@ -23,7 +23,7 @@
 *       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
 *       REAL               A( LDA, * ), EVECTL( LDU, * ),
 *      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
-*      $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 16 ),
+*      $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 17 ),
 *      $                   T1( LDA, * ), T2( LDA, * ), TAU( * ),
 *      $                   U( LDU, * ), UU( LDU, * ), UZ( LDU, * ),
 *      $                   WI1( * ), WI2( * ), WI3( * ), WORK( * ),
@@ -85,17 +85,21 @@
 *>
 *>    (10)    | L**H T - W**H L | / ( |T| |L| ulp )
 *>
-*>    (11)    | HX - XW | / ( |H| |X| ulp )
+*>    (11)    | ( W(Schur form) - W(eigenvalues only) ) s | / ( |W| ulp )
+*>            over the eigenvalues whose reciprocal condition number s
+*>            is at least sqrt(ulp); s = 1 for a normal matrix
 *>
-*>    (12)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
+*>    (12)    | HX - XW | / ( |H| |X| ulp )
 *>
-*>    (13)    | AX - XW | / ( |A| |X| ulp )
+*>    (13)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
 *>
-*>    (14)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
+*>    (14)    | AX - XW | / ( |A| |X| ulp )
 *>
-*>    (15)    | AR - RW | / ( |A| |R| ulp )
+*>    (15)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
 *>
-*>    (16)    | LA - WL | / ( |A| |L| ulp )
+*>    (16)    | AR - RW | / ( |A| |R| ulp )
+*>
+*>    (17)    | LA - WL | / ( |A| |L| ulp )
 *>
 *>    The "sizes" are specified by an array NN(1:NSIZES); the value of
 *>    each element NN(j) specifies one size.
@@ -433,7 +437,7 @@
       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
       REAL               A( LDA, * ), EVECTL( LDU, * ),
      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
-     $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 16 ),
+     $                   EVECTY( LDU, * ), H( LDA, * ), RESULT( 17 ),
      $                   T1( LDA, * ), T2( LDA, * ), TAU( * ),
      $                   U( LDU, * ), UU( LDU, * ), UZ( LDU, * ),
      $                   WI1( * ), WI2( * ), WI3( * ), WORK( * ),
@@ -451,10 +455,11 @@
 *     .. Local Scalars ..
       LOGICAL            BADNN, MATCH
       INTEGER            I, IHI, IINFO, ILO, IMODE, IN, ITYPE, J, JCOL,
-     $                   JJ, JSIZE, JTYPE, K, MTYPES, N, N1, NERRS,
+     $                   JJ, JP, JSIZE, JTYPE, K, MTYPES, N, N1, NERRS,
      $                   NMATS, NMAX, NSELC, NSELR, NTEST, NTESTT
-      REAL               ANINV, ANORM, COND, CONDS, OVFL, RTOVFL, RTULP,
-     $                   RTULPI, RTUNFL, TEMP1, TEMP2, ULP, ULPINV, UNFL
+      REAL               ANINV, ANORM, COND, CONDS, OVFL, PRODI, PRODR,
+     $                   RTOVFL, RTULP, RTULPI, RTUNFL, SJ, TEMP1,
+     $                   TEMP2, ULP, ULPINV, UNFL, XNORM, YNORM
 *     ..
 *     .. Local Arrays ..
       CHARACTER          ADUMMA( 1 )
@@ -464,8 +469,8 @@
       REAL               DUMMA( 6 )
 *     ..
 *     .. External Functions ..
-      REAL               SLAMCH
-      EXTERNAL           SLAMCH
+      REAL               SDOT, SLAMCH, SLAPY2, SNRM2
+      EXTERNAL           SDOT, SLAMCH, SLAPY2, SNRM2
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           SCOPY, SGEHRD, SGEMM, SGET10, SGET22, SHSEIN,
@@ -962,6 +967,62 @@
      $            N, JTYPE, IOLDSD
             END IF
 *
+*           Do Test 11: | ( W3 - W1 ) s | / ( max(|W1|,|W3|) ulp )
+*
+*           W1 comes from JOB = 'S' and W3 from JOB = 'E'.  Unlike test
+*           8, which varies only COMPZ, these two are not expected to
+*           agree exactly: the paths cover different index ranges and
+*           need not round alike.  s(j) = |y(j)**H x(j)| over
+*           ||y(j)|| ||x(j)||, the reciprocal condition number of
+*           eigenvalue j of T1, is what makes the comparison meaningful.
+*           A backward error eps in H moves that eigenvalue by
+*           eps / s(j), so the two can only be asked to agree to within
+*           |dW(j)| s(j); s(j) = 1 for a normal matrix.  Eigenvalues
+*           with s(j) < sqrt(ulp) are skipped: those are the ones the
+*           two paths have been seen to return in a different order,
+*           which the index-wise comparison could not tell apart from a
+*           real error.
+*
+            NTEST = 11
+            RESULT( 11 ) = ULPINV
+            TEMP1 = ZERO
+            TEMP2 = ZERO
+            DO 155 J = 1, N
+               IF( WI1( J ).LT.ZERO ) THEN
+                  JP = J - 1
+               ELSE
+                  JP = J
+               END IF
+               IF( WI1( JP ).EQ.ZERO ) THEN
+                  XNORM = SNRM2( N, EVECTR( 1, JP ), 1 )
+                  YNORM = SNRM2( N, EVECTL( 1, JP ), 1 )
+                  SJ = ABS( SDOT( N, EVECTL( 1, JP ), 1,
+     $                 EVECTR( 1, JP ), 1 ) )
+               ELSE
+                  XNORM = SLAPY2( SNRM2( N, EVECTR( 1, JP ), 1 ),
+     $                    SNRM2( N, EVECTR( 1, JP+1 ), 1 ) )
+                  YNORM = SLAPY2( SNRM2( N, EVECTL( 1, JP ), 1 ),
+     $                    SNRM2( N, EVECTL( 1, JP+1 ), 1 ) )
+                  PRODR = SDOT( N, EVECTL( 1, JP ), 1,
+     $                    EVECTR( 1, JP ), 1 )
+                  PRODR = PRODR + SDOT( N, EVECTL( 1, JP+1 ), 1,
+     $                    EVECTR( 1, JP+1 ), 1 )
+                  PRODI = SDOT( N, EVECTL( 1, JP ), 1,
+     $                    EVECTR( 1, JP+1 ), 1 )
+                  PRODI = PRODI - SDOT( N, EVECTL( 1, JP+1 ), 1,
+     $                    EVECTR( 1, JP ), 1 )
+                  SJ = SLAPY2( PRODR, PRODI )
+               END IF
+               SJ = SJ / MAX( XNORM*YNORM, UNFL )
+               TEMP1 = MAX( TEMP1, ABS( WR1( J ) )+ABS( WI1( J ) ),
+     $                 ABS( WR3( J ) )+ABS( WI3( J ) ) )
+               IF( SJ.GE.RTULP )
+     $            TEMP2 = MAX( TEMP2, SJ*( ABS( WR1( J )-WR3( J ) )+
+     $                 ABS( WI1( J )-WI3( J ) ) ) )
+  155       CONTINUE
+*
+            RESULT( 11 ) = TEMP2 / MAX( UNFL, ULP*MAX( TEMP1, TEMP2 ) )
+*
 *           Compute selected left eigenvectors and confirm that
 *           they agree with previous left eigenvectors
 *
@@ -1001,10 +1062,10 @@
      $         WRITE( NOUNIT, FMT = 9997 )'Left', 'STREVC', N, JTYPE,
      $         IOLDSD
 *
-*           Call SHSEIN for Right eigenvectors of H, do test 11
+*           Call SHSEIN for Right eigenvectors of H, do test 12
 *
-            NTEST = 11
-            RESULT( 11 ) = ULPINV
+            NTEST = 12
+            RESULT( 12 ) = ULPINV
             DO 230 J = 1, N
                SELECT( J ) = .TRUE.
   230       CONTINUE
@@ -1020,24 +1081,24 @@
      $            GO TO 250
             ELSE
 *
-*              Test 11:  | HX - XW | / ( |H| |X| ulp )
+*              Test 12:  | HX - XW | / ( |H| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL SGET22( 'N', 'N', 'N', N, H, LDA, EVECTX, LDU, WR3,
      $                      WI3, WORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 11 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 12 ) = DUMMA( 1 )*ANINV
                IF( DUMMA( 2 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Right', 'SHSEIN',
      $               DUMMA( 2 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call SHSEIN for Left eigenvectors of H, do test 12
+*           Call SHSEIN for Left eigenvectors of H, do test 13
 *
-            NTEST = 12
-            RESULT( 12 ) = ULPINV
+            NTEST = 13
+            RESULT( 13 ) = ULPINV
             DO 240 J = 1, N
                SELECT( J ) = .TRUE.
   240       CONTINUE
@@ -1053,24 +1114,24 @@
      $            GO TO 250
             ELSE
 *
-*              Test 12:  | YH - WY | / ( |H| |Y| ulp )
+*              Test 13:  | YH - WY | / ( |H| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL SGET22( 'C', 'N', 'C', N, H, LDA, EVECTY, LDU, WR3,
      $                      WI3, WORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 12 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 13 ) = DUMMA( 3 )*ANINV
                IF( DUMMA( 4 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Left', 'SHSEIN',
      $               DUMMA( 4 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call SORMHR for Right eigenvectors of A, do test 13
+*           Call SORMHR for Right eigenvectors of A, do test 14
 *
-            NTEST = 13
-            RESULT( 13 ) = ULPINV
+            NTEST = 14
+            RESULT( 14 ) = ULPINV
 *
             CALL SORMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTX, LDU, WORK, NWORK, IINFO )
@@ -1082,20 +1143,20 @@
      $            GO TO 250
             ELSE
 *
-*              Test 13:  | AX - XW | / ( |A| |X| ulp )
+*              Test 14:  | AX - XW | / ( |A| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL SGET22( 'N', 'N', 'N', N, A, LDA, EVECTX, LDU, WR3,
      $                      WI3, WORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 13 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 14 ) = DUMMA( 1 )*ANINV
             END IF
 *
-*           Call SORMHR for Left eigenvectors of A, do test 14
+*           Call SORMHR for Left eigenvectors of A, do test 15
 *
-            NTEST = 14
-            RESULT( 14 ) = ULPINV
+            NTEST = 15
+            RESULT( 15 ) = ULPINV
 *
             CALL SORMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTY, LDU, WORK, NWORK, IINFO )
@@ -1107,22 +1168,22 @@
      $            GO TO 250
             ELSE
 *
-*              Test 14:  | YA - WY | / ( |A| |Y| ulp )
+*              Test 15:  | YA - WY | / ( |A| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL SGET22( 'C', 'N', 'C', N, A, LDA, EVECTY, LDU, WR3,
      $                      WI3, WORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 14 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 15 ) = DUMMA( 3 )*ANINV
             END IF
 *
 *           Compute Left and Right Eigenvectors of A
 *
 *           Compute a Right eigenvector matrix:
 *
-            NTEST = 15
-            RESULT( 15 ) = ULPINV
+            NTEST = 16
+            RESULT( 16 ) = ULPINV
 *
             CALL SLACPY( ' ', N, N, UZ, LDU, EVECTR, LDU )
 *
@@ -1135,13 +1196,13 @@
                GO TO 250
             END IF
 *
-*           Test 15:  | AR - RW | / ( |A| |R| ulp )
+*           Test 16:  | AR - RW | / ( |A| |R| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL SGET22( 'N', 'N', 'N', N, A, LDA, EVECTR, LDU, WR1,
      $                   WI1, WORK, DUMMA( 1 ) )
-            RESULT( 15 ) = DUMMA( 1 )
+            RESULT( 16 ) = DUMMA( 1 )
             IF( DUMMA( 2 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Right', 'STREVC3',
      $            DUMMA( 2 ), N, JTYPE, IOLDSD
@@ -1149,8 +1210,8 @@
 *
 *           Compute a Left eigenvector matrix:
 *
-            NTEST = 16
-            RESULT( 16 ) = ULPINV
+            NTEST = 17
+            RESULT( 17 ) = ULPINV
 *
             CALL SLACPY( ' ', N, N, UZ, LDU, EVECTL, LDU )
 *
@@ -1163,13 +1224,13 @@
                GO TO 250
             END IF
 *
-*           Test 16:  | LA - WL | / ( |A| |L| ulp )
+*           Test 17:  | LA - WL | / ( |A| |L| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL SGET22( 'Trans', 'N', 'Conj', N, A, LDA, EVECTL, LDU,
      $                   WR1, WI1, WORK, DUMMA( 3 ) )
-            RESULT( 16 ) = DUMMA( 3 )
+            RESULT( 17 ) = DUMMA( 3 )
             IF( DUMMA( 4 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Left', 'STREVC3', DUMMA( 4 ),
      $            N, JTYPE, IOLDSD

--- a/TESTING/EIG/zchkee.F
+++ b/TESTING/EIG/zchkee.F
@@ -1842,10 +1842,10 @@
             CALL ZCHKHS( NN, NVAL, MAXTYP, DOTYPE, ISEED, THRESH, NOUT,
      $                   A( 1, 1 ), NMAX, A( 1, 2 ), A( 1, 3 ),
      $                   A( 1, 4 ), A( 1, 5 ), NMAX, A( 1, 6 ),
-     $                   A( 1, 7 ), DC( 1, 1 ), DC( 1, 2 ), A( 1, 8 ),
-     $                   A( 1, 9 ), A( 1, 10 ), A( 1, 11 ), A( 1, 12 ),
-     $                   DC( 1, 3 ), WORK, LWORK, RWORK, IWORK, LOGWRK,
-     $                   RESULT, INFO )
+     $                   A( 1, 7 ), DC( 1, 1 ), DC( 1, 4 ), DC( 1, 2 ),
+     $                   A( 1, 8 ), A( 1, 9 ), A( 1, 10 ), A( 1, 11 ),
+     $                   A( 1, 12 ), DC( 1, 3 ), WORK, LWORK, RWORK,
+     $                   IWORK, LOGWRK, RESULT, INFO )
             IF( INFO.NE.0 )
      $         WRITE( NOUT, FMT = 9980 )'ZCHKHS', INFO
   270    CONTINUE

--- a/TESTING/EIG/zchkhs.f
+++ b/TESTING/EIG/zchkhs.f
@@ -10,9 +10,9 @@
 *
 *       SUBROUTINE ZCHKHS( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
 *                          NOUNIT, A, LDA, H, T1, T2, U, LDU, Z, UZ, W1,
-*                          W3, EVECTL, EVECTR, EVECTY, EVECTX, UU, TAU,
-*                          WORK, NWORK, RWORK, IWORK, SELECT, RESULT,
-*                          INFO )
+*                          W2, W3, EVECTL, EVECTR, EVECTY, EVECTX, UU,
+*                          TAU, WORK, NWORK, RWORK, IWORK, SELECT,
+*                          RESULT, INFO )
 *
 *       .. Scalar Arguments ..
 *       INTEGER            INFO, LDA, LDU, NOUNIT, NSIZES, NTYPES, NWORK
@@ -26,8 +26,8 @@
 *      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
 *      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
 *      $                   T2( LDA, * ), TAU( * ), U( LDU, * ),
-*      $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W3( * ),
-*      $                   WORK( * ), Z( LDU, * )
+*      $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W2( * ),
+*      $                   W3( * ), WORK( * ), Z( LDU, * )
 *       ..
 *
 *
@@ -286,6 +286,12 @@
 *>           eigenvalues of the matrix in A.
 *>           Modified.
 *>
+*>  W2     - COMPLEX*16 array, dimension (max(NN))
+*>           The eigenvalues of A, as computed when T is computed but
+*>           not Z.  On exit, W2 contains the eigenvalues of the matrix
+*>           in A.
+*>           Modified.
+*>
 *>  W3     - COMPLEX*16 array, dimension (max(NN))
 *>           The eigenvalues of A, as computed by a partial Schur
 *>           decomposition (Z not computed, T only computed as much
@@ -415,8 +421,8 @@
 *  =====================================================================
       SUBROUTINE ZCHKHS( NSIZES, NN, NTYPES, DOTYPE, ISEED, THRESH,
      $                   NOUNIT, A, LDA, H, T1, T2, U, LDU, Z, UZ, W1,
-     $                   W3, EVECTL, EVECTR, EVECTY, EVECTX, UU, TAU,
-     $                   WORK, NWORK, RWORK, IWORK, SELECT, RESULT,
+     $                   W2, W3, EVECTL, EVECTR, EVECTY, EVECTX, UU,
+     $                   TAU, WORK, NWORK, RWORK, IWORK, SELECT, RESULT,
      $                   INFO )
       IMPLICIT NONE
 *
@@ -436,8 +442,8 @@
      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
      $                   T2( LDA, * ), TAU( * ), U( LDU, * ),
-     $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W3( * ),
-     $                   WORK( * ), Z( LDU, * )
+     $                   UU( LDU, * ), UZ( LDU, * ), W1( * ), W2( * ),
+     $                   W3( * ), WORK( * ), Z( LDU, * )
 *     ..
 *
 *  =====================================================================
@@ -782,11 +788,11 @@
                END IF
             END IF
 *
-*           Eigenvalues (W1) and Full Schur Form (T2)
+*           Eigenvalues (W2) and Full Schur Form (T2)
 *
             CALL ZLACPY( ' ', N, N, H, LDA, T2, LDA )
 *
-            CALL ZHSEQR( 'S', 'N', N, ILO, IHI, T2, LDA, W1, UZ, LDU,
+            CALL ZHSEQR( 'S', 'N', N, ILO, IHI, T2, LDA, W2, UZ, LDU,
      $                   WORK, NWORK, IINFO )
             IF( IINFO.NE.0 .AND. IINFO.LE.N+2 ) THEN
                WRITE( NOUNIT, FMT = 9999 )'ZHSEQR(S)', IINFO, N, JTYPE,
@@ -832,13 +838,17 @@
             CALL ZGET10( N, N, T2, LDA, T1, LDA, WORK, RWORK,
      $                   RESULT( 7 ) )
 *
-*           Do Test 8: | W3 - W1 | / ( max(|W1|,|W3|) ulp )
+*           Do Test 8: | W2 - W1 | / ( max(|W1|,|W2|) ulp )
+*
+*           Both lists come from JOB = 'S'; only COMPZ differs, and COMPZ
+*           decides nothing but whether Z is accumulated, so the two are
+*           expected to agree exactly.
 *
             TEMP1 = ZERO
             TEMP2 = ZERO
             DO 130 J = 1, N
-               TEMP1 = MAX( TEMP1, ABS( W1( J ) ), ABS( W3( J ) ) )
-               TEMP2 = MAX( TEMP2, ABS( W1( J )-W3( J ) ) )
+               TEMP1 = MAX( TEMP1, ABS( W1( J ) ), ABS( W2( J ) ) )
+               TEMP2 = MAX( TEMP2, ABS( W1( J )-W2( J ) ) )
   130       CONTINUE
 *
             RESULT( 8 ) = TEMP2 / MAX( UNFL, ULP*MAX( TEMP1, TEMP2 ) )

--- a/TESTING/EIG/zchkhs.f
+++ b/TESTING/EIG/zchkhs.f
@@ -21,7 +21,7 @@
 *       .. Array Arguments ..
 *       LOGICAL            DOTYPE( * ), SELECT( * )
 *       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
-*       DOUBLE PRECISION   RESULT( 16 ), RWORK( * )
+*       DOUBLE PRECISION   RESULT( 17 ), RWORK( * )
 *       COMPLEX*16         A( LDA, * ), EVECTL( LDU, * ),
 *      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
 *      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
@@ -95,17 +95,21 @@
 *>
 *>    (10)    | L**H T - W**H L | / ( |T| |L| ulp )
 *>
-*>    (11)    | HX - XW | / ( |H| |X| ulp )
+*>    (11)    | ( W(Schur form) - W(eigenvalues only) ) s | / ( |W| ulp )
+*>            over the eigenvalues whose reciprocal condition number s
+*>            is at least sqrt(ulp); s = 1 for a normal matrix
 *>
-*>    (12)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
+*>    (12)    | HX - XW | / ( |H| |X| ulp )
 *>
-*>    (13)    | AX - XW | / ( |A| |X| ulp )
+*>    (13)    | Y**H H - W**H Y | / ( |H| |Y| ulp )
 *>
-*>    (14)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
+*>    (14)    | AX - XW | / ( |A| |X| ulp )
 *>
-*>    (15)    | AR - RW | / ( |A| |R| ulp )
+*>    (15)    | Y**H A - W**H Y | / ( |A| |Y| ulp )
 *>
-*>    (16)    | LA - WL | / ( |A| |L| ulp )
+*>    (16)    | AR - RW | / ( |A| |R| ulp )
+*>
+*>    (17)    | LA - WL | / ( |A| |L| ulp )
 *>
 *>    The "sizes" are specified by an array NN(1:NSIZES); the value of
 *>    each element NN(j) specifies one size.
@@ -437,7 +441,7 @@
 *     .. Array Arguments ..
       LOGICAL            DOTYPE( * ), SELECT( * )
       INTEGER            ISEED( 4 ), IWORK( * ), NN( * )
-      DOUBLE PRECISION   RESULT( 16 ), RWORK( * )
+      DOUBLE PRECISION   RESULT( 17 ), RWORK( * )
       COMPLEX*16         A( LDA, * ), EVECTL( LDU, * ),
      $                   EVECTR( LDU, * ), EVECTX( LDU, * ),
      $                   EVECTY( LDU, * ), H( LDA, * ), T1( LDA, * ),
@@ -463,7 +467,8 @@
      $                   JJ, JSIZE, JTYPE, K, MTYPES, N, N1, NERRS,
      $                   NMATS, NMAX, NTEST, NTESTT
       DOUBLE PRECISION   ANINV, ANORM, COND, CONDS, OVFL, RTOVFL, RTULP,
-     $                   RTULPI, RTUNFL, TEMP1, TEMP2, ULP, ULPINV, UNFL
+     $                   RTULPI, RTUNFL, SJ, TEMP1, TEMP2, ULP, ULPINV,
+     $                   UNFL, XNORM, YNORM
 *     ..
 *     .. Local Arrays ..
       INTEGER            IDUMMA( 1 ), IOLDSD( 4 ), KCONDS( MAXTYP ),
@@ -473,8 +478,9 @@
       COMPLEX*16         CDUMMA( 4 )
 *     ..
 *     .. External Functions ..
-      DOUBLE PRECISION   DLAMCH
-      EXTERNAL           DLAMCH
+      DOUBLE PRECISION   DLAMCH, DZNRM2
+      COMPLEX*16         ZDOTC
+      EXTERNAL           DLAMCH, DZNRM2, ZDOTC
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DLAFTS, DLASUM, XERBLA, ZCOPY, ZGEHRD, ZGEMM,
@@ -940,6 +946,38 @@
      $            N, JTYPE, IOLDSD
             END IF
 *
+*           Do Test 11: | ( W3 - W1 ) s | / ( max(|W1|,|W3|) ulp )
+*
+*           W1 comes from JOB = 'S' and W3 from JOB = 'E'.  Unlike test
+*           8, which varies only COMPZ, these two are not expected to
+*           agree exactly: the paths cover different index ranges and
+*           need not round alike.  s(j) = |y(j)**H x(j)| over
+*           ||y(j)|| ||x(j)||, the reciprocal condition number of
+*           eigenvalue j of T1, is what makes the comparison meaningful.
+*           A backward error eps in H moves that eigenvalue by
+*           eps / s(j), so the two can only be asked to agree to within
+*           |dW(j)| s(j); s(j) = 1 for a normal matrix.  Eigenvalues
+*           with s(j) < sqrt(ulp) are skipped: those are the ones the
+*           two paths have been seen to return in a different order,
+*           which the index-wise comparison could not tell apart from a
+*           real error.
+*
+            NTEST = 11
+            RESULT( 11 ) = ULPINV
+            TEMP1 = ZERO
+            TEMP2 = ZERO
+            DO 155 J = 1, N
+               XNORM = DZNRM2( N, EVECTR( 1, J ), 1 )
+               YNORM = DZNRM2( N, EVECTL( 1, J ), 1 )
+               SJ = ABS( ZDOTC( N, EVECTL( 1, J ), 1,
+     $              EVECTR( 1, J ), 1 ) ) / MAX( XNORM*YNORM, UNFL )
+               TEMP1 = MAX( TEMP1, ABS( W1( J ) ), ABS( W3( J ) ) )
+               IF( SJ.GE.RTULP )
+     $            TEMP2 = MAX( TEMP2, SJ*ABS( W1( J )-W3( J ) ) )
+  155       CONTINUE
+*
+            RESULT( 11 ) = TEMP2 / MAX( UNFL, ULP*MAX( TEMP1, TEMP2 ) )
+*
 *           Compute selected left eigenvectors and confirm that
 *           they agree with previous left eigenvectors
 *
@@ -970,10 +1008,10 @@
      $         WRITE( NOUNIT, FMT = 9997 )'Left', 'ZTREVC', N, JTYPE,
      $         IOLDSD
 *
-*           Call ZHSEIN for Right eigenvectors of H, do test 11
+*           Call ZHSEIN for Right eigenvectors of H, do test 12
 *
-            NTEST = 11
-            RESULT( 11 ) = ULPINV
+            NTEST = 12
+            RESULT( 12 ) = ULPINV
             DO 220 J = 1, N
                SELECT( J ) = .TRUE.
   220       CONTINUE
@@ -989,24 +1027,24 @@
      $            GO TO 240
             ELSE
 *
-*              Test 11:  | HX - XW | / ( |H| |X| ulp )
+*              Test 12:  | HX - XW | / ( |H| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL ZGET22( 'N', 'N', 'N', N, H, LDA, EVECTX, LDU, W3,
      $                      WORK, RWORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 11 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 12 ) = DUMMA( 1 )*ANINV
                IF( DUMMA( 2 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Right', 'ZHSEIN',
      $               DUMMA( 2 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call ZHSEIN for Left eigenvectors of H, do test 12
+*           Call ZHSEIN for Left eigenvectors of H, do test 13
 *
-            NTEST = 12
-            RESULT( 12 ) = ULPINV
+            NTEST = 13
+            RESULT( 13 ) = ULPINV
             DO 230 J = 1, N
                SELECT( J ) = .TRUE.
   230       CONTINUE
@@ -1022,24 +1060,24 @@
      $            GO TO 240
             ELSE
 *
-*              Test 12:  | YH - WY | / ( |H| |Y| ulp )
+*              Test 13:  | YH - WY | / ( |H| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL ZGET22( 'C', 'N', 'C', N, H, LDA, EVECTY, LDU, W3,
      $                      WORK, RWORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 12 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 13 ) = DUMMA( 3 )*ANINV
                IF( DUMMA( 4 ).GT.THRESH ) THEN
                   WRITE( NOUNIT, FMT = 9998 )'Left', 'ZHSEIN',
      $               DUMMA( 4 ), N, JTYPE, IOLDSD
                END IF
             END IF
 *
-*           Call ZUNMHR for Right eigenvectors of A, do test 13
+*           Call ZUNMHR for Right eigenvectors of A, do test 14
 *
-            NTEST = 13
-            RESULT( 13 ) = ULPINV
+            NTEST = 14
+            RESULT( 14 ) = ULPINV
 *
             CALL ZUNMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTX, LDU, WORK, NWORK, IINFO )
@@ -1051,20 +1089,20 @@
      $            GO TO 240
             ELSE
 *
-*              Test 13:  | AX - XW | / ( |A| |X| ulp )
+*              Test 14:  | AX - XW | / ( |A| |X| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL ZGET22( 'N', 'N', 'N', N, A, LDA, EVECTX, LDU, W3,
      $                      WORK, RWORK, DUMMA( 1 ) )
                IF( DUMMA( 1 ).LT.ULPINV )
-     $            RESULT( 13 ) = DUMMA( 1 )*ANINV
+     $            RESULT( 14 ) = DUMMA( 1 )*ANINV
             END IF
 *
-*           Call ZUNMHR for Left eigenvectors of A, do test 14
+*           Call ZUNMHR for Left eigenvectors of A, do test 15
 *
-            NTEST = 14
-            RESULT( 14 ) = ULPINV
+            NTEST = 15
+            RESULT( 15 ) = ULPINV
 *
             CALL ZUNMHR( 'Left', 'No transpose', N, N, ILO, IHI, UU,
      $                   LDU, TAU, EVECTY, LDU, WORK, NWORK, IINFO )
@@ -1076,22 +1114,22 @@
      $            GO TO 240
             ELSE
 *
-*              Test 14:  | YA - WY | / ( |A| |Y| ulp )
+*              Test 15:  | YA - WY | / ( |A| |Y| ulp )
 *
 *                        (from inverse iteration)
 *
                CALL ZGET22( 'C', 'N', 'C', N, A, LDA, EVECTY, LDU, W3,
      $                      WORK, RWORK, DUMMA( 3 ) )
                IF( DUMMA( 3 ).LT.ULPINV )
-     $            RESULT( 14 ) = DUMMA( 3 )*ANINV
+     $            RESULT( 15 ) = DUMMA( 3 )*ANINV
             END IF
 *
 *           Compute Left and Right Eigenvectors of A
 *
 *           Compute a Right eigenvector matrix:
 *
-            NTEST = 15
-            RESULT( 15 ) = ULPINV
+            NTEST = 16
+            RESULT( 16 ) = ULPINV
 *
             CALL ZLACPY( ' ', N, N, UZ, LDU, EVECTR, LDU )
 *
@@ -1105,13 +1143,13 @@
                GO TO 250
             END IF
 *
-*           Test 15:  | AR - RW | / ( |A| |R| ulp )
+*           Test 16:  | AR - RW | / ( |A| |R| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL ZGET22( 'N', 'N', 'N', N, A, LDA, EVECTR, LDU, W1,
      $                   WORK, RWORK, DUMMA( 1 ) )
-            RESULT( 15 ) = DUMMA( 1 )
+            RESULT( 16 ) = DUMMA( 1 )
             IF( DUMMA( 2 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Right', 'ZTREVC3',
      $            DUMMA( 2 ), N, JTYPE, IOLDSD
@@ -1119,8 +1157,8 @@
 *
 *           Compute a Left eigenvector matrix:
 *
-            NTEST = 16
-            RESULT( 16 ) = ULPINV
+            NTEST = 17
+            RESULT( 17 ) = ULPINV
 *
             CALL ZLACPY( ' ', N, N, UZ, LDU, EVECTL, LDU )
 *
@@ -1134,13 +1172,13 @@
                GO TO 250
             END IF
 *
-*           Test 16:  | LA - WL | / ( |A| |L| ulp )
+*           Test 17:  | LA - WL | / ( |A| |L| ulp )
 *
 *                     (from Schur decomposition)
 *
             CALL ZGET22( 'Conj', 'N', 'Conj', N, A, LDA, EVECTL, LDU,
      $                   W1, WORK, RWORK, DUMMA( 3 ) )
-            RESULT( 16 ) = DUMMA( 3 )
+            RESULT( 17 ) = DUMMA( 3 )
             IF( DUMMA( 4 ).GT.THRESH ) THEN
                WRITE( NOUNIT, FMT = 9998 )'Left', 'ZTREVC3', DUMMA( 4 ),
      $            N, JTYPE, IOLDSD


### PR DESCRIPTION
## The failing test

ATfL 22.1.0, which is what the `ubuntu-24.04-arm` job uses, on the extended `_64` API shows the following error:

```
 Matrix order=   16, type=10, seed=2201,3345,1279,1121, result   8 is 3677.60
 ZHS:    1 out of  2016 tests failed to pass the threshold
```

## Summary

`xCHKHS` test 8 is documented as `| W(Z computed) - W(Z not computed) | / ( |W| ulp )`, and in the real drivers that is exactly what it is. The complex drivers have no `W2` array and compared against `W3`, which comes from `JOB = 'E'`, so they were varying `JOB` as well as `COMPZ` -- a stronger check than the description, and the one that fails on every LLVM Flang from 21 onwards. This PR restores test 8 to the `COMPZ` comparison in all four drivers, then adds the `JOB` comparison back as a new test 11 with a normalization that suits it.

## Commit 1: compare the test 8 eigenvalues at equal JOB

| drivers | before | after |
|---|---|---|
| `schkhs`, `dchkhs` | `WR1` from `('S','V')` vs `WR2` from `('S','N')` | unchanged |
| `cchkhs`, `zchkhs` | `W1` from `('S','V')` vs `W3` from `('E','N')` | `W1` vs a new `W2` from `('S','N')` |

`COMPZ` decides only whether `Z` is accumulated and never feeds back into the Hessenberg data, so the two lists agree exactly. Measured over 200 seeds and every matrix type, 126,000 ratios per precision: all zero, and `max = 0.00` with no scaling of any kind.

## Commit 2: check JOB = 'E' against JOB = 'S' as test 11

With test 8 restored, nothing compared the eigenvalues-only path against the full Schur path. The real drivers never did and the complex ones no longer do, so the new test adds that check to all four -- the first time the real drivers have had it.

It cannot be normalized by `ulp` times the largest eigenvalue. On ZHS type 10 at n=16 a relative O(ulp) perturbation of the Hessenberg matrix moves the spectrum by 1e12 to 2e14 in those units, with **200 of 200 trials over the threshold of 20**, and the eigenvalue that moves most is not a denormal straggler: it sits at 6 to 9% of the spectral radius with its own relative error 4.6% median, up to 57%.

So each difference is weighted by `s(j) = |y(j)**H x(j)| / ( ||y(j)|| ||x(j)|| )`, the reciprocal condition number of eigenvalue `j`, built from the eigenvectors tests 9 and 10 already compute. A backward error `eps` in `H` moves that eigenvalue by `eps / s(j)`, so `|dW(j)| s(j)` is the backward-error-scale quantity to test. `s(j) = 1` for a normal matrix, so the diagonal and Jordan types get the unscaled comparison.

Eigenvalues with `s(j) < sqrt(ulp)` are skipped. Those are the only ones the two paths have been seen to return in a **different order**, and the comparison is index-wise, so including them would mean comparing eigenvalues that do not correspond.

## Results

200 seeds x 21 types x 5 parameter sets x 7 orders = 126,000 ratios per precision, `THRESH` lowered to 0 so every value is recorded, flang 21.1.8 with default contraction:

| precision | old test 8 | new test 8 | new test 11 |
|---|---|---|---|
| S | 0 / 0.00 / 0 | 0 / 0.00 / 0 | 0 / 0.00 / 0 |
| D | 0 / 0.00 / 0 | 0 / 0.00 / 0 | 0 / 0.00 / 0 |
| C | 1408 / 4.868e+06 / **35** | 0 / 0.00 / 0 | 8 / 0.03 / 0 |
| Z | 1838 / 6.327e+14 / **36** | 0 / 0.00 / 0 | 0 / 0.00 / 0 |

(nonzero / max / at-or-over-20)

## Notes

- The `sqrt(ulp)` cutoff rests on measurement and on a mechanism, **not on a bound**. There is no theorem of the form "`s(j) >= c` implies the two paths agree on the ordering": the ordering follows from deflation decisions taken across the whole sweep, and a reordering among admitted eigenvalues would report a spurious difference. Every reordered eigenvalue found in 200 seeds and four precisions lay below the cutoff: by a factor of 8,900 in double but only **11 in single** precision.